### PR TITLE
Removing send() call from RTCPeerConnection

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -10,11 +10,11 @@
   <meta content="text/html; charset=us-ascii" http-equiv="Content-Type">
   <script class="remove" src="http://www.w3.org/Tools/respec/respec-w3c-common"
   type="text/javascript">
-// // keep this comment // 
+// // keep this comment //
   </script>
   <script class="remove" src="webrtc.js" type="text/javascript">
 // // keep
-    this comment // 
+    this comment //
   </script>
 </head>
 
@@ -539,7 +539,7 @@
 
             <p class="note">The creation of new incoming
             <code>MediaStream</code>s may be triggered either by SDP
-            negotiation or by the receipt of media on a given flow. 
+            negotiation or by the receipt of media on a given flow.
             <!--  [[OPEN ISSUE: How many <code>MediaStream</code>s are created
                 when you receive multiple conflicting pranswers?]] --></p>
           </li>
@@ -1317,73 +1317,7 @@
               needs this functionality it's really easy to make a clone of the
               stream, which will give it a new id, and send the clone.</p>
             </div>
-          </dd><!--
-    <dt>void send (DOMString text)</dt>
-
-    <dd>
-      <p>Attempts to send the given text to the remote peer. This uses UDP, which is
-      inherently unreliable; there is no guarantee that every message will be
-      received.</p>
-
-      <p>When a message sent in this manner from the other peer is received, a
-      <code><a href=
-      "#event-mediastream-message">message</a></code> event is fired at the
-      <code><a>RTCPeerConnection</a></code> object.</p>
-
-      <p>The maximum length of <var>text</var> is 504 bytes after encoding the
-      string as UTF-8; attempting to send a payload greater than 504 bytes results in an
-      <code>INVALID_ACCESS_ERR</code> exception.</p>
-
-      <p>When the <dfn id='dom-peerconnection-send'><code>send()</code></dfn>
-      method is invoked, the user agent MUST run the following steps:</p>
-
-      <ol>
-
-        <li>
-          <p>Let <var>message</var> be the methods first argument.</p>
-        </li>
-
-        <li>
-
-          <p>If the <code><a>RTCPeerConnection</a></code> objects <a
-           href="#dom-peerconnection-signaling-state"><code>RTCPeerConnection</code>
-          readiness state</a> is <code><a href=
-          "#widl-RTCPeerConnection-CLOSED">CLOSED</a></code> (3), throw an
-          <code>INVALID_STATE</code> exception.</p>
-
-        </li>
-
-        <li>
-          <p>Let <var>data</var> be <var>message</var> encoded as
-          UTF-8. [[!UTF-8]]</p>
-        </li>
-
-        <li>
-          <p>If <var>data</var> is longer than 504 bytes, throw an
-          <codeI>NVALID_ACCESS_ERR</code> exception and abort these steps.</p>
-        </li>
-
-       <li> <p>If the <code><a>RTCPeerConnection</a></code>s <a href=
-          "#rtcpeerconnection-data-udp-media-stream"><code>RTCPeerConnection</code>
-          data UDP media stream</a> is not an <a
-           href="#active-data-udp-media-stream">active data UDP media
-          stream</a>, abort these steps. No message is sent.</p> </li>
-
-        <li> <p>If the user agent is rate-limiting packets sent using this API,
-          and sending the data packet at this time would exceed the limit, then
-          abort these steps.  User agents MAY report this to the user, e.g. in a
-          development console.</p> </li>
-
-        <li> <p><a href="#transmit-a-data-packet-to-a-peer">Transmit a data
-          packet to a peer</a> using the <code><a>RTCPeerConnection</a></code>s
-          <a
-           href="#rtcpeerconnection-data-udp-media-stream"><code>RTCPeerConnection</code>
-          data UDP media stream</a> with <var>data</var> as the message.</p>
-          </li>
-
-      </ol>
-    </dd>
--->
+          </dd>
 
           <dt>void addStream (MediaStream stream)</dt>
 


### PR DESCRIPTION
Frankly, I was astounded to see this in the document at all.  I can't think of a single reason to keep it.
