### PR TITLE
Documenting practice with candidate events

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1943,27 +1943,25 @@
 
         <dl class="idl" data-merge="RTCIceCandidateInit" title=
         "interface RTCIceCandidate">
-          <dt>Constructor (optional RTCIceCandidateInit candidateInitDict)</dt>
+          <dt>Constructor (RTCIceCandidateInit candidateInitDict)</dt>
 
           <dd>The <dfn id=
           "dom-icecandidate"><code>RTCIceCandidate()</code></dfn> constructor
-          takes an optional dictionary argument, <var>candidateInitDict</var>,
+          takes a dictionary argument, <var>candidateInitDict</var>,
           whose content is used to initialize the new
-          <code><a>RTCIceCandidate</a></code> object. If a dictionary key is
-          not present in <var>candidateInitDict</var>, the corresponding
-          attribute will be initialized to null. If the constructor is run
-          without the dictionary argument, all attributes will be initialized
-          to null.</dd>
+          <code><a>RTCIceCandidate</a></code> object. When constructed, values
+          for <var>candidate</var> and either <var>sdpMid</var>
+          or <var>sdpMLineIndex</var> MUST be provided.</dd>
 
-          <dt>attribute DOMString? candidate</dt>
+          <dt>attribute DOMString candidate</dt>
 
-          <dd>This carries the candidate-attribute as defined in section 15.1
-          of [[!ICE]].</dd>
+          <dd>This carries the <code>candidate-attribute</code> as defined in
+          section 15.1 of [[!ICE]].</dd>
 
           <dt>attribute DOMString? sdpMid</dt>
 
           <dd>If present, this contains the identifier of the "media stream
-          identification" as defined in [[!RFC3388]] for the m-line this
+          identification" as defined in [[!RFC3388]] for the media section this
           candidate is associated with.</dd>
 
           <dt>attribute unsigned short? sdpMLineIndex</dt>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1997,6 +1997,12 @@
         <code>candidate</code> attribute set to the new ICE candidate, MUST be
         created and dispatched at the given target.</p>
 
+        <p>When firing an <code><a>RTCPeerConnectionIceEvent</a></code> event,
+        the <code><a>RTCIceCandidate</a></code> object provided by the user
+        agent MUST include values for
+        both <a href="#widl-RTCIceCandidate-sdpMid"><code>sdpMid</code></a>
+        and <a href="#widl-RTCIceCandidate-sdpMLineIndex"><code>sdpMLineIndex</code></a>.</p>
+
         <dl class="idl" data-merge="RTCPeerConnectionIceEventInit" title=
         "interface RTCPeerConnectionIceEvent : Event">
           <dt>Constructor(DOMString type, RTCPeerConnectionIceEventInit

--- a/webrtc.html
+++ b/webrtc.html
@@ -5561,6 +5561,7 @@ if (sender.dtmf) {
       <li>Bug 25724: Allow garbage collection of closed PeerConnections</li>
 
       <li>Bug 27214: Add onicegatheringstatechange event</li>
+      <li>Bug 26644: Fixing end of candidates event</li>
     </ol>
 
     <h3>Changes since April 10, 2014</h3>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1997,9 +1997,9 @@
         <code>candidate</code> attribute set to the new ICE candidate, MUST be
         created and dispatched at the given target.</p>
 
-        <p>When firing an <code><a>RTCPeerConnectionIceEvent</a></code> event,
-        the <code><a>RTCIceCandidate</a></code> object provided by the user
-        agent MUST include values for
+        <p>When firing an <code><a>RTCPeerConnectionIceEvent</a></code> event
+        that contains a <code><a>RTCIceCandidate</a></code> object, it MUST
+        include values for
         both <a href="#widl-RTCIceCandidate-sdpMid"><code>sdpMid</code></a>
         and <a href="#widl-RTCIceCandidate-sdpMLineIndex"><code>sdpMLineIndex</code></a>.</p>
 

--- a/webrtc.html
+++ b/webrtc.html
@@ -2008,12 +2008,18 @@
           <dt>Constructor(DOMString type, RTCPeerConnectionIceEventInit
           eventInitDict)</dt>
 
-          <dt>readonly attribute RTCIceCandidate candidate</dt>
+          <dt>readonly attribute RTCIceCandidate? candidate</dt>
 
           <dd>
             <p>The <code>candidate</code> attribute is the
             <code><a>RTCIceCandidate</a></code> object with the new ICE
             candidate that caused the event.</p>
+
+            <p>This attribute is set to <code>null</code> when an event is
+            generated to indicate the end of candidate gathering.</p>
+
+            <p class="Note">Even where there are multiple media sections, only
+            one event containing a <code>null</code> candidate is fired.</p>
           </dd>
         </dl>
 
@@ -2022,7 +2028,7 @@
           <dt>RTCIceCandidate candidate</dt>
 
           <dd>
-            <p>TODO</p>
+            <p>See <a href="#widl-RTCPeerConnectionIceEvent-candidate"><code>RTCPeerConnectionIceEvent.candidate</code>.</p>
           </dd>
         </dl>
       </section>


### PR DESCRIPTION
Three changes:
* RTCIceCandidate is now less optional and immutable
* sdpMid and sdpMLineIndex are mandatory for the browser to provide
* the candidate attribute on the icecandidate event is now actually nullable and there is documentation that explains what it means