### PR TITLE
onsignalingstatechange: readyState -> signalingState

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1272,7 +1272,8 @@
           "#event-signalingstatechange">signalingstatechange</a></code>, MUST
           be supported by all objects implementing the
           <code><a>RTCPeerConnection</a></code> interface. It is called any
-          time the <code>readyState</code> changes, i.e., from a call to
+          time the <a href="#dom-peerconnection-signaling-state">
+          <code>RTCPeerConnection</code> signaling state</a> changes, i.e., from a call to
           <code>setLocalDescription</code>, a call to
           <code>setRemoteDescription</code>, or code. It does not fire for the
           initial state change into <code>new</code>.</dd>


### PR DESCRIPTION
This seems to be outdated, please correct me if I'm wrong. 
As for the anchor tag, I followed the syntax from `onicegatheringstatechange`
for consistency.

I have no idea if this is the right approach for changing the spec, please let me know if this needs to go through the WG mailing list instead.