### PR TITLE
Harmonizing issue references

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -184,7 +184,7 @@
           [[!TRAM-TURN-THIRD-PARTY-AUTHZ]], Section 6.2.</dd>
         </dl>
 
-        <div class="note">
+        <div class="issue">
           <p>Should we have a "none" type, for cases where no authentication is
           needed? (e.g. STUN)
           </p>
@@ -522,7 +522,7 @@
           </li>
         </ol>
 
-        <div class="note">
+        <div class="issue">
           <p>The section above shouldn't need to reference MediaStreamTracks when
           discussing the ICE connection state; one problem with this is that
           it doesn't handle the data channel situation properly.
@@ -753,7 +753,7 @@
             description, or rollback to the old description if the remote side
             denied the change.</p>
 
-            <p class="issue">ISSUE: how to indicate to rollback?</p>
+            <p class="issue" data-number="141">How to indicate to rollback?</p>
 
             <p>To Do: specify what parts of the SDP can be changed between the
             createOffer and setLocalDescription</p>
@@ -842,7 +842,7 @@
                         valid description but cannot be applied at the media
                         layer.</p>
 
-                        <p>TODO ISSUE - next few points are probably wrong.
+                        <p class="issue">TODO - next few points are probably wrong.
                         Make sure to check this in setRemote too.</p>
 
                         <p>This can happen, e.g., if there are insufficient
@@ -1148,7 +1148,7 @@
               </li>
             </ol>
 
-            <div class="note">
+            <div class="issue">
               The exception types throw in the above algorithm are provisional
               (until we decide what to do in each case).
             </div>
@@ -1205,7 +1205,7 @@
               </li>
             </ol>
 
-            <div class="note">
+            <div class="issue">
               What errors do we need here? Should we reuse the
               *SessionDescriptionError names or invent new ones for candidates?
               Should this method be queued?
@@ -1673,8 +1673,8 @@
           <dt>completed</dt>
 
           <dd>The ICE Agent has finished gathering and checking and found a
-          connection for all components. Open issue: it is not clear how the
-          non controlling ICE side knows it is in the state.</dd>
+          connection for all components. <p class="issue">it is not clear how the
+          non controlling ICE side knows it is in the state</p>.</dd>
 
           <dt>failed</dt>
 
@@ -1795,7 +1795,7 @@
           at which the error was encountered.</dd>
         </dl>
 
-        <div class="note">
+        <div class="issue">
           <p>Ask the DOM team to extend their list with the following errors.
           The error names and their descriptions are directly copied from the
           old RTCErrorName enum and might need some adjustment before being
@@ -2416,7 +2416,7 @@
             </li>
           </ol>
 
-          <div class="note">
+          <div class="issue">
             <p>Since the beginning of this specification, remote MediaStreamTracks have been
             created by the setRemoteDescription call, one track for each non-rejected
             m-line in the remote description. This meant that at the caller,
@@ -2860,7 +2860,7 @@
       "#dfn-underlying-data-transport">data transport</a> <a href=
       "#data-transport-closed">closed</a>.</p>
 
-      <div class="note">
+      <div class="issue">
         References to protocol specification are needed.
       </div>
 
@@ -2874,7 +2874,7 @@
           object whose <a href="#dfn-underlying-data-transport">transport</a>
           was closed.</p>
 
-          <div class="note">
+          <div class="issue">
             The data transport protocol will specify what happens to, e.g.
             buffered data, when the data transport is closed.
           </div>
@@ -3457,7 +3457,7 @@
           of RTP packets but it MUST not increase either of them by more than
           the duration of a single RTP audio packet.</p>
 
-          <p class="issue">ISSUE: How are invalid values handled?</p>
+          <p class="issue">How are invalid values handled?</p>
 
           <p>When the <code><a>insertDTMF()</a></code> method is invoked, the
           user agent MUST run the following steps:</p>
@@ -3636,7 +3636,7 @@
       and the browser emits (in the JavaScript) a set of statistics that it
       believes is relevant to the selector.</p>
 
-      <div class="note">
+      <div class="issue">
         Evaluate the need for other selectors than MediaStreamTrack.
       </div>
 
@@ -3772,8 +3772,8 @@
       application. Thus, applications MUST be prepared to deal with unknown
       stats.</p>
 
-      <div class="note">
-        OPEN ISSUE: Need to define an IANA registry for this and populate with
+      <div class="issue">
+        Need to define an IANA registry for this and populate with
         pointers to existing things such as the RTCP statistics.
       </div>
 
@@ -3817,7 +3817,7 @@
           agents are free to pick any format for the id as long as it meets the
           requirements above.</p>
 
-          <div class="note">
+          <div class="issue">
             Consider naming id something that indicates that the id refers to
             the underlying object that was inspected to produce the stats,
             instead of being an id for the JavaScript object. Suggestions:
@@ -4637,7 +4637,7 @@ function logError(error) {
       data the <code>ended</code> event MUST be fired on the track, as
       specified in [[!GETUSERMEDIA]].</p>
 
-      <p class="issue">ISSUE: How do you know when it has stopped? This seems
+      <p class="issue">How do you know when it has stopped? This seems
       like an SDP question, not a media-level question. (Suggestion: when the
       track is ended, either through port 0, or removing the a=msid attrib)</p>
     </section>
@@ -5067,7 +5067,7 @@ var gameDataChan = peerConn.createDataChannel("data", { "reliable": false, "prio
     <section>
       <h3>Call Flow Browser to Browser</h3>
 
-      <p class="note">Editors' Note: This example flow needs to be discussed on
+      <p class="issue">Editors' Note: This example flow needs to be discussed on
       the list and is likely wrong in many ways.</p>
 
       <p>This shows an example of one possible call flow between two browsers.
@@ -5513,7 +5513,7 @@ if (sender.dtmf) {
     which IP addresses are made available to applications, based on the
     security posture desired by the user.</p>
 
-    <div class="note">
+    <div class="issue" data-number="179">
       <p>The working group is actively discussing what additional text
       regarding exposure of IP addresses is appropriate for this section.
       </p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1190,9 +1190,11 @@
               <li>
                 <p>If the candidate could not be successfully applied, reject
                 <var>p</var> with a <code>DOMError</code> object whose
-                <code>name</code> attribute has the value TBD (TODO
-                InvalidCandidate and InvalidMidIndex) and jump to the step
+                <code>name</code> attribute has the value TBD
+                and jump to the step
                 labeled <em>Return</em>.</p>
+                <p class="issue">TODO: define names for DOMError (
+                InvalidCandidate and InvalidMidIndex)</p>
               </li>
 
               <li>
@@ -2569,15 +2571,15 @@
 
         <dt>RTCRtpReceiver receiver</dt>
         <dd>
-          <p>TODO</p>
+          <p class="issue">TODO</p>
         </dd>
         <dt>MediaStreamTrack track</dt>
         <dd>
-          <p>TODO</p>
+          <p class="issue">TODO</p>
         </dd>
         <dt>MediaStream[] streams</dt>
         <dd>
-          <p>TODO</p>
+          <p class="issue">TODO</p>
         </dd>
       </dl>
     </section>
@@ -3361,7 +3363,7 @@
         <dt>RTCDataChannel channel</dt>
 
         <dd>
-          <p>TODO</p>
+          <p class="issue">TODO</p>
         </dd>
       </dl>
     </section>
@@ -3613,7 +3615,7 @@
         <dt>DOMString tone</dt>
 
         <dd>
-          <p>TODO</p>
+          <p class="issue">TODO</p>
         </dd>
       </dl>
     </section>
@@ -4034,11 +4036,12 @@ function logError(error) {
           identity assertions.</li>
         </ol>
 
-        <p>[TODO: This is not sufficient unless we expect the IdP to protect
+        <p class="issue">[TODO: This is not sufficient unless we expect the IdP to protect
         this information. Otherwise, the a=identity information can be copied
         from a session with "good" properties to any other session with the
         same fingerprint information. Since we want to reuse credentials, that
-        would be bad.] The identity mechanism MUST provide an indication to the
+        would be bad.]</p>
+        <p>The identity mechanism MUST provide an indication to the
         remote side of whether it requires the stream contents to be protected.
         Implementations MUST have an user interface that indicates the
         different cases and identity for these.</p>
@@ -4947,8 +4950,8 @@ function logError(error) {
 
       <div>
         <p>This example shows the more complete functionality.</p>
+<p class="issue">TODO</p>
         <pre class="example highlight" xml:space="preserve">
-TODO
 
 </pre>
       </div>
@@ -5227,7 +5230,7 @@ if (sender.dtmf) {
 
           <td><code><a>Event</a></code></td>
 
-          <td>TODO.</td>
+          <td><p class="issue">TODO</p>.</td>
         </tr>
 
         <tr>
@@ -5262,7 +5265,7 @@ if (sender.dtmf) {
 
           <td><code>Event</code></td>
 
-          <td>TODO</td>
+          <td><p class="issue">TODO</p></td>
         </tr><!--
         <tr>
           <td><dfn title="event-MediaStream-error"><code>error</code></dfn></td>

--- a/webrtc.html
+++ b/webrtc.html
@@ -676,7 +676,7 @@
             agent MUST reject the returned promise with
             an <code>DOMError</code> object of type TBD as its argument.</p>
 
-            <p>To Do: Discuss privacy aspects of this from a fingerprinting
+            <p class="issue">To Do: Discuss privacy aspects of this from a fingerprinting
             point of view - it's probably around as bad as access to a canvas
             :-)</p>
           </dd>
@@ -730,6 +730,7 @@
             <p>If the SDP generation process failed for any reason, the user
             agent MUST reject the returned promise with a <code>DOMError</code>
             object of type TBD.</p>
+            <p class="issue">TODO: define type of error for SDP generation</p>
           </dd>
 
           <dt>Promise&lt;void&gt; setLocalDescription (
@@ -755,7 +756,7 @@
 
             <p class="issue" data-number="141">How to indicate to rollback?</p>
 
-            <p>To Do: specify what parts of the SDP can be changed between the
+            <p class="issue">To Do: specify what parts of the SDP can be changed between the
             createOffer and setLocalDescription</p>
 
             <p>The following list describes the <dfn id=

--- a/webrtc.js
+++ b/webrtc.js
@@ -69,7 +69,7 @@ var respecConfig = {
   // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
   // Team Contact.
   wgPatentURI:  "http://www.w3.org/2004/01/pp-impl/47318/status",
-
+  issueBase: "https://github.com/w3c/webrtc-pc/issues/",
   otherLinks: [
     {
       key: "Participate",


### PR DESCRIPTION
This pull request brings more uniformity in what is marked up as "issue" in the document.

I've opted to use `class="issue"` for things that were marked up as notes, but were really todos or at least meant to be temporary until something happens.

I have also configured respec to refer to github issues when using the `data-number` attribute on issues (used for #179 and #141 for now); to avoid surprises (such as discovering "issues" hidden in the media capture streams doc as we were calling for last call approval), I would like to set up a Travis CI job that alerts us for any issue that is not linked to github, or for anything marked as an issue in the doc that refers to a closed issue.

But before I can look into that, we need to import all the things marked up as issues in the doc as issues in github (if they still apply).

(using the `data-number` attribute means that other issues are no longer numbered; that's probably a feature since these numbers were not very useful in the first place)