### PR TITLE
makes peerIdentity nullable and default to null in RTCConfiguration

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -157,7 +157,7 @@
             <p>Indicates which <a href="#target-bundle-policy">BundlePolicy</a> to use. </p>
           </dd>
 
-          <dt>DOMString peerIdentity</dt>
+          <dt>DOMString? peerIdentity = null</dt>
 
           <dd>
             <p>Sets the <a href="#target-peer-identity">target peer


### PR DESCRIPTION
no point in requiring it all the time
aligns with firefox's webidl http://mxr.mozilla.org/mozilla-central/source/dom/webidl/RTCConfiguration.webidl