### PR TITLE
Optional RTCConfiguration in RTCPC constructor

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -593,7 +593,7 @@
         <h3>Interface Definition</h3>
 
         <dl class="idl" title="interface RTCPeerConnection : EventTarget ">
-          <dt>Constructor (RTCConfiguration configuration)</dt>
+          <dt>Constructor (optional RTCConfiguration configuration)</dt>
 
           <dd>
             See the <a href="#dom-peerconnection">RTCPeerConnection constructor


### PR DESCRIPTION
[WebIDL requires it](http://heycam.github.io/webidl/#dfn-optional-argument):
"If the type of an argument is a dictionary type or a union type that has a dictionary type as one of its flattened member types, and this argument is either the final argument or is followed only by optional arguments, then the argument MUST be specified as optional. "
Firefox has it optional too: http://mxr.mozilla.org/mozilla-central/source/dom/webidl/RTCPeerConnection.webidl

see also #34 