### PR TITLE
Enqueue addIceCandidate

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -458,7 +458,8 @@
 
         <p>Once the RTCPeerConnection object has been initialized, for every
         call to <code>createOffer</code>, <code>setLocalDescription</code>,
-        <code>createAnswer</code> and <code>setRemoteDescription</code>;
+        <code>createAnswer</code>, <code>setRemoteDescription</code>,
+        and <code>addIceCandidate</code>;
         execute the following steps:</p>
 
         <ol>


### PR DESCRIPTION
ISTM that addIceCandidate needs to be queued because it has to be ordered wrt setRD.