### PR TITLE
Removing optionality from constructors

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1919,24 +1919,22 @@
 
         <dl class="idl" data-merge="RTCSessionDescriptionInit" title=
         "interface RTCSessionDescription">
-          <dt>Constructor (optional RTCSessionDescriptionInit
-          descriptionInitDict)</dt>
+          <dt>Constructor (RTCSessionDescriptionInit descriptionInitDict)</dt>
 
           <dd>The <dfn id=
           "dom-sessiondescription"><code>RTCSessionDescription()</code></dfn>
-          constructor takes an optional dictionary argument,
+          constructor takes an dictionary argument,
           <var>descriptionInitDict</var>, whose content is used to initialize
-          the new <code><a>RTCSessionDescription</a></code> object. If a
-          dictionary key is not present in <var>descriptionInitDict</var>, the
-          corresponding attribute will be initialized to null. If the
-          constructor is run without the dictionary argument, all attributes
-          will be initialized to null. This class is a future extensible
-          carrier for the data contained in it and does not perform any
-          substantive processing.</dd>
+          the new <code><a>RTCSessionDescription</a></code> object. If
+          the <code>sdp</code> dictionary key is not present
+          in <var>descriptionInitDict</var>, the corresponding attribute will be
+          initialized to null. This class is a future extensible carrier for the
+          data contained in it and does not perform any substantive
+          processing.</dd>
 
-          <dt>attribute RTCSdpType? type</dt>
+          <dt>attribute RTCSdpType type</dt>
 
-          <dd>The type of SDP this RTCSessionDescription represents.</dd>
+          <dd>The type of this RTCSessionDescription.</dd>
 
           <dt>attribute DOMString? sdp</dt>
 
@@ -1946,7 +1944,7 @@
         </dl>
 
         <dl class="idl" title="dictionary RTCSessionDescriptionInit">
-          <dt>RTCSdpType type</dt>
+          <dt>required RTCSdpType type</dt>
 
           <dt>DOMString sdp</dt>
         </dl>

--- a/webrtc.html
+++ b/webrtc.html
@@ -2053,7 +2053,7 @@
         </dl>
 
         <dl class="idl" title="dictionary RTCIceCandidateInit">
-          <dt>DOMString candidate</dt>
+          <dt>required DOMString candidate</dt>
 
           <dt>DOMString sdpMid</dt>
 

--- a/webrtc.html
+++ b/webrtc.html
@@ -1923,10 +1923,10 @@
 
           <dd>The <dfn id=
           "dom-sessiondescription"><code>RTCSessionDescription()</code></dfn>
-          constructor takes an dictionary argument,
+          constructor takes a dictionary argument,
           <var>descriptionInitDict</var>, whose content is used to initialize
           the new <code><a>RTCSessionDescription</a></code> object. If
-          the <code>sdp</code> dictionary key is not present
+          the <code>sdp</code> dictionary member is not present
           in <var>descriptionInitDict</var>, the corresponding attribute will be
           initialized to null. This class is a future extensible carrier for the
           data contained in it and does not perform any substantive

--- a/webrtc.html
+++ b/webrtc.html
@@ -1032,7 +1032,7 @@
             applied successfully, the user agent MUST <a href=
             "#dispatch-receiver">dispatch a receiver</a> for all new
             media descriptions [[!RTCWEB-JSEP]] before queuing the <a href=
-            "#setlocal-resolve">setLocalDescription() resolve task</a>.</p>            
+            "#setlocal-resolve">setLocalDescription() resolve task</a>.</p>
 
             <p>If an <code>a=identity</code> attribute is present in the session
             description, the browser <a href=
@@ -1925,12 +1925,9 @@
           "dom-sessiondescription"><code>RTCSessionDescription()</code></dfn>
           constructor takes a dictionary argument,
           <var>descriptionInitDict</var>, whose content is used to initialize
-          the new <code><a>RTCSessionDescription</a></code> object. If
-          the <code>sdp</code> dictionary member is not present
-          in <var>descriptionInitDict</var>, the corresponding attribute will be
-          initialized to null. This class is a future extensible carrier for the
-          data contained in it and does not perform any substantive
-          processing.</dd>
+          the new <code><a>RTCSessionDescription</a></code> object.  This class
+          is a future extensible carrier for the data contained in it and does
+          not perform any substantive processing.</dd>
 
           <dt>attribute RTCSdpType type</dt>
 
@@ -1938,7 +1935,8 @@
 
           <dt>attribute DOMString? sdp</dt>
 
-          <dd>The string representation of the SDP [[!SDP]]</dd>
+          <dd>The string representation of the SDP [[!SDP]] or
+          a <code>null</code> value.</dd>
 
           <dt>serializer = { attribute }</dt>
         </dl>
@@ -1946,7 +1944,7 @@
         <dl class="idl" title="dictionary RTCSessionDescriptionInit">
           <dt>required RTCSdpType type</dt>
 
-          <dt>DOMString sdp</dt>
+          <dt>DOMString? sdp = null</dt>
         </dl>
       </section>
 
@@ -2589,7 +2587,7 @@ params.encodings[0].active = false;
 sender.setParameters(params)
             </pre>
           </dd>
- 
+
         </dl>
       </section>
 


### PR DESCRIPTION
Removing the weird optionality from RTCSessionDescription and its constructor.

Making RTCIceCandidateInit.candidate required.  The dictionary argument to the constructor is not optional anyway (which is a WebIDL violation).