### PR TITLE
Remove SyntaxError on malformed ICE candidate

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1107,12 +1107,6 @@
               </li>
 
               <li>
-                <p>If the candidate parameter is malformed, reject <var>p</var>
-                with <code>SyntaxError</code> and jump to the step labeled
-                <em>Return</em>.</p>
-              </li>
-
-              <li>
                 <p>If the candidate could not be successfully applied, reject
                 <var>p</var> with a <code>DOMError</code> object whose
                 <code>name</code> attribute has the value TBD


### PR DESCRIPTION
* it is not defined what a "malformed" ICE candidate is
* no browser does this today
* from a flow perspective, an error will be triggered in the next step (can't be applied)