### PR TITLE
Fix error handling for certificate management

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2986,9 +2986,10 @@ sender.setParameters(params)
 
           <p>A <a>user agent</a> MUST reject a call
           to <code>generateCertificate()</code> with a <code>DOMError</code> of
-          type "InvalidAccessError" if the <var>keygenAlgorithm</var> parameter
-          identifies an algorithm that the <a>user agent</a> cannot or will not
-          use to generate a certificate for <code>RTCPeerConnection</code>.</p>
+          type <code>NotSupportedError</code> if the <var>keygenAlgorithm</var>
+          parameter identifies an algorithm that the <a>user agent</a> cannot or
+          will not use to generate a certificate
+          for <code>RTCPeerConnection</code>.</p>
 
           <p>The following values MUST be supported by a <a>user agent</a>:
             <code>{ name:

--- a/webrtc.html
+++ b/webrtc.html
@@ -2960,7 +2960,10 @@ sender.setParameters(params)
           of <code>generateKey</code> and a
           [[<a href="https://dvcs.w3.org/hg/webcrypto-api/raw-file/tip/spec/Overview.html#dfn-supportedAlgorithms">supportedAlgorithms</a>]]
           value specific to production of certificates
-          for <code>RTCPeerConnection</code>.</p>
+          for <code>RTCPeerConnection</code>.  If the algorithm normalization
+          process produces an error, the call
+          to <code>generateCertificate</code> MUST be rejected with that
+          error.</p>
 
           <p>Signatures produced by the generated key are used to authenticate
           the DTLS connection. The identified algorithm (as identified by


### PR DESCRIPTION
The certificate management description inadvertently requires the use of InvalidAccessError exclusively.  That's not good.

Otherwise, if the algorithm isn't supported, we should report NotSupportedError.