### PR TITLE
Fix prose on getStats() wo/selector + move type check to sync section

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4179,18 +4179,17 @@ sender.setParameters(params)
 
           <ol>
             <li>
-              <p>Let <var>p</var> be a new promise.</p>
-            </li>
-
-            <li>
               <p>Let <var>selectorArg</var> be the methods first argument.</p>
             </li>
 
             <li>
               <p>If <var>selectorArg</var> is neither <code>null</code> nor a
               valid <a href="#stats-selector">selector</a>,
-              reject <var>p</var> with a
-              new <code>DOMError</code> with name <code>TypeError</code>.</p>
+              return a promise rejected with a <code>TypeError</code>.</p>
+            </li>
+
+            <li>
+              <p>Let <var>p</var> be a new promise.</p>
             </li>
 
             <li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -4166,7 +4166,7 @@ sender.setParameters(params)
 
       <dl class="idl" title="partial interface RTCPeerConnection">
         <dt>Promise&lt;RTCStatsReport&gt; getStats(
-          optional MediaStreamTrack? selector)</dt>
+          optional MediaStreamTrack? selector = null)</dt>
 
         <dd>
           <p>Gathers stats for the given <a href="#stats-selector">selector</a>
@@ -4187,15 +4187,16 @@ sender.setParameters(params)
             </li>
 
             <li>
+              <p>If <var>selectorArg</var> is neither <code>null</code> nor a
+              valid <a href="#stats-selector">selector</a>,
+              reject <var>p</var> with a
+              new <code>DOMError</code> with name <code>TypeError</code>.</p>
+            </li>
+
+            <li>
               <p>Run the following steps in parallel:</p>
 
               <ol>
-                <li>
-                  <p>If <var>selectorArg</var> is an invalid <a href=
-                  "#stats-selector">selector</a>, reject <var>p</var> with a
-                  new <code>DOMError</code> with name <code>TypeError</code>.</p>
-                </li>
-
                 <li>
                   <p>Start gathering the stats indicated by <var>selectorArg</var>.
                   If <var>selectorArg</var> is null, stats MUST be gathered


### PR DESCRIPTION
Fix WebIDL and prose to handle the case where no selector is passed correctly, and move type check to the synchronous section, like we do over in https://github.com/w3c/mediacapture-main/pull/182.
