### PR TITLE
Change type of RtpEncodingParameters.priority to an enum.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2330,6 +2330,40 @@
         </dl>
       </section>
     </section>
+
+    <section>
+      <h2>Priority and QoS Model</h2>
+
+      <p> Many applications have multiple media flows of the same
+        data type and often some of the flows are more important than
+        others.  WebRTC uses the priority and Quality of Service (QoS) framework
+        described in [[!RTCWEB-TRANSPORT]] and [[!TSVWG-RTCWEB-QOS]]
+        to provide priority and DSCP marketing for packets that will
+        help provide QoS in some networking environments. The
+        priority setting can be used to indicate the relative priority
+        of various flows. The priority API allows the JavaScript
+        applications to tell the browser whether a particular media
+        flow is high, medium, low or of very low importance to the
+        application by setting the <code>RTCRtpEncodingParamters.priority</code>
+        to the follwing values.</p>
+
+      <section>
+        <h4>RTCPriorityType Enum</h4>
+        <dl class="idl" title="enum RTCPriorityType">
+          <dt>very-low</dt> <dd>See [[!RTCWEB-TRANSPORT]], Section 4.</dd>
+          <dt>low</dt> <dd>See [[!RTCWEB-TRANSPORT]], Section 4.</dd>
+          <dt>medium</dt> <dd>See [[!RTCWEB-TRANSPORT]], Section 4.</dd>
+          <dt>high</dt> <dd>See [[!RTCWEB-TRANSPORT]], Section 4.</dd>
+        </dl>
+      </section>
+
+      <p>
+        Applications that use this API should be aware that often
+        better overall user experience is obtained by lowering the
+        priority of things that are not as important rather than
+        raising the the priority of the things that are.
+      </p>
+    </section>
   </section>
 
   <section>
@@ -2740,7 +2774,6 @@
             <p>An array containing parameters for RTP encodings of media.</p>
           </dd>
         </dl>
-
         <dl class="idl" title="dictionary RTCRtpEncodingParameters">
           <dt>boolean active</dt>
 
@@ -2752,15 +2785,11 @@
             </p>
           </dd>
 
-          <dt>double priority</dt>
+          <dt>RTCPriorityType priority</dt>
           <dd>
             <p>
-              Indicates the relative priority of this encoding, across
-              all RtpSenders of a given PeerConnection.  When there is
-              limited bandwidth available to a PeerConnection, higher
-              prioirty encodings will be sent with more bandwidth, and
-              lower priority encodings will be sent with less
-              bandwidth.
+             Indicates the priority of this encoding.  It is specified
+             in [[!RTCWEB-TRANSPORT]], Section 4.
             </p>
           </dd>
         </dl>


### PR DESCRIPTION
Based on https://github.com/w3c/webrtc-pc/pull/228/files.  It pulls in everything from https://github.com/w3c/webrtc-pc/pull/228/files except the DataChannel priority attribute.