### PR TITLE
Editorial: Add note about the RTCPeerConnection interface being extended by partial interfaces

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -638,6 +638,13 @@
       <section>
         <h3>Interface Definition</h3>
 
+        <p>The <code><a>RTCPeerConnection</a></code> interface presented this
+        section is not complete. The interface is extended by several partial
+        interfaces throughout this specification. Notably, the <a href=
+        "#rtcpeerconnection-interface-extensions">RTP Media section</a>, that
+        adds the APIs to send and receive <code><a>MediaStreamTrack</a></code>
+        objects.</p>
+
         <dl class="idl" title="interface RTCPeerConnection : EventTarget ">
           <dt>Constructor (optional RTCConfiguration configuration)</dt>
 


### PR DESCRIPTION
With a link that makes it easy to navigate to the addTrack() API