### PR TITLE
fix RTCStatsReport with object and maplike instead of getter

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4507,7 +4507,7 @@ sender.setParameters(params)
         <dt>readonly maplike&lt;DOMString, object&gt;</dt>
 
         <dd>
-          This is a map accessor to retrieve the various dictionaries
+          Use these to retrieve the various dictionaries
           descended from <code><a>RTCStats</a></code> that
           this stats report is composed of.
           The set of supported property names [[!WEBIDL]] is defined as the

--- a/webrtc.html
+++ b/webrtc.html
@@ -4680,17 +4680,16 @@ pc.getStats(selector).then(function (report) {
 
 function processStats() {
     // compare the elements from the current report with the baseline
-    for (var i in currentReport) {
-        var now = currentReport[i];
+    currentReport.forEach (now => {
         if (now.type != "outboundrtp")
-            continue;
+            return;
 
         // get the corresponding stats from the baseline report
-        base = baselineReport[now.id];
+        base = baselineReport.get(now.id);
 
         if (base) {
-            remoteNow = currentReport[now.remoteId];
-            remoteBase = baselineReport[base.remoteId];
+            remoteNow = currentReport.get(now.remoteId);
+            remoteBase = baselineReport.get(base.remoteId);
 
             var packetsSent = now.packetsSent - base.packetsSent;
             var packetsReceived = remoteNow.packetsReceived - remoteBase.packetsReceived;

--- a/webrtc.html
+++ b/webrtc.html
@@ -4485,22 +4485,22 @@ sender.setParameters(params)
 
       <p>The <code><a href="#widl-RTCPeerConnection-getStats-Promise-RTCStatsReport--MediaStreamTrack-selector">
         getStats()</a></code>
-      method delivers a successful result in the form of a
-      <code><a>RTCStatsReport</a></code> object. A
-      <code><a>RTCStatsReport</a></code> object represents a map between
-      strings, identifying the inspected objects (<a href=
+      method delivers a successful result in the form of an
+      <code><a>RTCStatsReport</a></code> object. An
+      <code><a>RTCStatsReport</a></code> object is a map between
+      strings that identify the inspected objects (<a href=
       "#dom-rtcstats-id">RTCStats.id</a>), and their corresponding
-      <code><a>RTCStats</a></code> objects.</p>
+      <code><a>RTCStats</a></code>-derived dictionaries.</p>
 
       <p>An <code><a>RTCStatsReport</a></code> may be composed of several
-      <code><a>RTCStats</a></code> objects, each reporting stats for one
+      <code><a>RTCStats</a></code> dictionaries, each reporting stats for one
       underlying object that the implementation thinks is relevant for the
       <a href="#stats-selector">selector</a>. One achieves the total for the
       <a href="#stats-selector">selector</a> by summing over all the stats of a
       certain type; for instance, if a <code>MediaStreamTrack</code> is carried
       by multiple SSRCs over the network, the
-      <code><a>RTCStatsReport</a></code> may contain one <code>RTCStats</code>
-      object per SSRC (which can be distinguished by the value of the "ssrc"
+      <code><a>RTCStatsReport</a></code> may contain one <code>RTCStats</code>-derived
+      dictionary per SSRC (which can be distinguished by the value of the "ssrc"
       stats attribute).</p>
 
       <dl class="idl" title="interface RTCStatsReport">
@@ -4512,8 +4512,8 @@ sender.setParameters(params)
           this stats report is composed of.</p>
 
           <p>The set of supported property names [[!WEBIDL]] is defined as the
-          ids of all the <code><a>RTCStats</a></code> objects that has been
-          generated for this stats report.</p>
+          ids of all the <code><a>RTCStats</a></code>-derived dictionaries that
+          has been generated for this stats report.</p>
         </dd>
       </dl>
     </section>
@@ -4544,8 +4544,8 @@ sender.setParameters(params)
       "packetsSent" are both reported, they both need to be reported over the
       same interval, so that "average packet size" can be computed as "bytes /
       packets" - if the intervals are different, this will yield errors. Thus
-      implementations MUST return synchronized values for all stats in a
-      <code><a>RTCStats</a></code> object.</p>
+      implementations MUST return synchronized values for all stats in an
+      <code><a>RTCStats</a></code>-derived dictionary.</p>
 
       <dl class="idl" title="dictionary RTCStats">
         <dt>DOMHiResTimeStamp timestamp</dt>

--- a/webrtc.html
+++ b/webrtc.html
@@ -4507,13 +4507,12 @@ sender.setParameters(params)
         <dt>readonly maplike&lt;DOMString, object&gt;</dt>
 
         <dd>
-          <p>This is a map accessor to retrieve the various dictionaries
+          This is a map accessor to retrieve the various dictionaries
           descended from <code><a>RTCStats</a></code> that
-          this stats report is composed of.</p>
-
-          <p>The set of supported property names [[!WEBIDL]] is defined as the
+          this stats report is composed of.
+          The set of supported property names [[!WEBIDL]] is defined as the
           ids of all the <code><a>RTCStats</a></code>-derived dictionaries that
-          have been generated for this stats report.</p>
+          have been generated for this stats report.
         </dd>
       </dl>
     </section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -4493,7 +4493,7 @@ sender.setParameters(params)
       <code><a>RTCStats</a></code>-derived dictionaries.</p>
 
       <p>An <code><a>RTCStatsReport</a></code> may be composed of several
-      <code><a>RTCStats</a></code> dictionaries, each reporting stats for one
+      <code><a>RTCStats</a></code>-derived dictionaries, each reporting stats for one
       underlying object that the implementation thinks is relevant for the
       <a href="#stats-selector">selector</a>. One achieves the total for the
       <a href="#stats-selector">selector</a> by summing over all the stats of a

--- a/webrtc.html
+++ b/webrtc.html
@@ -4504,16 +4504,16 @@ sender.setParameters(params)
       stats attribute).</p>
 
       <dl class="idl" title="interface RTCStatsReport">
-        <dt>getter RTCStats (DOMString id)</dt>
+        <dt>readonly maplike&lt;DOMString, object&gt;</dt>
 
         <dd>
-          <p>Getter to retrieve the <code><a>RTCStats</a></code> objects that
+          <p>This is a map accessor to retrieve the various dictionaries
+          descended from <code><a>RTCStats</a></code> that
           this stats report is composed of.</p>
 
           <p>The set of supported property names [[!WEBIDL]] is defined as the
           ids of all the <code><a>RTCStats</a></code> objects that has been
-          generated for this stats report. The order of the property names is
-          left to the user agent.</p>
+          generated for this stats report.</p>
         </dd>
       </dl>
     </section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -4513,7 +4513,7 @@ sender.setParameters(params)
 
           <p>The set of supported property names [[!WEBIDL]] is defined as the
           ids of all the <code><a>RTCStats</a></code>-derived dictionaries that
-          has been generated for this stats report.</p>
+          have been generated for this stats report.</p>
         </dd>
       </dl>
     </section>


### PR DESCRIPTION
Fix for https://github.com/w3c/webrtc-pc/issues/275 and https://github.com/w3c/webrtc-pc/issues/285.