### PR TITLE
Removing interface use for RTCSessionDescription and RTCIceCandidate

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -611,7 +611,7 @@
 
                 <p>Add the candidate to <var>connection</var>'s
                 <code><a>localDescription</a></code> and create a
-                <code><a>RTCIceCandidate</a></code> object to represent the
+                <code><a>RTCIceCandidate</a></code> instance to represent the
                 candidate. Let <var>newCandidate</var> be that object.</p>
               </li>
 
@@ -2141,36 +2141,18 @@
       </section>
 
       <section>
-        <h4>RTCSessionDescription Class</h4>
+        <h4>RTCSessionDescription</h4>
 
-        <dl class="idl" data-merge="RTCSessionDescriptionInit" title=
-        "interface RTCSessionDescription">
-          <dt>Constructor (RTCSessionDescriptionInit descriptionInitDict)</dt>
-
-          <dd>The <dfn id=
-          "dom-sessiondescription"><code>RTCSessionDescription()</code></dfn>
-          constructor takes a dictionary argument,
-          <var>descriptionInitDict</var>, whose content is used to initialize
-          the new <code><a>RTCSessionDescription</a></code> object.  This class
-          is a future extensible carrier for the data contained in it and does
-          not perform any substantive processing.</dd>
-
-          <dt>attribute RTCSdpType type</dt>
+        <dl class="idl" title=
+        "dictionary RTCSessionDescription">
+          <dt>required RTCSdpType type</dt>
 
           <dd>The type of this RTCSessionDescription.</dd>
 
-          <dt>attribute DOMString? sdp</dt>
+          <dt>DOMString? sdp = null</dt>
 
           <dd>The string representation of the SDP [[!SDP]] or
           a <code>null</code> value.</dd>
-
-          <dt>serializer = { attribute }</dt>
-        </dl>
-
-        <dl class="idl" title="dictionary RTCSessionDescriptionInit">
-          <dt>required RTCSdpType type</dt>
-
-          <dt>DOMString? sdp = null</dt>
         </dl>
       </section>
 
@@ -2242,46 +2224,27 @@
       <section>
         <h4>RTCIceCandidate Type</h4>
 
-        <p>This class is a future extensible carrier for the data contained in
-        it and does not perform any substantive processing.</p>
+        <p>This describes an ICE candidate. Though not explicitly required,
+        values for <var>candidate</var> and either <var>sdpMid</var>
+        or <var>sdpMLineIndex</var> MUST be provided.</p>
 
-        <dl class="idl" data-merge="RTCIceCandidateInit" title=
-        "interface RTCIceCandidate">
-          <dt>Constructor (RTCIceCandidateInit candidateInitDict)</dt>
-
-          <dd>The <dfn id=
-          "dom-icecandidate"><code>RTCIceCandidate()</code></dfn> constructor
-          takes a dictionary argument, <var>candidateInitDict</var>,
-          whose content is used to initialize the new
-          <code><a>RTCIceCandidate</a></code> object. When constructed, values
-          for <var>candidate</var> and either <var>sdpMid</var>
-          or <var>sdpMLineIndex</var> MUST be provided.</dd>
-
-          <dt>attribute DOMString candidate</dt>
+        <dl class="idl" title=
+        "dictionary RTCIceCandidate">
+          <dt>required DOMString candidate</dt>
 
           <dd>This carries the <code>candidate-attribute</code> as defined in
           section 15.1 of [[!ICE]].</dd>
 
-          <dt>attribute DOMString? sdpMid</dt>
+          <dt>DOMString sdpMid</dt>
 
           <dd>If present, this contains the identifier of the "media stream
           identification" as defined in [[!RFC3388]] for the media section this
           candidate is associated with.</dd>
 
-          <dt>attribute unsigned short? sdpMLineIndex</dt>
+          <dt>unsigned short sdpMLineIndex</dt>
 
           <dd>This indicates the index (starting at zero) of the m-line in the
           SDP this candidate is associated with.</dd>
-
-          <dt>serializer = { attribute}</dt>
-        </dl>
-
-        <dl class="idl" title="dictionary RTCIceCandidateInit">
-          <dt>required DOMString candidate</dt>
-
-          <dt>DOMString sdpMid</dt>
-
-          <dt>unsigned short sdpMLineIndex</dt>
         </dl>
       </section>
 
@@ -6075,7 +6038,7 @@ function start() {
         })
         .then(function () {
             // send the offer to the other peer
-            signalingChannel.send(JSON.stringify({ "sdp": pc.localDescription }));
+            signalingChannel.send(JSON.stringify({ "desc": pc.localDescription }));
         })
         .catch(logError);
     };
@@ -6101,8 +6064,8 @@ signalingChannel.onmessage = function (evt) {
         start();
 
     var message = JSON.parse(evt.data);
-    if (message.sdp) {
-        var desc = new RTCSessionDescription(message.sdp);
+    if (message.desc) {
+        var desc = message.desc;
 
         // if we get an offer, we need to reply with an answer
         if (desc.type == "offer") {
@@ -6113,13 +6076,13 @@ signalingChannel.onmessage = function (evt) {
                 return pc.setLocalDescription(answer);
             })
             .then(function () {
-                signalingChannel.send(JSON.stringify({ "sdp": pc.localDescription }));
+                signalingChannel.send(JSON.stringify({ "desc": pc.localDescription }));
             })
             .catch(logError);
         } else
             pc.setRemoteDescription(desc).catch(logError);
     } else
-        pc.addIceCandidate(new RTCIceCandidate(message.candidate)).catch(logError);
+        pc.addIceCandidate(message.candidate).catch(logError);
 };
 
 function logError(error) {
@@ -6176,7 +6139,7 @@ function start(isInitiator) {
         })
         .then(function () {
             // send the offer to the other peer
-            signalingChannel.send(JSON.stringify({ "sdp": pc.localDescription }));
+            signalingChannel.send(JSON.stringify({ "desc": pc.localDescription }));
         })
         .catch(logError);
     };
@@ -6199,8 +6162,8 @@ signalingChannel.onmessage = function (evt) {
         start(false);
 
     var message = JSON.parse(evt.data);
-    if (message.sdp) {
-        var desc = new RTCSessionDescription(message.sdp);
+    if (message.desc) {
+        var desc = message.desc;
 
         // if we get an offer, we need to reply with an answer
         if (desc.type == "offer") {
@@ -6211,13 +6174,13 @@ signalingChannel.onmessage = function (evt) {
                 return pc.setLocalDescription(answer);
             })
             .then(function () {
-                signalingChannel.send(JSON.stringify({ "sdp": pc.localDescription }));
+                signalingChannel.send(JSON.stringify({ "desc": pc.localDescription }));
             })
             .catch(logError);
         } else
             pc.setRemoteDescription(desc).catch(logError);
     } else
-        pc.addIceCandidate(new RTCIceCandidate(message.candidate)).catch(logError);
+        pc.addIceCandidate(message.candidate).catch(logError);
 };
 
 function setupChat() {

--- a/webrtc.html
+++ b/webrtc.html
@@ -2155,6 +2155,10 @@
           <dd>The string representation of the SDP [[!SDP]] or
           a <code>null</code> value.</dd>
         </dl>
+        <div class="note">
+          <p>The constructor on <code><a>RTCSessionDescription</a></code> exists
+          for legacy compatibility reasons only.</p>
+        </div>
       </section>
 
       <section>
@@ -2246,6 +2250,10 @@
           <dd>This indicates the index (starting at zero) of the m-line in the
           SDP this candidate is associated with.</dd>
         </dl>
+        <div class="note">
+          <p>The constructor on <code><a>RTCSessionDescription</a></code> exists
+          for legacy compatibility reasons only.</p>
+        </div>
       </section>
 
       <section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -789,13 +789,13 @@
           </dd>
 
           <dt>Promise&lt;void&gt; setLocalDescription (
-            RTCSessionDescription description)</dt>
+            RTCSessionDescriptionInit description)</dt>
 
           <dd>
             <p>The <dfn id=
             "dom-peerconnection-setlocaldescription"><code>setLocalDescription()</code></dfn>
             method instructs the <code><a>RTCPeerConnection</a></code> to apply
-            the supplied <code><a>RTCSessionDescription</a></code> as the local
+            the supplied <code><a>RTCSessionDescriptionInit</a></code> as the local
             description.</p>
 
             <p>This API changes the local media state. In order to successfully
@@ -814,7 +814,7 @@
 
             <p>The following list describes the <dfn id=
             "set-description-model">processing model</dfn> for setting a new
-            <code><a>RTCSessionDescription</a></code>.</p>
+            <code><a>RTCSessionDescriptionInit</a></code>.</p>
 
             <ul>
               <li>
@@ -846,7 +846,7 @@
 
                   <li>
                     <p>The user agent MUST start the process to apply the
-                    <code><a>RTCSessionDescription</a></code> argument.</p>
+                    <code><a>RTCSessionDescriptionInit</a></code> argument.</p>
                   </li>
 
                   <li>
@@ -857,7 +857,7 @@
 
               <li>
                 <p>If the process to apply the
-                <code><a>RTCSessionDescription</a></code> argument fails for
+                <code><a>RTCSessionDescriptionInit</a></code> argument fails for
                 any reason, then user agent MUST queue a task runs the
                 following steps:</p>
 
@@ -880,9 +880,9 @@
                     <ul>
                       <li>
                         <p>The content of the
-                        <code><a>RTCSessionDescription</a></code> argument is
+                        <code><a>RTCSessionDescriptionInit</a></code> argument is
                         invalid or the <code><a href=
-                        "#widl-RTCSessionDescription-type">type</a></code> is
+                        "#widl-RTCSessionDescriptionInit-type">type</a></code> is
                         wrong for the current <a href=
                         "#dom-peerconnection-signaling-state">signaling
                         state</a> of <var>connection</var>.</p>
@@ -892,7 +892,7 @@
                       </li>
 
                       <li>
-                        <p>The <code><a>RTCSessionDescription</a></code> is a
+                        <p>The <code><a>RTCSessionDescriptionInit</a></code> is a
                         valid description but cannot be applied at the media
                         layer.</p>
 
@@ -923,7 +923,7 @@
               </li>
 
               <li>
-                <p>If the <code><a>RTCSessionDescription</a></code> argument is
+                <p>If the <code><a>RTCSessionDescriptionInit</a></code> argument is
                 applied successfully, then user agent MUST queue a task (<dfn
                 id="setlocal-resolve">setLocalDescription() resolve task</dfn>)
                 that runs the following steps:</p>
@@ -965,7 +965,7 @@
 
                     <!-- A transition stable to haveLocalOffer --> <li> <p>If
                     the local description was set, and the
-                    <code><a>RTCSessionDescription</a></code> argument has a
+                    <code><a>RTCSessionDescriptionInit</a></code> argument has a
                     type of "offer", and it has a version that is later than the
                     currentLocalDescription, then the pendingLocalDescription will be set to
                     the argument and the state will transition to
@@ -973,7 +973,7 @@
 
                     <!-- C transition haveRemoteOffer or haveLocalProvAnswer to
                     stable --> <li><p>If the local description was set, and the
-                    <code><a>RTCSessionDescription</a></code> argument has a
+                    <code><a>RTCSessionDescriptionInit</a></code> argument has a
                     type of "answer", then this completes an offer answer
                     negotiation and currentLocalDescription is set to the argument,
                     currentRemoteDescription is set to the value of pendingRemoteDescription,
@@ -982,7 +982,7 @@
 
                     <!-- D transition stable to haveRemoteOffer --> <li> <p>If
                     the remote description was set, and the
-                    <code><a>RTCSessionDescription</a></code> argument has a
+                    <code><a>RTCSessionDescriptionInit</a></code> argument has a
                     type of "offer", and it has a version that is later than the
                     currentRemoteDescription, then the pendingRemoteDescription will be set to
                     the argument and the state will transition to
@@ -990,7 +990,7 @@
 
                     <!-- F transition haveRemoteOffer or haveLocalProvAnswer to
                     stable --> <li><p>If the remote description was set, and the
-                    <code><a>RTCSessionDescription</a></code> argument has a
+                    <code><a>RTCSessionDescriptionInit</a></code> argument has a
                     type of "answer", then this completes an offer answer
                     negotiation and currentRemoteDescription is set to the argument,
                     currentLocalDescription is set to the value of pendingLocalDescription,
@@ -999,21 +999,21 @@
 
                     <!-- B transition rollback to haveLocalOffer to stable -->
                     <li> <p>If the local description was set, and the
-                    <code><a>RTCSessionDescription</a></code> argument has a
+                    <code><a>RTCSessionDescriptionInit</a></code> argument has a
                     type of "rollback", then this is a rollback and the
                     pendingLocalDescription is set to null and the state will
                     transition to stable.  </p> </li>
 
                     <!-- E transition rollback to haveRemoteOffer to stable -->
                     <li> <p>If the remote description was set, and the
-                    <code><a>RTCSessionDescription</a></code> argument has a
+                    <code><a>RTCSessionDescriptionInit</a></code> argument has a
                     type of "rollback", then this is a rollback and the
                     pendingRemoteDescription is set to null and the state will
                     transition to stable.  </p> </li>
 
                     <!-- G transition haveRemoteOffer to haveLocalProvAnswer -->
                     <li><p>If the local description was set, and the
-                    <code><a>RTCSessionDescription</a></code> argument has a
+                    <code><a>RTCSessionDescriptionInit</a></code> argument has a
                     type of "pranswer", then pendingLocalDescription will be set to the
                     argument and the state will transitions to
                     have-local-pranswer unless the state was stable,
@@ -1022,7 +1022,7 @@
 
                      <!-- H transition haveRemoteOffer to haveLocalProvAnswer
                     --> <li><p>If the remote description was set, and the
-                    <code><a>RTCSessionDescription</a></code> argument has a
+                    <code><a>RTCSessionDescriptionInit</a></code> argument has a
                     type of "pranswer", then pendingRemoteDescription will be set to
                     the argument and the state will transitions to
                     have-remote-pranswer unless the state was stable,
@@ -1135,13 +1135,13 @@
 
 
           <dt>Promise&lt;void&gt; setRemoteDescription (
-            RTCSessionDescription description)</dt>
+            RTCSessionDescriptionInit description)</dt>
 
           <dd>
             <p>The <dfn id=
             "dom-peerconnection-setremotedescription"><code>setRemoteDescription()</code></dfn>
             method instructs the <code><a>RTCPeerConnection</a></code> to apply
-            the supplied <code><a>RTCSessionDescription</a></code> as the
+            the supplied <code><a>RTCSessionDescriptionInit</a></code> as the
             remote offer or answer. This API changes the local media state.</p>
 
             <p>When the method is invoked, the user agent MUST follow the <a
@@ -1150,7 +1150,7 @@
             In addition, a remote description is processed to determine and
             verify the identity of the peer.</p>
 
-            <p>If the <code><a>RTCSessionDescription</a></code> argument is
+            <p>If the <code><a>RTCSessionDescriptionInit</a></code> argument is
             applied successfully, the user agent MUST <a href=
             "#dispatch-receiver">dispatch a receiver</a> for all new
             media descriptions [[!RTCWEB-JSEP]] before queuing the <a href=
@@ -1608,7 +1608,7 @@
             argument.</p>
           </dd>
 
-          <dt>void setLocalDescription (RTCSessionDescription description,
+          <dt>void setLocalDescription (RTCSessionDescriptionInit description,
           VoidFunction successCallback, RTCPeerConnectionErrorCallback
           failureCallback)</dt>
 
@@ -1679,7 +1679,7 @@
             argument.</p>
           </dd>
 
-          <dt>void setRemoteDescription (RTCSessionDescription description,
+          <dt>void setRemoteDescription (RTCSessionDescriptionInit description,
           VoidFunction successCallback, RTCPeerConnectionErrorCallback
           failureCallback)</dt>
 
@@ -2053,7 +2053,7 @@
         <dl class="idl" title="interface RTCSdpError : DOMError">
           <dt>readonly attribute long sdpLineNumber</dt>
 
-          <dd>The line number of an <code><a>RTCSessionDescription</a></code>
+          <dd>The line number of an <code><a>RTCSessionDescriptionInit</a></code>
           at which the error was encountered.</dd>
         </dl>
 
@@ -2065,13 +2065,13 @@
 
           <ul>
             <li>InvalidSessionDescriptionError: The provided
-            RTCSessionDescription contained invalid SDP, or the type was wrong
+            RTCSessionDescriptionInit contained invalid SDP, or the type was wrong
             for the current state of the RTCPeerConnection. User agents SHOULD
             provide as much additional information in the error message as
             possible, including the sdpLineNumber, if appropriate.</li>
 
             <li>IncompatibleSessionDescriptionError: The provided
-            RTCSessionDescription contained SDP that could not be correctly
+            RTCSessionDescriptionInit contained SDP that could not be correctly
             applied to the RTCPeerConnection due to its current state. User
             agents SHOULD provide as much additional information in the error
             message as possible, including the sdpLineNumber, if
@@ -2096,6 +2096,7 @@
         <h4>RTCSdpType</h4>
 
         <p>The RTCSdpType enum describes the type of an
+        <code><a>RTCSessionDescriptionInit</a></code> or
         <code><a>RTCSessionDescription</a></code> instance.</p>
 
         <dl class="idl" title="enum RTCSdpType">
@@ -2141,24 +2142,42 @@
       </section>
 
       <section>
-        <h4>RTCSessionDescription</h4>
+        <h4>RTCSessionDescription Class</h4>
 
-        <dl class="idl" title=
-            "[Constructor(RTCSessionDescription copy)] dictionary RTCSessionDescription">
+        <p>The <code>RTCSessionDescription</code> class is used by
+        <code><a>RTCPeerConnection</a></code> to expose local and remote session
+        descriptions.  Attributes on this interface are mutable for legacy
+        reasons.</p>
 
-          <dt>required RTCSdpType type</dt>
+        <dl class="idl" data-merge="RTCSessionDescriptionInit" title=
+        "interface RTCSessionDescription">
+          <dt>Constructor (RTCSessionDescriptionInit descriptionInitDict)</dt>
+
+          <dd>The <dfn id=
+          "dom-sessiondescription"><code>RTCSessionDescription()</code></dfn>
+          constructor takes a dictionary argument,
+          <var>descriptionInitDict</var>, whose content is used to initialize
+          the new <code><a>RTCSessionDescription</a></code> object.  This
+          constructor is deprecated; it exists for legacy compatibility reasons
+          only.</dd>
+
+          <dt>attribute RTCSdpType type</dt>
 
           <dd>The type of this RTCSessionDescription.</dd>
 
-          <dt>DOMString? sdp = null</dt>
+          <dt>attribute DOMString? sdp</dt>
 
           <dd>The string representation of the SDP [[!SDP]] or
           a <code>null</code> value.</dd>
+
+          <dt>serializer = { attribute }</dt>
         </dl>
-        <div class="note">
-          <p>The constructor on <code><a>RTCSessionDescription</a></code> exists
-          for legacy compatibility reasons only.</p>
-        </div>
+
+        <dl class="idl" title="dictionary RTCSessionDescriptionInit">
+          <dt>required RTCSdpType type</dt>
+
+          <dt>DOMString? sdp = null</dt>
+        </dl>
       </section>
 
       <section>
@@ -2251,7 +2270,7 @@
           SDP this candidate is associated with.</dd>
         </dl>
         <div class="note">
-          <p>The constructor on <code><a>RTCSessionDescription</a></code> exists
+          <p>The constructor on <code><a>RTCIceCandidate</a></code> exists
           for legacy compatibility reasons only.</p>
         </div>
       </section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -2144,7 +2144,8 @@
         <h4>RTCSessionDescription</h4>
 
         <dl class="idl" title=
-        "dictionary RTCSessionDescription">
+            "[Constructor(RTCSessionDescription copy)] dictionary RTCSessionDescription">
+
           <dt>required RTCSdpType type</dt>
 
           <dd>The type of this RTCSessionDescription.</dd>
@@ -2228,8 +2229,7 @@
         values for <var>candidate</var> and either <var>sdpMid</var>
         or <var>sdpMLineIndex</var> MUST be provided.</p>
 
-        <dl class="idl" title=
-        "dictionary RTCIceCandidate">
+        <dl class="idl" title="[Constructor(RTCIceCandidate copy)] dictionary RTCIceCandidate">
           <dt>required DOMString candidate</dt>
 
           <dd>This carries the <code>candidate-attribute</code> as defined in


### PR DESCRIPTION
We currently force people to do this:

```js
var x = new {moz|webkit|prefix}RTCIceCandidate(stuff_I_got_from_signaling);
pc.addCandidate(x);
```

This is nicer:
```js
pc.addCandidate(stuff_I_got_from_signaling);
```

Same for session descriptions.