### PR TITLE
Fix broken RTCPeerConnection's operations array to work with promises.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -542,8 +542,7 @@
             rejection handler, both of which MUST immediately decrement
             <var>connection</var>'s <var>operationsLength</var> by
             <code>1</code> and return <var>undefined</var> (this has no effect
-            on <var>p</var>). To ensure the decrement happens before any other
-            use of <var>p</var>, both handlers MUST not do anything else.</p>
+            on <var>p</var>).</p>
           </li>
 
           <li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -481,8 +481,9 @@
           </li>
 
           <li>
-            <p>Initialize an internal variable to represent a queue of
-            <code>operations</code> with an empty set.</p>
+            <p>On the <var>connection</var>, reserve an internal slot
+            <var>operations</var>, and initialize an internal slot
+            <var>operationsLength</var> to <code>0</code>.</p>
           </li>
 
           <li>
@@ -509,33 +510,60 @@
 
         <ol>
           <li>
-            <p>Append an object representing the current call being handled
-            (i.e. function name and corresponding arguments) to the
-            <code>operations</code> array.</p>
+            <p>Let <var>operation</var> be a function executing the steps of the
+            function in question.</p>
+          </li>
+          <li>
+            <p>If <var>connection</var>'s <a href=
+              "#dom-peerconnection-signaling-state"><code>RTCPeerConnection</code>
+              signalingState</a> is <code>closed</code>, throw an
+              <code>InvalidStateError</code> exception and abort these steps.</p>
+          </li>
+          <li>
+            <p>If <var>connection</var>'s <var>operationsLength</var> is
+            <code>0</code>, let <var>p</var> be the result of executing
+            <var>operation</var>; otherwise, let <var>p</var> be the result of
+            transforming <var>connection</var>'s <var>operations</var> by a
+            fulfillment handler that runs the following steps:</p>
+            <ol>
+              <li>
+                <p>If <var>connection</var>'s <a href=
+                "#dom-peerconnection-signaling-state"><code>RTCPeerConnection</code>
+                signalingState</a> is <code>closed</code>, return
+                <var>undefined</var> and abort these steps.</p>
+              </li>
+              <li>
+                <p>Return the result of executing <var>operation</var>.</p>
+              </li>
+            </ol>
           </li>
 
           <li>
-            <p>If the length of the <code>operations</code> array is exactly 1,
-            execute the function from the front of the queue
-            asynchronously.</p>
+            <p>Increment <var>connection</var>'s <var>operationsLength</var> by
+            <code>1</code>.</p>
+          </li>
+          <li>
+            <p>Set <var>connection</var>'s <var>operations</var> to the result
+            of transforming <var>p</var> by a fulfillment and
+            rejection handler, both of which decrement <var>connection</var>'s
+            <var>operationsLength</var> by <code>1</code> and return
+            <var>undefined</var> (this has no effect on <var>p</var>).
+            Both handlers MUST transform <var>p</var> directly, to ensure the
+            decrement happens before any other use of <var>p</var>.</p>
           </li>
 
           <li>
-            <p>When the asynchronous operation completes (either successfully
-            or with an error), remove the corresponding object from the
-            <code>operations</code> array. After removal, if the array is
-            non-empty, execute the first object queued asynchronously and
-            repeat this step on completion.</p>
+            <p>Return <var>p</var>.</p>
           </li>
         </ol>
 
         <p>The general idea is to have only one among <code>createOffer</code>,
-        <code>setLocalDescription</code>, <code>createAnswer</code> and
-        <code>setRemoteDescription</code> executing at any given time. If
+        <code>setLocalDescription</code>, <code>createAnswer</code>,
+        <code>setRemoteDescription</code> and <code>addIceCandidate</code>
+        executing at any given time. If
         subsequent calls are made while one of them is still executing, they
-        are added to a queue and processed when the previous operation is fully
-        completed. It is valid, and expected, for normal error handling
-        procedures to be applied.</p>
+        are added to a chain and processed upon fulfillment or rejection of the
+        previous operation's promise.</p>
 
         <p>Additionally, during the lifetime of the RTCPeerConnection object,
         the following procedures are followed when an ICE event occurs:</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -482,8 +482,8 @@
 
           <li>
             <p>On the <var>connection</var>, reserve an internal slot
-            <var>operations</var>, and initialize an internal slot
-            <var>operationsLength</var> to <code>0</code>.</p>
+            <var>operationsDone</var>, and initialize an internal slot
+            <var>operationsCount</var> to <code>0</code>.</p>
           </li>
 
           <li>
@@ -516,31 +516,27 @@
           <li>
             <p>If <var>connection</var>'s <a href=
               "#dom-peerconnection-signaling-state"><code>RTCPeerConnection</code>
-              signalingState</a> is <code>closed</code>, throw an
-              <code>InvalidStateError</code> exception and abort these steps.</p>
+              signalingState</a> is <code>closed</code>, return a promise
+              rejected with <code>InvalidStateError</code> and abort these steps.</p>
           </li>
           <li>
-            <p>If <var>connection</var>'s <var>operationsLength</var> is
+            <p>If <var>connection</var>'s <var>operationsCount</var> is
             <code>0</code>, let <var>p</var> be the result of executing
             <var>operation</var>; otherwise, let <var>p</var> be the result of
-            transforming <var>connection</var>'s <var>operations</var> by a
-            fulfillment handler that runs the following steps:</p>
-            <ol>
-              <li>
-                <p>Return the result of executing <var>operation</var>.</p>
-              </li>
-            </ol>
+            transforming <var>connection</var>'s <var>operationsDone</var> by a
+            fulfillment handler that returns the result of executing
+            <var>operation</var>.</p>
           </li>
 
           <li>
-            <p>Increment <var>connection</var>'s <var>operationsLength</var> by
+            <p>Increment <var>connection</var>'s <var>operationsCount</var> by
             <code>1</code>.</p>
           </li>
           <li>
-            <p>Set <var>connection</var>'s <var>operations</var> to the result
+            <p>Set <var>connection</var>'s <var>operationsDone</var> to the result
             of transforming <var>p</var> by a fulfillment and
             rejection handler, both of which MUST immediately decrement
-            <var>connection</var>'s <var>operationsLength</var> by
+            <var>connection</var>'s <var>operationsCount</var> by
             <code>1</code> and return <var>undefined</var> (this has no effect
             on <var>p</var>).</p>
           </li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -527,12 +527,6 @@
             fulfillment handler that runs the following steps:</p>
             <ol>
               <li>
-                <p>If <var>connection</var>'s <a href=
-                "#dom-peerconnection-signaling-state"><code>RTCPeerConnection</code>
-                signalingState</a> is <code>closed</code>, return
-                <var>undefined</var> and abort these steps.</p>
-              </li>
-              <li>
                 <p>Return the result of executing <var>operation</var>.</p>
               </li>
             </ol>
@@ -545,11 +539,11 @@
           <li>
             <p>Set <var>connection</var>'s <var>operations</var> to the result
             of transforming <var>p</var> by a fulfillment and
-            rejection handler, both of which decrement <var>connection</var>'s
-            <var>operationsLength</var> by <code>1</code> and return
-            <var>undefined</var> (this has no effect on <var>p</var>).
-            Both handlers MUST transform <var>p</var> directly, to ensure the
-            decrement happens before any other use of <var>p</var>.</p>
+            rejection handler, both of which MUST immediately decrement
+            <var>connection</var>'s <var>operationsLength</var> by
+            <code>1</code> and return <var>undefined</var> (this has no effect
+            on <var>p</var>). To ensure the decrement happens before any other
+            use of <var>p</var>, both handlers MUST not do any thing else.</p>
           </li>
 
           <li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -543,7 +543,7 @@
             <var>connection</var>'s <var>operationsLength</var> by
             <code>1</code> and return <var>undefined</var> (this has no effect
             on <var>p</var>). To ensure the decrement happens before any other
-            use of <var>p</var>, both handlers MUST not do any thing else.</p>
+            use of <var>p</var>, both handlers MUST not do anything else.</p>
           </li>
 
           <li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -514,12 +514,6 @@
             function in question.</p>
           </li>
           <li>
-            <p>If <var>connection</var>'s <a href=
-              "#dom-peerconnection-signaling-state"><code>RTCPeerConnection</code>
-              signalingState</a> is <code>closed</code>, return a promise
-              rejected with <code>InvalidStateError</code> and abort these steps.</p>
-          </li>
-          <li>
             <p>If <var>connection</var>'s <var>operationsCount</var> is
             <code>0</code>, let <var>p</var> be the result of executing
             <var>operation</var>; otherwise, let <var>p</var> be the result of
@@ -537,8 +531,7 @@
             of transforming <var>p</var> by a fulfillment and
             rejection handler, both of which MUST immediately decrement
             <var>connection</var>'s <var>operationsCount</var> by
-            <code>1</code> and return <var>undefined</var> (this has no effect
-            on <var>p</var>).</p>
+            <code>1</code>.</p>
           </li>
 
           <li>


### PR DESCRIPTION
I'm resubmitting this PR for consideration as a solution to https://github.com/w3c/webrtc-pc/issues/299, and I respectfully request that people take another look, as I don't see any competing PRs to solve this issue.