### PR TITLE
Update to PR 300

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3378,36 +3378,38 @@ sender.setParameters(params)
 
           <dt> sequence&lt;RTCRtpContributingSource&gt;
             getContributingSources ()  </dt>
-          <dd> <p>Returns a RTCRtpContributingSource for each unique
+          <dd> <p>Returns an <code><a>RTCRtpContributingSource</a></code> for each unique
               CSRC or SSRC received by this RTCRtpReceiver in the last 10
-            seconds. </p>
+            seconds.</p>
           </dd>
               
 	</dl>
 
-    <p> The RTCRtpContributingSource objects contains information information
-    about a given contribution source, including the time the most recent time a
+    <p> The <dfn>RTCRtpContributingSource</dfn> objects contain information
+    about a given contributing source, including the time the most recent time a
     packet was received from the source. The browser MUST keep information from
-    RTP packets received in the previous second. When a RTP packet is received,
-    the entries are updated for the SSRC of the RTP packet and for any CSRC
-    contained in it. </p>
+    RTP packets received in the previous 10 seconds.  Each time an RTP packet is received, 
+    the <code><a>RTCRtpContributingSource</a></code> objects are updated.  If the RTP packet 
+    contains CSRCs, then the <code><a>RTCRtpContributingSource</a></code> objects corresponding 
+    to those CSRCs are updated.  If the RTP packet contains no CSRCs, then the <code><a>RTCRtpContributingSource</a></code> 
+    object corresponding to the SSRC is updated.</p>
 
 	 <dl class="idl" title="interface RTCRtpContributingSource">
 
-	   <dt> readonly attribute DOMHighResTimeStamp timestamp</dt> <dd> Time of
-	   reception of the most recent RTP packet containing the contributing
-	   source. </dd>
+	   <dt> readonly attribute DOMHighResTimeStamp timestamp</dt> 
+	   <dd> <p>The timestamp of type DOMHighResTimeStamp [HIGHRES-TIME], indicating the time of 
+	   reception of the most recent RTP packet containing the source.  
+	   The timestamp corresponds to the local clock.</p> </dd>
 
 	   <dt> readonly attribute unsigned long source</dt> <dd> <p> The CSRC or
 	   SSRC value of the contributing source. </p> </dd>
 
 	   <dt> readonly attribute byte? audioLevel</dt> <dd> <p> The audio level
-       contained in the last RTP packet received from the this source. If the
-       source was set from an SSRC, this will be the value defined as the level
-       in [[!RFC6464]] while if the source was set from a CSRC, this will be the
-       value as defined in level in [[!RFC6465]]. If the RTP does not contain
-       the RFC646 extension header, then the browser will compute the value as
-       if it had come from RFC6464 and use that.  RFC 6464 and 6465 define the
+       contained in the last RTP packet received from the this source.  If the
+       source was set from an SSRC, this will be the level value defined
+       in [[!RFC6464]].  If an RFC 6464 extension header is not present, the browser will compute the value as
+       if it had come from RFC 6464 and use that.  If the source was set from a CSRC, this will be the
+       level value defined in [[!RFC6465]].  RFC 6464 and 6465 define the
        level as a integral value from 0 to -127 representing the audio level in
        decibels relative to the loudest signal that they system could possibly
        encode.  <p> </dd>


### PR DESCRIPTION
Some fixes to PR 300 to fix typos, fix inconsistencies in the time to keep entries (10 seconds vs. 1 second) and clarify when dictionary entries are updated. 