### PR TITLE
Adding additional members to RTCIceCandidate dictionary.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2429,10 +2429,7 @@
           <h4>The RTCIceTcpCandidateType</h4>
 
           <p>The <dfn>RTCIceTcpCandidateType</dfn> represents the type of the ICE TCP
-          candidate, as defined in [[!RFC6544]]. Browsers MUST gather <code>active</code>
-          TCP candidates and only <code>active</code> TCP candidates. Servers and other
-          endpoints MAY gather <code>active</code>, <code>passive</code> or <code>so</code>
-          candidates.</p>
+          candidate, as defined in [[!RFC6544]].</p>
 
           <dl class="idl" title="enum RTCIceTcpCandidateType">
             <dt>active</dt>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1271,7 +1271,9 @@
             <code>none</code>. This call will result in a change to the
             connection state of the ICE Agent, and may result in a change to
             media state if it results in different connectivity being
-            established.</p>
+            established. Note that the only members of the candidate attribute
+            used by this method are <var>candidate</var>, <var>sdpMid</var> and
+            <var>sdpMLineIndex</var>; the rest are ignored.</p>
 
             <ol>
               <li>
@@ -2354,11 +2356,126 @@
 
           <dd>This indicates the index (starting at zero) of the m-line in the
           SDP this candidate is associated with.</dd>
+
+          <dt>DOMString foundation</dt>
+
+          <dd>A unique identifier that allows ICE to correlate candidates that
+          appear on multiple <code><a>RTCIceTransport</a></code>s.</dd>
+
+          <dt>unsigned long priority</dt>
+
+          <dd>The assigned priority of the candidate. This is automatically
+          populated by the browser.</dd>
+
+          <dt>DOMString ip</dt>
+
+          <dd>The IP address of the candidate.</dd>
+
+          <dt>RTCIceProtocol protocol</dt>
+
+          <dd>The protocol of the candidate (<code>udp</code>/<code>tcp</code>).</dd>
+
+          <dt>unsigned short port</dt>
+
+          <dd>The port of the candidate.</dd>
+
+          <dt>RTCIceCandidateType type</dt>
+
+          <dd>The type of candidate.</dd>
+
+          <dt>RTCIceTcpCandidateType tcpType</dt>
+
+          <dd>If <code>protocol</code> is <code>tcp</code>, <code>tcpType</code> represents
+          the type of TCP candidate. Otherwise, <code>tcpType</code> is not present in the
+          dictionary.</dd>
+
+          <dt>DOMString relatedAddress</dt>
+
+          <dd>For a candidate that is derived from another, such as a relay or reflexive
+          candidate, the <dfn>relatedAddress</dfn> is the IP address of the candidate that
+          it is derived from. For host candidates, the <code>relatedAddress</code>
+          is not present in the dictionary.</dd>
+
+          <dt>unsigned short relatedPort</dt>
+
+          <dd>For a candidate that is derived from another, such as a relay or reflexive
+          candidate, the <dfn>relatedPort</dfn> is the port of the candidate that
+          it is derived from. For host candidates, the <code>relatedPort</code>
+          is not present in the dictionary.</dd>
+          </dd>
         </dl>
         <div class="note">
           <p>The constructor on <code><a>RTCIceCandidate</a></code> exists
           for legacy compatibility reasons only.</p>
         </div>
+
+        <section>
+          <h4>The RTCIceProtocol</h4>
+
+          <p>The <dfn>RTCIceProtocol</dfn> represents the protocol of the ICE candidate.</p>
+
+          <dl class="idl" title="enum RTCIceProtocol">
+            <dt>udp</dt>
+
+            <dd>A UDP candidate, as described in [[!ICE]].</dd>
+
+            <dt>tcp</dt>
+
+            <dd>A TCP candidate, as described in [[!RFC6544]].</dd>
+          </dl>
+        </section>
+
+        <section>
+          <h4>The RTCIceTcpCandidateType</h4>
+
+          <p>The <dfn>RTCIceTcpCandidateType</dfn> represents the type of the ICE TCP
+          candidate, as described in [[!RFC6544]]. Browsers MUST gather <code>active</code>
+          TCP candidates and only <code>active</code> TCP candidates. Servers and other
+          endpoints MAY gather <code>active</code>, <code>passive</code> or <code>so</code>
+          candidates.</p>
+
+          <dl class="idl" title="enum RTCIceTcpCandidateType">
+            <dt>active</dt>
+
+            <dd>An <code>active</code> TCP candidate is one for which the transport will
+            attempt to open an outbound connection but will not receive incoming
+            connection requests.</dd>
+
+            <dt>passive</dt>
+
+            <dd>A <code>passive</code> TCP candidate is one for which the transport
+            will receive incoming connection attempts but not attempt a connection.</dd>
+
+            <dt>so</dt>
+
+            <dd>An <code>so</code> candidate is one for which the transport will attempt
+             to open a connection simultaneously with its peer.</dd>
+          </dl>
+        </section>
+
+        <section>
+          <h4>The RTCIceCandidateType</h4>
+
+          <p>The <dfn>RTCIceCandidateType</dfn> represents the type of the ICE candidate.</p>
+
+          <dl class="idl" title="enum RTCIceCandidateType">
+            <dt>host</dt>
+
+            <dd>A host candidate.</dd>
+
+            <dt>srflx</dt>
+
+            <dd>A server reflexive candidate.</dd>
+
+            <dt>prflx</dt>
+
+            <dd>A peer reflexive candidate.</dd>
+
+            <dt>relay</dt>
+
+            <dd>A relay candidate.</dd>
+          </dl>
+        </section>
       </section>
 
       <section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1271,7 +1271,7 @@
             <code>none</code>. This call will result in a change to the
             connection state of the ICE Agent, and may result in a change to
             media state if it results in different connectivity being
-            established. Note that the only members of the candidate attribute
+            established. The only members of the candidate attribute
             used by this method are <var>candidate</var>, <var>sdpMid</var> and
             <var>sdpMLineIndex</var>; the rest are ignored.</p>
 
@@ -2429,7 +2429,7 @@
           <h4>The RTCIceTcpCandidateType</h4>
 
           <p>The <dfn>RTCIceTcpCandidateType</dfn> represents the type of the ICE TCP
-          candidate, as described in [[!RFC6544]]. Browsers MUST gather <code>active</code>
+          candidate, as defined in [[!RFC6544]]. Browsers MUST gather <code>active</code>
           TCP candidates and only <code>active</code> TCP candidates. Servers and other
           endpoints MAY gather <code>active</code>, <code>passive</code> or <code>so</code>
           candidates.</p>
@@ -2456,7 +2456,8 @@
         <section>
           <h4>The RTCIceCandidateType</h4>
 
-          <p>The <dfn>RTCIceCandidateType</dfn> represents the type of the ICE candidate.</p>
+          <p>The <dfn>RTCIceCandidateType</dfn> represents the type of the ICE candidate,
+          as defined in [[!ICE]].</p>
 
           <dl class="idl" title="enum RTCIceCandidateType">
             <dt>host</dt>


### PR DESCRIPTION
These attributes aren't used in addIceCandidate; they're just provided
in candidates signaled by onicecandidate, or retrieved from an
RTCIceCandidatePair. This will allow interested applications to get more
information about an ICE candidate, without parsing the candidate
string.

This is the change Peter suggested, which we agreed to at the Redmond f2f.