### PR TITLE
Adding sha-256 to the certificate management options for RSA

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2607,7 +2607,7 @@
           <p>The following values MUST be supported by a <a>user agent</a>:
             <code>{ name:
             "<a href="https://dvcs.w3.org/hg/webcrypto-api/raw-file/tip/spec/Overview.html#rsassa-pkcs1">RSASSA-PKCS1-v1_5</a>",
-            modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]) }</code>, and <code>{
+            modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: "SHA-256" }</code>, and <code>{
             name:
             "<a href="https://dvcs.w3.org/hg/webcrypto-api/raw-file/tip/spec/Overview.html#ecdsa">ECDSA</a>",
             namedCurve:


### PR DESCRIPTION
Closes #322.  This concedes that @alvestrand is right.  It is also what I just landed in Firefox.