### PR TITLE
Defining RTCIceCandidateInformation, which inherits from RTCIceCandidate.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -625,7 +625,7 @@
 
                 <p>Add the candidate to <var>connection</var>'s
                 <code><a>localDescription</a></code> and create a
-                <code><a>RTCIceCandidate</a></code> instance to represent the
+                <code><a>RTCIceCandidateFull</a></code> instance to represent the
                 candidate. Let <var>newCandidate</var> be that object.</p>
               </li>
 
@@ -1259,7 +1259,7 @@
             since the offer or answer was created.</p>
           </dd>
 
-          <dt>Promise&lt;void&gt; addIceCandidate (RTCSignaledIceCandidate candidate)</dt>
+          <dt>Promise&lt;void&gt; addIceCandidate (RTCIceCandidate candidate)</dt>
 
           <dd>
             <p>The <dfn id=
@@ -1757,7 +1757,7 @@
             argument.</p>
           </dd>
 
-          <dt>void addIceCandidate (RTCSignaledIceCandidate candidate, VoidFunction
+          <dt>void addIceCandidate (RTCIceCandidate candidate, VoidFunction
           successCallback, RTCPeerConnectionErrorCallback failureCallback)</dt>
 
           <dd>
@@ -2334,14 +2334,14 @@
       <section>
         <h4>ICE Candidate Dictionaries</h4>
 
-        <p>These dictionaries describe ICE candidates. <code>RTCSignaledIceCandidate</code>
+        <p>These dictionaries describe ICE candidates. <code>RTCIceCandidate</code>
         is used for candidates that the script supplies to the browser via <code><a href=
         "#dom-peerconnection-addicecandidate">addIceCandidate()</a></code>, and
-        <code>RTCIceCandidate</code> is used for candidates that the browser exposes to
+        <code>RTCIceCandidateFull</code> is used for candidates that the browser exposes to
         the script. Though not explicitly required, values for <var>candidate</var> and
         either <var>sdpMid</var> or <var>sdpMLineIndex</var> MUST be provided.</p>
 
-        <dl class="idl" title="[Constructor(RTCSignaledIceCandidate copy)] dictionary RTCSignaledIceCandidate">
+        <dl class="idl" title="[Constructor(RTCIceCandidate copy)] dictionary RTCIceCandidate">
           <dt>required DOMString candidate</dt>
 
           <dd>This carries the <code>candidate-attribute</code> as defined in
@@ -2359,11 +2359,11 @@
           SDP this candidate is associated with.</dd>
         </dl>
         <div class="note">
-          <p>The constructor on <code><a>RTCSignaledIceCandidate</a></code>
+          <p>The constructor on <code><a>RTCIceCandidate</a></code>
           exists for legacy compatibility reasons only.</p>
         </div>
 
-        <dl class="idl" title="dictionary RTCIceCandidate : RTCSignaledIceCandidate">
+        <dl class="idl" title="dictionary RTCIceCandidateFull : RTCIceCandidate">
           <dt>DOMString foundation</dt>
 
           <dd>A unique identifier that allows ICE to correlate candidates that
@@ -2487,7 +2487,7 @@
 
         <p><dfn data-lt="Fire an ice candidate event">Firing an
         <code><a>RTCPeerConnectionIceEvent</a></code> event named
-        <var>e</var></dfn> with an <code><a>RTCIceCandidate</a></code>
+        <var>e</var></dfn> with an <code><a>RTCIceCandidateFull</a></code>
         <var>candidate</var> means that an event with the name <var>e</var>,
         which does not bubble (except where otherwise stated) and is not
         cancelable (except where otherwise stated), and which uses the
@@ -2496,11 +2496,11 @@
         created and dispatched at the given target.</p>
 
         <p>When firing an <code><a>RTCPeerConnectionIceEvent</a></code> event
-        that contains a <code><a>RTCIceCandidate</a></code> object, it MUST
+        that contains a <code><a>RTCIceCandidateFull</a></code> object, it MUST
         include values for
         both <a href="#widl-RTCIceCandidate-sdpMid"><code>sdpMid</code></a>
         and <a href="#widl-RTCIceCandidate-sdpMLineIndex"><code>sdpMLineIndex</code></a>.
-        If the <code><a>RTCIceCandidate</a></code> is of type <code>srflx</code>
+        If the <code><a>RTCIceCandidateFull</a></code> is of type <code>srflx</code>
         or type <code>relay</code>, the <code>url</code> parameter MUST be
         filled in.</p>
 
@@ -2509,11 +2509,11 @@
           <dt>Constructor(DOMString type, RTCPeerConnectionIceEventInit
           eventInitDict)</dt>
 
-          <dt>readonly attribute RTCIceCandidate? candidate</dt>
+          <dt>readonly attribute RTCIceCandidateFull? candidate</dt>
 
           <dd>
             <p>The <code>candidate</code> attribute is the
-            <code><a>RTCIceCandidate</a></code> object with the new ICE
+            <code><a>RTCIceCandidateFull</a></code> object with the new ICE
             candidate that caused the event.</p>
 
             <p>This attribute is set to <code>null</code> when an event is
@@ -2535,7 +2535,7 @@
 
         <dl class="idl" title=
         "dictionary RTCPeerConnectionIceEventInit : EventInit">
-          <dt>RTCIceCandidate candidate</dt>
+          <dt>RTCIceCandidateFull candidate</dt>
 
           <dd>
             <p>See <a href="#widl-RTCPeerConnectionIceEvent-candidate"><code>RTCPeerConnectionIceEvent.candidate</code></a>.</p>
@@ -3864,7 +3864,7 @@ sender.setParameters(params)
             state of the transport.
           </dd>
 
-          <dt>sequence&lt;RTCIceCandidate&gt; getLocalCandidates()</dt>
+          <dt>sequence&lt;RTCIceCandidateFull&gt; getLocalCandidates()</dt>
 
           <dd>
             <p>An array containing the local ICE candiates gathered
@@ -3873,7 +3873,7 @@ sender.setParameters(params)
             "#dom-peerconnection-onicecandidate">onicecandidate</a></code></p>
           </dd>
 
-          <dt>sequence&lt;RTCIceCandidate&gt; getRemoteCandidates()</dt>
+          <dt>sequence&lt;RTCIceCandidateFull&gt; getRemoteCandidates()</dt>
 
           <dd>
             <p>An array containing the remote ICE candiates received by
@@ -3946,9 +3946,9 @@ sender.setParameters(params)
         </dl>
 
         <dl class="idl" title="dictionary RTCIceCandidatePair">
-          <dt>RTCIceCandidate local</dt>
+          <dt>RTCIceCandidateFull local</dt>
           <dd><p>The local ICE candidate.</p></dd>
-          <dt>RTCIceCandidate remote</dt>
+          <dt>RTCIceCandidateFull remote</dt>
           <dd><p>The remote ICE candidate.</p></dd>
         </dl>
 
@@ -7029,7 +7029,7 @@ if (sender.dtmf) {
 
           <td><code><a>RTCPeerConnectionIceEvent</a></code></td>
 
-          <td>A new <code><a>RTCIceCandidate</a></code> is made available to
+          <td>A new <code><a>RTCIceCandidateFull</a></code> is made available to
           the script.</td>
         </tr>
 

--- a/webrtc.html
+++ b/webrtc.html
@@ -1259,7 +1259,7 @@
             since the offer or answer was created.</p>
           </dd>
 
-          <dt>Promise&lt;void&gt; addIceCandidate (RTCIceCandidate candidate)</dt>
+          <dt>Promise&lt;void&gt; addIceCandidate (RTCSignaledIceCandidate candidate)</dt>
 
           <dd>
             <p>The <dfn id=
@@ -1271,9 +1271,7 @@
             <code>none</code>. This call will result in a change to the
             connection state of the ICE Agent, and may result in a change to
             media state if it results in different connectivity being
-            established. The only members of the candidate attribute
-            used by this method are <var>candidate</var>, <var>sdpMid</var> and
-            <var>sdpMLineIndex</var>; the rest are ignored.</p>
+            established.</p>
 
             <ol>
               <li>
@@ -1759,7 +1757,7 @@
             argument.</p>
           </dd>
 
-          <dt>void addIceCandidate (RTCIceCandidate candidate, VoidFunction
+          <dt>void addIceCandidate (RTCSignaledIceCandidate candidate, VoidFunction
           successCallback, RTCPeerConnectionErrorCallback failureCallback)</dt>
 
           <dd>
@@ -2334,13 +2332,16 @@
       <h3>Interfaces for Connectivity Establishment</h3>
 
       <section>
-        <h4>RTCIceCandidate Type</h4>
+        <h4>ICE Candidate Dictionaries</h4>
 
-        <p>This describes an ICE candidate. Though not explicitly required,
-        values for <var>candidate</var> and either <var>sdpMid</var>
-        or <var>sdpMLineIndex</var> MUST be provided.</p>
+        <p>These dictionaries describe ICE candidates. <code>RTCSignaledIceCandidate</code>
+        is used for candidates that the script supplies to the browser via <code><a href=
+        "#dom-peerconnection-addicecandidate">addIceCandidate()</a></code>, and
+        <code>RTCIceCandidate</code> is used for candidates that the browser exposes to
+        the script. Though not explicitly required, values for <var>candidate</var> and
+        either <var>sdpMid</var> or <var>sdpMLineIndex</var> MUST be provided.</p>
 
-        <dl class="idl" title="[Constructor(RTCIceCandidate copy)] dictionary RTCIceCandidate">
+        <dl class="idl" title="[Constructor(RTCSignaledIceCandidate copy)] dictionary RTCSignaledIceCandidate">
           <dt>required DOMString candidate</dt>
 
           <dd>This carries the <code>candidate-attribute</code> as defined in
@@ -2356,7 +2357,13 @@
 
           <dd>This indicates the index (starting at zero) of the m-line in the
           SDP this candidate is associated with.</dd>
+        </dl>
+        <div class="note">
+          <p>The constructor on <code><a>RTCSignaledIceCandidate</a></code>
+          exists for legacy compatibility reasons only.</p>
+        </div>
 
+        <dl class="idl" title="dictionary RTCIceCandidate : RTCSignaledIceCandidate">
           <dt>DOMString foundation</dt>
 
           <dd>A unique identifier that allows ICE to correlate candidates that
@@ -2404,10 +2411,6 @@
           is not present in the dictionary.</dd>
           </dd>
         </dl>
-        <div class="note">
-          <p>The constructor on <code><a>RTCIceCandidate</a></code> exists
-          for legacy compatibility reasons only.</p>
-        </div>
 
         <section>
           <h4>The RTCIceProtocol</h4>

--- a/webrtc.html
+++ b/webrtc.html
@@ -625,7 +625,7 @@
 
                 <p>Add the candidate to <var>connection</var>'s
                 <code><a>localDescription</a></code> and create a
-                <code><a>RTCIceCandidateFull</a></code> instance to represent the
+                <code><a>RTCIceCandidateInformation</a></code> instance to represent the
                 candidate. Let <var>newCandidate</var> be that object.</p>
               </li>
 
@@ -2337,7 +2337,7 @@
         <p>These dictionaries describe ICE candidates. <code>RTCIceCandidate</code>
         is used for candidates that the script supplies to the browser via <code><a href=
         "#dom-peerconnection-addicecandidate">addIceCandidate()</a></code>, and
-        <code>RTCIceCandidateFull</code> is used for candidates that the browser exposes to
+        <code>RTCIceCandidateInformation</code> is used for candidates that the browser exposes to
         the script. Though not explicitly required, values for <var>candidate</var> and
         either <var>sdpMid</var> or <var>sdpMLineIndex</var> MUST be provided.</p>
 
@@ -2363,7 +2363,7 @@
           exists for legacy compatibility reasons only.</p>
         </div>
 
-        <dl class="idl" title="dictionary RTCIceCandidateFull : RTCIceCandidate">
+        <dl class="idl" title="dictionary RTCIceCandidateInformation : RTCIceCandidate">
           <dt>DOMString foundation</dt>
 
           <dd>A unique identifier that allows ICE to correlate candidates that
@@ -2487,7 +2487,7 @@
 
         <p><dfn data-lt="Fire an ice candidate event">Firing an
         <code><a>RTCPeerConnectionIceEvent</a></code> event named
-        <var>e</var></dfn> with an <code><a>RTCIceCandidateFull</a></code>
+        <var>e</var></dfn> with an <code><a>RTCIceCandidateInformation</a></code>
         <var>candidate</var> means that an event with the name <var>e</var>,
         which does not bubble (except where otherwise stated) and is not
         cancelable (except where otherwise stated), and which uses the
@@ -2496,11 +2496,11 @@
         created and dispatched at the given target.</p>
 
         <p>When firing an <code><a>RTCPeerConnectionIceEvent</a></code> event
-        that contains a <code><a>RTCIceCandidateFull</a></code> object, it MUST
+        that contains a <code><a>RTCIceCandidateInformation</a></code> object, it MUST
         include values for
         both <a href="#widl-RTCIceCandidate-sdpMid"><code>sdpMid</code></a>
         and <a href="#widl-RTCIceCandidate-sdpMLineIndex"><code>sdpMLineIndex</code></a>.
-        If the <code><a>RTCIceCandidateFull</a></code> is of type <code>srflx</code>
+        If the <code><a>RTCIceCandidateInformation</a></code> is of type <code>srflx</code>
         or type <code>relay</code>, the <code>url</code> parameter MUST be
         filled in.</p>
 
@@ -2509,11 +2509,11 @@
           <dt>Constructor(DOMString type, RTCPeerConnectionIceEventInit
           eventInitDict)</dt>
 
-          <dt>readonly attribute RTCIceCandidateFull? candidate</dt>
+          <dt>readonly attribute RTCIceCandidateInformation? candidate</dt>
 
           <dd>
             <p>The <code>candidate</code> attribute is the
-            <code><a>RTCIceCandidateFull</a></code> object with the new ICE
+            <code><a>RTCIceCandidateInformation</a></code> object with the new ICE
             candidate that caused the event.</p>
 
             <p>This attribute is set to <code>null</code> when an event is
@@ -2535,7 +2535,7 @@
 
         <dl class="idl" title=
         "dictionary RTCPeerConnectionIceEventInit : EventInit">
-          <dt>RTCIceCandidateFull candidate</dt>
+          <dt>RTCIceCandidateInformation candidate</dt>
 
           <dd>
             <p>See <a href="#widl-RTCPeerConnectionIceEvent-candidate"><code>RTCPeerConnectionIceEvent.candidate</code></a>.</p>
@@ -3864,7 +3864,7 @@ sender.setParameters(params)
             state of the transport.
           </dd>
 
-          <dt>sequence&lt;RTCIceCandidateFull&gt; getLocalCandidates()</dt>
+          <dt>sequence&lt;RTCIceCandidateInformation&gt; getLocalCandidates()</dt>
 
           <dd>
             <p>An array containing the local ICE candiates gathered
@@ -3873,7 +3873,7 @@ sender.setParameters(params)
             "#dom-peerconnection-onicecandidate">onicecandidate</a></code></p>
           </dd>
 
-          <dt>sequence&lt;RTCIceCandidateFull&gt; getRemoteCandidates()</dt>
+          <dt>sequence&lt;RTCIceCandidateInformation&gt; getRemoteCandidates()</dt>
 
           <dd>
             <p>An array containing the remote ICE candiates received by
@@ -3946,9 +3946,9 @@ sender.setParameters(params)
         </dl>
 
         <dl class="idl" title="dictionary RTCIceCandidatePair">
-          <dt>RTCIceCandidateFull local</dt>
+          <dt>RTCIceCandidateInformation local</dt>
           <dd><p>The local ICE candidate.</p></dd>
-          <dt>RTCIceCandidateFull remote</dt>
+          <dt>RTCIceCandidateInformation remote</dt>
           <dd><p>The remote ICE candidate.</p></dd>
         </dl>
 
@@ -7029,7 +7029,7 @@ if (sender.dtmf) {
 
           <td><code><a>RTCPeerConnectionIceEvent</a></code></td>
 
-          <td>A new <code><a>RTCIceCandidateFull</a></code> is made available to
+          <td>A new <code><a>RTCIceCandidateInformation</a></code> is made available to
           the script.</td>
         </tr>
 


### PR DESCRIPTION
This makes it more clear that the only parameters relevant to
addIceCandidate() are candidate, sdpMid and sdpMLineIndex.