### PR TITLE
RTCRtpSender support objects -> interfaces

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3410,8 +3410,8 @@
           </dd>
         </dl>
 
-        <dl class="idl" title="dictionary RTCRtpCapabilities">
-          <dt>sequence&lt;RTCRtpCodecCapability&gt; codecs</dt>
+        <dl class="idl" title="interface RTCRtpCapabilities">
+          <dt>readonly attribute FrozenArray&lt;RTCRtpCodecCapability&gt; codecs</dt>
 
           <dd>
             <p>
@@ -3419,7 +3419,7 @@
             </p>
           </dd>
 
-          <dt>sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensions</dt>
+          <dt>readonly attribute FrozenArray&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensions</dt>
           <dd>
             <p>
               Supported RTP header extensions.

--- a/webrtc.html
+++ b/webrtc.html
@@ -3208,13 +3208,13 @@
         the encoding is changed appropriately.</p>
 
         <dl class="idl" title="interface RTCRtpParameters">
-          <dt>readonly attribute FrozenArray&lt;RTCRtpEncodingParameters&gt; encodings</dt>
+          <dt>attribute sequence&lt;RTCRtpEncodingParameters&gt; encodings</dt>
 
           <dd>
             <p>Parameters for RTP encodings of media.</p>
           </dd>
 
-          <dt>readonly attribute FrozenArray&lt;RTCRtpHeaderExtensionParameters&gt; headerExtensions</dt>
+          <dt>attribute sequence&lt;RTCRtpHeaderExtensionParameters&gt; headerExtensions</dt>
           <dd>
             <p>Parameters for RTP header extensions.</p>
           </dd>
@@ -3225,7 +3225,7 @@
             <p>Parameters used for RTCP.</p>
           </dd>
 
-          <dt>readonly attribute FrozenArray&lt;RTCRtpCodecParameters&gt; codecs</dt>
+          <dt>attribute sequence&lt;RTCRtpCodecParameters&gt; codecs</dt>
 
           <dd>
             <p>The codecs that
@@ -3261,7 +3261,7 @@
             <p>The parameters used for FEC, or unset if FEC is not being used.</p>
           </dd>
 
-          <dt>readonly attribute boolean active</dt>
+          <dt>attribute boolean active</dt>
 
           <dd>
             <p>
@@ -3271,7 +3271,7 @@
             </p>
           </dd>
 
-          <dt>readonly attribute RTCPriorityType priority</dt>
+          <dt>attribute RTCPriorityType priority</dt>
           <dd>
             <p>
              Indicates the priority of this encoding.  It is specified
@@ -3279,7 +3279,7 @@
             </p>
           </dd>
 
-          <dt>readonly attribute unsigned long maxBitrate</dt>
+          <dt>attribute unsigned long maxBitrate</dt>
           <dd>
             <p>
               Indicates the maximum bitrate that can be used to send
@@ -3294,7 +3294,7 @@
             webrtc-stats.</p>
           </dd>
 
-          <dt>readonly attribute RTCDegradationPreference degradationPreference</dt>
+          <dt>attribute RTCDegradationPreference degradationPreference</dt>
           <dd>
             <p>When bandwidth is constrained and
               the <code><a>RtpSender</a></code> must choose between
@@ -3305,9 +3305,6 @@
         </dl>
 
         <dl class="idl" title="dictionary RTCRtpEncodingParameterDict">
-          <dt>unsigned long ssrc</dt>
-          <dd>TODO: have a discussion about whether permitting this to be changed is a good idea.</dd>
-
           <dt>boolean active</dt>
 
           <dt>RTCPriorityType priority</dt>
@@ -3541,13 +3538,12 @@
 
           <dd>
             <p>The <dfn id="dom-rtpsender-getparameters"><code>RTCRtpSender.getParameters</code></dfn>
-            method returns the RtpSender's current parameters for how <code>RTCRtpSender.track</code>
+            method returns a copy of the <code>RTCRtpSender</code>'s current parameters for how <code>RTCRtpSender.track</code>
             is encoded and transmitted to a remote <code>RTCRtpReceiver</code>.
             It may used with <code>RTCRtpSender.setParameters</code> to change the parameters in the follwing way:</p>
 
             <pre class="example highlight">
 var params = sender.getParameters();
-params = copy(params);
 // ... make changes to params
 params.encodings[0].active = false;
 sender.setParameters(params);

--- a/webrtc.html
+++ b/webrtc.html
@@ -3427,8 +3427,8 @@
           </dd>
         </dl>
 
-        <dl class="idl" title="dictionary RTCRtpCodecCapability">
-          <dt>DOMString mimeType</dt>
+        <dl class="idl" title="interface RTCRtpCodecCapability">
+          <dt>readonly attribute DOMString mimeType</dt>
           <dd>
             <p>The codec MIME type. Valid types are listed in [IANA-RTP-2].
             </p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -3207,35 +3207,43 @@
         When methods are called on an <code>RTCRtpSender</code>, such as <code>RTCRtpSender.setParameters</code>,
         the encoding is changed appropriately.</p>
 
-        <dl class="idl" title="dictionary RTCRtpParameters">
-          <dt>sequence&lt;RTCRtpEncodingParameters&gt; encodings</dt>
+        <dl class="idl" title="interface RTCRtpParameters">
+          <dt>readonly attribute FrozenArray&lt;RTCRtpEncodingParameters&gt; encodings</dt>
 
           <dd>
-            <p>A sequence containing parameters for RTP encodings of media.</p>
+            <p>Parameters for RTP encodings of media.</p>
           </dd>
 
-          <dt>sequence&lt;RTCRtpHeaderExtensionParameters&gt; headerExtensions</dt>
+          <dt>readonly attribute FrozenArray&lt;RTCRtpHeaderExtensionParameters&gt; headerExtensions</dt>
           <dd>
-            <p>A sequence containing parameters for RTP header extensions.</p>
+            <p>Parameters for RTP header extensions.</p>
           </dd>
 
-          <dt>RTCRtcpParameters rtcp</dt>
+          <dt>readonly attribute RTCRtcpParameters rtcp</dt>
 
           <dd>
             <p>Parameters used for RTCP.</p>
           </dd>
 
-          <dt>sequence&lt;RTCRtpCodecParameters&gt; codecs</dt>
+          <dt>readonly attribute FrozenArray&lt;RTCRtpCodecParameters&gt; codecs</dt>
 
           <dd>
-            <p>An array containing codecs the codecs that
+            <p>The codecs that
               an <a><code>RTCRtpSender</code></a> will choose from in
               order to send media.</p>
           </dd>
         </dl>
 
-        <dl class="idl" title="dictionary RTCRtpEncodingParameters">
-          <dt>unsigned long ssrc</dt>
+        <dl class="idl" title="dictionary RTCRtpParameterDict">
+          <dt>sequence&lt;RTCRtpEncodingParameterDict&gt; encodings</dt>
+
+          <dt>sequence&lt;RTCRtpHeaderExtensionParameters&gt; headerExtensions</dt>
+
+          <dt>sequence&lt;RTCRtpCodecParameters&gt; codecs</dt>
+        </dl>
+
+        <dl class="idl" title="interface RTCRtpEncodingParameters">
+          <dt>readonly attribute unsigned long ssrc</dt>
           <dd>
             <p>
               The SSRC of the RTP source stream of this encoding
@@ -3243,17 +3251,17 @@
             </p>
           </dd>
 
-          <dt>RTCRtxParameters rtx</dt>
+          <dt>readonly attribute RTCRtxParameters rtx</dt>
           <dd>
             <p>The parameters used for RTX, or unset if RTX is not being used.</p>
           </dd>
 
-          <dt>RTCFecParameters fec</dt>
+          <dt>readonly attribute RTCFecParameters fec</dt>
           <dd>
             <p>The parameters used for FEC, or unset if FEC is not being used.</p>
           </dd>
 
-          <dt>boolean active</dt>
+          <dt>readonly attribute boolean active</dt>
 
           <dd>
             <p>
@@ -3263,7 +3271,7 @@
             </p>
           </dd>
 
-          <dt>RTCPriorityType priority</dt>
+          <dt>readonly attribute RTCPriorityType priority</dt>
           <dd>
             <p>
              Indicates the priority of this encoding.  It is specified
@@ -3271,7 +3279,7 @@
             </p>
           </dd>
 
-          <dt>unsigned long maxBitrate</dt>
+          <dt>readonly attribute unsigned long maxBitrate</dt>
           <dd>
             <p>
               Indicates the maximum bitrate that can be used to send
@@ -3286,7 +3294,7 @@
             webrtc-stats.</p>
           </dd>
 
-          <dt>RTCDegradationPreference degradationPreference = "balanced"</dt>
+          <dt>readonly attribute RTCDegradationPreference degradationPreference</dt>
           <dd>
             <p>When bandwidth is constrained and
               the <code><a>RtpSender</a></code> must choose between
@@ -3294,6 +3302,19 @@
               framerate, <code>degradationPreference</code> indicates what should be prefered.
             </p>
           </dd>
+        </dl>
+
+        <dl class="idl" title="dictionary RTCRtpEncodingParameterDict">
+          <dt>unsigned long ssrc</dt>
+          <dd>TODO: have a discussion about whether permitting this to be changed is a good idea.</dd>
+
+          <dt>boolean active</dt>
+
+          <dt>RTCPriorityType priority</dt>
+
+          <dt>unsigned long maxBitrate</dt>
+
+          <dt>RTCDegradationPreference degradationPreference = "balanced"</dt>
         </dl>
 
         <dl class="idl" title="enum RTCQualityPreference">
@@ -3316,67 +3337,66 @@
           </dd>
         </dl>
 
-        <dl class="idl" title="dictionary RTCRtxParameters">
-          <dt>unsigned long ssrc</dt>
+        <dl class="idl" title="interface RTCRtxParameters">
+          <dt>readonly attribute unsigned long ssrc</dt>
           <dd>
             <p>
-              The SSRC of the RTP stream for RTX. <a>Read-only parameter</a>.
+              The SSRC of the RTP stream for RTX.
             </p>
           </dd>
         </dl>
 
-        <dl class="idl" title="dictionary RTCFecParameters">
-          <dt>unsigned long ssrc</dt>
+        <dl class="idl" title="interface RTCFecParameters">
+          <dt>readonly attribute unsigned long ssrc</dt>
           <dd>
             <p>
-              The SSRC of the RTP stream for FEC. <a>Read-only parameter</a>.
+              The SSRC of the RTP stream for FEC.
             </p>
           </dd>
         </dl>
 
-        <dl class="idl" title="dictionary RTCRtcpParameters">
-          <dt>DOMString cname</dt>
+        <dl class="idl" title="interface RTCRtcpParameters">
+          <dt>readonly attribute DOMString cname</dt>
           <dd>
             <p>The Canonical Name (CNAME) used by RTCP (e.g. in SDES
-              messages). <a>Read-only parameter</a>.
+              messages).
           </dd>
 
-          <dt>boolean reducedSize</dt>
+          <dt>readonly attribute boolean reducedSize</dt>
           <dd>
             <p>Whether reduced size RTCP [RFC5506] is configured (if
             true) or compound RTCP as specified in [RFC3550] (if
-            false). <a>Read-only parameter</a>.
+            false).
           </dd>
         </dl>
 
-        <dl class="idl" title="dictionary RTCRtpHeaderExtensionParameters">
-          <dt>DOMString uri</dt>
+        <dl class="idl" title="interface RTCRtpHeaderExtensionParameters">
+          <dt>readonly attribute DOMString uri</dt>
           <dd>
             <p>
               The URI of the RTP header extension, as defined in
-              [RFC5285]. <a>Read-only parameter</a>.
+              [RFC5285].
             </p>
           </dd>
 
-          <dt>unsigned short id</dt>
+          <dt>readonly attribute unsigned short id</dt>
           <dd>
             <p>
               The value put in the RTP packet to identify the header
-              extension. <a>Read-only parameter</a>.
+              extension.
             </p>
           </dd>
 
-          <dt>boolean encrypted</dt>
+          <dt>readonly attribute boolean encrypted</dt>
           <dd>
             <p>
               Whether the header extension is encryted or not.
-              <a>Read-only parameter</a>.
             </p>
           </dd>
         </dl>
 
-        <dl class="idl" title="dictionary RTCRtpCodecParameters">
-          <dt>unsigned short payloadType</dt>
+        <dl class="idl" title="interface RTCRtpCodecParameters">
+          <dt>readonly attribute unsigned short payloadType</dt>
 
           <dd>
             <p>The RTP payload type.  This value can be set in the
@@ -3385,24 +3405,24 @@
             </p>
           </dd>
 
-          <dt>DOMString mimeType</dt>
+          <dt>readonly attribute DOMString mimeType</dt>
 
           <dd>
             <p>The codec MIME type. Valid types are listed in [IANA-RTP-2].</p>
           </dd>
 
-          <dt>unsigned long clockRate</dt>
+          <dt>readonly attribute unsigned long clockRate</dt>
 
           <dd>
             <p>The codec clock rate expressed in Hertz.</p>
           </dd>
 
-          <dt>unsigned short channels = 1</dt>
+          <dt>readonly attribute unsigned short channels</dt>
           <dd>
             <p>The number of channels (mono=1, stereo=2).</p>
           </dd>
 
-          <dt>DOMString sdpFmtpLine</dt>
+          <dt>readonly attribute DOMString sdpFmtpLine</dt>
 
           <dd>
             <p>The a=fmtp line in the SDP corresponding to the codec,
@@ -3443,8 +3463,7 @@
           </dd>
         </dl>
 
-        <dl class="idl" title=
-          "interface RTCRtpSender">
+        <dl class="idl" title="interface RTCRtpSender">
           <dt>readonly attribute MediaStreamTrack track</dt>
 
           <dd>
@@ -3503,17 +3522,10 @@
             </p>
           </dd>
 
-          <dt>void setParameters (RTCRtpParameters parameters)</dt>
+          <dt>void setParameters (RTCRtpParameterDict parameters)</dt>
           <dd>
             <p>The <code id="dom-rtpsender-setparameters">RTCRtpSender.setParameters</code>
             method updates how <code>RTCRtpSender.track</code> is encoded and transmitted to a remote <code>RTCRtpReceiver</code>.
-
-            <p>If any parameter in the <var>parameters</var> argument, marked
-            as a <dfn>Read-only parameter</dfn>, has a value that is different
-            from the corresponding parameter value returned from <code><a href=
-            "#dom-rtpsender-getparameters">getParameters()</a></code>, the User
-            Agent MUST throw a <code>ReadOnlyError</code> exception and abort
-            this operation without updating the current parameters.</p>
 
             <p>If codecs are reordered, the new order indicates the
             preference for sending, with the first codec being the
@@ -3535,9 +3547,10 @@
 
             <pre class="example highlight">
 var params = sender.getParameters();
-// ... make changes to RtpParameters
+params = copy(params);
+// ... make changes to params
 params.encodings[0].active = false;
-sender.setParameters(params)
+sender.setParameters(params);
             </pre>
           </dd>
 

--- a/webrtc.html
+++ b/webrtc.html
@@ -3435,8 +3435,8 @@
           </dd>
         </dl>
 
-        <dl class="idl" title="dictionary RTCRtpHeaderExtensionCapability">
-          <dt>DOMString uri</dt>
+        <dl class="idl" title="interface RTCRtpHeaderExtensionCapability">
+          <dt>readonly attribute DOMString uri</dt>
           <dd>
             <p>The URI of the RTP header extension, as defined in [RFC5285].
             </p>


### PR DESCRIPTION
There are very few things in here that are actually mutable as it turns out.  Having them as dictionaries is contrary to some of the advice I've received internally on the design of web APIs.

Most of the entire tree can be safely turned into interfaces with readonly attributes.  I think that ideally we should move `getParameters` to an attribute, but I don't want to re-open that discussion again.  I get the point of having an atomic `setParameters` though I think that we'll find that it isn't necessary in practice.

One consequence of this is that it is much more clear now on what can be changed and what cannot.  The SSRC was the only one that was previously mutable, which might have been inadvisable with a=ssrc in such heavy use; with the move to RID-based identification, I think that I can accept this being changed.

The main consequence of this change is that you have to take a copy of the parameters if you want to change them.  I think that this is an acceptable cost.