### PR TITLE
Use USVString for datachannel.send()

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4763,7 +4763,7 @@ sender.setParameters(params)
           the [[WEBSOCKETS-API]] for more information.</p>
         </dd>
 
-        <dt>void send(DOMString data)</dt>
+        <dt>void send(USVString data)</dt>
 
         <dd>
           <p>Run the steps described by the <code><a href=
@@ -4874,8 +4874,7 @@ sender.setParameters(params)
             <li>
               <p><code>string</code> object:</p>
 
-              <p>Let <var>data</var> be the result of converting the argument
-              object to a sequence of Unicode characters and increase the
+              <p>Let <var>data</var> be the object and increase the
               <code><a href=
               "#dom-datachannel-bufferedamount">bufferedAmount</a></code>
               attribute by the number of bytes needed to express


### PR DESCRIPTION
Align with [Web Sockets LS](https://html.spec.whatwg.org/multipage/comms.html#dom-websocket-send)
Avoids the "convert to a sequence of unicode chars"