### PR TITLE
Fix for Issue 329: "none" as a RTCIceCredentialType

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -243,12 +243,6 @@
           <dd>The credential is an access token, as described in
           [[!TRAM-TURN-THIRD-PARTY-AUTHZ]], Section 6.2.</dd>
         </dl>
-
-        <div data-number="329" class="issue">
-          <p>Should we have a "none" type, for cases where no authentication is
-          needed? (e.g. STUN)
-          </p>
-        </div>
       </section>
 
       <section>


### PR DESCRIPTION
Remove note on Issue 329 ("none" as RTCIceCredentialType).  Details here: 
https://github.com/w3c/webrtc-pc/issues/329