### PR TITLE
Fix for Issue 328: RTCBundlePolicy Enum section

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -327,14 +327,12 @@
       <section>
         <h4>RTCBundlePolicy Enum</h4>
 
-        <p>Defined in [[!RTCWEB-JSEP]].  The following is a non-normative
-        summary for convenience.</p>
-
-        <p>The BundlePolicy affects which media tracks are negotiated if
+        <p>As described in [[!RTCWEB-JSEP]] Section 4.1.1, BUNDLE policy
+        affects which media tracks are negotiated if
         the remote endpoint is not BUNDLE-aware, and what ICE
         candidates are gathered.  If the remote endpoint is
         BUNDLE-aware, all media tracks and data channels are BUNDLEd
-        onto the same transport.</p>
+        onto the same transport.  </p>
 
         <dl class="idl" title="enum RTCBundlePolicy" id="target-bundle-policy">
           <dt>balanced</dt>

--- a/webrtc.html
+++ b/webrtc.html
@@ -332,7 +332,7 @@
         the remote endpoint is not BUNDLE-aware, and what ICE
         candidates are gathered.  If the remote endpoint is
         BUNDLE-aware, all media tracks and data channels are BUNDLEd
-        onto the same transport.  </p>
+        onto the same transport.</p>
 
         <dl class="idl" title="enum RTCBundlePolicy" id="target-bundle-policy">
           <dt>balanced</dt>


### PR DESCRIPTION
Added reference to JSEP Section 4.1.1 and removed non-normative statement.  Issue: 
https://github.com/w3c/webrtc-pc/issues/328