### PR TITLE
Fix for Issue 408: Clarify component for IceTransport when RTP/RTCP mux is used

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4211,7 +4211,8 @@ sender.setParameters(params)
         <dl class="idl" title="enum RTCIceComponent">
           <dt>RTP</dt>
 
-          <dd>The ICE Transport is used for RTP (or RTP/RTCP-multiplexing), as defined in [[!ICE]], Section 4.1.1.1.</dd>
+          <dd>The ICE Transport is used for RTP (or RTP/RTCP-multiplexing), as defined in [[!ICE]], Section 4.1.1.1.
+          Protocols multiplexed with RTP (e.g. data channel) share its component ID.</dd>
 
           <dt>RTCP</dt>
 

--- a/webrtc.html
+++ b/webrtc.html
@@ -4211,7 +4211,7 @@ sender.setParameters(params)
         <dl class="idl" title="enum RTCIceComponent">
           <dt>RTP</dt>
 
-          <dd>The ICE Transport is used for RTP as defined in [[!ICE]], Section 4.1.1.1.</dd>
+          <dd>The ICE Transport is used for RTP (or RTP/RTCP-multiplexing), as defined in [[!ICE]], Section 4.1.1.1.</dd>
 
           <dt>RTCP</dt>
 


### PR DESCRIPTION
https://github.com/w3c/webrtc-pc/issues/408