### PR TITLE
fix setParameters invalid webidl

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3412,7 +3412,7 @@
             </p>
           </dd>
 
-          <dt>void setParameters (RTCRtpParameters parameters)</dt>
+          <dt>void setParameters (optional RTCRtpParameters parameters)</dt>
           <dd>
             <p>The <code id="dom-rtpsender-setparameters">setParameters</code>
             method updates how <code>track</code> is encoded and transmitted to a remote peer.


### PR DESCRIPTION
 0:21.52 WebIDL.WebIDLError: error: Dictionary argument or union argument containing a dictionary not followed by a required argument must be optional, /Users/Jan/moz/mozilla-central/dom/webidl/RTCRtpSender.webidl line 73:39
 0:21.52  void setParameters (RTCRtpParameters parameters);
