### PR TITLE
Adding expires attribute to generateCertificate.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2752,6 +2752,17 @@
           linked to a user or <a>user agent</a>.  Randomized values for
           distinguished name and serial number SHOULD be used.</p>
 
+          <p>An optional <code>expires</code> attribute MAY be added to
+          the <var>keygenAlgorithm</var> parameter.  If this contains
+          a <code><a>DOMTimeStamp</a></code> value, it indicates the maximum
+          time that the <code><a>RTCCertificate</a></code> is valid for relative
+          to the current time.  A <a>user agent</a> sets
+          the <code><a href="#widl-RTCCertificate-expires">expires</a></code>
+          attribute of the returned <code><a>RTCCertificate</a></code> to the
+          current time plus the value of the <code>expires</code> attribute.
+          However, a <a>user agent</a> MAY choose to limit the period over which
+          an <code><a>RTCCertificate</a></code> is valid.</p>
+
           <p>A <a>user agent</a> MUST reject a call
           to <code>generateCertificate()</code> with a <code>DOMError</code> of
           type <code>NotSupportedError</code> if the <var>keygenAlgorithm</var>


### PR DESCRIPTION
As I said on the list, and as @steelyglint has noted, I'm not sure that this is the best approach, but it's what Firefox currently does.

Closes #386.