### PR TITLE
Add maxFramerate knob for simulcast

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3610,11 +3610,19 @@ sender.setParameters(params)
             <p>
               Indicates the maximum bitrate that can be used to send
               this encoding.  The encoding may also be further
-              constrained by other bandwidth limits (such as
-              per-transport or per-session limits) below the maximum
+              constrained by other limits (such as maxFramerate or
+              per-transport or per-session bandwidth limits) below the maximum
               specified here.  maxBitrate is the Transport Independent Application Specific Maximum (TIAS)  
               bandwidth defined in [[RFC3890]] Section 6.2.2, which is the maximum bandwidth needed without 
               counting IP or other transport layers like TCP or UDP.
+           </p>
+          </dd>
+          
+          <dt>unsigned long maxFramerate</dt>
+          <dd>
+            <p>
+              Indicates the maximum framerate that can be used to send
+              this encoding.
            </p>
           </dd>
 


### PR DESCRIPTION
Added maxFramerate to RTCRtpEncodingParameters, addressing Issue  https://github.com/w3c/webrtc-pc/issues/412