### PR TITLE
Clarification for getRemoteCertificates()

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4018,7 +4018,7 @@ sender.setParameters(params)
 
           <dd>
             <p>Returns the certificate chain in use by the remote side, with each certificate
-            encoded in binary Distinguished Encoding Rules (DER) [[X.690]].</p>
+            encoded in binary Distinguished Encoding Rules (DER) [[!X690]].</p>
           </dd>
 
           <dt>attribute EventHandler onstatechange</dt>

--- a/webrtc.html
+++ b/webrtc.html
@@ -4017,8 +4017,8 @@ sender.setParameters(params)
           <dt>sequence&lt;ArrayBuffer&gt; getRemoteCertificates()</dt>
 
           <dd>
-            <p>Returns a sequence of <code>ArrayBuffer</code> containing the DER-encoded
-            certificate chain in use by the remote side.</p>
+            <p>Returns the certificate chain in use by the remote side, with each certificate
+            encoded in binary Distinguished Encoding Rules (DER) [[X.690]].</p>
           </dd>
 
           <dt>attribute EventHandler onstatechange</dt>

--- a/webrtc.html
+++ b/webrtc.html
@@ -4017,8 +4017,8 @@ sender.setParameters(params)
           <dt>sequence&lt;ArrayBuffer&gt; getRemoteCertificates()</dt>
 
           <dd>
-            <p>Returns a sequence of <code>ArrayBuffer</code> containing the remote certificates in use by
-            the remote side.</p>
+            <p>Returns a sequence of <code>ArrayBuffer</code> containing the DER-encoded
+            certificate chain in use by the remote side.</p>
           </dd>
 
           <dt>attribute EventHandler onstatechange</dt>


### PR DESCRIPTION
A potential clarification for Issue 378: 
https://github.com/w3c/webrtc-pc/issues/378