### PR TITLE
non-nullable RTCTrackEvent args means Init dict members are required.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4307,7 +4307,7 @@ sender.setParameters(params)
           associated with the <code><a>RTCRtpReceiver</a></code> identified by
           <code>receiver</code>.</p>
         </dd>
-        <dt>required sequence&lt;MediaStream&gt; streams</dt>
+        <dt>sequence&lt;MediaStream&gt; streams = []</dt>
         <dd>
           <p>The <code>streams</code>
            attribute returns an array of <code><a>MediaStream</a></code> objects

--- a/webrtc.html
+++ b/webrtc.html
@@ -4294,20 +4294,20 @@ sender.setParameters(params)
 
       <dl class="idl" title="dictionary RTCTrackEventInit : EventInit">
 
-        <dt>RTCRtpReceiver receiver</dt>
+        <dt>required RTCRtpReceiver receiver</dt>
         <dd>
           <p>The <code>receiver</code> attribute
           represents the <code><a>RTCRtpReceiver</a></code> object associated with
           the event.</p>
         </dd>
-        <dt>MediaStreamTrack track</dt>
+        <dt>required MediaStreamTrack track</dt>
         <dd>
           <p>The <code>track</code> attribute
           represents the <code><a>MediaStreamTrack</a></code> object that is
           associated with the <code><a>RTCRtpReceiver</a></code> identified by
           <code>receiver</code>.</p>
         </dd>
-        <dt>sequence&lt;MediaStream&gt; streams</dt>
+        <dt>required sequence&lt;MediaStream&gt; streams</dt>
         <dd>
           <p>The <code>streams</code>
            attribute returns an array of <code><a>MediaStream</a></code> objects


### PR DESCRIPTION
Mozilla's webidl compiler actually requires this or the binding code wont compile (it's undefined what happens when no args are passed). It's either this or make the RTCTrackEvent args nullable and default to `null`.