### PR TITLE
Clean up event handler attribute descriptions (fixes:  #383)

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1586,30 +1586,18 @@
           <dt>attribute EventHandler onsignalingstatechange</dt>
 
           <dd>The event type of this event handler is <code><a href=
-          "#event-signalingstatechange">signalingstatechange</a></code>. It is called any
-          time the
-          <code>RTCPeerConnection</code>'s <a>signaling state</a> changes, i.e., from a call to
-          <code>setLocalDescription</code> or a call to
-          <code>setRemoteDescription</code>. It does not fire for the
-          initial state change into <code>new</code>.</dd>
+          "#event-signalingstatechange">signalingstatechange</a></code>.</dd>
 
           <dt>attribute EventHandler oniceconnectionstatechange</dt>
 
-          <dd>
-            The event type of this event handler is <code><a href=
-            "#event-iceconnectionstatechange">iceconnectionstatechange</a></code>. It is called any
-            time the <code>RTCPeerConnection</code>'s
-            <a>ICE connection state</a> changes.
+          <dd>The event type of this event handler is <code><a href=
+          "#event-iceconnectionstatechange">iceconnectionstatechange</a></code>
           </dd>
 
           <dt>attribute EventHandler onicegatheringstatechange</dt>
 
-          <dd>
-            The event type of this event handler is <code><a href=
-            "#event-icegatheringstatechange">icegatheringstatechange</a></code>. It is called any
-            time
-            the <code>RTCPeerConnection</code>'s
-            <a>ICE gathering state</a> changes.
+          <dd>The event type of this event handler is <code><a href=
+          "#event-icegatheringstatechange">icegatheringstatechange</a></code>.
           </dd>
 
           <dt>attribute EventHandler onconnectionstatechange</dt>
@@ -5315,9 +5303,8 @@ sender.setParameters(params)
         <dt>attribute EventHandler ontonechange</dt>
 
         <dd>
-          <p>The event type of this event handler is <code><a>tonechange</a></code>. It returns the
-          character for each tone as it is played out. See
-          <code><a>RTCDTMFToneChangeEvent</a></code> for details.</p>
+          <p>The event type of this event handler is <code>
+          <a>tonechange</a></code>.</p>
         </dd>
 
         <dt>readonly attribute DOMString toneBuffer</dt>
@@ -7579,7 +7566,7 @@ if (sender.dtmf) {
           <td><dfn id=
           "event-RTCDTMFSender-tonechange"><code>tonechange</code></dfn></td>
 
-          <td><code><a>Event</a></code></td>
+          <td><code><a>RTCDTMFToneChangeEvent</a></code></td>
 
           <td>The <code><a>RTCDTMFSender</a></code> object has either just
           begun playout of a tone (returned as the <code><a>tone</a></code>


### PR DESCRIPTION
Text were removed from the following event handler attribute descriptions. The comment hints about where the functionality is specified in the document (so nothing is lost). Also fixed a minor bug in the Event Summary section (s/Event/RTCDTMFToneChangeEvent).

signalingstatechange: Event firing specified in "set an RTCSessionDescription" steps 3.2.5

iceconnectionstatechange: Event firing specified by "update the ICE connection state" steps (referenced by several algorithms in the Operations section)

onicegatheringstatechange: Event firing specified by "update the ICE gathering state" steps (referenced by several algorithms in the Operations section)

tonechange: Event firing specified in insertDTMF() steps 6.1 and 6.5. Info about tone is documented by the event.