### PR TITLE
Use enum for voiceActivityDetection

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -385,7 +385,7 @@
         the offer/answer creation process.</p>
 
         <dl class="idl" title="dictionary RTCOfferAnswerOptions">
-          <dt>boolean voiceActivityDetection = true</dt>
+          <dt>RTCVoiceActivityOption voiceActivityDetection = "enabled"</dt>
 
           <dd>
             <p>Many codecs and systems are capable of detecting "silence" and
@@ -396,6 +396,14 @@
             the application to provide information about whether it wishes this
             type of processing enabled or disabled.</p>
           </dd>
+        </dl>
+
+        <dl class="idl" title="enum RTCVoiceActivityOption">
+          <dt>enabled</dt>
+          <dd>Request voice activity detection to be enabled</dd>
+
+          <dt>disabled</dt>
+          <dd>Request voice activity detection to be disabled</dd>
         </dl>
 
         <dl class="idl" title="dictionary RTCOfferOptions : RTCOfferAnswerOptions">


### PR DESCRIPTION
part of #375, based on @martinthomson's [suggestion](https://github.com/w3c/webrtc-pc/issues/375#issuecomment-163433990)