### PR TITLE
Typo fixes

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3551,7 +3551,7 @@ sender.setParameters(params)
               <p>Changing dimensions and/or frame rates might not require
               negotiation. Cases that may require negotiation include:</p>
               <ol>
-                <li>Changing a frame rate to a value outside of the negotiated
+                <li>Changing a resolution to a value outside of the negotiated
                 imageattr bounds, as described in [[!RFC6236]].
                 </li>
                 <li>Changing a frame rate to a value that causes the block rate

--- a/webrtc.html
+++ b/webrtc.html
@@ -3428,7 +3428,7 @@
           <dt>static RTCRtpCapabilities getCapabilities(DOMString kind)</dt>
           <dd>
             <p>The <dfn id="dom-rtpsender-getcapabilities"><code>RTCRtpSender.getCapabilities</code></dfn>
-            method returns the most optimist view on the capabilities
+            method returns the most optimistic view of the capabilities
             of the system for sending media of the given kind. It does
             not reserve any resources, ports, or other state but is
             meant to provide a way to discover the types of


### PR DESCRIPTION
Fixed a typo where "framerate" was used where "resolution" was intended.