### PR TITLE
Remove ambiguous language on changing certificates in rtcconfig

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -217,8 +217,7 @@
             generation.</p>
 
             <p>The value for this configuration option cannot change after its
-            value is initially selected.  Attempts to change this value will be
-            rejected.</p>
+            value is initially selected.</p>
           </dd>
 
           <dt>unsigned short iceCandidatePoolSize = 0</dt>


### PR DESCRIPTION
Per https://github.com/w3c/webrtc-pc/commit/f1c0e97057c2232ae0535473eafcce9f3405cd2f#commitcomment-15652284