### PR TITLE
Add missing ReSpec configuration options related to current specStatus

### DIFF
--- a/webrtc.js
+++ b/webrtc.js
@@ -56,6 +56,10 @@ var respecConfig = {
   //      company: "Your Company", companyURL: "http://example.com/" }
   //],
 
+  // Requirements of the current specStatus: 'WD'
+  previousMaturity: "WD",
+  previousPublishDate: "2015-02-10",
+
   // name of the WG
   wg:           "Web Real-Time Communications Working Group",
 


### PR DESCRIPTION
specStats: 'WD' requires the previousPublishDate and previousMaturity options to be set.
This is needed to set up automatic publication with link such as:
http://w3c.github.io/webrtc-pc/webrtc.html?specStatus=WD