### PR TITLE
Reserve and use RangeError for scaleResolutionDownBy < 1.0.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3433,6 +3433,10 @@
 		    <code>InvalidModificationError</code>. Note that this also applies to
 		    <var>transactionId</var>.
 		  </li>
+		  <li>If the <code>scaleResolutionDownBy</code> parameter in the
+		    <var>parameters</var> argument has a value less than 1.0, abort these
+		    steps and return a promise rejected with <code>RangeError</code>.
+		  </li>
 		  <li>Set the RTPSender's internal <var>transactionId</var> slot
 		    to a previously unused value.
 		  </li>
@@ -3707,7 +3711,7 @@ sender.setParameters(params)
             example, if the value is 2.0, the video will be scaled down by a factor of 2
             in each dimension, resulting in sending a video of one quarter the size.  If
             the value is 1.0, the video will not be affected.  The value must be greater
-            than 0.</p>
+            than or equal to 1.0.</p>
           </dd>
         </dl>
 

--- a/webrtc.html
+++ b/webrtc.html
@@ -3430,7 +3430,7 @@
 		    the corresponding parameter value returned from
 		    <code><a href="#dom-rtpsender-getparameters">getParameters()</a></code>,
 		    abort these steps and return a promise rejected with
-		    <code>RangeError</code>. Note that this also applies to
+		    <code>InvalidModificationError</code>. Note that this also applies to
 		    <var>transactionId</var>.
 		  </li>
 		  <li>Set the RTPSender's internal <var>transactionId</var> slot


### PR DESCRIPTION
Fix for https://github.com/w3c/webrtc-pc/issues/493.