### PR TITLE
Fix "transeceivers" typos

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2851,7 +2851,9 @@
       <code>addTrack</code> method. <code>RTCRtpReceiver</code>s, on the other
       hand, are created when remote signaling indicates new tracks are available,
       and each new <code>MediaStreamTrack</code> and its associated <code>RTCRtpReceiver</code>
-      are surfaced to the application via the <code>ontrack</code> event.</p>
+      are surfaced to the application via the <code>ontrack</code> event.
+      Both <code>RTCRtpSender</code> and <code>RTCRtpReceiver</code> objects are created by
+      the <code>addTransceiver</code> method.</p>
 
       <p>A <code><a>RTCPeerConnection</a></code> object contains a
       <dfn id="senders-set">set of <code>RTCRtpSender</code>s</dfn>, representing tracks to
@@ -2910,17 +2912,17 @@
           <dd>
             <p>Returns a sequence
             of <code><a>RTCRtpTransceiver</a></code> objects
-            representing the RTP transeceivers that are currently
+            representing the RTP transceivers that are currently
             attached to this
             <code><a>RTCPeerConnection</a></code> object.</p>
 
             <p>The <dfn id=
-            "dom-peerconnection-gettranseceivers"><code>getTransceivers()</code></dfn>
+            "dom-peerconnection-gettransceivers"><code>getTransceivers()</code></dfn>
             method MUST return a new sequence that represents a snapshot of all
             the <code><a>RTCRtpTransceiver</a></code> objects in this
             <code><a>RTCPeerConnection</a></code> object's <a href=
-            "#transceivers-set">set of transeceivers</a>. The
-            conversion from the transeceiver set to the sequence, to
+            "#transceivers-set">set of transceivers</a>. The
+            conversion from the transceiver set to the sequence, to
             be returned, is user agent defined and the order does not
             have to be stable between calls.</p>
           </dd>


### PR DESCRIPTION
This PR fixes 3 mispellings of "transceivers" as well as adding a sentence about the addTransceiver() method.