### PR TITLE
Add getParameters() method to RTCRtpReceiver  

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3926,9 +3926,10 @@ sender.setParameters(params)
           
           <dt>RTCRtpParameters getParameters()</dt>
           <dd>
-            <p>The <dfn id="dom-rtpreceiver-getparameters"><code>getParameters</code></dfn>
-            method returns the <code>RTCRtpReceiver</code> object's current parameters for how <code>track</code>
-            is decoded.
+            <p>
+            	The <code>getParameters</code> method returns the 
+            	<code>RTCRtpReceiver</code> object's current parameters for 
+            	how <code>track</code> is decoded.
             </p>
           </dd>
 

--- a/webrtc.html
+++ b/webrtc.html
@@ -3923,6 +3923,14 @@ sender.setParameters(params)
             can consider mitigations such as reporting only a common subset
             of the capabilities.</p>
           </dd>
+          
+          <dt>RTCRtpParameters getParameters()</dt>
+          <dd>
+            <p>The <dfn id="dom-rtpreceiver-getparameters"><code>getParameters</code></dfn>
+            method returns the <code>RTCRtpReceiver</code> object's current parameters for how <code>track</code>
+            is decoded.
+            </p>
+          </dd>
 
           <dt> sequence&lt;RTCRtpContributingSource&gt;
             getContributingSources () </dt> <dd> <p>Returns an


### PR DESCRIPTION
Add getParameters() method to the RTCRtpReceiver.  

Related to Issue https://github.com/w3c/webrtc-pc/issues/473