### PR TITLE
Remove state check when ICE Agent is initialized (state is predictable)

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -435,12 +435,10 @@
 
         <ul>
           <li>
-            <p>When the <a>ICE Agent</a> is initialized, and
-            <code>RTCPeerConnection</code>'s <a>ICE gathering state</a> is
-            <code>new</code> and the <a>ICE candidate pool size</a> is nonzero,
-            the User Agent MUST queue a task to start gathering ICE addresses
-            and <a>update the ICE gathering state</a> to
-            <code>gathering</code>.</p>
+            <p>When the <a>ICE Agent</a> is initialized, and if the <a>ICE
+            candidate pool size</a> is nonzero, the User Agent MUST start
+            gathering ICE addresses and <a>update the ICE gathering state</a>
+            to <code>gathering</code>.</p>
           </li>
 
           <li>


### PR DESCRIPTION
The actions described in the modified text used to be triggered by "an ICE event". It's now triggered by the initialization of the ICE Agent so the state is known at creation.

This fix should have been part of PR #510.