### PR TITLE
Relation between local track and outgoing encoding (Issue #478)

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2849,6 +2849,16 @@
       Each track to be sent is associated with exactly one <code><a>RTCRtpSender</a></code>, and
       each track to be received is associated with exactly one <code><a>RTCRtpReceiver</a></code>.</p>
 
+      <p>The basic principle is that the encoding and transmission of each
+      <code>MediaStreamTrack</code> is made such that the characteristics are as far as possible
+      maintained by the track created on the remote side. In other words, the
+      <code>MediaTrackSettings</code> width, height, frameRate for a video track, and volume, sampleSize,
+      sampleRate and channelCount for an audio track should be maintained. There are situations when this
+      does not apply, there may for example be resource constraints (HW Codec, CPU, network throughput
+      etc.) that makes this impossible, or there may be <code><a>RTCRtpSender</a></code> settings applied
+      that instruct the implementation to deviate from this principle.</p> 
+
+
       <p><code><a>RTCRtpSender</a></code>s are created when the application attaches a
       <code>MediaStreamTrack</code> to a <code><a>RTCPeerConnection</a></code>, via the
       <code>addTrack</code> method. <code><a>RTCRtpReceiver</a></code>s, on the other

--- a/webrtc.html
+++ b/webrtc.html
@@ -2850,8 +2850,8 @@
       each track to be received is associated with exactly one <code><a>RTCRtpReceiver</a></code>.</p>
 
       <p>The encoding and transmission of each <code>MediaStreamTrack</code> SHOULD be made such that
-      characteristics (width, height and frameRate for video tracks, and volume, sampleSize, 
-      sampleRate and channelCount for audio tracks) are as far as possible
+      its characteristics (width, height and frameRate for video tracks; volume, sampleSize, 
+      sampleRate and channelCount for audio tracks) are to a reasonable degree
       retained by the track created on the remote side. There are situations when this
       does not apply, there may for example be resource constraints at either endpoint or in the network
       or there may be <code><a>RTCRtpSender</a></code> settings applied that instruct

--- a/webrtc.html
+++ b/webrtc.html
@@ -2850,13 +2850,13 @@
       each track to be received is associated with exactly one <code><a>RTCRtpReceiver</a></code>.</p>
 
       <p>The basic principle is that the encoding and transmission of each
-      <code>MediaStreamTrack</code> is made such that the characteristics are as far as possible
-      maintained by the track created on the remote side. In other words, the
-      <code>MediaTrackSettings</code> width, height, frameRate for a video track, and volume, sampleSize,
-      sampleRate and channelCount for an audio track should be maintained. There are situations when this
-      does not apply, there may for example be resource constraints (HW Codec, CPU, network throughput
-      etc.) that makes this impossible, or there may be <code><a>RTCRtpSender</a></code> settings applied
-      that instruct the implementation to deviate from this principle.</p> 
+      <code>MediaStreamTrack</code> is made such that its characteristics are as far as possible
+      maintained by the track created on the remote side. This applies to 
+      <code>MediaTrackSettings</code> width, height, frameRate for video tracks, and volume, sampleSize,
+      sampleRate and channelCount for audio tracks. There are situations when this
+      does not apply, there may for example be resource constraints (e.g. HW codec availability, CPU,
+      network throughput) or there may be <code><a>RTCRtpSender</a></code> settings applied that instruct
+      the implementation to deviate from this principle.</p> 
 
 
       <p><code><a>RTCRtpSender</a></code>s are created when the application attaches a

--- a/webrtc.html
+++ b/webrtc.html
@@ -2849,14 +2849,13 @@
       Each track to be sent is associated with exactly one <code><a>RTCRtpSender</a></code>, and
       each track to be received is associated with exactly one <code><a>RTCRtpReceiver</a></code>.</p>
 
-      <p>The basic principle is that the encoding and transmission of each
-      <code>MediaStreamTrack</code> is made such that its characteristics are as far as possible
-      maintained by the track created on the remote side. This applies to 
-      <code>MediaTrackSettings</code> width, height, frameRate for video tracks, and volume, sampleSize,
-      sampleRate and channelCount for audio tracks. There are situations when this
-      does not apply, there may for example be resource constraints (e.g. HW codec availability, CPU,
-      network throughput) or there may be <code><a>RTCRtpSender</a></code> settings applied that instruct
-      the implementation to deviate from this principle.</p> 
+      <p>The encoding and transmission of each <code>MediaStreamTrack</code> SHOULD be made such that
+      characteristics (width, height and frameRate for video tracks, and volume, sampleSize, 
+      sampleRate and channelCount for audio tracks) are as far as possible
+      retained by the track created on the remote side. There are situations when this
+      does not apply, there may for example be resource constraints at either endpoint or in the network
+      or there may be <code><a>RTCRtpSender</a></code> settings applied that instruct
+      the implementation to act differently.</p> 
 
 
       <p><code><a>RTCRtpSender</a></code>s are created when the application attaches a


### PR DESCRIPTION
Could we address #478 with something like this?