### PR TITLE
Typo and grammar cleanup

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3422,7 +3422,7 @@
 	      MUST run the following steps:
 		<ol>
 		  <li>Let <var>sender</var> be the <code><a>RTCRtpSender</a></code> object on which
-		    <code>replaceTrack</code> is invoked.
+		    <code>setParameters</code> is invoked.
 		  </li>
 		  <li>Let <var>p</var> be a new promise.
 		  </li>
@@ -3458,15 +3458,15 @@
             renegotiated.  After the codecs are renegotiated, they are
             set to the value negotiated, and <code>setParameters</code> needs
 	    to be called again to re-apply codec preferences.</p>
-            <p>The setParameters does not cause renegotiation at the SDP level
+            <p><code>setParameters</code> does not cause SDP renegotiation
             and can only be used to change what the media stack is sending or
-            receiving within the envelope negotiated by the Offer/Answer. The
-            attributes in the <code>RTCRtpParameters</code> dictionary are
-            designed to not enable this so things like <code>ssrc</code> that
+            receiving within the envelope negotiated by Offer/Answer. The
+            attributes in the <code><a>RTCRtpParameters</a></code> dictionary are
+            designed to not enable this, so attributes like <code>ssrc</code> that
             cannot be changed are read only. Other things, like bitrate, are
-            controlled using limits such as the <code>maxBitrate</code> from
-            this dictionary where the User Agent need to ensure that it does not
-            exceed the maximum bitrate found in this dictionary where at the
+            controlled using limits such as <code>maxBitrate</code>, 
+            where the User Agent needs to ensure it does not exceed the maximum
+            bitrate specified by <code>maxBitrate</code>, while at the
             same time making sure it satisfies constraints on bitrate specified
             in other places such as the SDP.</p>
            


### PR DESCRIPTION
Cleaned up typos and grammar in Section 5.2.2 setParameters() description.