### PR TITLE
Removal of "server cannot be reached" error

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2667,10 +2667,6 @@
           <dd>
             <p>The <code>errorCode</code> attribute is the numeric STUN
             error code returned by the STUN or TURN server [[STUN-PARAMETERS]].</p>
-            <p>If the server could not be reached, <code>errorCode</code> will
-            be set to a TBD value in the 7XX range, as this does not conflict
-            with the STUN error code range.</p>
-            <p class="issue">Error code to be defined</p>
           </dd>
 
           <dt>readonly attribute USVString errorText</dt>


### PR DESCRIPTION
Removed "server cannot be reached" error, responding to Robin Raymond's comment on Issue https://github.com/w3c/webrtc-pc/issues/521