### PR TITLE
Never close the RTCPeerConnection if setting a local/remote description fails (issue #364)

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -688,7 +688,9 @@
                     "#widl-RTCSessionDescription-type">type</a></code> is wrong for
                     the current <a>signaling state</a> of
                     <var>connection</var>, then reject <var>p</var> with a <code>InvalidStateError</code> and abort these steps.</p>
+                  </li>
 
+                  <li>
                     <p>If the content of <var>description</var> is invalid,
                     then reject <var>p</var> with an
                     <code>InvalidAccessError</code> and abort these
@@ -696,30 +698,9 @@
                   </li>
 
                   <li>
-                    <p>If <var>description</var> cannot be applied at the media
-                    layer, but the User Agent recovered, possibly by rolling back
-                    to the previous configuration, then reject <var>p</var> with
-                    <code>OperationError</code> and abort
-                    these steps.</p>
-
-                    <p>This occurs, for example, when the version of
-                    <var>description</var> is older than the one currently
-                    being used.</p>
-                  </li>
-
-                  <li>
-                    <p>Otherwise, set <var>connection</var>'s <a>signaling state</a> to
-                    <code>closed</code>.</p>
-                  </li>
-
-                  <li>
-                    <p>Fire a simple event named <code><a href=
-                    "#event-signalingstatechange">signalingstatechange</a></code>
-                    at <var>connection</var>.</p>
-                  </li>
-
-                  <li>
-                    <p>Reject <var>p</var> with <code>OperationError</code>.</p>
+                    <p>For all other errors, for example if
+                    <var>description</var> cannot be applied at the media layer,
+                    reject <var>p</var> with <code>OperationError</code>.</p>
                   </li>
                 </ol>
               </li>


### PR DESCRIPTION
* Removed text about rollback since the 'process to apply description' should either succeed or fail. And in case of failure, the description should not be updated.
* Added a "catch all/rest" error case.