### PR TITLE
Revert "Added initialization of readonly and remote attributes for in…

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3318,16 +3318,6 @@
                 </li>
 
                 <li>
-                  <p>Initialize <code><var>track</var>.readonly</code>
-                  attribute to <code>true</code>.</p>
-                </li>
-
-                <li>
-                  <p>Initialize <code><var>track</var>.remote</code>
-                  attribute to <code>true</code>.</p>
-                </li>
-
-                <li>
                   <p>Initialize <code><var>track</var>.readyState</code>
                   attribute to <code>live</code>.</p>
                 </li>


### PR DESCRIPTION
…coming tracks."

This reverts commit 5d1a60576687910cc61eaebe97482d922db35ca6, meaning we remove initialization of remote and readonly when creating MediaStreamTracks on PeerConnection. The reason is that these attributes have been removed from the definition of MediaStreamTrack in mediacapture-main.

Close #556 .