### PR TITLE
Make RTCSessionDescription readonly, and createOffer return dictionary.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -926,7 +926,7 @@
             algorithm</a>.
           </dd>
 
-          <dt>Promise&lt;RTCSessionDescription&gt; createOffer (
+          <dt>Promise&lt;RTCSessionDescriptionInit&gt; createOffer (
             optional RTCOfferOptions options)</dt>
 
           <dd>
@@ -1002,7 +1002,7 @@
             <code>DOMException</code> object of type <code>OperationError</code> as its argument.</p>
           </dd>
 
-          <dt>Promise&lt;RTCSessionDescription&gt; createAnswer (optional
+          <dt>Promise&lt;RTCSessionDescriptionInit&gt; createAnswer (optional
           RTCAnswerOptions options)</dt>
 
           <dd>
@@ -2313,11 +2313,11 @@
           constructor is deprecated; it exists for legacy compatibility reasons
           only.</dd>
 
-          <dt>attribute RTCSdpType type</dt>
+          <dt>readonly attribute RTCSdpType type</dt>
 
           <dd>The type of this RTCSessionDescription.</dd>
 
-          <dt>attribute DOMString sdp</dt>
+          <dt>readonly attribute DOMString sdp</dt>
 
           <dd>The string representation of the SDP [[!SDP]].</dd>
 


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/573.