### PR TITLE
latest respec2html needs node >= 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ addons:
       - libcss-dom-perl
       - python-lxml
       - cmake
-      - cmake-data
       - gcc-4.8
       - g++-4.8
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,7 @@ addons:
       - gcc-4.8
       - g++-4.8
 before_install:
-  - export CXX="g++-4.8" CC="gcc-4.8"
-  - nvm install 5
-  - "export DISPLAY=:99.0"
-  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16 -extension RANDR"
-  - sh -e /etc/init.d/xvfb start
+ - make travis_before_install
 install:
  - make travissetup
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,7 @@ addons:
       - gcc-4.8
       - g++-4.8
 before_install:
-  - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.8
-  - gcc --version && g++ --version
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
   - nvm install 5
 install:
  - make travissetup

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ addons:
 before_install:
   - export CXX="g++-4.8" CC="gcc-4.8"
   - nvm install 5
+  - "export DISPLAY=:99.0"
+  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16 -extension RANDR"
+  - sh -e /etc/init.d/xvfb start
 install:
  - make travissetup
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,18 @@ addons:
   apt:
     sources:
       - george-edison55-precise-backports
+      - ubuntu-toolchain-r-test
     packages:
       - libwww-perl
       - libcss-dom-perl
       - python-lxml
       - cmake
       - cmake-data
+      - gcc-4.8
+      - g++-4.8
 before_install:
+  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.8
+  - gcc --version && g++ --version
   - nvm install 5
 install:
  - make travissetup

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ addons:
       - gcc-4.8
       - g++-4.8
 before_install:
-  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.8
+  - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.8
   - gcc --version && g++ --version
   - nvm install 5
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ addons:
       - gcc-4.8
       - g++-4.8
 before_install:
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+  - export CXX="g++-4.8" CC="gcc-4.8"
   - nvm install 5
 install:
  - make travissetup

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,11 @@ addons:
       - gcc-4.8
       - g++-4.8
 before_install:
- - make travis_before_install
+  - export CXX="g++-4.8" CC="gcc-4.8"
+  - nvm install 5
+  - "export DISPLAY=:99.0"
+  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16 -extension RANDR"
+  - sh -e /etc/init.d/xvfb start
 install:
  - make travissetup
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ addons:
       - python-lxml
       - cmake
       - cmake-data
+before_install:
+  - nvm install 5
 install:
  - make travissetup
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ addons:
       - libcss-dom-perl
       - python-lxml
       - cmake
+      - cmake-data
       - gcc-4.8
       - g++-4.8
 before_install:


### PR DESCRIPTION
and it can be installed with nvm only from the .travis.yml file

This is based on:
https://github.com/travis-ci/travis-ci/issues/3900#issuecomment-102249706
http://stackoverflow.com/a/36033744