### PR TITLE
replaceTrack: Use 'transceiver kind' instead of track.kind (track may be null) (issue: #634)

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3600,14 +3600,19 @@ sender.setParameters(params)
               </li>
 
               <li>
+                <p>Let <var>transceiver</var> be the <code>
+                <a>RTCRtpTransceiver</a></code> object associated with
+                <var>sender</var>.</p>
+              </li>
+
+              <li>
                 <p>If <code><var>withTrack</var>.kind</code> differs
                 from the <code><var>sender</var>.<a href="#dom-rtpsender-track">track</a>.kind</code>,
                 return a promise rejected with a <code>TypeError</code>.</p>
               </li>
 
               <li>
-                <p>If the <a><code>RTCRtpTransceiver</code></a> which
-                <var>sender</var> belongs to is not yet associated with a
+                <p>If <var>transceiver</var> is not yet associated with a
                 <a>media description</a> <span data-jsep=
                 "rtptransceivers">[[!JSEP]]</span>, then set
                 <var>sender</var>'s <code><a href=

--- a/webrtc.html
+++ b/webrtc.html
@@ -3607,7 +3607,7 @@ sender.setParameters(params)
 
               <li>
                 <p>If <code><var>withTrack</var>.kind</code> differs
-                from the <code><var>sender</var>.<a href="#dom-rtpsender-track">track</a>.kind</code>,
+                from the <a>transceiver kind</a> of <var>transceiver</var>,
                 return a promise rejected with a <code>TypeError</code>.</p>
               </li>
 

--- a/webrtc.html
+++ b/webrtc.html
@@ -4079,7 +4079,12 @@ sender.setParameters(params)
         <p>The <a><code>RTCRtpTransceiver</code></a> interface
         represents a combination of an <a><code>RTCRtpSender</code></a> and
         an <a><code>RTCRtpReceiver</code></a> that share a
-        common <code>mid</code>.
+        common <code>mid</code>.</p>
+
+        <p>The <dfn>transceiver kind</dfn> of an <code>
+        <a>RTCRtpTransceiver</a></code> is defined by the kind of the
+        associated <code><a>RTCRtpReceiver</a></code>'s <code>
+        <a>MediaStreamTrack</a></code> object.</p>
 
         <dl class="idl" title=
           "interface RTCRtpTransceiver">


### PR DESCRIPTION
Fixes issue: #634

First commit it shared with PR #635