### PR TITLE
Make last arg (a dictionary) of addTransceiver optional

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3738,7 +3738,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
     sequence&lt;RTCRtpTransceiver&gt; getTransceivers ();
     RTCRtpSender                addTrack (MediaStreamTrack track, MediaStream... streams);
     void                        removeTrack (RTCRtpSender sender);
-    RTCRtpTransceiver           addTransceiver ((MediaStreamTrack or DOMString) trackOrKind, RTCRtpTransceiverInit init);
+    RTCRtpTransceiver           addTransceiver ((MediaStreamTrack or DOMString) trackOrKind, optional RTCRtpTransceiverInit init);
                     attribute EventHandler ontrack;
 };</pre>
         <section>
@@ -4079,8 +4079,8 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                     <td class="prmType"><code>RTCRtpTransceiverInit</code></td>
                     <td class="prmNullFalse"><span role="img" aria-label=
                     "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
+                    <td class="prmOptTrue"><span role="img" aria-label=
+                    "True">&#10004;</span></td>
                     <td class="prmDesc"></td>
                   </tr>
                 </tbody>


### PR DESCRIPTION
Per http://heycam.github.io/webidl/#dfn-optional-argument
> If the type of an argument is a dictionary type or a union type that has a dictionary type as one of its flattened member types, and that dictionary type and its ancestors have no required members, and the argument is either the final argument or is followed only by optional arguments, then the argument MUST be specified as optional

close #639