### PR TITLE
Clarification on RTX in Codec Capabilities/Parameters

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4714,11 +4714,11 @@ sender.setParameters(params)
             <dd>
             <p>
               A sequence containing the media codecs that an <code><a>RTCRtpSender</a></code>
-              will choose from, as well RTX, RED and FEC entries. Corresponding to each media
-              codec where retransmission via rtx is enabled, there will be an entry in
-              <code>codecs[]</code> with a <code>mimeType</code> value indicating
-              retransmission via rtx, and an <code>sdpFmtpLine</code> attribute (providing
-              the "apt" and "rtx-time" parameters).
+              will choose from, as well as entries for RTX, RED and FEC mechanisms.
+              Corresponding to each media codec where retransmission via rtx is enabled,
+              there will be an entry in <code>codecs[]</code> with a <code>mimeType</code>
+              value indicating retransmission via rtx, and an <code>sdpFmtpLine</code>
+              attribute (providing the "apt" and "rtx-time" parameters).
             </p>
             </dd>
             <dt><dfn><code>degradationPreference</code></dfn> of type

--- a/webrtc.html
+++ b/webrtc.html
@@ -4718,7 +4718,8 @@ sender.setParameters(params)
               Corresponding to each media codec where retransmission via RTX is enabled,
               there will be an entry in <code>codecs[]</code> with a <code>mimeType</code>
               attribute indicating retransmission via "audio/rtx" or "video/rtx", and an
-              <code>sdpFmtpLine</code> attribute (providing the "apt" and "rtx-time" parameters).
+              <code>sdpFmtpLine</code> attribute (providing the "apt" and "rtx-time"
+              parameters).
             </p>
             </dd>
             <dt><dfn><code>degradationPreference</code></dfn> of type

--- a/webrtc.html
+++ b/webrtc.html
@@ -5012,8 +5012,9 @@ sender.setParameters(params)
             "idlMemberType">sequence&lt;<a>RTCRtpCodecCapability</a>&gt;</span></dt>
             <dd>
               <p>
-                Supported codecs (including RTX/RED/FEC). There only will be a
-                single entry in <code>codecs[]</code> for retransmission via rtx.
+                Supported media codecs as well as entries for RTX, RED and FEC mechanisms.
+                There will only be a single entry in <code>codecs[]</code> for retransmission
+                via rtx.
               </p>
             </dd>
             <dt><dfn><code>headerExtensions</code></dfn> of type <span class=

--- a/webrtc.html
+++ b/webrtc.html
@@ -4714,9 +4714,10 @@ sender.setParameters(params)
             <dd>
             <p>
               A sequence containing the codecs (including RTX/RED/FEC) that
-              an <a><code>RTCRtpSender</code></a> will choose from in order
-              to send media. There will be an "rtx" entry in <code>codecs[]</code>
-              for each media codec that can be retransmitted, each with their own
+              an <code><a>RTCRtpSender</a></code> will choose from in order
+              to send media. Corresponding to each media codec where retransmission
+              via rtx is enabled, there will be an entry in <code>codecs[]</code>
+              with a <var>mimeType</var> value of "rtx", but with a distinct
               <var>sdpFmtpLine</var> attribute (providing an "apt" parameter).
             </p>
             </dd>
@@ -5011,7 +5012,7 @@ sender.setParameters(params)
             <dd>
               <p>
                 Supported codecs (including RTX/RED/FEC). There only will be a
-                single "rtx" entry in <code>codecs[]</code>.
+                single entry in <code>codecs[]</code> for retransmission via rtx.
               </p>
             </dd>
             <dt><dfn><code>headerExtensions</code></dfn> of type <span class=

--- a/webrtc.html
+++ b/webrtc.html
@@ -4715,10 +4715,10 @@ sender.setParameters(params)
             <p>
               A sequence containing the media codecs that an <code><a>RTCRtpSender</a></code>
               will choose from, as well as entries for RTX, RED and FEC mechanisms.
-              Corresponding to each media codec where retransmission via rtx is enabled,
-              there will be an entry in <code>codecs[]</code> with a <code>mimeType</code>
-              value indicating retransmission via rtx, and an <code>sdpFmtpLine</code>
-              attribute (providing the "apt" and "rtx-time" parameters).
+              Corresponding to each media codec where retransmission via RTX is enabled,
+              there will be an entry in <code>codecs[]</code> with an <code>mimeType</code>
+              attribute indicating retransmission via "audio/rtx" or "video/rtx", and an
+              <code>sdpFmtpLine</code> attribute (providing the "apt" and "rtx-time" parameters).
             </p>
             </dd>
             <dt><dfn><code>degradationPreference</code></dfn> of type

--- a/webrtc.html
+++ b/webrtc.html
@@ -4713,13 +4713,12 @@ sender.setParameters(params)
             "idlMemberType">sequence&lt;<a>RTCRtpCodecParameters</a>&gt;</span></dt>
             <dd>
             <p>
-              A sequence containing the codecs that an
-              <code><a>RTCRtpSender</a></code> will choose from in order to send
-              media, as well RTX, RED and FEC entries. Corresponding to each media
-              codec where retransmission via rtx is enabled, there will be an entry
-              in <code>codecs[]</code> with a <code>mimeType</code> value indicating
-              retransmission via rtx, and an <code>sdpFmtpLine</code> attribute
-              (providing the "apt" and "rtx-time" parameters).
+              A sequence containing the media codecs that an <code><a>RTCRtpSender</a></code>
+              will choose from, as well RTX, RED and FEC entries. Corresponding to each media
+              codec where retransmission via rtx is enabled, there will be an entry in
+              <code>codecs[]</code> with a <code>mimeType</code> value indicating
+              retransmission via rtx, and an <code>sdpFmtpLine</code> attribute (providing
+              the "apt" and "rtx-time" parameters).
             </p>
             </dd>
             <dt><dfn><code>degradationPreference</code></dfn> of type

--- a/webrtc.html
+++ b/webrtc.html
@@ -4717,8 +4717,8 @@ sender.setParameters(params)
               will choose from in order to send media, as well RTX, RED and FEC
               entries. Corresponding to each media codec where retransmission
               via rtx is enabled, there will be an entry in <code>codecs[]</code>
-              with a <var>mimeType</var> value indicating retransmission via rtx,
-              and an <var>sdpFmtpLine</var> attribute (providing the "apt" and
+              with a <code>mimeType</code> value indicating retransmission via rtx,
+              and an <code>sdpFmtpLine</code> attribute (providing the "apt" and
               "rtx-time" parameters).
             </p>
             </dd>

--- a/webrtc.html
+++ b/webrtc.html
@@ -4717,8 +4717,9 @@ sender.setParameters(params)
               an <code><a>RTCRtpSender</a></code> will choose from in order
               to send media. Corresponding to each media codec where retransmission
               via rtx is enabled, there will be an entry in <code>codecs[]</code>
-              with a <var>mimeType</var> value of "rtx", but with a distinct
-              <var>sdpFmtpLine</var> attribute (providing an "apt" parameter).
+              with a <var>mimeType</var> value indicating retransmission via rtx,
+              but with a distinct <var>sdpFmtpLine</var> attribute (providing an
+              "apt" parameter).
             </p>
             </dd>
             <dt><dfn><code>degradationPreference</code></dfn> of type

--- a/webrtc.html
+++ b/webrtc.html
@@ -4716,7 +4716,7 @@ sender.setParameters(params)
               A sequence containing the media codecs that an <code><a>RTCRtpSender</a></code>
               will choose from, as well as entries for RTX, RED and FEC mechanisms.
               Corresponding to each media codec where retransmission via RTX is enabled,
-              there will be an entry in <code>codecs[]</code> with an <code>mimeType</code>
+              there will be an entry in <code>codecs[]</code> with a <code>mimeType</code>
               attribute indicating retransmission via "audio/rtx" or "video/rtx", and an
               <code>sdpFmtpLine</code> attribute (providing the "apt" and "rtx-time" parameters).
             </p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -4713,13 +4713,13 @@ sender.setParameters(params)
             "idlMemberType">sequence&lt;<a>RTCRtpCodecParameters</a>&gt;</span></dt>
             <dd>
             <p>
-              A sequence containing the codecs (including RTX/RED/FEC) that
-              an <code><a>RTCRtpSender</a></code> will choose from in order
-              to send media. Corresponding to each media codec where retransmission
+              A sequence containing the codecs that an <code><a>RTCRtpSender</a></code>
+              will choose from in order to send media, as well RTX, RED and FEC
+              entries. Corresponding to each media codec where retransmission
               via rtx is enabled, there will be an entry in <code>codecs[]</code>
               with a <var>mimeType</var> value indicating retransmission via rtx,
-              but with a distinct <var>sdpFmtpLine</var> attribute (providing an
-              "apt" parameter).
+              and an <var>sdpFmtpLine</var> attribute (providing the "apt" and
+              "rtx-time" parameters).
             </p>
             </dd>
             <dt><dfn><code>degradationPreference</code></dfn> of type

--- a/webrtc.html
+++ b/webrtc.html
@@ -5013,7 +5013,7 @@ sender.setParameters(params)
               <p>
                 Supported media codecs as well as entries for RTX, RED and FEC mechanisms.
                 There will only be a single entry in <code>codecs[]</code> for retransmission
-                via rtx.
+                via RTX.
               </p>
             </dd>
             <dt><dfn><code>headerExtensions</code></dfn> of type <span class=

--- a/webrtc.html
+++ b/webrtc.html
@@ -4712,9 +4712,13 @@ sender.setParameters(params)
             <dt><dfn><code>codecs</code></dfn> of type <span class=
             "idlMemberType">sequence&lt;<a>RTCRtpCodecParameters</a>&gt;</span></dt>
             <dd>
-              <p>A sequence containing the codecs that an
-              <a><code>RTCRtpSender</code></a> will choose from in order to
-              send media.</p>
+            <p>
+              A sequence containing the codecs (including RTX/RED/FEC) that
+              an <a><code>RTCRtpSender</code></a> will choose from in order
+              to send media. There will be an "rtx" entry in <code>codecs[]</code>
+              for each media codec that can be retransmitted, each with their own
+              <var>sdpFmtpLine</var> attribute (providing an "apt" parameter).
+            </p>
             </dd>
             <dt><dfn><code>degradationPreference</code></dfn> of type
             <span class="idlMemberType"><a>RTCDegradationPreference</a></span>,
@@ -5005,7 +5009,10 @@ sender.setParameters(params)
             <dt><dfn><code>codecs</code></dfn> of type <span class=
             "idlMemberType">sequence&lt;<a>RTCRtpCodecCapability</a>&gt;</span></dt>
             <dd>
-              <p>Supported codecs.</p>
+              <p>
+                Supported codecs (including RTX/RED/FEC). There only will be a
+                single "rtx" entry in <code>codecs[]</code>.
+              </p>
             </dd>
             <dt><dfn><code>headerExtensions</code></dfn> of type <span class=
             "idlMemberType">sequence&lt;<a>RTCRtpHeaderExtensionCapability</a>&gt;</span></dt>

--- a/webrtc.html
+++ b/webrtc.html
@@ -4713,13 +4713,13 @@ sender.setParameters(params)
             "idlMemberType">sequence&lt;<a>RTCRtpCodecParameters</a>&gt;</span></dt>
             <dd>
             <p>
-              A sequence containing the codecs that an <code><a>RTCRtpSender</a></code>
-              will choose from in order to send media, as well RTX, RED and FEC
-              entries. Corresponding to each media codec where retransmission
-              via rtx is enabled, there will be an entry in <code>codecs[]</code>
-              with a <code>mimeType</code> value indicating retransmission via rtx,
-              and an <code>sdpFmtpLine</code> attribute (providing the "apt" and
-              "rtx-time" parameters).
+              A sequence containing the codecs that an
+              <code><a>RTCRtpSender</a></code> will choose from in order to send
+              media, as well RTX, RED and FEC entries. Corresponding to each media
+              codec where retransmission via rtx is enabled, there will be an entry
+              in <code>codecs[]</code> with a <code>mimeType</code> value indicating
+              retransmission via rtx, and an <code>sdpFmtpLine</code> attribute
+              (providing the "apt" and "rtx-time" parameters).
             </p>
             </dd>
             <dt><dfn><code>degradationPreference</code></dfn> of type


### PR DESCRIPTION
Fix for Issue https://github.com/openpeer/ortc/issues/539 (filed against ORTC, but also applies to WebRTC 1.0).

Rebase of PR https://github.com/w3c/webrtc-pc/pull/631

This PR could be invalidated by a future proposal on handling of RTX/RED/FEC - please do not merge until Issue https://github.com/w3c/webrtc-pc/issues/548 is resolved. 