### PR TITLE
transports can be null

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4367,7 +4367,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
       <div>
         <pre class="idl">interface RTCRtpSender {
     readonly        attribute MediaStreamTrack? track;
-    readonly        attribute RTCDtlsTransport  transport;
+    readonly        attribute RTCDtlsTransport?  transport;
     readonly        attribute RTCDtlsTransport? rtcpTransport;
     static RTCRtpCapabilities getCapabilities (DOMString kind);
     Promise&lt;void&gt;             setParameters (optional RTCRtpParameters parameters);
@@ -5064,7 +5064,7 @@ sender.setParameters(params)
       <div>
         <pre class="idl">interface RTCRtpReceiver {
     readonly        attribute MediaStreamTrack  track;
-    readonly        attribute RTCDtlsTransport  transport;
+    readonly        attribute RTCDtlsTransport?  transport;
     readonly        attribute RTCDtlsTransport? rtcpTransport;
     static RTCRtpCapabilities          getCapabilities (DOMString kind);
     RTCRtpParameters                   getParameters ();
@@ -5434,7 +5434,10 @@ sender.setParameters(params)
       SCTP packets sent and received by data channels. In particular, DTLS adds
       security to an underlying transport, and the
       <code>RTCDtlsTransport</code> interface allows access to information
-      about the underlying transport and the security added.</p>
+      about the underlying transport and the security added.
+      <code><a>RTCDtlsTransport</a></code> objects are constructed
+      and destroyed as a result of calls to <code>setLocalDescription()</code>
+      and <code>setRemoteDescription()</code>.</p>
       <div>
         <pre class="idl">interface RTCDtlsTransport {
     readonly        attribute RTCIceTransport       transport;


### PR DESCRIPTION
RTCRtpSender.transport and RTCRtpReceiver.transport can be null since the DTLS transports only come into existence after calls to setLocalDescription() and setRemoteDescription().

Still work-in-progress (do not merge yet).

Related to Issue https://github.com/w3c/webrtc-pc/issues/651