### PR TITLE
transceiver.stop() causes negotiation-needed to be set

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5370,8 +5370,9 @@ sender.setParameters(params)
             <dt><code>stop</code></dt>
             <dd>
               <p>The <dfn><code>stop</code></dfn> method stops the
-              <a><code>RTCRtpTransceiver</code></a>. The sender of this
-              transceiver will no longer send, and the receiver will no longer
+              <a><code>RTCRtpTransceiver</code></a> and sets the
+              negotiation-needed flag. The sender of this transceiver
+              will no longer send, and the receiver will no longer
               receive.</p>
               <div>
                 <em>No parameters.</em>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/674