### PR TITLE
Fix invalid id value that started by an '#'

### DIFF
--- a/archives/20160513/webrtc.html
+++ b/archives/20160513/webrtc.html
@@ -2753,7 +2753,7 @@ interface <span class="idlInterfaceID"><a data-for="" data-link-type="dfn" class
                   </li>
                   <li>
                     <p>Run the steps specified by
-                    <code><a data-link-type="dfn" class="internalDFN" href="#dom-rtcpeerconnection"><code>RTCPeerConnection</code></a></code>'s <a data-link-type="dfn" class="internalDFN" href="##widl-RTCPeerConnection-getStats-Promise-RTCStatsReport--MediaStreamTrack-selector" data-for="RTCPeerConnection">getStats()</a> method with
+                    <code><a data-link-type="dfn" class="internalDFN" href="#dom-rtcpeerconnection"><code>RTCPeerConnection</code></a></code>'s <a data-link-type="dfn" class="internalDFN" href="#widl-RTCPeerConnection-getStats-Promise-RTCStatsReport--MediaStreamTrack-selector" data-for="RTCPeerConnection">getStats()</a> method with
                     <var>selector</var> as the sole argument, and let
                     <var>p</var> be the resulting promise.</p>
                   </li>
@@ -7428,7 +7428,7 @@ interface <span class="idlInterfaceID"><a data-for="" data-link-type="dfn" class
       track to be a valid selector, it <em title="MUST" class="rfc2119">MUST</em> be a <code>MediaStreamTrack</code>
       that is sent or received by the <code><a data-link-type="dfn" class="internalDFN" href="#dom-rtcpeerconnection"><code>RTCPeerConnection</code></a></code>
       object on which the stats request was issued. The calling Web application
-      provides the selector to the <code><a data-link-type="dfn" class="internalDFN" href="##widl-RTCPeerConnection-getStats-Promise-RTCStatsReport--MediaStreamTrack-selector" data-for="RTCPeerConnection">getStats()</a></code> method and the browser emits
+      provides the selector to the <code><a data-link-type="dfn" class="internalDFN" href="#widl-RTCPeerConnection-getStats-Promise-RTCStatsReport--MediaStreamTrack-selector" data-for="RTCPeerConnection">getStats()</a></code> method and the browser emits
       (in the JavaScript) a set of statistics that it believes is relevant to
       the selector.</p>
       <div id="issue-7" class="issue"><div id="h-issue7" role="heading" aria-level="4" class="issue-title marker"><span>Issue 7</span></div><div class="">
@@ -7454,7 +7454,7 @@ interface <span class="idlInterfaceID"><a data-for="" data-link-type="dfn" class
             <dd>
               <p>Gathers stats for the given <a data-link-type="dfn" class="internalDFN" href="#stats-selector">selector</a> and reports the
               result asynchronously.</p>
-              <p>When the <dfn data-dfn-type="dfn" id="#widl-RTCPeerConnection-getStats-Promise-RTCStatsReport--MediaStreamTrack-selector">
+              <p>When the <dfn data-dfn-type="dfn" id="widl-RTCPeerConnection-getStats-Promise-RTCStatsReport--MediaStreamTrack-selector">
               <code>getStats()</code></dfn> method is invoked, the user agent
               <em title="MUST" class="rfc2119">MUST</em> run the following steps:</p>
               <ol>
@@ -7537,7 +7537,7 @@ interface <span class="idlInterfaceID"><a data-for="" data-link-type="dfn" class
     </section>
     <section property="bibo:hasPart" resource="#rtcstatsreport-object" typeof="bibo:Chapter" id="rtcstatsreport-object">
       <h3 resource="#h-rtcstatsreport-object" id="h-rtcstatsreport-object"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.4 </span>RTCStatsReport Object</span></h3>
-      <p>The <code><a data-link-type="dfn" class="internalDFN" href="##widl-RTCPeerConnection-getStats-Promise-RTCStatsReport--MediaStreamTrack-selector" data-for="RTCPeerConnection">getStats()</a></code> method
+      <p>The <code><a data-link-type="dfn" class="internalDFN" href="#widl-RTCPeerConnection-getStats-Promise-RTCStatsReport--MediaStreamTrack-selector" data-for="RTCPeerConnection">getStats()</a></code> method
       delivers a successful result in the form of an
       <code><a data-link-type="dfn" class="internalDFN" href="#idl-def-rtcstatsreport"><code>RTCStatsReport</code></a></code> object. An
       <code><a data-link-type="dfn" class="internalDFN" href="#idl-def-rtcstatsreport"><code>RTCStatsReport</code></a></code> object is a map between strings that

--- a/webrtc.html
+++ b/webrtc.html
@@ -7437,7 +7437,7 @@ interface RTCDTMFToneChangeEvent : Event {
               <p>Gathers stats for the given <a>selector</a> and reports the
               result asynchronously.</p>
               <p>When the <dfn id=
-              "#widl-RTCPeerConnection-getStats-Promise-RTCStatsReport--MediaStreamTrack-selector">
+              "widl-RTCPeerConnection-getStats-Promise-RTCStatsReport--MediaStreamTrack-selector">
               <code>getStats()</code></dfn> method is invoked, the user agent
               MUST run the following steps:</p>
               <ol>


### PR DESCRIPTION
This is to fix this markup issue that prevents automatic publishing (has the markup validation fails).
```
"message": "Bad value “##widl-RTCPeerConnection-getStats-Promise-RTCStatsReport--MediaStreamTrack-selector” for attribute “href” on element “a”: Illegal character in fragment: “#” is not allowed."
```
https://lists.w3.org/Archives/Public/public-tr-notifications/2016May/0089.html