### PR TITLE
update JSEP link for reuse to include subsequent answers

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3860,7 +3860,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   <code>createOffer</code> and <code>createAnswer</code> to
                   mark the corresponding <a>media description</a> as
                   <code>sendrecv</code> or <code>sendonly</code>, as defined in
-                  <span data-jsep="subsequent-offers">[[!JSEP]]</span>.</p>
+                  <span data-jsep="subsequent-offers subsequent-answers">[[!JSEP]]</span>.</p>
                   <p>If any <code><a>RTCRtpSender</a></code> object, in
                   <var>connection</var>'s set of senders matches the following
                   criteria, let <var>sender</var> be that object:</p>


### PR DESCRIPTION
In 5.1 addtrack() step 4, update JSEP reference to also include subsequent answers.

This is a work item for issue #337.
