### PR TITLE
Add RTCRtpCodecRtxParameters dictionary (related to #548)

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4979,7 +4979,7 @@ sender.setParameters(params)
             "idlMemberType"><a>DOMString</a></span></dt>
             <dd>
               <p>The codec MIME type. Valid types are listed in
-              [[IANA-RTP-2]]. RTP retransmission MIME types are not allowed.</p>
+              [[IANA-RTP-2]]. RTP retransmission MIME types, as defined in [[!RFC4588]], are not allowed.</p>
             </dd>
             <dt><dfn><code>clockRate</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long</a></span></dt>
@@ -5018,7 +5018,7 @@ sender.setParameters(params)
             <dt><dfn><code>payloadType</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned short</a></span></dt>
             <dd>
-              <p>The retransmission payload type.</p>
+              <p>The payload type of retransmission packets defined in [[!RFC4588]].</p>
             </dd>
             <dt><dfn><code>rtxTime</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long</a></span></dt>
@@ -5064,7 +5064,7 @@ sender.setParameters(params)
             "idlMemberType"><a>DOMString</a></span></dt>
             <dd>
               <p>The codec MIME type. Valid types are listed in
-              [[IANA-RTP-2]]. RTP retransmission MIME types are not included.</p>
+              [[IANA-RTP-2]]. RTP retransmission MIME types, as defined in [[!RFC4588]], are not included.</p>
             </dd>
           </dl>
         </section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -4721,7 +4721,8 @@ sender.setParameters(params)
             <dd>
               <p>A sequence containing the codecs that an
               <a><code>RTCRtpSender</code></a> will choose from in order to
-              send media.</p>
+              send media. Entries for the RTP retransmission mechanism defined
+              in [[!RFC4588]] are not included.</p>
             </dd>
             <dt><dfn><code>degradationPreference</code></dfn> of type
             <span class="idlMemberType"><a>RTCDegradationPreference</a></span>,
@@ -4979,7 +4980,7 @@ sender.setParameters(params)
             "idlMemberType"><a>DOMString</a></span></dt>
             <dd>
               <p>The codec MIME type. Valid types are listed in
-              [[IANA-RTP-2]]. RTP retransmission MIME types, as defined in [[!RFC4588]], are not allowed.</p>
+              [[IANA-RTP-2]].</p>
             </dd>
             <dt><dfn><code>clockRate</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long</a></span></dt>
@@ -5041,7 +5042,8 @@ sender.setParameters(params)
             <dt><dfn><code>codecs</code></dfn> of type <span class=
             "idlMemberType">sequence&lt;<a>RTCRtpCodecCapability</a>&gt;</span></dt>
             <dd>
-              <p>Supported codecs.</p>
+              <p>Supported codecs. Entries for the RTP retransmission mechanism
+              defined in [[!RFC4588]] are not included.</p>
             </dd>
             <dt><dfn><code>headerExtensions</code></dfn> of type <span class=
             "idlMemberType">sequence&lt;<a>RTCRtpHeaderExtensionCapability</a>&gt;</span></dt>
@@ -5064,7 +5066,7 @@ sender.setParameters(params)
             "idlMemberType"><a>DOMString</a></span></dt>
             <dd>
               <p>The codec MIME type. Valid types are listed in
-              [[IANA-RTP-2]]. RTP retransmission MIME types, as defined in [[!RFC4588]], are not included.</p>
+              [[IANA-RTP-2]].</p>
             </dd>
           </dl>
         </section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -4957,11 +4957,12 @@ sender.setParameters(params)
       </div>
       <div>
         <pre class="idl">dictionary RTCRtpCodecParameters {
-             unsigned short payloadType;
-             DOMString      mimeType;
-             unsigned long  clockRate;
-             unsigned short channels = 1;
-             DOMString      sdpFmtpLine;
+             unsigned short           payloadType;
+             DOMString                mimeType;
+             unsigned long            clockRate;
+             unsigned short           channels = 1;
+             RTCRtpCodecRtxParameters rtx;
+             DOMString                sdpFmtpLine;
 };</pre>
         <section>
           <h2>Dictionary <a class="idlType">RTCRtpCodecParameters</a>
@@ -4978,7 +4979,7 @@ sender.setParameters(params)
             "idlMemberType"><a>DOMString</a></span></dt>
             <dd>
               <p>The codec MIME type. Valid types are listed in
-              [[IANA-RTP-2]].</p>
+              [[IANA-RTP-2]]. RTP retransmission MIME types are not allowed.</p>
             </dd>
             <dt><dfn><code>clockRate</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long</a></span></dt>
@@ -4991,11 +4992,39 @@ sender.setParameters(params)
             <dd>
               <p>The number of channels (mono=1, stereo=2).</p>
             </dd>
+            <dt><dfn><code>rtx</code></dfn> of type <span class=
+            "idlMemberType"><a>RTCRtpCodecRtxParameters</a></span></dt>
+            <dd>
+              <p>Retransmission parameters for the codec.</p>
+            </dd>
             <dt><dfn><code>sdpFmtpLine</code></dfn> of type <span class=
             "idlMemberType"><a>DOMString</a></span></dt>
             <dd>
               <p>The a=fmtp line in the SDP corresponding to the codec, as
               defined by <span data-jsep="parsing-a-desc">[[!JSEP]]</span>.</p>
+            </dd>
+          </dl>
+        </section>
+      </div>
+      <div>
+        <pre class="idl">dictionary RTCRtpCodecRtxParameters {
+             unsigned short payloadType;
+             unsigned long rtxTime;
+};</pre>
+        <section>
+          <h2>Dictionary <a class="idlType">RTCRtpCodecRtxParameters</a> Members</h2>
+          <dl data-link-for="RTCRtpCodecRtxParameters" data-dfn-for=
+          "RTCRtpCodecRtxParameters" class="dictionary-members">
+            <dt><dfn><code>payloadType</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned short</a></span></dt>
+            <dd>
+              <p>The retransmission payload type.</p>
+            </dd>
+            <dt><dfn><code>rtxTime</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned long</a></span></dt>
+            <dd>
+              <p>The maximum time (measured in milliseconds) a sender will keep
+              an original RTP packet in its buffers available for retransmission.</p>
             </dd>
           </dl>
         </section>
@@ -5035,7 +5064,7 @@ sender.setParameters(params)
             "idlMemberType"><a>DOMString</a></span></dt>
             <dd>
               <p>The codec MIME type. Valid types are listed in
-              [[IANA-RTP-2]].</p>
+              [[IANA-RTP-2]]. RTP retransmission MIME types are not included.</p>
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
As discussed in #548, and also in [ORTC](https://github.com/openpeer/ortc/issues/444#issuecomment-203560671), having RTX as a separate codec is of little use and error prune as it implies cross references in the codec list (assuming the needed but undocumented `parameters.apt` existed).

This pull request adds a new `rtx` parameter of type `RTCRtpCodecRtxParameters` to the `RTCRtpCodecParameters` dictionary, and also disallows RTX codecs in both `RTCRtpParameters.codecs` and `RTCRtpCodecCapability`.