### PR TITLE
add JSEP reference detail for RID

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4810,8 +4810,10 @@ sender.setParameters(params)
             <dt><dfn><code>rid</code></dfn> of type <span class=
             "idlMemberType"><a>DOMString</a></span></dt>
             <dd>
-              <p>If set, this RTP encoding will be sent with the RID header
-              extension as defined by [[!JSEP]]. The RID is not modifiable via
+              <p>If set, this RTP encoding will be sent with the RID
+              header extension as defined
+              by <span data-jsep="initial-offers">[[!JSEP]]</span>. The
+              RID is not modifiable via
               <code>setParameters</code>. It can only be set or modified in
               <code>addTransceiver</code> or <code>addTrack</code>.</p>
             </dd>


### PR DESCRIPTION
Add JSEP section number for 'rid' description in RTCRtpEncodingParameters.

This is a work item for issue #337.