### PR TITLE
add jsep references for mid

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5370,10 +5370,8 @@ sender.setParameters(params)
               <p>The <dfn id="dom-rtptransceiver-mid"><code>mid</code></dfn>
               attribute is the <code>mid</code> negotatiated and present in the
               local and remote descriptions as defined in
-              <span>[[!JSEP]]</span>. <!--
-            TODO add data-jsep="initial-offers initial-answers" to the span
-            -->
-               Before negotiation is complete, the <code>mid</code> value may
+              <span data-jsep="initial-offers initial-answers">[[!JSEP]]</span>.
+              Before negotiation is complete, the <code>mid</code> value may
               be null. If there is no MID value in the remote SDP, and no MID
               value was previously assigned, a random value will be created for
               the <code>mid</code> as described in <span data-jsep=


### PR DESCRIPTION
Add detailed JSEP section references in description for the mid attribute in RTCRtpTransceiver.

This is a work item for issue #337.