### PR TITLE
issue 566: replace set of senders/receivers/transceivers with algorithms

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1813,9 +1813,10 @@ interface RTCPeerConnection : EventTarget  {
                     </p>
                   </li>
                   <li>
-                    <p>
+                    <p>Let <var>senders</var> be the result of executing the
+                     <code><a>CollectSenders</a></code> algorithm.
                       For every <code><a>RTCRtpSender</a></code> <var>sender</var> in
-                      <var>connection</var>'s <a>set of senders</a>,
+                      <var>senders</var>,
                       set <code><var>sender.transport.state</var></code> and
                       <code><var>sender.transport.transport.state</var></code> to
                       "closed". If <code><var>sender.rtcpTransport</var></code>
@@ -1825,9 +1826,10 @@ interface RTCPeerConnection : EventTarget  {
                     </p>
                   </li>
                   <li>
-                    <p>
+                    <p>Let <var>receivers</var> be the result of executing
+                      the <code><a>CollectReceivers</a></code> algorithm.
                       For every <code><a>RTCRtpReceiver</a></code> <var>receiver</var> in
-                      <var>connection</var>'s <a>set of receivers</a>,
+                      <var>receivers</var>,
                       set <code><var>receiver.transport.state</var></code> and
                       <code><var>receiver.transport.transport.state</var></code> to
                       "closed". If <code><var>receiver.rtcpTransport</var></code>
@@ -1839,14 +1841,14 @@ interface RTCPeerConnection : EventTarget  {
                   <li>
                     <p>
                       All <code><a>RTCRtpSender</a></code>s in
-                      <var>connection</var>'s <a>set of senders</a> are now
+                      <var>senders</var> are now
                       considered <a>stopped</a>.
                     </p>
                   </li>
                   <li>
                     <p>
                       All <code><a>RTCRtpReceiver</a></code>s in
-                      <var>connection</var>'s <a>set of receivers</a> are now
+                      <var>receivers</var> are now
                       considered <a>stopped</a>.
                     </p>
                   </li>
@@ -3760,14 +3762,10 @@ interface RTCPeerConnectionIceErrorEvent : Event {
     <code><a>RTCRtpReceiver</a></code> objects are created by the
     <code>addTransceiver</code> method.</p>
     <p>A <code><a>RTCPeerConnection</a></code> object contains a <dfn id=
-    "senders-set">set of <code><a>RTCRtpSender</a></code>s</dfn>, representing
-    tracks to be sent, and a <dfn data-lt="set of receivers" id=
-    "receivers-set">set of <code><a>RTCRtpReceiver</a></code>s</dfn>,
-    representing tracks that are to be received on this
-    <code><a>RTCPeerConnection</a></code> object, and a <dfn id=
-    "transceivers-set">set of <code><a>RTCRtpTransceiver</a></code>s</dfn>,
-    representing the paired senders and receiver with some shared state. All of
-    these sets are initialized to empty sets when the
+    "transceivers-set" data-lt="set of transceivers">set of
+    <code><a>RTCRtpTransceiver</a></code>s</dfn>,
+    representing the paired senders and receivers with some shared state.
+    This set is initialized to the empty set when the
     <code><a>RTCPeerConnection</a></code> object is created.</p>
     <section>
       <h3>RTCPeerConnection Interface Extensions</h3>
@@ -3806,12 +3804,29 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <code><a>RTCPeerConnection</a></code> object.</p>
               <p>The <dfn id=
               "dom-peerconnection-getsenders"><code>getSenders</code></dfn>
-              method MUST return a new sequence that represents a snapshot of
-              all the <code><a>RTCRtpSender</a></code> objects in this
-              <code><a>RTCPeerConnection</a></code> object's <a>set of
-              senders</a>. The conversion from the senders set to the sequence,
-              to be returned, is user agent defined and the order does not have
-              to be stable between calls.</p>
+              method MUST return the result of executing the
+              <code><a>CollectSenders</a></code> algorithm.<p>
+              <p>We define the <dfn>CollectSenders</dfn> algorithm as follows:
+              <ol>
+                <li>Let <var>transceivers</var> be the result of executing
+                the <code><a>CollectTransceivers</a></code> algorithm.</li>
+                <li>Let <var>senderset</var> be a new empty set.</li>
+                <li>For each <var>transceiver</var> in <var>transceivers</var>,
+                  <ol>
+                    <li>Let <var>sender</var> be
+                      <var>transceiver</var>.sender.</li>
+                    <li>Add <var>sender</var> to <var>senderset</var>.</li>
+                  </ol>
+                </li>
+                <li>Let <var>senders</var> be a new sequence consisting of
+              all the <code><a>RTCRtpSender</a></code> objects in 
+              <var>senderset</var>.
+              The conversion from the senders set to the sequence
+              is user agent defined and the order does not have
+              to be stable between calls.
+                <li>Return <var>senders</var>.
+              </ol>
+              </p>
               <div>
                 <em>No parameters.</em>
               </div>
@@ -3827,12 +3842,29 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               object.</p>
               <p>The <dfn id=
               "dom-peerconnection-getreceivers"><code>getReceivers</code></dfn>
-              method MUST return a new sequence that represents a snapshot of
-              all the <code><a>RTCRtpReceiver</a></code> objects in this
-              <code><a>RTCPeerConnection</a></code> object's <a>set of
-              receivers</a>. The conversion from the receivers set to the
-              sequence, to be returned, is user agent defined and the order
-              does not have to be stable between calls.</p>
+              method MUST return the result of executing
+              the <code><a>CollectReceivers</a></code> algorithm.<p>
+              <p>We define the <dfn>CollectReceivers</dfn> algorithm as follows:
+              <ol>
+                <li>Let <var>transceivers</var> be the result of executing
+                the <code><a>CollectTransceivers</a></code> algorithm.</li>
+                <li>Let <var>receiverset</var> be a new empty set.</li>
+                <li>For each <var>transceiver</var> in <var>transceivers</var>,
+                  <ol>
+                    <li>Let <var>receiver</var> be
+                      <var>transceiver</var>.receiver.</li>
+                    <li>Add <var>receiver</var> to <var>receiverset</var>.</li>
+                  </ol>
+                </li>
+                <li>Let <var>receivers</var> be a new sequence consisting of
+              all the <code><a>RTCRtpReceiver</a></code> objects in 
+              <var>receiverset</var>.
+              The conversion from the receivers set to the sequence
+              is user agent defined and the order does not have
+              to be stable between calls.
+                <li>Return <var>receivers</var>.
+              </ol>
+              </p>
               <div>
                 <em>No parameters.</em>
               </div>
@@ -3849,12 +3881,20 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               object.</p>
               <p>The <dfn id=
               "dom-peerconnection-gettranseceivers"><code>getTransceivers</code></dfn>
-              method MUST return a new sequence that represents a snapshot of
+              method MUST return the result of executing the
+              <code><a>CollectTransceivers</a></code> algorithm.<p>
+              <p>We define the <dfn>CollectTransceivers</dfn> algorithm as
+              follows:</p>
+              <ol>
+                <li>Let <var>transceivers</var> be a new sequence that
+                represents a snapshot of
               all the <code><a>RTCRtpTransceiver</a></code> objects in this
               <code><a>RTCPeerConnection</a></code> object's <a>set of
               transceivers</a>. The conversion from the transceiver set to the
-              sequence, to be returned, is user agent defined and the order
-              does not have to be stable between calls.</p>
+              sequence is user agent defined and the order
+              does not have to be stable between calls.</li>
+                <li>Return <var>transceivers</var>.</li>
+              </ol>
               <div>
                 <em>No parameters.</em>
               </div>
@@ -3893,9 +3933,11 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   exception and abort these steps.</p>
                 </li>
                 <li>
-                  <p>If an <code><a>RTCRtpSender</a></code> for
-                  <var>track</var> already exists in <var>connection</var>'s
-                  <a>set of senders</a>, throw an
+                  <p>Let <var>senders</var> be the result of executing the
+                    <code><a>CollectSenders</a></code> algorithm.
+                    If an <code><a>RTCRtpSender</a></code> for
+                  <var>track</var> already exists in <var>senders</var>,
+                  throw an
                   <code>InvalidAccessError</code> exception and abort these
                   steps.</p>
                 </li>
@@ -3907,8 +3949,8 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   <code>sendrecv</code> or <code>sendonly</code>
                   and add the MSID of the track added, as defined in
                   <span data-jsep="subsequent-offers subsequent-answers">[[!JSEP]]</span>.</p>
-                  <p>If any <code><a>RTCRtpSender</a></code> object, in
-                  <var>connection</var>'s set of senders matches all the
+                  <p>If any <code><a>RTCRtpSender</a></code> object in
+                  <var>senders</var> matches all the
                   following criteria, let <var>sender</var> be that object, or
                   <code>null</code> otherwise:</p>
                   <ul>
@@ -4059,8 +4101,10 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   exception and abort these steps.</p>
                 </li>
                 <li>
-                  <p>If <var>sender</var> is <a>stopped</a> or not in
-                  <var>connection</var>'s <a>set of senders</a>, then abort
+                  <p>Let <var>senders</var> be the result of executing the
+                    <code><a>CollectSenders</a></code> algorithm.
+                    If <var>sender</var> is <a>stopped</a> or not in
+                  <var>senders</var>, then abort
                   these steps.</p>
                 </li>
                 <li>
@@ -4097,9 +4141,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             <dt><dfn><code>addTransceiver</code></dfn></dt>
             <dd>
               <p>Create a new <code><a>RTCRtpTransceiver</a></code> and add it
-              to the collection of transceivers that will be returned by
-              <code><a data-for=
-              "RTCPeerConnection">getTransceivers</a></code>.</p>
+              to the <a>set of transceivers</a>.</p>
               <p>Adding a transceiver will cause future calls to
               <code>createOffer</code> to add a <a>media description</a> for
               the corresponding transceiver, as defined in <span data-jsep=
@@ -4380,7 +4422,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           <li>
             <p>Create a new <code><a>RTCRtpReceiver</a></code> object
             <var>receiver</var> for <var>track</var>, and add it to
-            <var>connection</var>'s <a>set of receivers</a>.</p>
+            <var>connection</var>'s set of receivers.</p>
           </li>
           <li>
             <p>Fire an event named <code title=
@@ -4419,8 +4461,8 @@ interface RTCPeerConnectionIceErrorEvent : Event {
            task ran -->
               <li>
                 <p>Remove the <code><a>RTCRtpReceiver</a></code> associated
-                with <var>track</var> from <var>connection</var>'s <a>set of
-                receivers</a>.</p>
+                with <var>track</var> from <var>connection</var>'s set of
+                receivers.</p>
               </li>
             </ol>
           </li>
@@ -9845,7 +9887,7 @@ if (sender.dtmf) {
           <td>
             A new incoming <code>MediaStreamTrack</code> has been created, and
             an associated <code>RTCRtpReceiver</code> has been added to the
-            <a>set of receivers</a>.
+            set of receivers.
           </td>
         </tr>
         <tr>

--- a/webrtc.html
+++ b/webrtc.html
@@ -3806,7 +3806,8 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               "dom-peerconnection-getsenders"><code>getSenders</code></dfn>
               method MUST return the result of executing the
               <code><a>CollectSenders</a></code> algorithm.<p>
-              <p>We define the <dfn>CollectSenders</dfn> algorithm as follows:
+              <p>We define the <dfn>CollectSenders</dfn> algorithm as
+              follows:</p>
               <ol>
                 <li>Let <var>transceivers</var> be the result of executing
                 the <code><a>CollectTransceivers</a></code> algorithm.</li>
@@ -3826,7 +3827,6 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               to be stable between calls.
                 <li>Return <var>senders</var>.
               </ol>
-              </p>
               <div>
                 <em>No parameters.</em>
               </div>
@@ -3844,7 +3844,8 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               "dom-peerconnection-getreceivers"><code>getReceivers</code></dfn>
               method MUST return the result of executing
               the <code><a>CollectReceivers</a></code> algorithm.<p>
-              <p>We define the <dfn>CollectReceivers</dfn> algorithm as follows:
+              <p>We define the <dfn>CollectReceivers</dfn> algorithm as
+              follows:</p>
               <ol>
                 <li>Let <var>transceivers</var> be the result of executing
                 the <code><a>CollectTransceivers</a></code> algorithm.</li>
@@ -3864,7 +3865,6 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               to be stable between calls.
                 <li>Return <var>receivers</var>.
               </ol>
-              </p>
               <div>
                 <em>No parameters.</em>
               </div>


### PR DESCRIPTION
I have (mostly) replaced "set of senders" and "set of receivers" with new algorithms based on the set of transceivers (issue #566), but I'm not clear on how to get access to the appropriate transceiver in addTrack, so it and the related track event have not been updated.  Interestingly, in 'dispatch a receiver' in 5.1.1, step 7, a transceiver variable is already being used but was never defined.  Clearly the magic happens in step 6, but again, not clear how to find the correct transceiver on which the new receiver should appear (unless I just defer to JSEP).

So we can apply this PR and then clean up the three remaining uses of "set of receivers" in a new PR, or someone can modify my PR.  Thoughts?