### PR TITLE
Reference to RTCRtpReceiver.stop()

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5422,7 +5422,7 @@ sender.setParameters(params)
             	<code><a>RTCRtpReceiver</a></code> object. Note that
             	<code>track.stop()</code> is final, although clones
             	are not affected. Since <code>track.stop()</code> does
-            	not implicitly call <code>RTCRtpReceiver.stop()</code>, 
+            	not implicitly call <code>RTCRtpTransceiver.stop()</code>, 
             	Receiver Reports continue to be sent.
             </p>
             </dd>

--- a/webrtc.html
+++ b/webrtc.html
@@ -5421,8 +5421,8 @@ sender.setParameters(params)
             	attribute is the track that is associated with this
             	<code><a>RTCRtpReceiver</a></code> object. Note that
             	<code>track.stop()</code> is final, although clones
-            	are not affected. Since <code>track.stop()</code> does
-            	not implicitly call <code>RTCRtpTransceiver.stop()</code>, 
+            	are not affected. Since <code>receiver.track.stop()</code> does
+            	not implicitly stop <var>receiver</var>, 
             	Receiver Reports continue to be sent.
             </p>
             </dd>


### PR DESCRIPTION
There is no RTCRtpReceiver.stop() method, only RTCRtpTransceiver.stop().  So this looks like a typo