### PR TITLE
Integrate queueing into the setLocal/RemoteDescription steps

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -689,13 +689,9 @@
         </ol>
         <p>To <dfn id="set-description" data-lt="set the RTCSessionDescription">set an RTCSessionDescription</dfn>
         <var>description</var> on an <code><a>RTCPeerConnection</a></code>
-        object <var>connection</var>, run the following steps:</p>
+        object <var>connection</var>, <a href=
+        "#enqueue-an-operation">enqueue</a> the following steps:</p>
         <ol>
-          <li>
-            <p>If <var>connection</var>'s [[<a>isClosed</a>]] slot is
-            <code>true</code>, the user agent MUST return a promise rejected
-            with an <code>InvalidStateError</code>.</p>
-          </li>
           <li>
             <p>Let <var>p</var> be a new promise.</p>
           </li>
@@ -1395,7 +1391,8 @@ interface RTCPeerConnection : EventTarget  {
                 which point the <code><a>RTCPeerConnection</a></code> can fully
                 adopt the pending local description, or rollback to the current
                 description if the remote side rejected the change.</p>
-                <p>When the method is invoked, the user agent must <a>set the
+                <p>When the method is invoked, the User Agent MUST return the
+                result of <a href="#set-description">setting the
                 RTCSessionDescription</a> indicated by the method's first
                 argument.</p>
                 <p><span data-jsep="configurable-sdp-paramete">[[!JSEP]]</span>
@@ -1435,9 +1432,11 @@ interface RTCPeerConnection : EventTarget  {
                 apply the supplied
                 <code><a>RTCSessionDescriptionInit</a></code> as the remote
                 offer or answer. This API changes the local media state.</p>
-                <p>When the method is invoked, the user agent must <a>set the
+                <p>When the method is invoked, the User Agent MUST return the
+                result of <a href="#set-description">setting the
                 RTCSessionDescription</a> indicated by the method's first
-                argument. In addition, a remote description is processed to
+                argument.</p>
+                <p>In addition, a remote description is processed to
                 determine and verify the identity of the peer.</p>
                 <p>If an <code>a=identity</code> attribute is present in the
                 session description, the browser <a href=


### PR DESCRIPTION
Fixes issue #755 
Related to issue #600 

This change suggests that the entire 'set an RTCSessionDescription' algorithm should be enqueued instead of adding the queueing step to the algorithm and indenting all the steps.