### PR TITLE
Adding more detail to the definition of the ICE `disconnected` state.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6432,14 +6432,22 @@ sender.setParameters(params)
             </tr>
             <tr>
               <td><dfn><code>disconnected</code></dfn></td>
-              <td>Liveness checks have failed. This is more aggressive than
-              <code>failed</code>, and may trigger intermittently (and resolve
-              itself without action) on a flaky network. Alternatively, the
-              <code><a>RTCIceTransport</a></code> has finished checking all
-              existing candidates pairs and failed to find a connection (or
-              consent checks [[!RFC7675]] once successful, have now failed),
-              but is still gathering and/or waiting for additional remote
-              candidates.</td>
+              <td>The ICE agent has determined that connectivity is currently
+              lost for this <code><a> RTCIceTransport</a></code>. This is more
+              aggressive than <code>failed</code>, and may trigger
+              intermittently (and resolve itself without action) on a flaky
+              network. The way this state is determined is implementation
+              dependent. Examples include:
+              <ul>
+                <li>Losing the network interface for the connection in use.</li>
+                <li>Repeatedly failing to receive a response to STUN
+                requests.</li>
+              </ul>
+              Alternatively, the <code><a>RTCIceTransport</a></code> has
+              finished checking all existing candidates pairs and failed to find
+              a connection (or consent checks [[!RFC7675]] once successful, have
+              now failed), but it is still gathering and/or waiting for
+              additional remote candidates.</td>
             </tr>
             <tr>
               <td><dfn><code>closed</code></dfn></td>


### PR DESCRIPTION
This addresses issue #692, and follows the decision reached at the Aug
23 virtual iterim. It replaces "liveness checks have failed" with "the
ICE agent has determined that connectivity is currently lost". The way
this is determined is left implementation dependent; a couple examples
are provided.