### PR TITLE
Fix WebIDL of RTCDTMFSender

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7545,8 +7545,8 @@ interface RTCDataChannelEvent : Event {
     <section>
       <h4>RTCDTMFSender</h4>
       <div>
-        <pre class="idl">[NoInterfaceObject]
-interface RTCDTMFSender {
+        <pre class="idl">
+interface RTCDTMFSender : EventTarget {
     void insertDTMF (DOMString tones, optional unsigned long duration = 100, optional unsigned long interToneGap = 70);
                     attribute EventHandler ontonechange;
     readonly        attribute DOMString    toneBuffer;


### PR DESCRIPTION
Remove unnecessary NoInterfaceObject extended attribute - close #766
Inherit from EventTarget - close #767