### PR TITLE
facingMode et al are non-nullable and cannot "return null".

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9371,14 +9371,14 @@ interface RTCIdentityAssertion {
         <code>MediaTrackSettings</code> is outlined in
         [[!GETUSERMEDIA]]. However, the <code>MediaTrackSettings</code>
         for a <code>MediaStreamTrack</code> sourced by a
-        <code><a>RTCPeerConnection</a></code> will only be populated to the
-        extent that data is supplied by means of the remote
+        <code><a>RTCPeerConnection</a></code> will only be populated with
+        members to the extent that data is supplied by means of the remote
         <code><a>RTCSessionDescription</a></code> applied via
         <code>setRemoteDescription</code> and the actual RTP data. This means
-        that certain settings, such as <code>facingMode</code>,
+        that certain members, such as <code>facingMode</code>,
         <code>echoCancellation</code> , <code>latency</code>,
         <code>deviceId</code> and <code>groupId</code>, will
-        always return null.</p>
+        always be missing.</p>
       </section>
     </section>
     <section>


### PR DESCRIPTION
Fix for language discovered in https://github.com/w3c/webrtc-pc/issues/305#issuecomment-247762455.