### PR TITLE
Remove clearing negotiation-needed flag when firing corresponding event

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -960,8 +960,7 @@
                     <code>stable</code>, and the negotiation-needed flag is
                     set, the User Agent MUST queue a task to fire a simple
                     event named <code><a>negotiationneeded</a></code> at
-                    <var>connection</var> and clear the negotiation-needed
-                    flag.</p>
+                    <var>connection</var>.</p>
                   </li>
                   <li>
                     <p>Resolve <var>p</var> with <var>undefined</var>.</p>


### PR DESCRIPTION
Proposed fix for #579