### PR TITLE
When a DTMFToneChangeEvent is fired with an empty string

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8041,7 +8041,7 @@ interface RTCDTMFToneChangeEvent : Event {
               <p>The <dfn><code>tone</code></dfn> attribute contains the
               character for the tone that has just begun playout (see
               <code><a>insertDTMF</a></code> ). If the value is the empty
-              string, it indicates that the previous tone has completed
+              string, it indicates that the previous tones have completed
               playback.</p>
             </dd>
           </dl>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/799