### PR TITLE
Remove reference to IANA registry for Statistics

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8289,10 +8289,6 @@ interface RTCDTMFToneChangeEvent : Event {
       may be using experimental values or values not yet known to the Web
       application. Thus, applications MUST be prepared to deal with unknown
       stats.</p>
-      <div class="issue">
-        Need to define an IANA registry for this and populate with pointers to
-        existing things such as the RTCP statistics.
-      </div>
       <p>Statistics need to be synchronized with each other in order to yield
       reasonable values in computation; for instance, if "bytesSent" and
       "packetsSent" are both reported, they both need to be reported over the


### PR DESCRIPTION
Remove reference to IANA registry for Stats.

Fix for Issue https://github.com/w3c/webrtc-pc/issues/839