### PR TITLE
Throw InvalidAccessError if removeTrack is called with invalid sender

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4350,9 +4350,17 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <li>
                   <p>Let <var>senders</var> be the result of executing the
                     <code><a>CollectSenders</a></code> algorithm.
-                    If <var>sender</var> is <a>stopped</a> or not in
-                  <var>senders</var>, then abort
-                  these steps.</p>
+                </li>
+                <li>
+                  <p>If <var>sender</var> is not in <var>senders</var> (which
+                  indicates that it was created by a different
+                  <code><a>RTCPeerConnection</a></code> object), throw an
+                  <code>InvalidAccessError</code> exception and abort these
+                  steps.</p>
+                </li>
+                <li>
+                  If <var>sender</var> is <a>stopped</a>, then abort these
+                  steps.</p>
                 </li>
                 <li>
                   <p><a>Stop</a> <var>sender</var>.</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -4359,7 +4359,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   steps.</p>
                 </li>
                 <li>
-                  If <var>sender</var> is <a>stopped</a>, then abort these
+                  <p>If <var>sender</var> is <a>stopped</a>, then abort these
                   steps.</p>
                 </li>
                 <li>


### PR DESCRIPTION
Fixes issue #727. "invalid sender" refers to one that was created by
another RTCPeerConnection. The working group agreed to this at TPAC
2016.