### PR TITLE
Fix RTCDTMFSender attribute types in prose to match WebIDL.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7856,7 +7856,7 @@ interface RTCDTMFSender : EventTarget {
               see <code><a>insertDTMF</a></code>.</p>
             </dd>
             <dt><code>duration</code> of type <span class=
-            "idlAttrType"><a>long</a></span>, readonly</dt>
+            "idlAttrType"><a>unsigned long</a></span>, readonly</dt>
             <dd>
               <p>The <dfn id=
               "dom-RTCDTMFSender-duration"><code>duration</code></dfn>
@@ -7867,7 +7867,7 @@ interface RTCDTMFSender : EventTarget {
               duration.</p>
             </dd>
             <dt><code>interToneGap</code> of type <span class=
-            "idlAttrType"><a>long</a></span>, readonly</dt>
+            "idlAttrType"><a>unsigned long</a></span>, readonly</dt>
             <dd>
               <p>The <dfn id=
               "dom-RTCDTMFSender-intertonegap"><code>interToneGap</code></dfn>


### PR DESCRIPTION
The WebIDL says unsigned long, which matches insertDTMF inputs. Prose says long.

Fix prose to say unsigned long.