### PR TITLE
Unclear when a DTMFToneChangeEvent is fired with an empty string

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8085,8 +8085,9 @@ interface RTCDTMFToneChangeEvent : Event {
               <p>The <dfn><code>tone</code></dfn> attribute contains the
               character for the tone that has just begun playout (see
               <code><a>insertDTMF</a></code> ). If the value is the empty
-              string, it indicates that the previous tones have completed
-              playback.</p>
+              string, it indicates that the <code><a data-for=
+              "RTCDTMFSender">toneBuffer</a></code> is an empty string and 
+              that the previous tones have completed playback.</p>
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
Another fix for Issue https://github.com/w3c/webrtc-pc/issues/799