### PR TITLE
Clarify when removeTrack should throw an exception.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4347,15 +4347,20 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   exception and abort these steps.</p>
                 </li>
                 <li>
+		  <p>If <var>sender</var> was not created by <var>connection
+                  </var>, throw an <code>InvalidAccessError</code> exception
+                  and abort these steps.</p>
+                </li>
+                <li>
                   <p>Let <var>senders</var> be the result of executing the
-                    <code><a>CollectSenders</a></code> algorithm.
+                  <code><a>CollectSenders</a></code> algorithm.
                 </li>
                 <li>
                   <p>If <var>sender</var> is not in <var>senders</var> (which
-                  indicates that it was created by a different
-                  <code><a>RTCPeerConnection</a></code> object), throw an
-                  <code>InvalidAccessError</code> exception and abort these
-                  steps.</p>
+                  indicates that it was removed due to <a href=
+                  "#set-description"> setting an RTCSessionDescription</a> of
+                  type "rollback"), then abort these steps.
+                  </p>
                 </li>
                 <li>
                   <p>If <var>sender</var> is <a>stopped</a>, then abort these


### PR DESCRIPTION
In PR #844, the intent was to throw an exception when the sender wasn't created
by the connection on which the method was called. And the assumption was that
senders are never removed, so the algorithm can simply check if it's in the
connection's set of senders.

But something I didn't consider is that rollbacks are able to remove
transceivers (and thus senders). So more clarity is needed.