### PR TITLE
transceiver.stop() effect on transceiver.receiver.track "onended" event

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6042,8 +6042,8 @@ sender.setParameters(params)
               <p>The <dfn><code>stop</code></dfn> method stops the
               <a><code>RTCRtpTransceiver</code></a>. The sender of this
               transceiver will no longer send, the receiver will no longer
-              receive, <code>receiver.track</code>'s "onended" event will
-              fire, and the connection is marked as needing negotiation.</p>
+              receive, and the connection is marked as needing negotiation.
+              <code>receiver.track</code>'s "onended" event will not fire.</p>
               <div>
                 <em>No parameters.</em>
               </div>

--- a/webrtc.html
+++ b/webrtc.html
@@ -6043,7 +6043,7 @@ sender.setParameters(params)
               <a><code>RTCRtpTransceiver</code></a>. The sender of this
               transceiver will no longer send, the receiver will no longer
               receive, <code>receiver.track</code>'s "onended" event will
-              fire, and the <a>negotiation-needed flag</a> is set.</p>
+              fire, and the connection is marked as negotiation-needed.</p>
               <div>
                 <em>No parameters.</em>
               </div>

--- a/webrtc.html
+++ b/webrtc.html
@@ -6042,7 +6042,8 @@ sender.setParameters(params)
               <p>The <dfn><code>stop</code></dfn> method stops the
               <a><code>RTCRtpTransceiver</code></a>. The sender of this
               transceiver will no longer send, the receiver will no longer
-              receive, and the <a>negotiation-needed flag</a> is set.</p>
+              receive, <code>receiver.track</code>'s "onended" event will
+              fire, and the <a>negotiation-needed flag</a> is set.</p>
               <div>
                 <em>No parameters.</em>
               </div>

--- a/webrtc.html
+++ b/webrtc.html
@@ -6043,7 +6043,7 @@ sender.setParameters(params)
               <a><code>RTCRtpTransceiver</code></a>. The sender of this
               transceiver will no longer send, the receiver will no longer
               receive, <code>receiver.track</code>'s "onended" event will
-              fire, and the connection is marked as negotiation-needed.</p>
+              fire, and the connection is marked as needing negotiation.</p>
               <div>
                 <em>No parameters.</em>
               </div>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/841