### PR TITLE
Fix JSEP reference about generating a mid if not provided by remote peer

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5955,7 +5955,7 @@ sender.setParameters(params)
               be null. If there is no MID value in the remote SDP, and no MID
               value was previously assigned, a random value will be created for
               the <code>mid</code> as described in <span data-jsep=
-              "ice-candidate-format">[[!JSEP]]</span> when the remote SDP is
+              "applying-a-remote-desc">[[!JSEP]]</span> when the remote SDP is
               set. After rollbacks, the value may change from a non-null value
               to null.</p>
             </dd>


### PR DESCRIPTION
Fix #698