### PR TITLE
Rewrite the createOffer algorithm to eliminate race conditions (restructured).

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1316,6 +1316,11 @@ interface RTCPeerConnection : EventTarget  {
                     method was invoked.</p>
                   </li>
                   <li>
+                    <p>If <var>connection</var>'s [[<a>isClosed</a>]] slot is
+                    <code>true</code>, throw an <code>InvalidStateError</code>
+                    exception and abort these steps.</p>
+                  </li>
+                  <li>
                     <p>If <var>connection</var> is configured with an
                     identity provider, and an identity assertion has not
                     yet been generated using said identity provider, then

--- a/webrtc.html
+++ b/webrtc.html
@@ -970,6 +970,83 @@
             <p>Return <var>p</var>.</p>
           </li>
         </ol>
+        <p>The <dfn>steps to create an offer</dfn> given a promise
+        <var>p</var> are as follows:</p>
+        <ol>
+          <li>
+            <p>If the need for an identity assertion was identified when
+            <code>createOffer</code> was invoked, wait for <a href=
+            "#sec.identity-proxy-assertion-request">the identity assertion
+            request process</a> to complete.</p>
+          </li>
+          <li>
+            <p>If the identity provider was unable to produce an identity
+            assertion, reject <var>p</var> with a
+            <code>DOMException</code> object whose <code>name</code>
+            attribute has the value <code>NotReadableError</code>, and
+            abort these steps.</p>
+          </li>
+          <li>
+            <p>If <var>connection</var> was not constructed with a set of
+            certificates, and one has not yet been generated, wait for it
+            to be generated.</p>
+          </li>
+          <li>
+            <p>Inspect the system state to determine the currently
+            available resources as necessary for generating the offer, as
+            described in <span data-jsep="createoffer">[[!JSEP]]</span>.
+            </p>
+          </li>
+          <li>
+            <p>If this inspection failed for any reason, reject
+            <var>p</var> with a <code>DOMException</code> object whose
+            <code>name</code> attribute has the value
+            <code>OperationError</code>, and abort these steps.</p>
+          </li>
+          <li>
+            <p>Queue a task that runs the <a>final steps to create an
+            offer</a>, given <var>p</var>.</p>
+          </li>
+        </ol>
+        <p>The <dfn>final steps to create an offer</dfn> given a promise
+        <var>p</var> are as follows:</p>
+        <ol>
+          <li>
+            <p>If <var>connection</var>'s [[<a>isClosed</a>]] slot is
+            <code>true</code>, then abort these steps.</p>
+          </li>
+          <li>
+            <p>If <var>connection</var> was modified in such a way that
+            additional inspection of the system state is necessary, then
+            in parallel begin the <a>
+            steps to create an offer</a> again, given <var>p</var>, and
+            abort these steps.</p>
+
+            <div class="note">This may be necessary if, for example,
+            <code>createOffer</code> was called when only an audio
+            <code><a>RTCRtpTransceiver</a></code> was added to
+            <var>connection</var>, but while performing the <a>steps to
+            create an offer</a> in parallel, a video
+            <code><a>RTCRtpTransceiver</a></code> was added, requiring
+            additional inspection of video system resources.</div>
+          </li>
+          <li>
+            <p>Given the information that was obtained from previous
+            inspection, generate an SDP offer, <var>sdpString</var>, as
+            described in <span data-jsep="create-offer">[[!JSEP]]</span>.
+            </p>
+          </li>
+          <li>
+            <p>Let <var>offer</var> be a newly created
+            <code><a>RTCSessionDescriptionInit</a></code> dictionary with
+            its <code>type</code> member initialized to the string
+            <code>"offer"</code> and its <code>sdp</code> member
+            initialized to <var>sdpString</var>.</p>
+          </li>
+          <li>
+            <p>Resolve <var>p</var> with <var>offer</var>.</p>
+          </li>
+        </ol>
         <p>The task source for the tasks listed in this section is the
         <a>networking task source</a>.</p>
       </section>
@@ -1333,93 +1410,8 @@ interface RTCPeerConnection : EventTarget  {
                         <p>Let <var>p</var> be a new promise.</p>
                       </li>
                       <li>
-                        <p>In parallel, perform the following steps:</p>
-                        <ol>
-                          <li>
-                            <p>If the need for an identity assertion was
-                            identified when <code>createOffer</code> was
-                            invoked, wait for <a href=
-                            "#sec.identity-proxy-assertion-request">the
-                            identity assertion request process</a> to
-                            complete.
-                          </li>
-                          <li>
-                            <p>If the identity provider was unable to produce
-                            an identity assertion, reject <var>p</var> with a
-                            <code>DOMException</code> object whose
-                            <code>name</code> attribute has the value
-                            <code>NotReadableError</code>, and abort these
-                            steps.</p>
-                          </li>
-                          <li>
-                            <p>If <var>connection</var> was not
-                            constructed with a set of certificates, and
-                            one has not yet been generated, wait for it to
-                            be generated.</p>
-                          </li>
-                          <li>
-                            <p>Inspect the system state to determine the
-                            currently available resources as necessary for
-                            generating the offer, as described in
-                            <span data-jsep=
-                            "createoffer">[[!JSEP]]</span>.</p>
-                          </li>
-                          <li>
-                            <p>If this inspection failed for any reason,
-                            reject <var>p</var> with a
-                            <code>DOMException</code> object whose
-                            <code>name</code> attribute has the value
-                            <code>OperationError</code>, and abort these
-                            steps.</p>
-                          </li>
-                          <li>
-                            <p>Queue a task that runs the following
-                            steps:</p>
-                            <ol>
-                              <li>
-                                <p>If <var>connection</var>'s [[<a>isClosed</a>]]
-                                slot is <code>true</code>, then abort these
-                                steps.</p>
-                              </li>
-                              <li>
-                                <p>If <var>connection</var> mas modified
-                                in such a way that additional inspection
-                                of the system state is necessary, then
-                                return to the parallel steps above, and
-                                abort these steps.</p>
-
-                                <p>This may be necessary if, for example,
-                                <code>createOffer</code> was called when
-                                only an audio
-                                <code><a>RTCRtpTransceiver</a></code> was
-                                added to <var>connection</var>, but while
-                                performing the above parallel steps, a
-                                video
-                                <code><a>RTCRtpTransceiver</a></code> was
-                                added, requiring additional inspection of
-                                video system resources.</p>
-                              </li>
-                              <li>
-                                <p>Generate an SDP offer,
-                                <var>sdpString</var>, as described in
-                                <span data-jsep=
-                                "create-offer">[[!JSEP]]</span>.</p>
-                              </li>
-                              <li>
-                                <p>Let <var>offer</var> be a newly created
-                                <code><a>RTCSessionDescriptionInit</a></code>
-                                dictionary with its <code>type</code> member
-                                initialized to the string <code>"offer"</code>
-                                and its <code>sdp</code> member initialized to
-                                <var>sdpString</var>.</p>
-                              </li>
-                              <li>
-                                <p>Resolve <var>p</var> with
-                                <var>offer</var>.</p>
-                              </li>
-                            </ol>
-                          </li>
-                        </ol>
+                        <p>In parallel, begin the <a>steps to create an
+                        offer</a>, given <var>p</var>.</p>
                       </li>
                       <li>
                         <p>Return <var>p</var>.</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1317,8 +1317,8 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>If <var>connection</var>'s [[<a>isClosed</a>]] slot is
-                    <code>true</code>, throw an <code>InvalidStateError</code>
-                    exception and abort these steps.</p>
+                    <code>true</code>, return a promise rejected with an
+                    <code>InvalidStateError</code>.</p>
                   </li>
                   <li>
                     <p>If <var>connection</var> is configured with an

--- a/webrtc.html
+++ b/webrtc.html
@@ -970,83 +970,6 @@
             <p>Return <var>p</var>.</p>
           </li>
         </ol>
-        <p>The <dfn>steps to create an offer</dfn> given a promise
-        <var>p</var> are as follows:</p>
-        <ol>
-          <li>
-            <p>If the need for an identity assertion was identified when
-            <code>createOffer</code> was invoked, wait for <a href=
-            "#sec.identity-proxy-assertion-request">the identity assertion
-            request process</a> to complete.</p>
-          </li>
-          <li>
-            <p>If the identity provider was unable to produce an identity
-            assertion, reject <var>p</var> with a
-            <code>DOMException</code> object whose <code>name</code>
-            attribute has the value <code>NotReadableError</code>, and
-            abort these steps.</p>
-          </li>
-          <li>
-            <p>If <var>connection</var> was not constructed with a set of
-            certificates, and one has not yet been generated, wait for it
-            to be generated.</p>
-          </li>
-          <li>
-            <p>Inspect the system state to determine the currently
-            available resources as necessary for generating the offer, as
-            described in <span data-jsep="createoffer">[[!JSEP]]</span>.
-            </p>
-          </li>
-          <li>
-            <p>If this inspection failed for any reason, reject
-            <var>p</var> with a <code>DOMException</code> object whose
-            <code>name</code> attribute has the value
-            <code>OperationError</code>, and abort these steps.</p>
-          </li>
-          <li>
-            <p>Queue a task that runs the <a>final steps to create an
-            offer</a>, given <var>p</var>.</p>
-          </li>
-        </ol>
-        <p>The <dfn>final steps to create an offer</dfn> given a promise
-        <var>p</var> are as follows:</p>
-        <ol>
-          <li>
-            <p>If <var>connection</var>'s [[<a>isClosed</a>]] slot is
-            <code>true</code>, then abort these steps.</p>
-          </li>
-          <li>
-            <p>If <var>connection</var> was modified in such a way that
-            additional inspection of the system state is necessary, then
-            in parallel begin the <a>
-            steps to create an offer</a> again, given <var>p</var>, and
-            abort these steps.</p>
-
-            <div class="note">This may be necessary if, for example,
-            <code>createOffer</code> was called when only an audio
-            <code><a>RTCRtpTransceiver</a></code> was added to
-            <var>connection</var>, but while performing the <a>steps to
-            create an offer</a> in parallel, a video
-            <code><a>RTCRtpTransceiver</a></code> was added, requiring
-            additional inspection of video system resources.</div>
-          </li>
-          <li>
-            <p>Given the information that was obtained from previous
-            inspection, generate an SDP offer, <var>sdpString</var>, as
-            described in <span data-jsep="create-offer">[[!JSEP]]</span>.
-            </p>
-          </li>
-          <li>
-            <p>Let <var>offer</var> be a newly created
-            <code><a>RTCSessionDescriptionInit</a></code> dictionary with
-            its <code>type</code> member initialized to the string
-            <code>"offer"</code> and its <code>sdp</code> member
-            initialized to <var>sdpString</var>.</p>
-          </li>
-          <li>
-            <p>Resolve <var>p</var> with <var>offer</var>.</p>
-          </li>
-        </ol>
         <p>The task source for the tasks listed in this section is the
         <a>networking task source</a>.</p>
       </section>
@@ -1417,6 +1340,88 @@ interface RTCPeerConnection : EventTarget  {
                         <p>Return <var>p</var>.</p>
                       </li>
                     </ol>
+                  </li>
+                </ol>
+                <p>The <dfn>steps to create an offer</dfn> given a promise
+                <var>p</var> are as follows:</p>
+                <ol>
+                  <li>
+                    <p>If the need for an identity assertion was
+                    identified when <code>createOffer</code> was invoked,
+                    wait for <a href=
+                    "#sec.identity-proxy-assertion-request">the identity
+                    assertion request process</a> to complete.</p>
+                  </li>
+                  <li>
+                    <p>If the identity provider was unable to produce an
+                    identity assertion, reject <var>p</var> with a
+                    <code>DOMException</code> object whose
+                    <code>name</code> attribute has the value
+                    <code>NotReadableError</code>, and abort these
+                    steps.</p>
+                  </li>
+                  <li>
+                    <p>If <var>connection</var> was not constructed with a
+                    set of certificates, and one has not yet been
+                    generated, wait for it to be generated.</p>
+                  </li>
+                  <li>
+                    <p>Inspect the system state to determine the currently
+                    available resources as necessary for generating the
+                    offer, as described in <span
+                    data-jsep="createoffer">[[!JSEP]]</span>.</p>
+                  </li>
+                  <li>
+                    <p>If this inspection failed for any reason, reject
+                    <var>p</var> with a <code>DOMException</code> object
+                    whose <code>name</code> attribute has the value
+                    <code>OperationError</code>, and abort these
+                    steps.</p>
+                  </li>
+                  <li>
+                    <p>Queue a task that runs the <a>final steps to create
+                    an offer</a>, given <var>p</var>.</p>
+                  </li>
+                </ol>
+                <p>The <dfn>final steps to create an offer</dfn> given a
+                promise <var>p</var> are as follows:</p>
+                <ol>
+                  <li>
+                    <p>If <var>connection</var>'s [[<a>isClosed</a>]] slot
+                    is <code>true</code>, then abort these steps.</p>
+                  </li>
+                  <li>
+                    <p>If <var>connection</var> was modified in such a way
+                    that additional inspection of the system state is
+                    necessary, then in parallel begin the <a> steps to
+                    create an offer</a> again, given <var>p</var>, and
+                    abort these steps.</p>
+
+                    <div class="note">This may be necessary if, for
+                    example, <code>createOffer</code> was called when only
+                    an audio <code><a>RTCRtpTransceiver</a></code> was
+                    added to <var>connection</var>, but while performing
+                    the <a>steps to create an offer</a> in parallel, a
+                    video <code><a>RTCRtpTransceiver</a></code> was added,
+                    requiring additional inspection of video system
+                    resources.</div>
+                  </li>
+                  <li>
+                    <p>Given the information that was obtained from
+                    previous inspection, generate an SDP offer,
+                    <var>sdpString</var>, as described in <span
+                    data-jsep="create-offer">[[!JSEP]]</span>.</p>
+                  </li>
+                  <li>
+                    <p>Let <var>offer</var> be a newly created
+                    <code><a>RTCSessionDescriptionInit</a></code>
+                    dictionary with its <code>type</code> member
+                    initialized to the string <code>"offer"</code> and its
+                    <code>sdp</code> member initialized to
+                    <var>sdpString</var>.</p>
+                  </li>
+                  <li>
+                    <p>Resolve <var>p</var> with <var>offer</var>.</p>
                   </li>
                 </ol>
                 <table class="parameters">

--- a/webrtc.html
+++ b/webrtc.html
@@ -1408,7 +1408,9 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>Given the information that was obtained from
-                    previous inspection, generate an SDP offer,
+                    previous inspection and the current state of
+                    <var>connection</var> and its <code><a>
+                    RTCRtpTransceiver</a></code>s, generate an SDP offer,
                     <var>sdpString</var>, as described in <span
                     data-jsep="create-offer">[[!JSEP]]</span>.</p>
                   </li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1316,6 +1316,15 @@ interface RTCPeerConnection : EventTarget  {
                     method was invoked.</p>
                   </li>
                   <li>
+                    <p>If <var>connection</var> is configured with an
+                    identity provider, and an identity assertion has not
+                    yet been generated using said identity provider, then
+                    begin <a href=
+                    "#sec.identity-proxy-assertion-request">the identity
+                    assertion request process</a> if it has not already
+                    begun.</p>
+                  </li>
+                  <li>
                     <p>Return the result of <a href=
                     "#enqueue-an-operation">enqueuing</a> the following
                     steps:</p>
@@ -1324,38 +1333,24 @@ interface RTCPeerConnection : EventTarget  {
                         <p>Let <var>p</var> be a new promise.</p>
                       </li>
                       <li>
-                        <p>If <var>connection</var> is configured with an
-                        identity provider, and an identity assertion has
-                        not yet been generated using said identity
-                        provider, then perform the following steps:</p>
+                        <p>In parallel, perform the following steps:</p>
                         <ol>
                           <li>
-                            <p>Begin <a
-                            href="#sec.identity-proxy-assertion-request">the
-                            identity assertion request process</a> if it
-                            has not already begun.</p>
+                            <p>If the need for an identity assertion was
+                            identified when <code>createOffer</code> was
+                            invoked, wait for <a href=
+                            "#sec.identity-proxy-assertion-request">the
+                            identity assertion request process</a> to
+                            complete.
                           </li>
                           <li>
-                            <p>Upon fulfillment of the promise returned by
-                            the IdP proxy, perform the parallel steps
-                            below.</p>
-                          </li>
-                          <li>
-                            <p>Upon rejection of the promise returned by
-                            the IdP proxy, reject <var>p</var> with a
+                            <p>If the identity provider was unable to produce
+                            an identity assertion, reject <var>p</var> with a
                             <code>DOMException</code> object whose
                             <code>name</code> attribute has the value
                             <code>NotReadableError</code>, and abort these
                             steps.</p>
                           </li>
-                          <li>
-                            <p>Return <var>p</var>.</p>
-                          </li>
-                        </ol>
-                      </li>
-                      <li>
-                        <p>In parallel, perform the following steps:</p>
-                        <ol>
                           <li>
                             <p>If <var>connection</var> was not
                             constructed with a set of certificates, and
@@ -1387,20 +1382,11 @@ interface RTCPeerConnection : EventTarget  {
                                 steps.</p>
                               </li>
                               <li>
-                                <p>If <var>connection</var> was configured
-                                with a new identity provider while
-                                performing the above parallel steps, then
-                                return to the start of this operation (but
-                                using <var>p</var> rather than creating a
-                                new promise).</p>
-                              </li>
-                              <li>
                                 <p>If <var>connection</var> mas modified
                                 in such a way that additional inspection
                                 of the system state is necessary, then
-                                return to the start of this operation (but
-                                using <var>p</var> rather than creating a
-                                new promise).</p>
+                                return to the parallel steps above, and
+                                abort these steps.</p>
 
                                 <p>This may be necessary if, for example,
                                 <code>createOffer</code> was called when

--- a/webrtc.html
+++ b/webrtc.html
@@ -1324,15 +1324,61 @@ interface RTCPeerConnection : EventTarget  {
                         <p>Let <var>p</var> be a new promise.</p>
                       </li>
                       <li>
-                        <p>In parallel, start the process to generate an SDP
-                        offer, as described in <span data-jsep=
-                        "create-offer">[[!JSEP]]</span>.</p>
+                        <p>If <var>connection</var> is configured with an
+                        identity provider, and an identity assertion has
+                        not yet been generated using said identity
+                        provider, then perform the following steps:</p>
                         <ol>
                           <li>
-                            <p>If the process to generate an SDP offer failed
-                            for any reason, or if the identity provider was
-                            unable to produce an identity assertion, the User
-                            Agent MUST queue a task that runs the following
+                            <p>Begin <a
+                            href="#sec.identity-proxy-assertion-request">the
+                            identity assertion request process</a> if it
+                            has not already begun.</p>
+                          </li>
+                          <li>
+                            <p>Upon fulfillment of the promise returned by
+                            the IdP proxy, perform the parallel steps
+                            below.</p>
+                          </li>
+                          <li>
+                            <p>Upon rejection of the promise returned by
+                            the IdP proxy, reject <var>p</var> with a
+                            <code>DOMException</code> object whose
+                            <code>name</code> attribute has the value
+                            <code>NotReadableError</code>, and abort these
+                            steps.</p>
+                          </li>
+                          <li>
+                            <p>Return <var>p</var>.</p>
+                          </li>
+                        </ol>
+                      </li>
+                      <li>
+                        <p>In parallel, perform the following steps:</p>
+                        <ol>
+                          <li>
+                            <p>If <var>connection</var> was not
+                            constructed with a set of certificates, and
+                            one has not yet been generated, wait for it to
+                            be generated.</p>
+                          </li>
+                          <li>
+                            <p>Inspect the system state to determine the
+                            currently available resources as necessary for
+                            generating the offer, as described in
+                            <span data-jsep=
+                            "createoffer">[[!JSEP]]</span>.</p>
+                          </li>
+                          <li>
+                            <p>If this inspection failed for any reason,
+                            reject <var>p</var> with a
+                            <code>DOMException</code> object whose
+                            <code>name</code> attribute has the value
+                            <code>OperationError</code>, and abort these
+                            steps.</p>
+                          </li>
+                          <li>
+                            <p>Queue a task that runs the following
                             steps:</p>
                             <ol>
                               <li>
@@ -1341,30 +1387,37 @@ interface RTCPeerConnection : EventTarget  {
                                 steps.</p>
                               </li>
                               <li>
-                                <p>If the identity provider was unable to
-                                produce an identity assertion, reject
-                                <var>p</var> with a <code>DOMException</code>
-                                object whose <code>name</code> attribute has
-                                the value <code>NotReadableError</code>, and
-                                abort these steps.</p>
+                                <p>If <var>connection</var> was configured
+                                with a new identity provider while
+                                performing the above parallel steps, then
+                                return to the start of this operation (but
+                                using <var>p</var> rather than creating a
+                                new promise).</p>
                               </li>
                               <li>
-                                <p>Reject <var>p</var> with a
-                                <code>DOMException</code> object whose
-                                <code>name</code> attribute has the value
-                                <code>OperationError</code>.</p>
+                                <p>If <var>connection</var> mas modified
+                                in such a way that additional inspection
+                                of the system state is necessary, then
+                                return to the start of this operation (but
+                                using <var>p</var> rather than creating a
+                                new promise).</p>
+
+                                <p>This may be necessary if, for example,
+                                <code>createOffer</code> was called when
+                                only an audio
+                                <code><a>RTCRtpTransceiver</a></code> was
+                                added to <var>connection</var>, but while
+                                performing the above parallel steps, a
+                                video
+                                <code><a>RTCRtpTransceiver</a></code> was
+                                added, requiring additional inspection of
+                                video system resources.</p>
                               </li>
-                            </ol>
-                          </li>
-                          <li>
-                            <p>If an SDP offer, <var>sdpString</var>, was
-                            successfully generated, the User Agent MUST queue a
-                            task that runs the following steps:</p>
-                            <ol>
                               <li>
-                                <p>If <var>connection</var>'s [[<a>isClosed</a>]]
-                                slot is <code>true</code>, then abort these
-                                steps.</p>
+                                <p>Generate an SDP offer,
+                                <var>sdpString</var>, as described in
+                                <span data-jsep=
+                                "create-offer">[[!JSEP]]</span>.</p>
                               </li>
                               <li>
                                 <p>Let <var>offer</var> be a newly created


### PR DESCRIPTION
A revised version of PR #874. Turns the single bulky `createOffer` algorithm into three separate sub-algorithms. Some miscellaneous cleanup, but mostly just restructuring.