### PR TITLE
Cleanup the definition of expires, use IDL

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3777,7 +3777,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
       SHA-256 hash.</p>
       <div>
         <pre class="idl">partial interface RTCPeerConnection {
-    static Promise&lt;RTCCertificate&gt; generateCertificate (AlgorithmIdentifier keygenAlgorithm);
+    static Promise&lt;RTCCertificate&gt; generateCertificate (RTCGenerateCertificateOptions keygenAlgorithm);
 };</pre>
         <section>
           <h2>Methods</h2>
@@ -3831,16 +3831,6 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <p>The resulting certificate MUST NOT include information that
               can be linked to a user or <a>user agent</a>. Randomized values
               for distinguished name and serial number SHOULD be used.</p>
-              <p>An optional <code>expires</code> attribute MAY be added to the
-              <var>keygenAlgorithm</var> parameter. If this contains a
-              <code><a>DOMTimeStamp</a></code> value, it indicates the maximum
-              time that the <code><a>RTCCertificate</a></code> is valid for
-              relative to the current time. A <a>user agent</a> sets the
-              <code><a data-for="RTCCertificate">expires</a></code> attribute
-              of the returned <code><a>RTCCertificate</a></code> to the current
-              time plus the value of the <code>expires</code> attribute.
-              However, a <a>user agent</a> MAY choose to limit the period over
-              which an <code><a>RTCCertificate</a></code> is valid.</p>
               <p>A <a>user agent</a> MUST reject a call to
               <code>generateCertificate()</code> with a
               <code>DOMException</code> of type <code>NotSupportedError</code>
@@ -3886,6 +3876,29 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           </dl>
         </section>
       </div>
+      <section>
+        <h2>Dictionary <code><a>RTCGenerateCertificateOptions</a></code></h2>
+        <p><code><a>RTCGenerateCertificateOptions</a></code> extends <code><a href="https://w3c.github.io/webcrypto/Overview.html#dfn-Algorithm">Algorithm</a></code> from WebCrypto.</p>
+        <pre class="idl">dictionary RTCGenerateCertificateOptions : Algorithm {
+    DOMTimeStamp expires;
+};</pre>
+        <dl data-link-for="RTCGenerateCertificateOptions" data-dfn-for=
+        "RTCGenerateCertificateOptions" class="methods">
+          <dt><dfn data-for="RTCGenerateCertificateOptions"><code>expires</code></dfn></dt>
+          <dd>
+            <p>An optional <code>expires</code> attribute MAY be added to the
+            definition of the algorithm that is passed to <code><a>generateCertificate</a></code>.
+            If this parameter is present it indicates the maximum
+            time that the <code><a>RTCCertificate</a></code> is valid for
+            relative to the current time. A <a>user agent</a> sets the
+            <code><a data-for="RTCCertificate">expires</a></code> attribute
+            of the returned <code><a>RTCCertificate</a></code> to the current
+            time plus the value of the <code>expires</code> attribute.
+            However, a <a>user agent</a> MAY choose to limit the period over
+            which an <code><a>RTCCertificate</a></code> is valid.</p>
+          </dd>
+        </dl>
+      </section>
       <section>
         <h2>RTCCertificate Interface</h2>
         <p>The <dfn><code>RTCCertificate</code></dfn> interface represents a


### PR DESCRIPTION
The definition of expires was at best improvised.  This cleans it up to use WebIDL properly.

Closes #879
