### PR TITLE
Adding steps in "setting a description" for rolling back transceivers.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -959,6 +959,34 @@
                     descriptions.</p>
                   </li>
                   <li>
+                    <p>If <var>description</var> is of type "rollback", then run
+                    the following steps:</p>
+                    <ol>
+                      <li>
+                        <p>If the <code><a data-for=
+                        "RTCRtpTransceiver">mid</a></code> value of an
+                        <code><a>RTCRtpTransceiver</a></code> was set to a
+                        non-null value by the
+                        <code><a>RTCSessionDescription</a></code> that is being
+                        rolled back, set the <code><a data-for=
+                        "RTCRtpTransceiver">mid</a></code> value of that
+                        transceiver to null, as described by <span data-jsep=
+                        "rollback">[[!JSEP]]</span>.</p>
+                      </li>
+                      <li>
+                        <p>If an <code><a>RTCRtpTransceiver</a></code> was
+                        created by applying the
+                        <code><a>RTCSessionDescription</a></code> that is
+                        being rolled back, and a track has not been attached to
+                        it via <code><a>addTrack</a></code>, remove that
+                        transceiver from <var>connection</var>'s <a
+                        href="#transceivers-set">set of transceivers</a>, as
+                        described by <span data-jsep=
+                        "rollback">[[!JSEP]]</span>.</p>
+                      </li>
+                    </ol>
+                  </li>
+                  <li>
                     <p>If <var>connection</var>'s <a>signaling state</a> is now
                     <code>stable</code>, and the <a>negotiation-needed flag</a>
                     is set, the User Agent MUST queue a task to fire a simple
@@ -3040,14 +3068,6 @@ interface RTCPeerConnection : EventTarget  {
                   the local or remote SDP descriptions in the previous stable
                   state could be null if there has not yet been a successful
                   offer-answer negotiation.</p>
-                  <p>If the <code><a data-for=
-                  "RTCRtpTransceiver">mid</a></code> value of an
-                  <code><a>RTCRtpTransceiver</a></code> was set to a non-null
-                  value by an <code><a>RTCSessionDescription</a></code> that is
-                  rolled back, the <code><a data-for=
-                  "RTCRtpTransceiver">mid</a></code> value will be set back to
-                  null, as defined by <span data-jsep=
-                  "rollback">[[!JSEP]]</span>.</p>
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
This moves the explanation of the mid being reset to null, and adds the
missing step of removing transceivers that were created by applying a
rolled-back description.

Fixes issue #859.
