### PR TITLE
Mandatory to implement stats section, remove overlap with stats

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8582,11 +8582,11 @@ interface RTCDTMFToneChangeEvent : Event {
       attributes that are listed when they are valid for that object:</p>
       <ul>
         <li>RTCRTPStreamStats, with attributes ssrc, associateStatsId,
-        isREmote, mediaType, mediaTrackId, transportId, codecId, nackCount</li>
-        <li>RTCInboundRTPStreamStats, with all attributes from
+        isRemote, mediaType, mediaTrackId, transportId, codecId, nackCount</li>
+        <li>RTCInboundRTPStreamStats, with all required attributes from
         RTCRTPStreamStats, and also attributes packetsReceived, bytesReceived,
         packetsLost, jitter, packetsDiscarded</li>
-        <li>RTCOutboundRTPStreamStats, with all attributes from
+        <li>RTCOutboundRTPStreamStats, with all required attributes from
         RTCRTPStreamStats, and also attributes packetsSent, bytesSent,
         roundTripTime</li>
         <li>RTCPeerConnectionStats, with attributes dataChannelsOpened,
@@ -8596,13 +8596,13 @@ interface RTCDTMFToneChangeEvent : Event {
         bytesReceived</li>
         <li>RTCMediaStreamStats, with attributes streamIdentifer, trackIds</li>
         <li>RTCMediaStreamTrackStats, with attributes trackIdentifier,
-        remoteSource, ended, ssrcIds, frameWidth, frameHeight, framesPerSecond,
-        framesSent, framesReceived, framesDecoded, framesDropped,
-        framesCorrupted, audioLevel</li>
+        remoteSource, ended, detached, ssrcIds, frameWidth, frameHeight,
+        framesPerSecond, framesSent, framesReceived, framesDecoded,
+        framesDropped, framesCorrupted, audioLevel</li>
         <li>RTCCodecStats, with attributes payloadType, codec, clockRate,
         channels, parameters</li>
         <li>RTCTransportStats, with attributes bytesSent, bytesReceived,
-        rtcpTransportStatsId, actieConnection, selectedCandidatePairId,
+        rtcpTransportStatsId, activeConnection, selectedCandidatePairId,
         localCertificateId, remoteCertificateId</li>
         <li>RTCIceCandidatePairStats, with attributes transportId,
         localCandidateId, remoteCandidateId, state, priority, nominated,

--- a/webrtc.html
+++ b/webrtc.html
@@ -2989,6 +2989,7 @@ interface RTCPeerConnection : EventTarget  {
     </section>
     <section>
       <h3>Callback Definitions</h3>
+      <p>These callbacks are only used on the legacy APIs.</p>
       <section>
         <h4>RTCPeerConnectionErrorCallback</h4>
         <div>
@@ -3020,6 +3021,26 @@ interface RTCPeerConnection : EventTarget  {
               <dt><code>sdp</code> of type <span class=
               "idlMemberType"><a>RTCSessionDescription</a></span></dt>
               <dd>The object containing the SDP [[!SDP]].</dd>
+            </dl>
+          </section>
+        </div>
+      </section>
+      <section>
+        <h4>RTCStatsCallback</h4>
+        <div>
+          <pre class="idl">
+        callback RTCStatsCallback = void (RTCStatsReport report);</pre>
+          <section>
+            <h2>Callback <a class="idlType">RTCStatsCallback</a>
+            Parameters</h2>
+            <dl data-link-for="RTCStatsCallback" data-dfn-for=
+            "RTCStatsCallback" class="callback-members">
+              <dt><code>report</code> of type <span class=
+              "idlMemberType"><a>RTCStatsReport</a></span></dt>
+              <dd>
+                <p>A <code><a>RTCStatsReport</a></code> representing the
+                gathered stats.</p>
+              </dd>
             </dl>
           </section>
         </div>
@@ -8450,25 +8471,6 @@ interface RTCDTMFToneChangeEvent : Event {
       </div>
     </section>
     <section>
-      <h3>RTCStatsCallback</h3>
-      <div>
-        <pre class="idl">
-        callback RTCStatsCallback = void (RTCStatsReport report);</pre>
-        <section>
-          <h2>Callback <a class="idlType">RTCStatsCallback</a> Parameters</h2>
-          <dl data-link-for="RTCStatsCallback" data-dfn-for="RTCStatsCallback"
-          class="callback-members">
-            <dt><code>report</code> of type <span class=
-            "idlMemberType"><a>RTCStatsReport</a></span></dt>
-            <dd>
-              <p>A <code><a>RTCStatsReport</a></code> representing the gathered
-              stats.</p>
-            </dd>
-          </dl>
-        </section>
-      </div>
-    </section>
-    <section>
       <h3>RTCStatsReport Object</h3>
       <p>The <code><a data-for="RTCPeerConnection">getStats()</a></code> method
       delivers a successful result in the form of an
@@ -8558,113 +8560,61 @@ interface RTCDTMFToneChangeEvent : Event {
               the same id if they were produced by inspecting the same
               underlying object. User agents are free to pick any format for
               the id as long as it meets the requirements above.</p>
-              <div class="issue">
-                Consider naming id something that indicates that the id refers
-                to the underlying object that was inspected to produce the
-                stats, instead of being an id for the JavaScript object.
-                Suggestions: statsObjectId, reporterId, srcId.
-              </div>
             </dd>
           </dl>
         </section>
       </div>
       <div>
         <pre class="idl">enum RTCStatsType {
-    "inboundrtp",
-    "outboundrtp"
 };</pre>
-        <table data-link-for="RTCStatsType" data-dfn-for="RTCStatsType" class=
-        "simple">
-          <tbody>
-            <tr>
-              <th colspan="2">Enumeration description</th>
-            </tr>
-            <tr>
-              <td><dfn><code>inboundrtp</code></dfn></td>
-              <td>Inbound RTP.</td>
-            </tr>
-            <tr>
-              <td><dfn><code>outboundrtp</code></dfn></td>
-              <td>Outbound RTP.</td>
-            </tr>
-          </tbody>
-        </table>
       </div>
+      <p>The set of valid values for RTCStatsType, and the dictionaries derived
+      from RTCStats that they indicate, are documented in
+      [[!WEBRTC-STATS]].</p>
     </section>
     <section>
-      <h3>Derived Stats Dictionaries</h3>
-      <div>
-        <pre class="idl">dictionary RTCRTPStreamStats : RTCStats {
-             unsigned long ssrc;
-             DOMString     remoteId;
-};</pre>
-        <section>
-          <h2>Dictionary <a class="idlType">RTCRTPStreamStats</a> Members</h2>
-          <dl data-link-for="RTCRTPStreamStats" data-dfn-for=
-          "RTCRTPStreamStats" class="dictionary-members">
-            <dt><dfn><code>ssrc</code></dfn> of type <span class=
-            "idlMemberType"><a>unsigned long</a></span></dt>
-            <dd>
-              <p>...</p>
-            </dd>
-            <dt><dfn><code>remoteId</code></dfn> of type <span class=
-            "idlMemberType"><a>DOMString</a></span></dt>
-            <dd>
-              <p>The <code>remoteId</code> can be used to look up the
-              corresponding <code><a>RTCStats</a></code> object that represents
-              stats reported by the other peer.</p>
-            </dd>
-          </dl>
-        </section>
-      </div>
-      <div>
-        <pre class="idl">
-        dictionary RTCInboundRTPStreamStats : RTCRTPStreamStats {
-             unsigned long packetsReceived;
-             unsigned long bytesReceived;
-};</pre>
-        <section>
-          <h2>Dictionary <a class="idlType">RTCInboundRTPStreamStats</a>
-          Members</h2>
-          <dl data-link-for="RTCInboundRTPStreamStats" data-dfn-for=
-          "RTCInboundRTPStreamStats" class="dictionary-members">
-            <dt><dfn><code>packetsReceived</code></dfn> of type <span class=
-            "idlMemberType"><a>unsigned long</a></span></dt>
-            <dd>
-              <p>...</p>
-            </dd>
-            <dt><dfn><code>bytesReceived</code></dfn> of type <span class=
-            "idlMemberType"><a>unsigned long</a></span></dt>
-            <dd>
-              <p>...</p>
-            </dd>
-          </dl>
-        </section>
-      </div>
-      <div>
-        <pre class="idl">
-        dictionary RTCOutboundRTPStreamStats : RTCRTPStreamStats {
-             unsigned long packetsSent;
-             unsigned long bytesSent;
-};</pre>
-        <section>
-          <h2>Dictionary <a class="idlType">RTCOutboundRTPStreamStats</a>
-          Members</h2>
-          <dl data-link-for="RTCOutboundRTPStreamStats" data-dfn-for=
-          "RTCOutboundRTPStreamStats" class="dictionary-members">
-            <dt><dfn><code>packetsSent</code></dfn> of type <span class=
-            "idlMemberType"><a>unsigned long</a></span></dt>
-            <dd>
-              <p>...</p>
-            </dd>
-            <dt><dfn><code>bytesSent</code></dfn> of type <span class=
-            "idlMemberType"><a>unsigned long</a></span></dt>
-            <dd>
-              <p>...</p>
-            </dd>
-          </dl>
-        </section>
-      </div>
+      <h3>Mandatory To Implement Stats</h3>
+      <p>The stats listed in [[WEBRTC-STATS]] are intended to cover a wide
+      range of use cases. Not all of them have to be implemented by every
+      WebRTC implementation.</p>
+      <p>An implementation MUST support generating statistics of the following
+      types when the corresponding objects exist on a PeerConnection, with the
+      attributes that are listed when they are valid for that object:</p>
+      <ul>
+        <li>RTCRTPStreamStats, with attributes ssrc, associateStatsId,
+        isREmote, mediaType, mediaTrackId, transportId, codecId, nackCount</li>
+        <li>RTCInboundRTPStreamStats, with all attributes from
+        RTCRTPStreamStats, and also attributes packetsReceived, bytesReceived,
+        packetsLost, jitter, packetsDiscarded</li>
+        <li>RTCOutboundRTPStreamStats, with all attributes from
+        RTCRTPStreamStats, and also attributes packetsSent, bytesSent,
+        roundTripTime</li>
+        <li>RTCPeerConnectionStats, with attributes dataChannelsOpened,
+        dataChannelsClosed</li>
+        <li>RTCDataChannelStats, with attributes label, protocol,
+        datachannelId, state, messagesSent, bytesSent, messagesReceived,
+        bytesReceived</li>
+        <li>RTCMediaStreamStats, with attributes streamIdentifer, trackIds</li>
+        <li>RTCMediaStreamTrackStats, with attributes trackIdentifier,
+        remoteSource, ended, ssrcIds, frameWidth, frameHeight, framesPerSecond,
+        framesSent, framesReceived, framesDecoded, framesDropped,
+        framesCorrupted, audioLevel</li>
+        <li>RTCCodecStats, with attributes payloadType, codec, clockRate,
+        channels, parameters</li>
+        <li>RTCTransportStats, with attributes bytesSent, bytesReceived,
+        rtcpTransportStatsId, actieConnection, selectedCandidatePairId,
+        localCertificateId, remoteCertificateId</li>
+        <li>RTCIceCandidatePairStats, with attributes transportId,
+        localCandidateId, remoteCandidateId, state, priority, nominated,
+        writable, readable, bytesSent, bytesReceived, totalRtt, currentRtt</li>
+        <li>RTCIceCandidateStats, with attributes ip, port, protocol,
+        candidateType, priority, url</li>
+        <li>RTCCertificateStats, with attributes fingerprint,
+        fingerprintAlgorithm, base64Certificate, issuerCertificateId</li>
+      </ul>
+      <p>An implementation MAY support generating any other statistic defined
+      in [[!WEBRTC-STATS]], and MAY generate statistics that are not
+      documented.</p>
     </section>
     <section>
       <h3>Example</h3>


### PR DESCRIPTION
This deletes the definitions that overlap with the
stats document, and adds a new section that defines
the MTI for this specification.

Fixes #561 