### PR TITLE
Make url member of RTCPeerConnectionIceEvent dictionary nullable

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3594,7 +3594,7 @@ interface RTCPeerConnectionIceEvent : Event {
           <pre class="idl">
           dictionary RTCPeerConnectionIceEventInit : EventInit {
              RTCIceCandidate? candidate;
-             DOMString       url;
+             DOMString?       url;
 };</pre>
           <section>
             <h2>Dictionary <a class="idlType">RTCPeerConnectionIceEventInit</a>


### PR DESCRIPTION
This is analogous to #856 and #863.