### PR TITLE
Removing incorrect statement related to IP leaking issue.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3367,9 +3367,7 @@ interface RTCIceCandidate {
                   communicating party, either temporarily or permanently, by
                   forcing the <a>ICE Agent</a> to report only relay candidates
                   via the <code>iceTransportPolicy</code> member of
-                  <code><a>RTCConfiguration</a></code>, or by not signalling
-                  non-relay ICE candidates (e.g. until the user has accepted to
-                  share media).</p>
+                  <code><a>RTCConfiguration</a></code>.</p>
                   <p>To limit the IP addresses exposed to the application
                   itself, browsers can offer their users different policies
                   regarding sharing local IP addresses, as defined in


### PR DESCRIPTION
The incorrect statement is "Applications can avoid exposing IP
addresses... by not signalling non-relay ICE candidates."

However, simply not signaling candidates is not enough to prevent IP
addresses from leaking. These candidates will still be gathered and used
to form candidate pairs, which means connectivity checks will be sent
leaking the server reflexive address for every network interface.