### PR TITLE
Splitting transceiver direction into "direction" and "currentDirection".

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4440,9 +4440,9 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                     <li>
                       <p>The sender has never been used to send. More
                       precisely, the <code><a>RTCRtpTransceiver</a></code>
-                      associated with the sender has always had a direction of
-                      either <code>recvonly</code> or
-                      <code>inactive</code>.</p>
+                      associated with the sender has never had a <code><a
+                      data-link-for="RTCRtpTransceiver">currentDirection</a></code>
+                      of <code>sendrecv</code> or <code>sendonly</code>.</p>
                     </li>
                   </ul>
                 </li>
@@ -6094,13 +6094,14 @@ sender.setParameters(params)
       </ol>
       <div>
         <pre class="idl">interface RTCRtpTransceiver {
-    readonly        attribute DOMString?                 mid;
+    readonly        attribute DOMString?                  mid;
     [SameObject]
-    readonly        attribute RTCRtpSender               sender;
+    readonly        attribute RTCRtpSender                sender;
     [SameObject]
-    readonly        attribute RTCRtpReceiver             receiver;
-    readonly        attribute boolean                    stopped;
-    readonly        attribute RTCRtpTransceiverDirection direction;
+    readonly        attribute RTCRtpReceiver              receiver;
+    readonly        attribute boolean                     stopped;
+    readonly        attribute RTCRtpTransceiverDirection  direction;
+    readonly        attribute RTCRtpTransceiverDirection? currentDirection;
     void setDirection (RTCRtpTransceiverDirection direction);
     void stop ();
     void setCodecPreferences (sequence&lt;RTCRtpCodecCapability&gt; codecs);
@@ -6151,12 +6152,30 @@ sender.setParameters(params)
             "idlAttrType"><a>RTCRtpTransceiverDirection</a></span>,
             readonly</dt>
             <dd>
-              <p>The <var>direction</var> attribute indicates the direction of
-              this transceiver. The value of <var>direction</var> is
-              independent of the value of <var>encodings[].active</var> since
-              one cannot be deduced from the other. If the <code>stop()</code>
-              method is called, <var>direction</var> retains the value it had
-              prior to calling <code>stop()</code>.</p>
+              <p>As defined in <span data-jsep=
+              "transceiver-direction">[[!JSEP]]</span>, the
+              <var>direction</var> attribute indicates the preferred direction
+              of this transceiver, which will be used in calls to <code><a
+              data-for="RTCPeerConnection">createOffer</a></code> and <code><a
+              data-for="RTCPeerConnection">createAnswer</a></code>. The value of
+              <var>direction</var> does not change except due to calls to
+              <code><a>setDirection</a></code>.</p>
+            </dd>
+            <dt><dfn><code>currentDirection</code></dfn> of type <span class=
+            "idlAttrType"><a>RTCRtpTransceiverDirection</a></span>,
+            readonly, nullable</dt>
+            <dd>
+              <p>As defined in <span data-jsep=
+              "transceiver-current-direction">[[!JSEP]]</span>, the
+              <var>currentDirection</var> attribute indicates the current
+              direction negotiated for this transceiver. The value of
+              <var>currentDirection</var> is independent of the value of
+              <code>RTCRtpEncodingParameters.<a data-link-for=
+              "RTCRtpEncodingParameters">active</a></code> since one cannot be
+              deduced from the other. If this transceiver has never been
+              represented in an offer/answer exchange, or if the transceiver is
+              <code><a>stopped</a></code>, <var>currentDirection</var> is
+              null.</p>
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
"direction" is now purely what goes *into* SDP negotiation, and
"currentDirection" is purely what comes out of it.

Points to JSEP, depending on:
https://github.com/rtcweb-wg/jsep/pull/410

Related to issue #927.