### PR TITLE
Revert "Respec now uses yarn instead of npm"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ addons:
 before_install:
   - export CXX="g++-4.8" CC="gcc-4.8"
   - nvm install 6
-  - npm install -g yarn
   - "export DISPLAY=:99.0"
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16 -extension RANDR"
   - sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
Reverts w3c/webrtc-pc#935

respec switched back to npm...
See: https://github.com/w3c/webrtc-respec-ci/pull/14