### PR TITLE
Give legacy callbacks RTCSessionDescriptionInit so they can modify sdp

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3017,14 +3017,14 @@ interface RTCPeerConnection : EventTarget  {
         <h4>RTCSessionDescriptionCallback</h4>
         <div>
           <pre class="idl">
-          callback RTCSessionDescriptionCallback = void (RTCSessionDescription sdp);</pre>
+          callback RTCSessionDescriptionCallback = void (RTCSessionDescriptionInit description);</pre>
           <section>
             <h2>Callback <a class="idlType">RTCSessionDescriptionCallback</a>
             Parameters</h2>
             <dl data-link-for="RTCSessionDescriptionCallback" data-dfn-for=
             "RTCSessionDescriptionCallback" class="callback-members">
-              <dt><code>sdp</code> of type <span class=
-              "idlMemberType"><a>RTCSessionDescription</a></span></dt>
+              <dt><code>description</code> of type <span class=
+              "idlMemberType"><a>RTCSessionDescriptionInit</a></span></dt>
               <dd>The object containing the SDP [[!SDP]].</dd>
             </dl>
           </section>


### PR DESCRIPTION
Alternative fix for https://github.com/w3c/webrtc-pc/issues/933.

If we don't take https://github.com/w3c/webrtc-pc/pull/934 then we need this IMHO.

Looking for swift resolution either way, as I'm trying to remove [the need for the constructors in Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1263312#c17).