### PR TITLE
change titles for getStats and identity samples

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8885,7 +8885,7 @@ interface RTCDTMFToneChangeEvent : Event {
       documented.</p>
     </section>
     <section>
-      <h3>Example</h3>
+      <h3>GetStats Example</h3>
       <p>Consider the case where the user is experiencing bad sound and the
       application wants to determine if the cause of it is packet loss. The
       following example code might be used:</p>
@@ -9747,7 +9747,7 @@ interface RTCIdentityAssertion {
       </div>
     </section>
     <section>
-      <h3>Examples</h3>
+      <h3>Identity Examples</h3>
       <p>The identity system is designed so that applications need not take any
       special action in order for users to generate and verify identity
       assertions; if a user has configured an IdP into their browser, then the


### PR DESCRIPTION
changes the title of the getStats and identity samples section
to generate nicer link anchors than "#sample" and "#samples".