### PR TITLE
Add ufrag to IceCandidate, and use IceCandidate for end-of-candidates.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1726,10 +1726,11 @@ interface RTCPeerConnection : EventTarget  {
                 <code>candidate</code>. The only members of the argument used
                 by this method are <code><a data-for=
                 "RTCIceCandidate">candidate</a></code>, <code><a data-for=
-                "RTCIceCandidate">sdpMid</a></code> and <code><a data-for=
-                "RTCIceCandidate">sdpMLineIndex</a></code>; the rest are
-                ignored. When the method is invoked, the User Agent MUST run
-                the following steps:</p>
+                "RTCIceCandidate">sdpMid</a></code>, <code><a data-for=
+                "RTCIceCandidate">sdpMLineIndex</a></code>, and
+                <code><a data-for="RTCIceCandidate">ufrag</a></code>; the rest
+                are ignored. When the method is invoked, the User Agent MUST
+                run the following steps:</p>
                 <ol>
                   <li>
                     <p>Let <var>candidate</var> be the methods argument.</p>
@@ -1758,28 +1759,6 @@ interface RTCPeerConnection : EventTarget  {
                       </li>
                       <li>
                         <p>Let <var>p</var> be a new promise.</p>
-                      </li>
-                      <li>
-                        <p>If <var>candidate</var> is <code>null</code>, the
-                        User Agent MUST queue a task that runs the following
-                        steps, and abort these steps:</p>
-                        <ol>
-                          <li>
-                            <p>If <var>connection</var>'s [[<a>isClosed</a>]]
-                            slot is <code>true</code>, abort these steps.</p>
-                          </li>
-                          <li>
-                            <p>For each <a>media description</a> in the last
-                            successfully applied remote description, perform
-                            the processing for an end-of-candidates indication
-                            for said <a>media description</a> as defined in
-                            [[TRICKLE-ICE]].</p>
-                          </li>
-                          <li>
-                            <p>Resolve <var>p</var> with
-                            <code>undefined</code>.</p>
-                          </li>
-                        </ol>
                       </li>
                       <li>
                         <p>If <var>candidate.sdpMid</var> is not null, run the
@@ -1816,9 +1795,20 @@ interface RTCPeerConnection : EventTarget  {
                         </ol>
                       </li>
                       <li>
+                        <p>If <code><var>candidate</var>.ufrag</code> is not
+                        equal to any ufrag present in the corresponding
+                        <a>media description</a> of an applied remote
+                        description, reject <var>p</var> with an
+                        <code>OperationError</code> and abort these steps.</p>
+                      </li>
+                      <li>
                         <p>In parallel, add the ICE candidate
                         <var>candidate</var> as described in <span data-jsep=
-                        "addicecandidate">[[!JSEP]]</span>.</p>
+                        "addicecandidate">[[!JSEP]]</span>. If
+                        <code><var>candidate</var>.candidate</code> is null,
+                        process <var>candidate</var> as an end-of-candidates
+                        indication for the corresponding <a>media
+                        description</a> and ICE candidate generation.</p>
                         <ol>
                           <li>
                             <p>If <var>candidate</var> could not be
@@ -3344,19 +3334,20 @@ interface RTCSessionDescription {
           <pre class="idl">
           [ Constructor (RTCIceCandidateInit candidateInitDict)]
 interface RTCIceCandidate {
-    readonly        attribute DOMString               candidate;
+    readonly        attribute DOMString?              candidate;
     readonly        attribute DOMString?              sdpMid;
     readonly        attribute unsigned short?         sdpMLineIndex;
-    readonly        attribute DOMString               foundation;
-    readonly        attribute unsigned long           priority;
-    readonly        attribute DOMString               ip;
-    readonly        attribute RTCIceProtocol          protocol;
-    readonly        attribute unsigned short          port;
-    readonly        attribute RTCIceCandidateType     type;
+    readonly        attribute DOMString?              foundation;
+    readonly        attribute unsigned long?          priority;
+    readonly        attribute DOMString?              ip;
+    readonly        attribute RTCIceProtocol?         protocol;
+    readonly        attribute unsigned short?         port;
+    readonly        attribute RTCIceCandidateType?    type;
     readonly        attribute RTCIceTcpCandidateType? tcpType;
     readonly        attribute DOMString?              relatedAddress;
     readonly        attribute unsigned short?         relatedPort;
-    serializer = {candidate, sdpMid, sdpMLineIndex};
+    readonly        attribute DOMString               ufrag;
+    serializer = {candidate, sdpMid, sdpMLineIndex, ufrag};
 };</pre>
           <section>
             <h2>Constructors</h2>
@@ -3483,6 +3474,10 @@ interface RTCIceCandidate {
               or reflexive candidate, the <dfn>relatedPort</dfn> is the port of
               the candidate that it is derived from. For host candidates, the
               <code>relatedPort</code> is <code>null</code>.</dd>
+              <dt><code>ufrag</code> of type <span class=
+              "idlAttrType"><a>DOMString</a></span>, readonly</dt>
+              <dd>This carries the <code>ufrag</code> as defined in section
+              15.4 of [[!ICE]].</dd>
             </dl>
           </section>
           <section>
@@ -3490,15 +3485,16 @@ interface RTCIceCandidate {
             <div>
               <p>Instances of this interface are serialized as a map with
               entries for the following attributes: candidate, sdpMid,
-              sdpMLineIndex.</p>
+              sdpMLineIndex, ufrag.</p>
             </div>
           </section>
         </div>
         <div>
           <pre class="idl">dictionary RTCIceCandidateInit {
-    required DOMString       candidate;
+             DOMString?      candidate = null;
              DOMString?      sdpMid = null;
              unsigned short? sdpMLineIndex = null;
+    required DOMString       ufrag;
 };</pre>
           <section>
             <h2>Dictionary <a class="idlType">RTCIceCandidateInit</a>
@@ -3515,6 +3511,9 @@ interface RTCIceCandidate {
               <dt><dfn><code>sdpMLineIndex</code></dfn> of type <span class=
               "idlMemberType"><a>unsigned short</a></span>, nullable,
               defaulting to <code>null</code></dt>
+              <dd></dd>
+              <dt><dfn><code>ufrag</code></dfn> of type <span class=
+              "idlMemberType"><a>DOMString</a></span></dt>
               <dd></dd>
             </dl>
           </section>
@@ -6619,6 +6618,45 @@ sender.setParameters(params)
           <p><a>Update the ICE gathering state</a> of <var>connection</var>.</p>
         </li>
       </ol>
+
+      <p>Additionally, when the <a>ICE Agent</a> indicates that it finished
+      gathering an individual generation of candidates for an
+      <code><a>RTCIceTransport</a></code>, the User Agent MUST queue
+      a task that runs the following steps:</p>
+      <ol>
+        <li>
+          <p>Let <var>connection</var> be the
+          <code><a>RTCPeerConnection</a></code> object associated with this
+          <a>ICE Agent</a>.</p>
+        </li>
+        <li>
+          <p>If <var>connection</var>'s [[<a>isClosed</a>]] slot is
+          <code>true</code>, abort these steps.</p>
+        </li>
+        <li>
+          <p>Let <var>transport</var> be the relevant
+          <code><a>RTCIceTransport</a></code>.</p>
+        </li>
+        <li>
+          <p>Create an <code><a>RTCIceCandidate</a></code> instance, with
+          <code><a data-for="RTCIceCandidate">sdpMid</a></code> and
+          <code><a data-for="RTCIceCandidate">sdpMLineIndex</a></code>
+          set to the values associated with this
+          <code><a>RTCIceTransport</a></code>, with
+          <code><a data-for="RTCIceCandidate">ufrag</a></code> set to the ufrag
+          of the generation of candidates for which gathering finished, and
+          with all other nullable members set to null.</p>
+        </li>
+        <li>
+          <p>Fire an event named <code><a>icecandidate</a></code> with
+          <var>newCandidate</var> at <var>connection</var>.</p>
+        </li>
+      </ol>
+      <div class="issue">
+        ICEbis doesn't define what a "generation of candidates" is, though this
+        terminology is used in places like [[TRICKLE-ICE]]. Once a definition is
+        added we should reference it here.
+      </div>
 
       <p>When the <a>ICE Agent</a> indicates that a new ICE candidate is
       available for an <code><a>RTCIceTransport</a></code>, either by taking one

--- a/webrtc.html
+++ b/webrtc.html
@@ -6585,10 +6585,9 @@ sender.setParameters(params)
       <code><a>RTCIceTransport</a></code> changes when the <a>ICE Agent</a>
       provides indications to the User Agent as described below.</p>
 
-      <p>When the <a>ICE Agent</a> indicates that the
-      <code><a>RTCIceGathererState</a></code> for an
-      <code><a>RTCIceTransport</a></code> has changed, the User Agent MUST queue
-      a task that runs the following steps:</p>
+      <p>When the <a>ICE Agent</a> indicates that it began gathering a
+      generation of candidates for an <code><a>RTCIceTransport</a></code>, the
+      User Agent MUST queue a task that runs the following steps:</p>
       <ol>
         <li>
           <p>Let <var>connection</var> be the
@@ -6601,16 +6600,12 @@ sender.setParameters(params)
         </li>
         <li>
           <p>Let <var>transport</var> be the <code><a>RTCIceTransport</a></code>
-          whose state is changing.</p>
-        </li>
-        <li>
-          <p>Let <var>newState</var> be the new indicated
-          <code><a>RTCIceGathererState</a></code>.
+          for which candidate gathering began.</p>
         </li>
         <li>
           <p>Set <var>transport</var>'s <code><a data-link-for=
-          "RTCIceTransport">gatheringState</a></code> to
-          <var>newState</var>.</p>
+          "RTCIceTransport">gatheringState</a></code> to <code><a
+          data-link-for="RTCIceGathererState">gathering</a></code>.</p>
         </li>
         <li>
           <p>Fire a simple event named <code><a>gatheringstatechange</a></code>
@@ -6621,10 +6616,9 @@ sender.setParameters(params)
         </li>
       </ol>
 
-      <p>Additionally, when the <a>ICE Agent</a> indicates that it finished
-      gathering an individual generation of candidates for an
-      <code><a>RTCIceTransport</a></code>, the User Agent MUST queue
-      a task that runs the following steps:</p>
+      <p>When the <a>ICE Agent</a> indicates that it finished gathering a
+      generation of candidates for an <code><a>RTCIceTransport</a></code>, the
+      User Agent MUST queue a task that runs the following steps:</p>
       <ol>
         <li>
           <p>Let <var>connection</var> be the
@@ -6636,12 +6630,13 @@ sender.setParameters(params)
           <code>true</code>, abort these steps.</p>
         </li>
         <li>
-          <p>Let <var>transport</var> be the relevant
-          <code><a>RTCIceTransport</a></code>.</p>
+          <p>Let <var>transport</var> be the <code><a>RTCIceTransport</a></code>
+          for which candidate gathering finished.</p>
         </li>
         <li>
-          <p>Create an <code><a>RTCIceCandidate</a></code> instance, with
-          <code><a data-for="RTCIceCandidate">sdpMid</a></code> and
+          <p>Create an <code><a>RTCIceCandidate</a></code> instance
+          <var>newCandidate</var>, with <code><a
+          data-for="RTCIceCandidate">sdpMid</a></code> and
           <code><a data-for="RTCIceCandidate">sdpMLineIndex</a></code>
           set to the values associated with this
           <code><a>RTCIceTransport</a></code>, with
@@ -6653,6 +6648,26 @@ sender.setParameters(params)
         <li>
           <p>Fire an event named <code><a>icecandidate</a></code> with
           <var>newCandidate</var> at <var>connection</var>.</p>
+        </li>
+        <li>
+          <p>If another generation of candidates is still being gathered, abort
+          these steps.</p>
+          <div class="note">
+            This may occur if an ICE restart is initiated while the ICE agent
+            is still gathering the previous generation of candidates.
+          </div>
+        </li>
+        <li>
+          <p>Set <var>transport</var>'s <code><a data-link-for=
+          "RTCIceTransport">gatheringState</a></code> to <code><a
+          data-link-for="RTCIceGathererState">complete</a></code>.</p>
+        </li>
+        <li>
+          <p>Fire a simple event named <code><a>gatheringstatechange</a></code>
+          at <var>transport</var>.</p>
+        </li>
+        <li>
+          <p><a>Update the ICE gathering state</a> of <var>connection</var>.</p>
         </li>
       </ol>
       <div class="issue">

--- a/webrtc.html
+++ b/webrtc.html
@@ -3493,7 +3493,7 @@ interface RTCIceCandidate {
         </div>
         <div>
           <pre class="idl">dictionary RTCIceCandidateInit {
-             DOMString       candidate;
+             DOMString       candidate = "";
              DOMString?      sdpMid = null;
              unsigned short? sdpMLineIndex = null;
     required DOMString       ufrag;
@@ -3504,7 +3504,8 @@ interface RTCIceCandidate {
             <dl data-link-for="RTCIceCandidateInit" data-dfn-for=
             "RTCIceCandidateInit" class="dictionary-members">
               <dt><dfn><code>candidate</code></dfn> of type <span class=
-              "idlMemberType"><a>DOMString</a></span>, required</dt>
+              "idlMemberType"><a>DOMString</a></span>, defaulting to
+              <code>""</code></dt>
               <dd></dd>
               <dt><dfn><code>sdpMid</code></dfn> of type <span class=
               "idlMemberType"><a>DOMString</a></span>, nullable, defaulting to

--- a/webrtc.html
+++ b/webrtc.html
@@ -965,7 +965,7 @@ interface RTCPeerConnection : EventTarget  {
     readonly        attribute RTCSessionDescription?    remoteDescription;
     readonly        attribute RTCSessionDescription?    currentRemoteDescription;
     readonly        attribute RTCSessionDescription?    pendingRemoteDescription;
-    Promise&lt;void&gt;                      addIceCandidate ((RTCIceCandidateInit or RTCIceCandidate)? candidate);
+    Promise&lt;void&gt;                      addIceCandidate ((RTCIceCandidateInit or RTCIceCandidate) candidate);
     readonly        attribute RTCSignalingState         signalingState;
     readonly        attribute RTCIceGatheringState      iceGatheringState;
     readonly        attribute RTCIceConnectionState     iceConnectionState;
@@ -1722,9 +1722,9 @@ interface RTCPeerConnection : EventTarget  {
                 "dom-peerconnection-addicecandidate"><code>addIceCandidate()</code></dfn>
                 method provides a remote candidate to the <a>ICE Agent</a>.
                 This method can also be used to indicate the end of remote
-                candidates when called with a <code>null</code> value for
-                <code>candidate</code>. The only members of the argument used
-                by this method are <code><a data-for=
+                candidates when called with an empty string for <code><a
+                data-for="RTCIceCandidate">candidate</a></code>. The only
+                members of the argument used by this method are <code><a data-for=
                 "RTCIceCandidate">candidate</a></code>, <code><a data-for=
                 "RTCIceCandidate">sdpMid</a></code>, <code><a data-for=
                 "RTCIceCandidate">sdpMLineIndex</a></code>, and
@@ -1733,7 +1733,7 @@ interface RTCPeerConnection : EventTarget  {
                 run the following steps:</p>
                 <ol>
                   <li>
-                    <p>Let <var>candidate</var> be the methods argument.</p>
+                    <p>Let <var>candidate</var> be the method's argument.</p>
                   </li>
                   <li>
                     <p>Let <var>connection</var> be the
@@ -1741,10 +1741,9 @@ interface RTCPeerConnection : EventTarget  {
                     method was invoked.</p>
                   </li>
                   <li>
-                    <p>If <var>candidate</var> is not <code>null</code> but is
-                    missing values for both <var>sdpMid</var> and
-                    <var>sdpMLineIndex</var>, return a promise rejected with a
-                    <code>TypeError</code>.</p>
+                    <p>If <var>candidate</var> is missing values for both
+                    <var>sdpMid</var> and <var>sdpMLineIndex</var>, return a
+                    promise rejected with a <code>TypeError</code>.</p>
                   </li>
                   <li>
                     <p>Return the result of <a href=
@@ -1805,10 +1804,11 @@ interface RTCPeerConnection : EventTarget  {
                         <p>In parallel, add the ICE candidate
                         <var>candidate</var> as described in <span data-jsep=
                         "addicecandidate">[[!JSEP]]</span>. If
-                        <code><var>candidate</var>.candidate</code> is null,
-                        process <var>candidate</var> as an end-of-candidates
-                        indication for the corresponding <a>media
-                        description</a> and ICE candidate generation.</p>
+                        <code><var>candidate</var>.candidate</code> is an empty
+                        string, process <var>candidate</var> as an
+                        end-of-candidates indication for the corresponding
+                        <a>media description</a> and ICE candidate
+                        generation.</p>
                         <ol>
                           <li>
                             <p>If <var>candidate</var> could not be
@@ -2519,7 +2519,7 @@ interface RTCPeerConnection : EventTarget  {
                   <li>
                     <p>Run the steps specified by
                     <code><a>RTCPeerConnection</a></code>'s <a data-for=
-                    "RTCPeerConnection">addIceCandiddate()</a> method with
+                    "RTCPeerConnection">addIceCandidate()</a> method with
                     <var>candidate</var> as the sole argument, and let
                     <var>p</var> be the resulting promise.</p>
                   </li>
@@ -3334,7 +3334,7 @@ interface RTCSessionDescription {
           <pre class="idl">
           [ Constructor (RTCIceCandidateInit candidateInitDict)]
 interface RTCIceCandidate {
-    readonly        attribute DOMString?              candidate;
+    readonly        attribute DOMString               candidate;
     readonly        attribute DOMString?              sdpMid;
     readonly        attribute unsigned short?         sdpMLineIndex;
     readonly        attribute DOMString?              foundation;
@@ -3392,7 +3392,9 @@ interface RTCIceCandidate {
               <dt><dfn><code>candidate</code></dfn> of type <span class=
               "idlAttrType"><a>DOMString</a></span>, readonly</dt>
               <dd>This carries the <code>candidate-attribute</code> as defined
-              in section 15.1 of [[!ICE]].</dd>
+              in section 15.1 of [[!ICE]]. If this <code>RTCIceCandidate</code>
+              represents an end-of-candidates indication,
+              <code>candidate</code> is an empty string.</dd>
               <dt><dfn><code>sdpMid</code></dfn> of type <span class=
               "idlAttrType"><a>DOMString</a></span>, readonly , nullable</dt>
               <dd>If not <code>null</code>, this contains the identifier of the
@@ -3407,15 +3409,15 @@ interface RTCIceCandidate {
                 is associated with.
               </dd>
               <dt><dfn><code>foundation</code></dfn> of type <span class=
-              "idlAttrType"><a>DOMString</a></span>, readonly</dt>
+              "idlAttrType"><a>DOMString</a></span>, readonly, nullable</dt>
               <dd>A unique identifier that allows ICE to correlate candidates
               that appear on multiple
               <code><a>RTCIceTransport</a></code>s.</dd>
               <dt><dfn><code>priority</code></dfn> of type <span class=
-              "idlAttrType"><a>unsigned long</a></span>, readonly</dt>
+              "idlAttrType"><a>unsigned long</a></span>, readonly, nullable</dt>
               <dd>The assigned priority of the candidate.</dd>
               <dt><dfn><code>ip</code></dfn> of type <span class=
-              "idlAttrType"><a>DOMString</a></span>, readonly</dt>
+              "idlAttrType"><a>DOMString</a></span>, readonly, nullable</dt>
               <dd>
                 <p>The IP address of the candidate.</p>
                 <div class="note">
@@ -3445,30 +3447,30 @@ interface RTCIceCandidate {
                 </div>
               </dd>
               <dt><dfn><code>protocol</code></dfn> of type <span class=
-              "idlAttrType"><a>RTCIceProtocol</a></span>, readonly</dt>
+              "idlAttrType"><a>RTCIceProtocol</a></span>, readonly, nullable</dt>
               <dd>The protocol of the candidate
               (<code>udp</code>/<code>tcp</code>).</dd>
               <dt><dfn><code>port</code></dfn> of type <span class=
-              "idlAttrType"><a>unsigned short</a></span>, readonly</dt>
+              "idlAttrType"><a>unsigned short</a></span>, readonly, nullable</dt>
               <dd>The port of the candidate.</dd>
               <dt><dfn><code>type</code></dfn> of type <span class=
-              "idlAttrType"><a>RTCIceCandidateType</a></span>, readonly</dt>
+              "idlAttrType"><a>RTCIceCandidateType</a></span>, readonly, nullable</dt>
               <dd>The type of the candidate.</dd>
               <dt><dfn><code>tcpType</code></dfn> of type <span class=
-              "idlAttrType"><a>RTCIceTcpCandidateType</a></span>, readonly ,
+              "idlAttrType"><a>RTCIceTcpCandidateType</a></span>, readonly,
               nullable</dt>
               <dd>If <code>protocol</code> is <code>tcp</code>,
               <code>tcpType</code> represents the type of TCP candidate.
               Otherwise, <code>tcpType</code> is <code>null</code>.</dd>
               <dt><code>relatedAddress</code> of type <span class=
-              "idlAttrType"><a>DOMString</a></span>, readonly , nullable</dt>
+              "idlAttrType"><a>DOMString</a></span>, readonly, nullable</dt>
               <dd>For a candidate that is derived from another, such as a relay
               or reflexive candidate, the <dfn>relatedAddress</dfn> is the IP
               address of the candidate that it is derived from. For host
               candidates, the <code>relatedAddress</code> is
               <code>null</code>.</dd>
               <dt><code>relatedPort</code> of type <span class=
-              "idlAttrType"><a>unsigned short</a></span>, readonly ,
+              "idlAttrType"><a>unsigned short</a></span>, readonly,
               nullable</dt>
               <dd>For a candidate that is derived from another, such as a relay
               or reflexive candidate, the <dfn>relatedPort</dfn> is the port of
@@ -3491,7 +3493,7 @@ interface RTCIceCandidate {
         </div>
         <div>
           <pre class="idl">dictionary RTCIceCandidateInit {
-             DOMString?      candidate = null;
+             DOMString       candidate;
              DOMString?      sdpMid = null;
              unsigned short? sdpMLineIndex = null;
     required DOMString       ufrag;
@@ -6644,8 +6646,9 @@ sender.setParameters(params)
           set to the values associated with this
           <code><a>RTCIceTransport</a></code>, with
           <code><a data-for="RTCIceCandidate">ufrag</a></code> set to the ufrag
-          of the generation of candidates for which gathering finished, and
-          with all other nullable members set to null.</p>
+          of the generation of candidates for which gathering finished, with
+          <code><a data-for="RTCIceCandidate">candidate</a></code> set to an
+          empty string, and with all other nullable members set to null.</p>
         </li>
         <li>
           <p>Fire an event named <code><a>icecandidate</a></code> with


### PR DESCRIPTION
Since RTCIceCandidate can be used for end-of-candidates, all the
attributes besides "ufrag" now become nullable.

Rebase of PR #757. Fixes #726.