### PR TITLE
Make candidate argument in RTCPeerConnection#addIceCandidate non-nullable

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -965,7 +965,7 @@ interface RTCPeerConnection : EventTarget  {
     readonly        attribute RTCSessionDescription?    remoteDescription;
     readonly        attribute RTCSessionDescription?    currentRemoteDescription;
     readonly        attribute RTCSessionDescription?    pendingRemoteDescription;
-    Promise&lt;void&gt;                      addIceCandidate ((RTCIceCandidateInit or RTCIceCandidate)? candidate);
+    Promise&lt;void&gt;                      addIceCandidate ((RTCIceCandidateInit or RTCIceCandidate) candidate);
     readonly        attribute RTCSignalingState         signalingState;
     readonly        attribute RTCIceGatheringState      iceGatheringState;
     readonly        attribute RTCIceConnectionState     iceConnectionState;


### PR DESCRIPTION
It makes no sense to add a null object as an IceCandidate