### PR TITLE
Add RTCOfferOptions.reofferOptions.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -427,6 +427,7 @@
         <div>
           <pre class="idl">dictionary RTCOfferOptions : RTCOfferAnswerOptions {
              boolean iceRestart = false;
+             boolean reofferCodecs = false;
 };</pre>
           <section>
             <h2>Dictionary <a class="idlType">RTCOfferOptions</a> Members</h2>
@@ -449,6 +450,15 @@
                 same ICE credentials as the current value from the
                 <code><a data-link-for=
                 "RTCPeerConnection">localDescription</a></code> attribute.</p>
+              </dd>
+              <dt><dfn><code>reofferCodecs</code></dfn> of type <span class=
+              "idlMemberType"><a>boolean</a></span>, defaulting to
+              <code>false</code></dt>
+              <dd>
+                <p>When the value of this dictionary member is true,
+                the generated description will include codecs that
+                were excluded by the current remote description, as
+                defined in [[!JSEP]].</p>
               </dd>
             </dl>
           </section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -457,7 +457,7 @@
               <dd>
                 <p>When the value of this dictionary member is true,
                 the generated description will include codecs that
-                were excluded by the current remote description, as
+                were excluded by the most recent answer, as
                 defined in [[!JSEP]].</p>
               </dd>
             </dl>

--- a/webrtc.html
+++ b/webrtc.html
@@ -456,8 +456,8 @@
               <code>false</code></dt>
               <dd>
                 <p>When the value of this dictionary member is true,
-                the generated description will include codecs that
-                were excluded by the most recent answer, as
+                the generated description will include codecs even if
+                they were excluded by the most recent answer, as
                 defined in [[!JSEP]].</p>
               </dd>
             </dl>


### PR DESCRIPTION
An idea for how to allow control of when do reoffer codecs that have been excluded by the remote description.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/pthatcherg/webrtc-pc/pull/988.html" title="Last updated on Apr 21, 2018, 1:42 AM GMT (5799ff5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/988/35725f7...pthatcherg:5799ff5.html" title="Last updated on Apr 21, 2018, 1:42 AM GMT (5799ff5)">Diff</a>