### PR TITLE
Fix warnings about in-prose definitions

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2520,7 +2520,7 @@ interface RTCPeerConnection : EventTarget  {
               </dd>
               <dt><code>addIceCandidate</code></dt>
               <dd>
-                <p>When the <dfn data-lt="addIceCandidate!overload-1" data-lt-nodefault>addIceCandidate</code> method is called, the
+                <p>When the <dfn data-lt="addIceCandidate!overload-1" data-lt-nodefault>addIceCandidate</dfn> method is called, the
                 user agent MUST run the following steps:</p>
                 <ol>
                   <li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -452,6 +452,7 @@
           </section>
         </div>
         <div>
+          <p>The <dfn>RTCAnswerOptions</dfn> dictionary describe options specific to session description of type <code>answer</code> (none in this version of the specification).</p>
           <pre class="idl">
           dictionary RTCAnswerOptions : RTCOfferAnswerOptions {
 };</pre>
@@ -1623,7 +1624,7 @@ interface RTCPeerConnection : EventTarget  {
               <dt><code>setLocalDescription</code></dt>
               <dd>
                 <p>The <dfn id=
-                "dom-peerconnection-setlocaldescription"><code>setLocalDescription</code></dfn>
+                "dom-peerconnection-setlocaldescription"><code>setLocalDescription()</code></dfn>
                 method instructs the <code><a>RTCPeerConnection</a></code> to
                 apply the supplied
                 <code><a>RTCSessionDescriptionInit</a></code> as the local
@@ -5010,7 +5011,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           "methods">
             <dt><code>getCapabilities</code>, static</dt>
             <dd>
-              <p>The <dfn><code>RTCRtpSender.getCapabilities</code></dfn>
+              <p>The <dfn>getCapabilities()</dfn>
               method returns the most optimist view on the capabilities of the
               system for sending media of the given kind. It does not reserve
               any resources, ports, or other state but is meant to provide a
@@ -5132,7 +5133,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             </dd>
             <dt><code>getParameters</code></dt>
             <dd>
-              <p>The <dfn><code>RTCRtpSender.getParameters</code></dfn> method
+              <p>The <dfn>getParameters()</dfn> method
               returns the <code><a>RTCRtpSender</a></code> object's current
               parameters for how <code>track</code> is encoded and transmitted
               to a remote <code><a>RTCRtpReceiver</a></code>. It may used with
@@ -5883,7 +5884,7 @@ sender.setParameters(params)
           class="methods">
             <dt><code>getCapabilities</code>, static</dt>
             <dd>
-              <p>The <dfn><code>RTCRtpReceiver.getCapabilities</code></dfn>
+              <p>The <dfn>getCapabilities()</dfn>
               method returns the most optimistic view of the capabilities of
               the system for receiving media of the given kind. It does not
               reserve any resources, ports, or other state but is meant to
@@ -5920,7 +5921,7 @@ sender.setParameters(params)
             </dd>
             <dt><code>getParameters</code></dt>
             <dd>
-              <p>The <dfn><code>RTCRtpReceiver.getParameters</code></dfn> method
+              <p>The <dfn>getParameters()</dfn> method
               returns the <code>RTCRtpReceiver</code> object's current parameters
               for how <code>track</code> is decoded.</p>
               <div>
@@ -9750,7 +9751,7 @@ interface RTCIdentityAssertion {
     attribute DOMString name;
 };</pre>
         <section>
-          <h2>Attributes</h2>
+          <h2><dfn>RTCIdentityAssertion</dfn> Attributes</h2>
           <dl data-link-for="RTCIdentityAssertion" data-dfn-for=
           "RTCIdentityAssertion" class="attributes">
             <dt><dfn><code>idp</code></dfn> of type <span class=

--- a/webrtc.html
+++ b/webrtc.html
@@ -2520,7 +2520,7 @@ interface RTCPeerConnection : EventTarget  {
               </dd>
               <dt><code>addIceCandidate</code></dt>
               <dd>
-                <p>When the <code>addIceCandidate</code> method is called, the
+                <p>When the <dfn data-lt="addIceCandidate!overload-1" data-lt-nodefault>addIceCandidate</code> method is called, the
                 user agent MUST run the following steps:</p>
                 <ol>
                   <li>


### PR DESCRIPTION
for #978 (which will be cleared once https://github.com/w3c/respec/pull/1043 gets deployed)