### PR TITLE
Separated auth dictionaries for STUN/TURN (issue 714)

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -198,7 +198,7 @@
         <div>
           <pre class="idl">enum RTCIceCredentialType {
     "password",
-    "token"
+    "oauth"
 };</pre>
           <table data-link-for="RTCIceCredentialType" data-dfn-for=
           "RTCIceCredentialType" class="simple">
@@ -208,28 +208,168 @@
               </tr>
               <tr>
                 <td><dfn><code>password</code></dfn></td>
-                <td>The credential is a long-term authentication password, as
-                described in [[!RFC5389]], Section 10.2.</td>
+                <td>The credential is a long-term authentication username and
+                password, as described in [[!RFC5389]], Section 10.2.
+                </td>
               </tr>
               <tr>
-                <td><dfn><code>token</code></dfn></td>
-                <td>The credential is an access token, as described in
-                [[!TRAM-TURN-THIRD-PARTY-AUTHZ]], Section 6.2.</td>
+                <td><dfn><code>oauth</code></dfn></td>
+                <td>An OAuth 2.0 based authentication method, that's described
+                in [[!RFC7635]]. It uses the OAuth 2.0 Implicit Grant type,
+                with PoP (Proof-of-Possession) Token type. Find more details in
+                [[!RFC6749]] and in [[!OAUTH-POP-KEY-DISTRIBUTION]].
+                <p>The OAuth client is responsible to refresh and keep the
+                credential information fresh, and update ICE agent with fresh
+                new credential before the access_token expires. The OAuth
+                client could use the <a href="#interface-definition"><code>
+                RTCPeerConnection</code></a> <a data-lt="setConfiguration"
+                href="#dom-rtcpeerconnection-setconfiguration"><code>
+                setConfiguration</code></a> method to refresh periodically the
+                TURN credentials.
+                </p>
+                <p>For OAuth Authntication the <code>TURN client</code>
+                require three credential information. The credential is
+                composed of <code>kid</code>, <code>macKey</code>, and <code>
+                accessToken</code>. All these information could be extracted
+                from the OAuth response parameters, that are received from the
+                <code>Auth Server</code> (AS). The relevant OAuth response
+                parameters are the "kid", the "key", and the "access_token".
+                These could be used, to extract all the credential infromation
+                (the <code>kid</code>, the <code>macKey</code>, and <code>
+                accessToken</code>), that are requied for the <code>TURN client
+                </code> for the Authentication.
+                </p>
+                <p>Find more details about the <code>Access-Token</code> in
+                [[!RFC7635]], Section 6.2.
+                </p>
+                </td>
               </tr>
             </tbody>
           </table>
         </div>
       </section>
       <section>
-        <h4><dfn>RTCIceServer</dfn> Dictionary</h4>
+        <h4><dfn>PasswordCredential</dfn> Dictionary</h4>
+        <p>The <code>PasswordCredential</code> dictionary is used to describe
+        a Long Term Credential information that can be used by the STUN/TURN
+        client (inside the <a>ICE Agent</a>), to authenticate against a
+        STUN/TURN server. Find more details in [[!RFC5389]] Section 10.2.
+        </p>
+        <div>
+          <pre class="idl">dictionary PasswordCredential {
+    required DOMString        username;
+    required DOMString        password;
+};</pre>
+          <section>
+            <h2>Dictionary <a class="idlType">PasswordCredential</a> Members
+            </h2>
+            <dl data-link-for="PasswordCredential"
+            data-dfn-for="PasswordCredential" class="dictionary-members">
+              <dt><dfn><code>username</code></dfn> of type <span class=
+              "idlMemberType"><a>DOMString</a></span>, required</dt>
+              <dd>
+                <p>If this <code><a>PasswordCredential</a></code> object
+                represents a password credential, then this attribute specifies
+                the username to use with the related TURN server.</p>
+              </dd>
+              <dt><dfn><code>password</code></dfn> of type <span class=
+              "idlMemberType"><a>DOMString</a></span>, required</dt>
+              <dd>
+                <p>If this <code><a>PasswordCredential</a></code> object
+                represents a password credential, then this attribute specifies
+                the password or credential to use with the related TURN
+                 server.</p>
+              </dd>
+           </dl>
+          </section>
+        </div>
+        <p>An example array of PasswordCredential objects is:</p>
+        <pre class="example highlight"><code>{
+       "username": "user",
+       "password": "myPassword",
+}</code></pre>
+      </section>
+      <section>
+        <h4><dfn>OAuthCredential</dfn> Dictionary</h4>
+        <p>The <code>OAuthCredential</code> dictionary is used to describe an
+        OAuth auth credential information, that can be used by the STUN/TURN
+        client (inside the ICE Agent), to authenticate against a STUN/TURN
+        server. Find more details in [[!RFC7635]].
+        </p>
+        <div>
+          <pre class="idl">dictionary OAuthCredential {
+    required DOMString        kid;
+    required DOMString        macKey;
+    required DOMString        accessToken;
+};</pre>
+          <section>
+            <h2>Dictionary <a class="idlType">OAuthCredential</a> Members</h2>
+            <dl data-link-for="OAuthCredential" data-dfn-for="OAuthCredential" class=
+            "dictionary-members">
+              <dt><dfn><code>kid</code></dfn> of type <span class=
+              "idlMemberType"><a>DOMString</a></span>, required</dt>
+              <dd>
+                <p>is the Key ID of the shared symmetric key, which is
+                shared between the TURN server and the Auth Server (AS). It is
+                an ephemeral and unique key identifier.  The kid also allows
+                the TURN server to select the appropriate keying material for
+                decryption of the Access-Token, so the key identified by this
+                <code>kid</code> is used in the Authenticated Encryption of the
+                "access_token". The <code>kid</code> value is equal with the
+                OAuth response "kid" parameter. Find more details in 
+                [[!RFC7635]] and kid definition in [[!RFC7515]] Section 4.1.4
+              </p>
+              </dd>
+              <dt><dfn><code>macKey</code></dfn> of type <span class=
+              "idlMemberType"><a>DOMString</a></span>, required</dt>
+              <dd>
+                <p>contains the "mac_key" in base64url encoded format.
+                It is used in STUN message Integrity hash calculation (like
+                "password" is used in password based authentication). Please
+                be aware, that OAuth response "key" parameter is in JSON Web Key
+                (JWK) or a JWK encrypted with a JWE format. Notice that this is
+                the only oauth parameter that's value is not used directly, but
+                you have to extract the "k" parameter value from the JWK, what
+                contains the needed base64 encoded "mac_key".
+                </p>
+              </dd>
+              <dt><dfn><code>accessToken</code></dfn> of type <span class=
+              "idlMemberType"><a>DOMString</a></span>, required</dt>
+              <dd>
+                <p>is encoded in base64 format. The "access_token" is an
+                encrypted self-contained token that is opaque for the app.
+                Authenticated encryption is used for message encryption and
+                integrity protection. It contains a not encrypted nonce value,
+                that is used by the Auth Server for unique mac_key generation.
+                The second part of the token is protected by Authenticated 
+                Encryption. It contains the mac_key and a timestamp and a
+                lifetime. The timestamp combined lifetime gives the expiry
+                information, these information describes the time window during
+                the token credential is valid and accepted by the TRUN server.
+                </p>
+                <p>
+                Find more details in [[!RFC7635]], Section 6.2.
+                </p>
+              </dd>
+           </dl>
+          </section>
+        </div>
+        <p>An example array of OAuthCredential objects is:</p>
+        <pre class="example highlight"><code>{
+    "kid": "22BIjxU93h/IgwEb",
+    "macKey": "ZksjpweoixXmvn67534m",
+    "accessToken": "AAwg3kPHWPfvk9bDFL936wYvkoctMADzQ5VhNDgeMR3+ZlZ35byg972fW8QjpEl7bx91YLBPFsIhsxloWcXPhA=="
+}</code></pre>
+      </section>
+      <section>
+         <h4><dfn>RTCIceServer</dfn> Dictionary</h4>
         <p>The <code>RTCIceServer</code> dictionary is used to describe the
         STUN and TURN servers that can be used by the <a>ICE Agent</a> to
         establish a connection with a peer.</p>
         <div>
           <pre class="idl">dictionary RTCIceServer {
     required (DOMString or sequence&lt;DOMString&gt;) urls;
-             DOMString                          username;
-             DOMString                          credential;
+             (PasswordCredential or OAuthCredential)        credential;
              RTCIceCredentialType               credentialType = "password";
 };</pre>
           <section>
@@ -243,15 +383,8 @@
                 <p>STUN or TURN URI(s) as defined in [[!RFC7064]] and
                 [[!RFC7065]] or other URI types.</p>
               </dd>
-              <dt><dfn><code>username</code></dfn> of type <span class=
-              "idlMemberType"><a>DOMString</a></span></dt>
-              <dd>
-                <p>If this <code><a>RTCIceServer</a></code> object represents a
-                TURN server, then this attribute specifies the username to use
-                with that TURN server.</p>
-              </dd>
               <dt><dfn><code>credential</code></dfn> of type <span class=
-              "idlMemberType"><a>DOMString</a></span></dt>
+              "idlMemberType">(<a>PasswordCredential</a> or <a>OAuthCredential</a>)</span></dt>
               <dd>
                 <p>If this <code><a>RTCIceServer</a></code> object represents a
                 TURN server, then this attribute specifies the credential to
@@ -273,9 +406,19 @@
         <pre class="example highlight"><code>[
      { "urls": "stun:stun1.example.net" },
      { "urls": ["turns:turn.example.org", "turn:turn.example.net"],
-       "username": "user",
-       "credential": "myPassword",
-       "credentialType": "password" }
+       "credential": { 
+                       "username": "user",
+                       "password": "myPassword"
+                     },
+       "credentialType": "password" },
+     { "urls": "turns:turn2.example.net",
+       "credential": { 
+                       "kid": "22BIjxU93h/IgwEb",
+                       "macKey": "ZksjpweoixXmvn67534m",
+                       "accessToken": "AAwg3kPHWPfvk9bDFL936wYvkoctMADzQ5VhNDgeMR3+ZlZ35byg972fW8QjpEl7bx91YLBPFsIhsxloWcXPhA=="
+                     },
+       "credentialType": "oauth" },
+     }
 ]</code></pre>
       </section>
       <section>
@@ -2022,10 +2165,32 @@ interface RTCPeerConnection : EventTarget  {
                       </li>
                       <li>
                         <p>If <var>scheme name</var> is <code>turn</code> or
-                        <code>turns</code>, and either of
-                        <code><var>server</var>.username</code> or
-                        <code><var>server</var>.credential</code> are omitted,
+                        <code>turns</code>, and 
+                        <code><var>server</var>.credential</code> is omitted,
                         then throw an <code>InvalidAccessError</code> and abort
+                        these steps.</p>
+                      </li>
+                      <li>
+                        <p>If <var>scheme name</var> is <code>turn</code> or
+                        <code>turns</code>, and
+                        <code><var>server</var>.credentialType</code> value is
+                        <code>"password"</code>, and either of
+                        <code><var>server</var>.passwordCredential.username
+                        </code> or <code><var>server</var>
+                        .passwordCredential.password</code> are omitted, then
+                         throw an <code>InvalidAccessError</code> and abort
+                        these steps.</p>
+                      </li>
+                      <li>
+                        <p>If <var>scheme name</var> is <code>turn</code> or
+                        <code>turns</code> and
+                        <code><var>server</var>.credentialType</code> value is
+                        <code>oauth</code> , and either of
+                        <code><var>server</var>.oauthCredential.kid</code> or
+                        <code><var>server</var>.oauthCredential.macKey</code>
+                        or <code><var>server</var>
+                        .oauthCredential.accessToken</code> are omitted, then
+                        throw an <code>InvalidAccessError</code> and abort
                         these steps.</p>
                       </li>
                       <li>
@@ -2155,7 +2320,7 @@ interface RTCPeerConnection : EventTarget  {
                         <p>Set <code><var>receiver</var>.track.readyState</code> to <code>ended</code>.</p>
                       </li>
                       <li>
-                        <p>Set <code><var>transceiver</var>.stopped</code> to <code>true</code>.</p>                 
+                        <p>Set <code><var>transceiver</var>.stopped</code> to <code>true</code>.</p>
                       </li>
                     </ol>
                   </li>
@@ -6235,13 +6400,13 @@ sender.setParameters(params)
               following steps:</p>
               <ol>
                 <li>
-                  <p>Let <var>transceiver</var> be the 
+                  <p>Let <var>transceiver</var> be the
                   <code><a>RTCRtpTransceiver</a></code> object which is to
                   be stopped.</p>
                 </li>
                 <li>
                   <p>If <code><var>transceiver</var>.stopped</code> is
-                  <code>true</code>, abort these steps.</p> 
+                  <code>true</code>, abort these steps.</p>
                 </li>
                 <li>
                   <p>Let <var>connection</var> be the
@@ -6259,22 +6424,22 @@ sender.setParameters(params)
                 <li>
                   <p>Let <var>receiver</var> be <code><var>transceiver</var>.receiver</code>.</p>
                 </li>
-                <li> 
+                <li>
                   <p>Stop sending media with <var>sender</var>.</p>
                 </li>
-                <li> 
+                <li>
                   <p>Stop receiving media with <var>receiver</var>.</p>
                 </li>
-                <li> 
+                <li>
                   <p>Set <code><var>receiver</var>.track.readyState</code> to <code>ended</code>.</p>
                 </li>
                 <li>
-                  <p>Set <code><var>transceiver</var>.stopped</code> to <code>true</code>.</p>                 
+                  <p>Set <code><var>transceiver</var>.stopped</code> to <code>true</code>.</p>
                 </li>
                 <li>
                   <p>Mark <var>connection</var> as needing negotiation.</p>
                 </li>
-              </ol>              
+              </ol>
               <div>
                 <em>No parameters.</em>
               </div>
@@ -10943,17 +11108,17 @@ if (sender.dtmf) {
         </section>
         <section>
           <h2>RTCError.prototype.errorDetail</h2>
-          <p>The initial value of the <code>errorDetail</code> property of the prototype for 
+          <p>The initial value of the <code>errorDetail</code> property of the prototype for
           the <code><a>RTCError</a></code> constructor is the empty String.</p>
         </section>
         <section>
           <h2>RTCError.prototype.sdpLineNumber</h2>
-          <p>The initial value of the <code>sdpLineNumber</code> property of the prototype for 
+          <p>The initial value of the <code>sdpLineNumber</code> property of the prototype for
           the <code><a>RTCError</a></code> constructor is 0.</p>
         </section>
         <section>
           <h2>RTCError.prototype.httpRequestStatusCode</h2>
-          <p>The initial value of the <code>httpRequestStatusCode</code> property of the prototype for 
+          <p>The initial value of the <code>httpRequestStatusCode</code> property of the prototype for
           the <code><a>RTCError</a></code> constructor is 0.</p>
         </section>
         <section>
@@ -11250,8 +11415,8 @@ interface RTCErrorEvent : Event {
           "event-fingerprintfailure"><code>fingerprintfailure</code></dfn></td>
           <td><code><a>Event</a></code></td>
           <td>
-            The <code>RTCPeerConnection</code>'s DTLS Certificate did not 
-            match any of the fingerprints in the SDP. 
+            The <code>RTCPeerConnection</code>'s DTLS Certificate did not
+            match any of the fingerprints in the SDP.
           </td>
         </tr>
       </tbody>

--- a/webrtc.html
+++ b/webrtc.html
@@ -240,47 +240,50 @@
                 requied for the <code>TURN client </code> for the
                 Authentication.
                 </p>
-                <p>The OAuth client sends an OAuth request to the <code>Auth
-                Server</code> with OAuth params
+                <p>The <code>OAuth Client</code> sends an <code>OAuth Request</code> to the
+                <code>Auth Server</code> with OAuth params
                 <code>grant_type=implicit</code>, <code>token_type=pop</code>
                 and <code>alg=</code> ( alg value is set according the supported
-                HMAC capabilities of the client), and many further OAuth related
-                parameters, to get an OAuth response with the
+                HMAC capabilities of the Client), and further OAuth related
+                parameters,<br> to get an <code>OAuth Response</code> with the
                 <code>access_token</code>, <code>key</code>, <code>kid</code>,
-                and many further OAuth related parameters.
+                and further OAuth related parameters.
                 </p>
-                <p>
-                As mentioned the OAuth client provide information about the
-                client HMAC alg capability, which HMAC algorithms are supported
-                by the client, to help Auth Server to generate approriate HMAC
-                key length and type (symmetric/asymmetric).
+                <p>If the <code>Auth Server</code> doesn't have prior knowledge
+                of the capabilities of the client, then the <code>OAuth
+                Client</code> needs to provide information about the
+                <code>STUN/TURN Client</code> HMAC "alg" capabilities. This
+                information about which HMAC algorithms supported by the
+                <code>STUN/TURN Client</code>, helps the <code>Auth
+                Server</code> to generate the approriate HMAC key, with the
+                approprite key length and type (symmetric/asymmetric).
                 </p>
-                <p>
-                Find more details about OAuth PoP client in
-                [[!OAUTH-POP-KEY-DISTRIBUTION] Section 4.1
+                <p>According to [[!RFC7635]] Section 4.1 HMAC key MUST be a
+                symmetric key.
                 </p>
-                <div class="note">When [[!RFC7635]] is used in WebRTC context, this
-                specification adds one addtional consideration to [[!RFC7635]]:
-
-                This specification considers to use a 256 bit length HMAC key.
-                </div>
-                <p>
-                (This was W3C WebRTC WG decision that this key length should be
-                considered as a static 256 bit value, instead of discover the
-                STUN/TURN client implementation capability, so the supported
-                HMAC algortihms, and this way discover the key length.)
+                <p>The W3C WebRTC WG made a decision, that the length of the
+                HMAC key should be considered as a static 256 bit value, instead
+                of discovered from the <code>STUN/TURN Client</code>
+                implementation capability. This way instead of discover the
+                supported HMAC algortihms, and so discover the key length,
+                implementation use "alg" in this static 256 bit HMAC key length.
                 </p>
+                <div class="note">When [[!RFC7635]] is used in WebRTC context,
+                this specification adds one addtional consideration to
+                [[!RFC7635]]
                 <p>
-                According to [[!RFC7635]] Section 4.1 key MUST be a symmetric
-                key.
+                This specification considers to use a constant, 256 bit HMAC key
+                length.
                 </p>
+                This way this specification propose to use in <code>OAuth
+                Client</code> requests the "alg" value "HS256" (according
+                [[!RFC7518]] Section 3.1.)</div>
                 <p>
-                This way this specification propose to use "alg" value "HS256"
-                according [[!RFC7518]] Section 3.1.
+                If shorter HMAC key is needed for the <code>STUN/TURN
+                Client</code> then it should be truncated.
                 </p>
-                <p>
-                If shorter HMAC key is needed for the STUN/TURN client then it
-                should be truncated.
+                <p>Find more details about OAuth PoP Client in
+                [[!OAUTH-POP-KEY-DISTRIBUTION]] Section 4.
                 </p>
                 </td>
               </tr>

--- a/webrtc.html
+++ b/webrtc.html
@@ -316,7 +316,7 @@
                 decryption of the Access-Token, so the key identified by this
                 <code>kid</code> is used in the Authenticated Encryption of the
                 "access_token". The <code>kid</code> value is equal with the
-                OAuth response "kid" parameter. Find more details in 
+                OAuth response "kid" parameter. Find more details in
                 [[!RFC7635]] and kid definition in [[!RFC7515]] Section 4.1.4
               </p>
               </dd>
@@ -341,7 +341,7 @@
                 Authenticated encryption is used for message encryption and
                 integrity protection. It contains a not encrypted nonce value,
                 that is used by the Auth Server for unique mac_key generation.
-                The second part of the token is protected by Authenticated 
+                The second part of the token is protected by Authenticated
                 Encryption. It contains the mac_key and a timestamp and a
                 lifetime. The timestamp combined lifetime gives the expiry
                 information, these information describes the time window during
@@ -406,13 +406,13 @@
         <pre class="example highlight"><code>[
      { "urls": "stun:stun1.example.net" },
      { "urls": ["turns:turn.example.org", "turn:turn.example.net"],
-       "credential": { 
+       "credential": {
                        "username": "user",
                        "password": "myPassword"
                      },
        "credentialType": "password" },
      { "urls": "turns:turn2.example.net",
-       "credential": { 
+       "credential": {
                        "kid": "22BIjxU93h/IgwEb",
                        "macKey": "ZksjpweoixXmvn67534m",
                        "accessToken": "AAwg3kPHWPfvk9bDFL936wYvkoctMADzQ5VhNDgeMR3+ZlZ35byg972fW8QjpEl7bx91YLBPFsIhsxloWcXPhA=="
@@ -1371,9 +1371,9 @@ interface RTCPeerConnection : EventTarget  {
               <span class="idlAttrType"><a>EventHandler</a></span></dt>
               <dd>The event type of this event handler is
               <code><a>connectionstatechange</a></code>.</dd>
-              <dt><dfn><code>onfingerprintfailure</code></dfn> of type 
+              <dt><dfn><code>onfingerprintfailure</code></dfn> of type
               <span class="idlAttrType"><a>EventHandler</a></span></dt>
-              <dd>The event type of this event handler is 
+              <dd>The event type of this event handler is
               <code><a>fingerprintfailure</a></code>.</dd>
             </dl>
           </section>
@@ -2165,7 +2165,7 @@ interface RTCPeerConnection : EventTarget  {
                       </li>
                       <li>
                         <p>If <var>scheme name</var> is <code>turn</code> or
-                        <code>turns</code>, and 
+                        <code>turns</code>, and
                         <code><var>server</var>.credential</code> is omitted,
                         then throw an <code>InvalidAccessError</code> and abort
                         these steps.</p>
@@ -5566,7 +5566,7 @@ sender.setParameters(params)
               causes this encoding to no longer be sent. Setting it to <code>true</code>
               causes this encoding to be sent. For an <code><a>RTCRtpReceiver</a></code>,
               a value of <code>true</code> indicates that this encoding is being decoded.
-              A value of <code>false</code> indicates this encoding is no longer being 
+              A value of <code>false</code> indicates this encoding is no longer being
               decoded.</p>
             </dd>
             <dt><dfn><code>priority</code></dfn> of type <span class=

--- a/webrtc.html
+++ b/webrtc.html
@@ -227,20 +227,60 @@
                 setConfiguration</code></a> method to refresh periodically the
                 TURN credentials.
                 </p>
-                <p>For OAuth Authntication the <code>TURN client</code>
-                require three credential information. The credential is
-                composed of <code>kid</code>, <code>macKey</code>, and <code>
-                accessToken</code>. All these information could be extracted
-                from the OAuth response parameters, that are received from the
-                <code>Auth Server</code> (AS). The relevant OAuth response
-                parameters are the "kid", the "key", and the "access_token".
-                These could be used, to extract all the credential infromation
-                (the <code>kid</code>, the <code>macKey</code>, and <code>
-                accessToken</code>), that are requied for the <code>TURN client
-                </code> for the Authentication.
+                <p>During the OAuth Authntication process the <code>TURN
+                client</code> require three credential information. The
+                credential is composed of <code>kid</code>, <code>macKey</code>,
+                and <code> accessToken</code>. All these information could be
+                extracted from the OAuth response parameters, that are received
+                from the <code>Auth Server</code> (AS). The relevant OAuth
+                response parameters are the "kid", the "key", and the
+                "access_token". These could be used, to extract all the
+                credential infromation (the <code>kid</code>, the
+                <code>macKey</code>, and <code> accessToken</code>), that are
+                requied for the <code>TURN client </code> for the
+                Authentication.
                 </p>
-                <p>Find more details about the <code>Access-Token</code> in
-                [[!RFC7635]], Section 6.2.
+                <p>The OAuth client sends an OAuth request to the <code>Auth
+                Server</code> with OAuth params
+                <code>grant_type=implicit</code>, <code>token_type=pop</code>
+                and <code>alg=</code> ( alg value is set according the supported
+                HMAC capabilities of the client), and many further OAuth related
+                parameters, to get an OAuth response with the
+                <code>access_token</code>, <code>key</code>, <code>kid</code>,
+                and many further OAuth related parameters.
+                </p>
+                <p>
+                As mentioned the OAuth client provide information about the
+                client HMAC alg capability, which HMAC algorithms are supported
+                by the client, to help Auth Server to generate approriate HMAC
+                key length and type (symmetric/asymmetric).
+                </p>
+                <p>
+                Find more details about OAuth PoP client in
+                [[!OAUTH-POP-KEY-DISTRIBUTION] Section 4.1
+                </p>
+                <div class="note">When [[!RFC7635]] is used in WebRTC context, this
+                specification adds one addtional consideration to [[!RFC7635]]:
+
+                This specification considers to use a 256 bit length HMAC key.
+                </div>
+                <p>
+                (This was W3C WebRTC WG decision that this key length should be
+                considered as a static 256 bit value, instead of discover the
+                STUN/TURN client implementation capability, so the supported
+                HMAC algortihms, and this way discover the key length.)
+                </p>
+                <p>
+                According to [[!RFC7635]] Section 4.1 key MUST be a symmetric
+                key.
+                </p>
+                <p>
+                This way this specification propose to use "alg" value "HS256"
+                according [[!RFC7518]] Section 3.1.
+                </p>
+                <p>
+                If shorter HMAC key is needed for the STUN/TURN client then it
+                should be truncated.
                 </p>
                 </td>
               </tr>


### PR DESCRIPTION
* Updated RFC7635 bib link
* Added PasswordCredential, and OAuthCredential dictionaries
* rename token type to oauth
* Not allow to omit credential in case of turn/turns
* Renamed in PasswordCredential to password
* Clean trailing whitespaces