### PR TITLE
"Hybrid" OAuth solution.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -248,8 +248,53 @@
                 <code>macKey</code>, and <code>accessToken</code>) that
                 are required by the <a>ICE Agent</a> for the Authentication.
                 </p>
-                <p>More details about the <code>Access-Token</code> can be
-                found in [[!RFC7635]], Section 6.2.
+                <p>If the <a>Auth Server</a> doesn't have prior knowledge of the
+                capabilities of the client, then the <code>OAuth Client</code>
+                needs to provide information about the <a>ICE Agent</a> HMAC
+                "alg" capabilities. This information helps the <a>Auth
+                Server</a> to generate the approriate HMAC key, with the
+                approprite key length and algorithm type (e.g.
+                symmetric/asymmetric).
+                </p>
+                <p>According to [[!RFC7635]] Section 4.1 HMAC key MUST be a
+                symmetric key.
+                </p>
+                <p>The <dfn>OAuth Client</dfn> sends an <code>OAuth
+                Request</code> to the <a>Auth Server</a> with OAuth param
+                <code>alg</code> (The alg value is set according the
+                supported HMAC capabilities of the <a>ICE Agent</a>.) and
+                further OAuth related parameters, to get an <code>OAuth
+                Response</code> with the <code>access_token</code>,
+                <code>key</code>, <code>kid</code>, and further OAuth related
+                parameters.
+                </p>
+                <p>The W3C WebRTC WG made such a decision, that the length of
+                the HMAC key should be considered as a static 256 bit value(,
+                instead of discovery HMAC Algorithm capabilities of the <a>ICE
+                Agent)</a>.
+                </p>
+                <div class="note">
+                  <p>When [[!RFC7635]] is used in WebRTC context, this
+                  specification adds one addtional consideration to [[!RFC7635]]
+                  </p>
+                  <p>This specification considers to use a constant,
+                  <code>256</code> bit HMAC key length.
+                  </p>
+                  <p>This specification propose to set <a>OAuth Client</a>
+                  request <code>alg</code> value to <code>HS256</code> (Find
+                  more details about algorithms in [[!RFC7518]] Section 3.1.).
+                  </p>
+                </div>
+                <p>
+                If shorter HMAC key is needed for the <a>ICE Agent</a>, then it
+                should be truncated.
+                </p>
+                <p>More details about OAuth PoP Client can be found in
+                [[!OAUTH-POP-KEY-DISTRIBUTION]] Section 4.
+                </p>
+                <p>
+                More details about <code>Access-Token</code> can be found in
+                [[!RFC7635]], Section 6.2.
                 </p>
                 </td>
               </tr>
@@ -1497,9 +1542,9 @@ interface RTCPeerConnection : EventTarget  {
               <span class="idlAttrType"><a>EventHandler</a></span></dt>
               <dd>The event type of this event handler is
               <code><a>connectionstatechange</a></code>.</dd>
-              <dt><dfn><code>onfingerprintfailure</code></dfn> of type 
+              <dt><dfn><code>onfingerprintfailure</code></dfn> of type
               <span class="idlAttrType"><a>EventHandler</a></span></dt>
-              <dd>The event type of this event handler is 
+              <dd>The event type of this event handler is
               <code><a>fingerprintfailure</a></code>.</dd>
             </dl>
           </section>
@@ -2485,7 +2530,7 @@ interface RTCPeerConnection : EventTarget  {
                         <p>Stop sending media with <var>sender</var>.</p>
                       </li>
                       <li>
-                        <p>Send an RTCP BYE for each SSRC in 
+                        <p>Send an RTCP BYE for each SSRC in
                         <code><var>sender</var>.getParameters().encodings[<var>i</var>].ssrc</code>,
                         <code><var>sender</var>.getParameters().encodings[<var>i</var>].fec.ssrc</code> and
                         <code><var>sender</var>.getParameters().encodings[<var>i</var>].rtx.ssrc</code>
@@ -2499,7 +2544,7 @@ interface RTCPeerConnection : EventTarget  {
                         <p>Set <code><var>receiver</var>.track.readyState</code> to <code>ended</code>.</p>
                       </li>
                       <li>
-                        <p>Set <code><var>transceiver</var>.stopped</code> to <code>true</code>.</p>                 
+                        <p>Set <code><var>transceiver</var>.stopped</code> to <code>true</code>.</p>
                       </li>
                     </ol>
                   </li>
@@ -5768,7 +5813,7 @@ sender.setParameters(params)
               causes this encoding to no longer be sent. Setting it to <code>true</code>
               causes this encoding to be sent. For an <code><a>RTCRtpReceiver</a></code>,
               a value of <code>true</code> indicates that this encoding is being decoded.
-              A value of <code>false</code> indicates this encoding is no longer being 
+              A value of <code>false</code> indicates this encoding is no longer being
               decoded.</p>
             </dd>
             <dt><dfn><code>priority</code></dfn> of type <span class=
@@ -6252,8 +6297,8 @@ sender.setParameters(params)
               by <var>receiver</var> is removed (either due to reception of
               a BYE or via timeout), the <code>mute</code> event is fired at
               <code>track</code>.  If and when packets are received again,
-              the <code>unmute</code> event is fired at <code>track</code>.</p>                
-              <p>Note that <code>track.stop()</code> is final, although            
+              the <code>unmute</code> event is fired at <code>track</code>.</p>
+              <p>Note that <code>track.stop()</code> is final, although
               clones are not affected. Since
               <code><var>receiver</var>.track.stop()</code>
               does not implicitly stop <var>receiver</var>, Receiver
@@ -6640,7 +6685,7 @@ sender.setParameters(params)
               <ol>
                 <li>
                   <p>If <code><var>transceiver</var>.stopped</code> is
-                  <code>true</code>, abort these steps.</p> 
+                  <code>true</code>, abort these steps.</p>
                 </li>
                 <li>
                   <p>Let <var>connection</var> be the
@@ -6658,27 +6703,27 @@ sender.setParameters(params)
                 <li>
                   <p>Let <var>receiver</var> be <code><var>transceiver</var>.receiver</code>.</p>
                 </li>
-                <li> 
+                <li>
                   <p>Stop sending media with <var>sender</var>.</p>
                 </li>
                 <li>
-                  <p>Send an RTCP BYE for each SSRC in 
+                  <p>Send an RTCP BYE for each SSRC in
                   <code><var>transceiver</var>.sender.getParameters().encodings[<var>i</var>].ssrc</code>,
                   <code><var>transceiver</var>.sender.getParameters().encodings[<var>i</var>].fec.ssrc</code> and
                   <code><var>transceiver</var>.sender.getParameters().encodings[<var>i</var>].rtx.ssrc</code>
                   where <var>i</var> goes from 0 to
                   <code><var>transceiver</var>.sender.getParameters().encodings.length-1</code>.<p>
                 </li>
-                <li> 
+                <li>
                   <p>Stop receiving media with <var>receiver</var>.</p>
                 </li>
-                <li> 
+                <li>
                   <p><code><var>receiver</var>.track</code> is now said to be
                   <a href="https://www.w3.org/TR/mediacapture-streams/#track-ended">
                   ended</a>.</p>
                 </li>
                 <li>
-                  <p>Set <code><var>transceiver</var>.stopped</code> to <code>true</code>.</p>                 
+                  <p>Set <code><var>transceiver</var>.stopped</code> to <code>true</code>.</p>
                 </li>
                 <li>
                   <p><a>Update the negotiation-needed flag</a> for
@@ -11440,17 +11485,17 @@ if (sender.dtmf) {
         </section>
         <section>
           <h2>RTCError.prototype.errorDetail</h2>
-          <p>The initial value of the <code>errorDetail</code> property of the prototype for 
+          <p>The initial value of the <code>errorDetail</code> property of the prototype for
           the <code><a>RTCError</a></code> constructor is the empty String.</p>
         </section>
         <section>
           <h2>RTCError.prototype.sdpLineNumber</h2>
-          <p>The initial value of the <code>sdpLineNumber</code> property of the prototype for 
+          <p>The initial value of the <code>sdpLineNumber</code> property of the prototype for
           the <code><a>RTCError</a></code> constructor is 0.</p>
         </section>
         <section>
           <h2>RTCError.prototype.httpRequestStatusCode</h2>
-          <p>The initial value of the <code>httpRequestStatusCode</code> property of the prototype for 
+          <p>The initial value of the <code>httpRequestStatusCode</code> property of the prototype for
           the <code><a>RTCError</a></code> constructor is 0.</p>
         </section>
         <section>
@@ -11740,8 +11785,8 @@ interface RTCErrorEvent : Event {
           "event-fingerprintfailure"><code>fingerprintfailure</code></dfn></td>
           <td><code><a>Event</a></code></td>
           <td>
-            The <code>RTCPeerConnection</code>'s DTLS Certificate did not 
-            match any of the fingerprints in the SDP. 
+            The <code>RTCPeerConnection</code>'s DTLS Certificate did not
+            match any of the fingerprints in the SDP.
           </td>
         </tr>
       </tbody>

--- a/webrtc.html
+++ b/webrtc.html
@@ -271,14 +271,24 @@
                 <code>key</code>, <code>kid</code>, and further OAuth related
                 parameters.
                 </p>
-                <p>However, this specification uses a simplified constant
-                <a>alg</a> approach. The length of the HMAC key
-                (<code>OAuthCredential.macKey</code>) MUST be a static 256-bit
-                value, which negates the need to query the HMAC Algorithm
-                capabilities of the <a>ICE Agent</a>. This means that this
-                specification does not support transitioning to a new hash
-                algorithm that uses a key larger than 256 bits, as described
-                by [[!STUN-BIS]], Section 15.3.</p>
+                <p>However, this specification uses a simplified <a>alg</a>
+                approach. The length of the HMAC key
+                (<code>OAuthCredential.macKey</code>) MAY be any multiple of
+                bytes greater than 20 (160 bits). When the <a>ICE Agent</a>
+                computes the message integrity attributes it supports, it will
+                shorten the key to the length required by each algorithm,
+                according to [[!RFC7635]]. For example, a 256-bit key can be
+                used to compute both the HMAC-SHA-1 and HMAC-SHA-256 message
+                integrity attributes, shortening the key to 160 bits in the
+                case of HMAC-SHA-1. This negates the need to query the HMAC
+                Algorithm capabilities of the <a>ICE Agent</a>, and still
+                allows for hash agility as described by [[STUN-BIS]], Section
+                15.3.</p>
+                <div class="issue">[[!RFC7635]] doesn't explicitly define
+                how keys are shortened; there is only a brief reference to this
+                in Appendix B. This needs to be adressed in the tram working
+                group.
+                </div>
                 <div class="note">According to [[!RFC7635]] Section 4.1, the
                 HMAC key MUST be a symmetric key.
                 </div>
@@ -296,7 +306,7 @@
                 result in a 256-bit HMAC key.
                 </p>
                 <p><code>HS256</code> is defined in [[!RFC7518]] Section 3.1.
-                It has been choosen because:
+                It is recommended here because:
                 <ul>
                   <li>The OAuth respose key parameter is received in JWK format
                   according to [[!OAUTH-POP-KEY-DISTRIBUTION]] Section 4.2.
@@ -305,19 +315,10 @@
                   </li>
                   <li>STUN/TURN currently use SHA family HMAC algorithms only.
                   </li>
-                  <li>The key MUST be symmetric, according [[!RFC7635]].</li>
-                  <li>As metioned above, this specification requires a key
-                  length of 256 bits.</li>
+                  <li>The key MUST be symmetric, according to [[!RFC7635]].</li>
+                  <li>A 256-bit key is large enough to support all currently
+                  defined STUN message integrity attributes.</li>
                 </ul>
-                </p>
-                <p>
-                In order to compute the HMAC-SHA1 of a STUN message given a
-                256-bit key to compute a MESSAGE-INTEGRITY attribute, the
-                the <a>ICE Agent</a> MUST calculate a 160-bit key for
-                HMAC-SHA-1 using the SHA1 algorithm, and taking the 256-bit key as
-                the input. As described above,  input 256-bit key is received
-                by the <a>OAuth Client</a> from the <a>Authorization Server</a>
-                (with OAuth parameter <code>alg=HS256</code>).
                 </p>
                 <p>More details about OAuth PoP Client can be found in
                 [[!OAUTH-POP-KEY-DISTRIBUTION]] Section 4.

--- a/webrtc.html
+++ b/webrtc.html
@@ -229,7 +229,7 @@
                 Server</dfn> roles are defined in [[!RFC6749]] Section 1.1.
                 </p>
                 <p>
-                If [[!RFC7635]] is used in WebRTC context then the <a>OAuth
+                If [[!RFC7635]] is used in the WebRTC context then the <a>OAuth
                 Client</a> is responsible for refreshing the credential
                 information, and updating the <a>ICE Agent</a> with fresh new
                 credentials before the <code>accessToken</code> expires. The
@@ -271,53 +271,53 @@
                 <code>key</code>, <code>kid</code>, and further OAuth related
                 parameters.
                 </p>
-                <div class="note">The [[!OAUTH-POP-KEY-DISTRIBUTION]] propose
-                that the alg value is set according the supported HMAC
-                capabilities of the <a>ICE Agent</a>, but this specification use
-                a simplified constant <a>alg</a> apporroach. The length of the
-                HMAC key SHOULD be considered as a static 256-bit value (which
-                negates the need to query the HMAC Algorithm capabilities of the
-                <a>ICE Agent</a>). </div>
+                <p>However, this specification uses a simplified constant
+                <a>alg</a> approach. The length of the HMAC key
+                (<code>OAuthCredential.macKey</code>) MUST be a static 256-bit
+                value, which negates the need to query the HMAC Algorithm
+                capabilities of the <a>ICE Agent</a>. This means that this
+                specification does not support transitioning to a new hash
+                algorithm that uses a key larger than 256 bits, as described
+                by [[!STUN-BIS]], Section 15.3.</p>
                 <div class="note">According to [[!RFC7635]] Section 4.1, the
                 HMAC key MUST be a symmetric key.
                 </div>
-                <p>Actually the STUN/TURN protocols use only SHA-1 and SHA-2
-                family hash algorithms for Message Integrity Protection. Find
-                more details in [[!RFC5389]] Section 15.4, and [[!STUN-BIS]]
+                <p>Currently the STUN/TURN protocols use only SHA-1 and SHA-2
+                family hash algorithms for Message Integrity Protection, as
+                defined in [[!RFC5389]] Section 15.4, and [[!STUN-BIS]]
                 Section 14.6.
                 </p>
-                <div class="note">
-                  <p>When [[!RFC7635]] is used in WebRTC context, this
-                  specification adds the following additional consideration to
-                  it.
-                  </p>
-                  <p>The <a>OAuth Client</a> SHOULD obtain the mac_key by
-                  requesting an <a>alg</a> value of HS256. This will result in a
-                  256-bit HMAC key.
-                  </p>
-                  <p><code>HS256</code>, is defined in [[!RFC7518]] Section 3.1.
-                  It has been choosen, because
-                  <ul>
-                    <li>OAuth respose key parameter is received in JWK format
-                    according [[!OAUTH-POP-KEY-DISTRIBUTION]] Section 4.2.
-                    JWK's algorithm's normaly registered in the IANA "JSON Web
-                    Signature and Encryption Algorithms" registry.
-                    </li>
-                    <li>STUN/TURN use actually SHA familly HMAC algorithms only.
-                    </li>
-                    <li>key MUST be symmetric, according [[!RFC7635]]</li>
-                    <li>key MUST be constant 256 bit long , according W3C WebRTC
-                    WorkGroup decision. </li>
-                  </ul>
-                  </p>
-                </div>
+                <p>When [[!RFC7635]] is used in WebRTC context, this
+                specification adds the following additional consideration to
+                it.
+                </p>
+                <p>The <a>OAuth Client</a> SHOULD obtain the mac_key by
+                requesting an <a>alg</a> value of <code>HS256</code>. This will
+                result in a 256-bit HMAC key.
+                </p>
+                <p><code>HS256</code> is defined in [[!RFC7518]] Section 3.1.
+                It has been choosen because:
+                <ul>
+                  <li>The OAuth respose key parameter is received in JWK format
+                  according to [[!OAUTH-POP-KEY-DISTRIBUTION]] Section 4.2.
+                  JWK's algorithms are normatively registered in the IANA
+                  "JSON Web Signature and Encryption Algorithms" registry.
+                  </li>
+                  <li>STUN/TURN currently use SHA family HMAC algorithms only.
+                  </li>
+                  <li>The key MUST be symmetric, according [[!RFC7635]].</li>
+                  <li>As metioned above, this specification requires a key
+                  length of 256 bits.</li>
+                </ul>
+                </p>
                 <p>
-                If the SHA1 HMAC algorithm has been negotiated by the <a>ICE
-                Agent</a> with the ICE Server, then the <a>ICE Agent</a> MUST
-                calculate a 160-bit key for HMAC-SHA-1 using SHA1 algorithm, and
-                take the 256-bit key as the input. The input 256-bit key is
-                received by the <a>OAuth Client</a> from the <a>Authorization
-                Server</a> (with OAuth parameter alg=HS256).
+                In order to compute the HMAC-SHA1 of a STUN message given a
+                256-bit key to compute a MESSAGE-INTEGRITY attribute, the
+                the <a>ICE Agent</a> MUST calculate a 160-bit key for
+                HMAC-SHA-1 using the SHA1 algorithm, and taking the 256-bit key as
+                the input. As described above,  input 256-bit key is received
+                by the <a>OAuth Client</a> from the <a>Authorization Server</a>
+                (with OAuth parameter <code>alg=HS256</code>).
                 </p>
                 <p>More details about OAuth PoP Client can be found in
                 [[!OAUTH-POP-KEY-DISTRIBUTION]] Section 4.

--- a/webrtc.html
+++ b/webrtc.html
@@ -204,7 +204,7 @@
         <div>
           <pre class="idl">enum RTCIceCredentialType {
     "password",
-    "token"
+    "oauth"
 };</pre>
           <table data-link-for="RTCIceCredentialType" data-dfn-for=
           "RTCIceCredentialType" class="simple">
@@ -214,20 +214,109 @@
               </tr>
               <tr>
                 <td><dfn><code>password</code></dfn></td>
-                <td>The credential is a long-term authentication password, as
-                described in [[!RFC5389]], Section 10.2.</td>
+                <td>The credential is a long-term authentication username and
+                password, as described in [[!RFC5389]], Section 10.2.
+                </td>
               </tr>
               <tr>
-                <td><dfn><code>token</code></dfn></td>
-                <td>The credential is an access token, as described in
-                [[!TRAM-TURN-THIRD-PARTY-AUTHZ]], Section 6.2.</td>
+                <td><dfn><code>oauth</code></dfn></td>
+                <td><p>An OAuth 2.0 based authentication method, as described in
+                [[!RFC7635]]. It uses the OAuth 2.0 Implicit Grant type, with
+                PoP (Proof-of-Possession) Token type, as described in
+                [[!RFC6749]] and [[!OAUTH-POP-KEY-DISTRIBUTION]].</p>
+                <p>The OAuth client is responsible for refreshing the
+                credential information, and updating the <a>ICE Agent</a> with
+                fresh new credentials before the <code>accessToken</code>
+                expires. The OAuth client can use the
+                <a href="#interface-definition"><code>
+                RTCPeerConnection</code></a> <a data-lt="setConfiguration"
+                href="#dom-rtcpeerconnection-setconfiguration"><code>
+                setConfiguration</code></a> method to periodically refresh the
+                TURN credentials.
+                </p>
+                <p>For OAuth Authentication, the <a>ICE Agent</a> requires
+                three pieces of credential information. The credential is
+                composed of a <code>kid</code>, which the <a>RTCIceServer</a>
+                <code>username</code> member is used for, and
+                <code>macKey</code> and <code> accessToken</code>, which are
+                placed in the <a>OAuthCredential</a> dictionary. All of this
+                information can be extracted from the OAuth response
+                parameters, which are received from the <dfn>Auth Server</dfn>
+                (AS). The relevant OAuth response parameters are the "kid", the
+                "key", and the "access_token". These can be used to extract
+                all the necessary credential infromation (the <code>kid</code>,
+                <code>macKey</code>, and <code> accessToken</code>) that
+                are required by the <a>ICE Agent</a> for the Authentication.
+                </p>
+                <p>More details about the <code>Access-Token</code> can be
+                found in [[!RFC7635]], Section 6.2.
+                </p>
+                </td>
               </tr>
             </tbody>
           </table>
         </div>
       </section>
       <section>
-        <h4><dfn>RTCIceServer</dfn> Dictionary</h4>
+      <section>
+        <h4><dfn>OAuthCredential</dfn> Dictionary</h4>
+        <p>The <code>OAuthCredential</code> dictionary is used to describe the
+        OAuth auth credential information which is used by the STUN/TURN client
+        (inside the <a>ICE Agent</a>) to authenticate against a STUN/TURN
+        server, as described in [[!RFC7635]]. Note that the <code>kid</code>
+        parameter is not located in this dictionary, but in
+        <code>RTCIceServer</code>'s <code>username</code> member.
+        </p>
+        <div>
+          <pre class="idl">dictionary OAuthCredential {
+    required DOMString        macKey;
+    required DOMString        accessToken;
+};</pre>
+          <section>
+            <h2>Dictionary <a class="idlType">OAuthCredential</a> Members</h2>
+            <dl data-link-for="OAuthCredential" data-dfn-for="OAuthCredential" class=
+            "dictionary-members">
+              <dt><dfn><code>macKey</code></dfn> of type <span class=
+              "idlMemberType"><a>DOMString</a></span>, required</dt>
+              <dd>
+                <p>The "mac_key", as described in [[!RFC7635]], Section 6.2, in
+                a base64-url encoded format. It is used in STUN message
+                integrity hash calculation (as the password is used in password
+                based authentication). Note that the OAuth response "key"
+                parameter is a JSON Web Key (JWK) or a JWK encrypted with a JWE
+                format. Also note that this is the only OAuth parameter whose
+                value is not used directly, but must be extracted from the "k"
+                parameter value from the JWK, which contains the needed
+                base64-encoded "mac_key".</p>
+              </dd>
+              <dt><dfn><code>accessToken</code></dfn> of type <span class=
+              "idlMemberType"><a>DOMString</a></span>, required</dt>
+              <dd>
+                <p>The "access_token", as described in [[!RFC7635]], Section
+                6.2, in a base64-encoded format. This is an encrypted
+                self-contained token that is opaque to the application.
+                Authenticated encryption is used for message encryption and
+                integrity protection. The access token contains a non-encrypted
+                nonce value, which is used by the Auth Server for unique
+                mac_key generation. The second part of the token is protected
+                by Authenticated Encryption. It contains the mac_key, a
+                timestamp and a lifetime. The timestamp combined with lifetime
+                provides expiry information; this information describes the
+                time window during which the token credential is valid and
+                accepted by the TURN server.
+                </p>
+              </dd>
+           </dl>
+          </section>
+        </div>
+        <p>An example of an OAuthCredential dictionary is:</p>
+        <pre class="example highlight"><code>{
+    "macKey": "ZksjpweoixXmvn67534m",
+    "accessToken": "AAwg3kPHWPfvk9bDFL936wYvkoctMADzQ5VhNDgeMR3+ZlZ35byg972fW8QjpEl7bx91YLBPFsIhsxloWcXPhA=="
+}</code></pre>
+      </section>
+      <section>
+         <h4><dfn>RTCIceServer</dfn> Dictionary</h4>
         <p>The <code>RTCIceServer</code> dictionary is used to describe the
         STUN and TURN servers that can be used by the <a>ICE Agent</a> to
         establish a connection with a peer.</p>
@@ -235,7 +324,7 @@
           <pre class="idl">dictionary RTCIceServer {
     required (DOMString or sequence&lt;DOMString&gt;) urls;
              DOMString                          username;
-             DOMString                          credential;
+             (DOMString or OAuthCredential)     credential;
              RTCIceCredentialType               credentialType = "password";
 };</pre>
           <section>
@@ -253,15 +342,36 @@
               "idlMemberType"><a>DOMString</a></span></dt>
               <dd>
                 <p>If this <code><a>RTCIceServer</a></code> object represents a
-                TURN server, then this attribute specifies the username to use
-                with that TURN server.</p>
+                TURN server, and <code>credentialType</code> is
+                <code>"password"</code>, then this attribute specifies the
+                username to use with that TURN server.</p>
+                <p>If this <code><a>RTCIceServer</a></code> object represents a
+                TURN server, and <code>credentialType</code> is
+                <code>"oauth"</code>, then this attribute specifies the Key ID
+                (<code>kid</code>) of the shared symmetric key, which is shared
+                between the TURN server and the Auth Server (AS), as described
+                in [!RFC7635]]. It is an ephemeral and unique key identifier.
+                The <code>kid</code> allows the TURN server to select the
+                appropriate keying material for decryption of the Access-Token,
+                so the key identified by this <code>kid</code> is used in the
+                Authenticated Encryption of the "access_token". The
+                <code>kid</code> value is equal with the OAuth response "kid"
+                parameter, as defined in [[!RFC7515]] Section 4.1.4.
+              </p>
               </dd>
               <dt><dfn><code>credential</code></dfn> of type <span class=
-              "idlMemberType"><a>DOMString</a></span></dt>
+              "idlMemberType">(<a>DOMString</a> or <a>OAuthCredential</a>)</span></dt>
               <dd>
                 <p>If this <code><a>RTCIceServer</a></code> object represents a
                 TURN server, then this attribute specifies the credential to
                 use with that TURN server.</p>
+                <p>If <code>credentialType</code> is <code>"password"</code>,
+                <code>credential</code> is a <a>DOMString</a>, and represents a
+                long-term authentication password, as described in
+                [[!RFC5389]], Section 10.2.</p>
+                <p>If <code>credentialType</code> is <code>"oauth"</code>,
+                <code>credential</code> is a <a>OAuthCredential</a>, which
+                contains the OAuth access token and MAC key.</p>
               </dd>
               <dt><dfn><code>credentialType</code></dfn> of type <span class=
               "idlMemberType"><a>RTCIceCredentialType</a></span>, defaulting to
@@ -281,7 +391,15 @@
      { "urls": ["turns:turn.example.org", "turn:turn.example.net"],
        "username": "user",
        "credential": "myPassword",
-       "credentialType": "password" }
+       "credentialType": "password" },
+     { "urls": "turns:turn2.example.net",
+       "username": "22BIjxU93h/IgwEb",
+       "credential": {
+                       "macKey": "ZksjpweoixXmvn67534m",
+                       "accessToken": "AAwg3kPHWPfvk9bDFL936wYvkoctMADzQ5VhNDgeMR3+ZlZ35byg972fW8QjpEl7bx91YLBPFsIhsxloWcXPhA=="
+                     },
+       "credentialType": "oauth" },
+     }
 ]</code></pre>
       </section>
       <section>
@@ -2225,6 +2343,26 @@ interface RTCPeerConnection : EventTarget  {
                         <code><var>server</var>.username</code> or
                         <code><var>server</var>.credential</code> are omitted,
                         then <a>throw</a> an <code>InvalidAccessError</code>.</p>
+                      </li>
+                      <li>
+                        <p>If <var>scheme name</var> is <code>turn</code> or
+                        <code>turns</code>, and
+                        <code><var>server</var>.credentialType</code> is
+                        <code>"password"</code>, and
+                        <code><var>server</var>.credential is not a
+                        <a>DOMString</a>, then throw an
+                        <code>InvalidAccessError</code> and abort these
+                        steps.</p>
+                      </li>
+                      <li>
+                        <p>If <var>scheme name</var> is <code>turn</code> or
+                        <code>turns</code>, and
+                        <code><var>server</var>.credentialType</code> is
+                        <code>"oauth"</code>, and
+                        <code><var>server</var>.credential</code> is not an
+                        <a>OAuthCredential</a>, then throw an
+                        <code>InvalidAccessError</code> and abort these
+                        steps.</p>
                       </li>
                       <li>
                         <p>Append <var>server</var> to

--- a/webrtc.html
+++ b/webrtc.html
@@ -2348,8 +2348,8 @@ interface RTCPeerConnection : EventTarget  {
                         <p>If <var>scheme name</var> is <code>turn</code> or
                         <code>turns</code>, and
                         <code><var>server</var>.credentialType</code> is
-                        <code>"password"</code>, and
-                        <code><var>server</var>.credential is not a
+                        <code>password</code>, and
+                        <code><var>server</var>.credential</code> is not a
                         <a>DOMString</a>, then throw an
                         <code>InvalidAccessError</code> and abort these
                         steps.</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -256,7 +256,7 @@
                 approprite key length and algorithm type (e.g.
                 symmetric/asymmetric).
                 </p>
-                <p>According to [[!RFC7635]] Section 4.1 HMAC key MUST be a
+                <p>According to [[!RFC7635]] Section 4.1, the HMAC key MUST be a
                 symmetric key.
                 </p>
                 <p>The <dfn>OAuth Client</dfn> sends an <code>OAuth
@@ -268,26 +268,25 @@
                 <code>key</code>, <code>kid</code>, and further OAuth related
                 parameters.
                 </p>
-                <p>The W3C WebRTC WG made such a decision, that the length of
-                the HMAC key should be considered as a static 256 bit value(,
-                instead of discovery HMAC Algorithm capabilities of the <a>ICE
-                Agent)</a>.
+                <p>The length of the HMAC key SHOULD be considered as a static
+                256 bit value (which negates the need to query the HMAC Algorithm
+                capabilities of the <a>ICE Agent</a>).
                 </p>
                 <div class="note">
                   <p>When [[!RFC7635]] is used in WebRTC context, this
-                  specification adds one addtional consideration to [[!RFC7635]]
+                  specification adds one additional consideration to [[!RFC7635]].
                   </p>
                   <p>This specification considers to use a constant,
                   <code>256</code> bit HMAC key length.
                   </p>
-                  <p>This specification propose to set <a>OAuth Client</a>
-                  request <code>alg</code> value to <code>HS256</code> (Find
-                  more details about algorithms in [[!RFC7518]] Section 3.1.).
+                  <p>This specification proposes to set the <a>OAuth Client</a>
+                  request <code>alg</code> value to <code>HS256</code>, as defined
+                  in [[!RFC7518]] Section 3.1.).
                   </p>
                 </div>
                 <p>
-                If shorter HMAC key is needed for the <a>ICE Agent</a>, then it
-                should be truncated.
+                If a shorter HMAC key is needed by the <a>ICE Agent</a>, then it
+                MUST be truncated by the implementation.
                 </p>
                 <p>More details about OAuth PoP Client can be found in
                 [[!OAUTH-POP-KEY-DISTRIBUTION]] Section 4.

--- a/webrtc.html
+++ b/webrtc.html
@@ -245,7 +245,7 @@
                 (AS). The relevant OAuth response parameters are the "kid", the
                 "key", and the "access_token". These can be used to extract
                 all the necessary credential infromation (the <code>kid</code>,
-                <code>macKey</code>, and <code> accessToken</code>) that
+                <code>macKey</code>, and <code>accessToken</code>) that
                 are required by the <a>ICE Agent</a> for the Authentication.
                 </p>
                 <p>More details about the <code>Access-Token</code> can be
@@ -2348,7 +2348,7 @@ interface RTCPeerConnection : EventTarget  {
                         <p>If <var>scheme name</var> is <code>turn</code> or
                         <code>turns</code>, and
                         <code><var>server</var>.credentialType</code> is
-                        <code>password</code>, and
+                        <code>"password"</code>, and
                         <code><var>server</var>.credential</code> is not a
                         <a>DOMString</a>, then throw an
                         <code>InvalidAccessError</code> and abort these

--- a/webrtc.html
+++ b/webrtc.html
@@ -334,7 +334,6 @@
         </div>
       </section>
       <section>
-      <section>
         <h4><dfn>OAuthCredential</dfn> Dictionary</h4>
         <p>The <code>OAuthCredential</code> dictionary is used to describe the
         OAuth auth credential information which is used by the STUN/TURN client

--- a/webrtc.html
+++ b/webrtc.html
@@ -223,70 +223,101 @@
                 <td><p>An OAuth 2.0 based authentication method, as described in
                 [[!RFC7635]]. It uses the OAuth 2.0 Implicit Grant type, with
                 PoP (Proof-of-Possession) Token type, as described in
-                [[!RFC6749]] and [[!OAUTH-POP-KEY-DISTRIBUTION]].</p>
-                <p>The OAuth client is responsible for refreshing the
-                credential information, and updating the <a>ICE Agent</a> with
-                fresh new credentials before the <code>accessToken</code>
-                expires. The OAuth client can use the
-                <a href="#interface-definition"><code>
-                RTCPeerConnection</code></a> <a data-lt="setConfiguration"
+                [[!RFC6749]] and [[!OAUTH-POP-KEY-DISTRIBUTION]].
+                </p>
+                <p>The <dfn>OAuth Client</dfn> and the <dfn>Auhorization
+                Server</dfn> roles are defined in [[!RFC6749]] Section 1.1.
+                </p>
+                <p>
+                If [[!RFC7635]] is used in WebRTC context then the <a>OAuth
+                Client</a> is responsible for refreshing the credential
+                information, and updating the <a>ICE Agent</a> with fresh new
+                credentials before the <code>accessToken</code> expires. The
+                <a>OAuth Client</a> can use the <a
+                href="#interface-definition"><code>RTCPeerConnection</code></a>
+                <a data-lt="setConfiguration"
                 href="#dom-rtcpeerconnection-setconfiguration"><code>
                 setConfiguration</code></a> method to periodically refresh the
-                TURN credentials.
-                </p>
-                <p>For OAuth Authentication, the <a>ICE Agent</a> requires
-                three pieces of credential information. The credential is
-                composed of a <code>kid</code>, which the <a>RTCIceServer</a>
+                TURN credentials. </p>
+                <p>For OAuth Authentication, the <a>ICE Agent</a> requires three
+                pieces of credential information. The credential is composed of
+                a <code>kid</code>, which the <a>RTCIceServer</a>
                 <code>username</code> member is used for, and
                 <code>macKey</code> and <code> accessToken</code>, which are
                 placed in the <a>OAuthCredential</a> dictionary. All of this
-                information can be extracted from the OAuth response
-                parameters, which are received from the <dfn>Auth Server</dfn>
-                (AS). The relevant OAuth response parameters are the "kid", the
-                "key", and the "access_token". These can be used to extract
-                all the necessary credential infromation (the <code>kid</code>,
-                <code>macKey</code>, and <code>accessToken</code>) that
-                are required by the <a>ICE Agent</a> for the Authentication.
+                information can be extracted from the OAuth response parameters,
+                which are received from the <dfn>Authorization Server</dfn>. The
+                relevant OAuth response parameters are the "kid", the "key", and
+                the "access_token". These can be used to extract all the
+                necessary credential infromation (the <code>kid</code>,
+                <code>macKey</code>, and <code>accessToken</code>) that are
+                required by the <a>ICE Agent</a> for the Authentication.
                 </p>
-                <p>If the <a>Auth Server</a> doesn't have prior knowledge of the
-                capabilities of the client, then the <code>OAuth Client</code>
-                needs to provide information about the <a>ICE Agent</a> HMAC
-                "alg" capabilities. This information helps the <a>Auth
-                Server</a> to generate the approriate HMAC key, with the
-                approprite key length and algorithm type (e.g.
+                <p>The [[!OAUTH-POP-KEY-DISTRIBUTION]] defines <dfn>alg</dfn>
+                parameter in Section 4.1 and 6. and describes that if the
+                <a>Authorization Server</a> doesn't have prior knowledge of the
+                capabilities of the client, then the <a>OAuth Client</a> needs
+                to provide information about the <a>ICE Agent</a> HMAC
+                <a>alg</a> capabilities. This information helps the
+                <a>Authorization Server</a> to generate the approriate HMAC key.
+                The HMAC <a>alg</a> defines the input key length, and HMAC
+                algorithm Familly (e.g. SHA), and HMAC algorithm type (e.g.
                 symmetric/asymmetric).
                 </p>
-                <p>According to [[!RFC7635]] Section 4.1, the HMAC key MUST be a
-                symmetric key.
-                </p>
-                <p>The <dfn>OAuth Client</dfn> sends an <code>OAuth
-                Request</code> to the <a>Auth Server</a> with OAuth param
-                <code>alg</code> (The alg value is set according the
-                supported HMAC capabilities of the <a>ICE Agent</a>.) and
-                further OAuth related parameters, to get an <code>OAuth
+                <p>The <a>OAuth Client</a> sends an <code>OAuth Request</code>
+                to the <a>Authorization Server</a> with OAuth param <a>alg</a>
+                and further OAuth related parameters, to get an <code>OAuth
                 Response</code> with the <code>access_token</code>,
                 <code>key</code>, <code>kid</code>, and further OAuth related
                 parameters.
                 </p>
-                <p>The length of the HMAC key SHOULD be considered as a static
-                256 bit value (which negates the need to query the HMAC Algorithm
-                capabilities of the <a>ICE Agent</a>).
+                <div class="note">The [[!OAUTH-POP-KEY-DISTRIBUTION]] propose
+                that the alg value is set according the supported HMAC
+                capabilities of the <a>ICE Agent</a>, but this specification use
+                a simplified constant <a>alg</a> apporroach. The length of the
+                HMAC key SHOULD be considered as a static 256-bit value (which
+                negates the need to query the HMAC Algorithm capabilities of the
+                <a>ICE Agent</a>). </div>
+                <div class="note">According to [[!RFC7635]] Section 4.1, the
+                HMAC key MUST be a symmetric key.
+                </div>
+                <p>Actually the STUN/TURN protocols use only SHA-1 and SHA-2
+                family hash algorithms for Message Integrity Protection. Find
+                more details in [[!RFC5389]] Section 15.4, and [[!STUN-BIS]]
+                Section 14.6.
                 </p>
                 <div class="note">
                   <p>When [[!RFC7635]] is used in WebRTC context, this
-                  specification adds one additional consideration to [[!RFC7635]].
+                  specification adds the following additional consideration to
+                  it.
                   </p>
-                  <p>This specification considers to use a constant,
-                  <code>256</code> bit HMAC key length.
+                  <p>The <a>OAuth Client</a> SHOULD obtain the mac_key by
+                  requesting an <a>alg</a> value of HS256. This will result in a
+                  256-bit HMAC key.
                   </p>
-                  <p>This specification proposes to set the <a>OAuth Client</a>
-                  request <code>alg</code> value to <code>HS256</code>, as defined
-                  in [[!RFC7518]] Section 3.1.).
+                  <p><code>HS256</code>, is defined in [[!RFC7518]] Section 3.1.
+                  It has been choosen, because
+                  <ul>
+                    <li>OAuth respose key parameter is received in JWK format
+                    according [[!OAUTH-POP-KEY-DISTRIBUTION]] Section 4.2.
+                    JWK's algorithm's normaly registered in the IANA "JSON Web
+                    Signature and Encryption Algorithms" registry.
+                    </li>
+                    <li>STUN/TURN use actually SHA familly HMAC algorithms only.
+                    </li>
+                    <li>key MUST be symmetric, according [[!RFC7635]]</li>
+                    <li>key MUST be constant 256 bit long , according W3C WebRTC
+                    WorkGroup decision. </li>
+                  </ul>
                   </p>
                 </div>
                 <p>
-                If a shorter HMAC key is needed by the <a>ICE Agent</a>, then it
-                MUST be truncated by the implementation.
+                If the SHA1 HMAC algorithm has been negotiated by the <a>ICE
+                Agent</a> with the ICE Server, then the <a>ICE Agent</a> MUST
+                calculate a 160-bit key for HMAC-SHA-1 using SHA1 algorithm, and
+                take the 256-bit key as the input. The input 256-bit key is
+                received by the <a>OAuth Client</a> from the <a>Authorization
+                Server</a> (with OAuth parameter alg=HS256).
                 </p>
                 <p>More details about OAuth PoP Client can be found in
                 [[!OAUTH-POP-KEY-DISTRIBUTION]] Section 4.
@@ -341,7 +372,7 @@
                 self-contained token that is opaque to the application.
                 Authenticated encryption is used for message encryption and
                 integrity protection. The access token contains a non-encrypted
-                nonce value, which is used by the Auth Server for unique
+                nonce value, which is used by the Authorization Server for unique
                 mac_key generation. The second part of the token is protected
                 by Authenticated Encryption. It contains the mac_key, a
                 timestamp and a lifetime. The timestamp combined with lifetime
@@ -393,7 +424,7 @@
                 TURN server, and <code>credentialType</code> is
                 <code>"oauth"</code>, then this attribute specifies the Key ID
                 (<code>kid</code>) of the shared symmetric key, which is shared
-                between the TURN server and the Auth Server (AS), as described
+                between the TURN server and the Authorization Server, as described
                 in [!RFC7635]]. It is an ephemeral and unique key identifier.
                 The <code>kid</code> allows the TURN server to select the
                 appropriate keying material for decryption of the Access-Token,

--- a/webrtc.html
+++ b/webrtc.html
@@ -356,7 +356,7 @@
         </div>
         <p>An example of an OAuthCredential dictionary is:</p>
         <pre class="example highlight"><code>{
-    "macKey": "ZksjpweoixXmvn67534m",
+    "macKey": "WmtzanB3ZW9peFhtdm42NzUzNG0=",
     "accessToken": "AAwg3kPHWPfvk9bDFL936wYvkoctMADzQ5VhNDgeMR3+ZlZ35byg972fW8QjpEl7bx91YLBPFsIhsxloWcXPhA=="
 }</code></pre>
       </section>
@@ -440,7 +440,7 @@
      { "urls": "turns:turn2.example.net",
        "username": "22BIjxU93h/IgwEb",
        "credential": {
-                       "macKey": "ZksjpweoixXmvn67534m",
+                       "macKey": "WmtzanB3ZW9peFhtdm42NzUzNG0=",
                        "accessToken": "AAwg3kPHWPfvk9bDFL936wYvkoctMADzQ5VhNDgeMR3+ZlZ35byg972fW8QjpEl7bx91YLBPFsIhsxloWcXPhA=="
                      },
        "credentialType": "oauth" },

--- a/webrtc.html
+++ b/webrtc.html
@@ -307,6 +307,7 @@
                 </p>
                 <p><code>HS256</code> is defined in [[!RFC7518]] Section 3.1.
                 It is recommended here because:
+                </p>
                 <ul>
                   <li>The OAuth respose key parameter is received in JWK format
                   according to [[!OAUTH-POP-KEY-DISTRIBUTION]] Section 4.2.
@@ -319,7 +320,6 @@
                   <li>A 256-bit key is large enough to support all currently
                   defined STUN message integrity attributes.</li>
                 </ul>
-                </p>
                 <p>More details about OAuth PoP Client can be found in
                 [[!OAUTH-POP-KEY-DISTRIBUTION]] Section 4.
                 </p>


### PR DESCRIPTION
Fixes #714.

The working group decided on this solution in the Jan 25 2017 virtual
interim. The "username" field will be used for the kid, and the other
two pieces of credential information will go in "credential". The reasoning
for this decision was that it's backwards compatible, and doesn't add
more fields to the RTCIceServer dictionary.

Based on earlier PR from @misi, with some minor editorial tweaks.