### PR TITLE
maxSimulcastStreams attribute in RTCRtpCodecCapability

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5808,6 +5808,7 @@ sender.setParameters(params)
       <div>
         <pre class="idl">dictionary RTCRtpCodecCapability {
              DOMString mimeType;
+             unsigned short maxSimulcastStreams = 0;
 };</pre>
         <section>
           <h2>Dictionary <dfn>RTCRtpCodecCapability</dfn>
@@ -5819,6 +5820,13 @@ sender.setParameters(params)
             <dd>
               <p>The codec MIME media type/subtype. Valid media types and
               subtypes are listed in [[IANA-RTP-2]].</p>
+            </dd>
+            <dt><dfn><code>maxSimulcastStreams</code></dfn> of type <span class=
+             "idlMemberType"><a>unsigned short</a></span>, defaulting to
+            <code>0</code></dt>
+            <dd>
+               <p>Maximum number of simulcast streams supported for this
+               codec. A value of 0 indicates no support for simulcast.</p>
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
For discussion at the virtual interim.

Partial fix for Issue https://github.com/w3c/webrtc-pc/issues/763