### PR TITLE
Clarify which timestamp RTCStats.timestamp represents.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8929,7 +8929,12 @@ interface RTCDTMFToneChangeEvent : Event {
               <p>The <dfn><code>timestamp</code></dfn>, of type
               <code>DOMHighResTimeStamp</code> [[!HIGHRES-TIME]], associated
               with this object. The time is relative to the UNIX epoch (Jan 1,
-              1970, UTC).</p>
+              1970, UTC). For statistics that came from a remote source (e.g.,
+              from received RTCP packets), <code>timestamp</code> represents
+              the time at which the information arrived at the local endpoint.
+              The remote timestamp can be found in an additional field in an
+              <code><a>RTCStats</a></code>-derived dictionary, if
+              applicable.</p>
             </dd>
             <dt><code>type</code> of type <span class=
             "idlMemberType"><a>RTCStatsType</a></span></dt>


### PR DESCRIPTION
Fixes #729.

"timestamp" always refers to the locally measured timestamp. In the case
of stats with a remote source, this means the timestamp at which the
RTCP packet was received.

The remote timestamp will be added in a separate webrtc-stats PR:
https://github.com/w3c/webrtc-stats/pull/164