### PR TITLE
Label 'Warm-up example' as 'advanced p2p example'

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -10356,7 +10356,7 @@ function logError(error) {
       </div>
     </section>
     <section>
-      <h3>Simple Peer-to-peer Example with Warm-up</h3>
+      <h3>Advanced Peer-to-peer Example with Warm-up</h3>
       <div>
         <p>When two peers decide they are going to set up a connection to each
         other and want to have the ICE, DTLS, and media connections "warmed up"
@@ -10484,7 +10484,7 @@ function logError(error) {
       </div>
     </section>
     <section>
-      <h3>Simple Peer-to-peer Example with media before signaling</h3>
+      <h3>Peer-to-peer Example with media before signaling</h3>
       <div>
         <p>The answerer may wish to send media in parallel with sending the
         answer, and the offerer may wish to render the media before the answer
@@ -10569,7 +10569,7 @@ function logError(error) {
       </div>
     </section>
     <section>
-      <h3>Simple Simulcast Example</h3>
+      <h3>Simulcast Example</h3>
       <div>
         <p>A client wants to send multiple RTP encodings (simulcast) to a
         server.</p>
@@ -10631,15 +10631,6 @@ function logError(error) {
     log(error.name + ": " + error.message);
 }
 
-</pre>
-      </div>
-    </section>
-    <section>
-      <h3>Advanced Peer-to-peer Example</h3>
-      <div>
-        <p>This example shows the more complete functionality.</p>
-        <p class="issue">TODO</p>
-        <pre class="example highlight">
 </pre>
       </div>
     </section>


### PR DESCRIPTION
Fixes #959 

Changes:
* Label "p2p Warm-up example" as advanced and remove the advanced example place holder.
* Remove "Simple" from all example titles, but the first.