### PR TITLE
Adding "[EnforceRange]" to RTCDataChannelInit.id.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8279,6 +8279,7 @@ interface RTCTrackEvent : Event {
              unsigned short maxRetransmits;
              USVString      protocol = "";
              boolean        negotiated = false;
+             [EnforceRange]
              unsigned short id;
              RTCPriorityType priority = "low";
 };</pre>


### PR DESCRIPTION
Fixes #1046.

Without doing this, values outside the 0-65535 range will be
converted to that range using modulo arithmetic, which isn't
something we want.