### PR TITLE
Changing iceCandidatePoolSize to an octet and adding EnforceRange.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -111,7 +111,8 @@
              RTCRtcpMuxPolicy         rtcpMuxPolicy = "require";
              DOMString                peerIdentity;
              sequence&lt;RTCCertificate&gt; certificates;
-             unsigned short           iceCandidatePoolSize = 0;
+             [EnforceRange]
+             octet                    iceCandidatePoolSize = 0;
 };</pre>
           <section>
             <h2>Dictionary <a class="idlType">RTCConfiguration</a> Members</h2>


### PR DESCRIPTION
Fixes #1048.

Changing it to an octet limits the range to 0-255; there shouldn't be
any situation where an application wants to create thousands of pooled
candidates.

Adding [EnforceRange] means that if the application provides a negative
value or one greater than 255, a TypeError is thrown, rather than the
value being converted to the valid range by doing "mod 256".