### PR TITLE
Switching to new, consistent terminology when talking about exceptions.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -84,6 +84,11 @@
     <p>The term <dfn>Blob</dfn> is defined in [[!FILEAPI]].</p>
     <p>The term <dfn>media description</dfn> is defined in [[!RFC4566]].</p>
     <p>The term <dfn>generation</dfn> is defined in [[!TRICKLE-ICE]] Section 2.</p>
+    <p>When referring to exceptions, the terms <dfn><a
+    href="https://www.w3.org/TR/WebIDL-1/#dfn-throw">throw</a></dfn> and
+    <dfn data-dfn-for="exception"><a href=
+    "https://www.w3.org/TR/WebIDL-1/#dfn-create-exception">create</a></dfn> are
+    defined in [[!WEBIDL-1]].</p>
   </section>
   <section>
     <h2>Peer-to-peer connections</h2>
@@ -556,8 +561,8 @@
             <p>If the <code>certificates</code> value in the
             <code>RTCConfiguration</code> structure is non-empty, check that
             the <code>expires</code> on each value is in the future. If a
-            certificate has expired, throw an <code>InvalidAccessError</code>
-            exception and abort these steps; otherwise, store the certificates.
+            certificate has expired, <a>throw</a> an
+            <code>InvalidAccessError</code>; otherwise, store the certificates.
             If no <code>certificates</code> value was specified, one or more
             new <code>RTCCertificate</code> instances are generated for use
             with this <code>RTCPeerConnection</code> instance.</p>
@@ -586,7 +591,8 @@
           </li>
           <li>
             <p>If <var>connection</var>'s [[<a>isClosed</a>]] slot is
-            <code>true</code>, return a promise rejected with an
+            <code>true</code>, return a promise rejected with a newly
+            <a data-link-for="exception" data-lt="create">created</a>
             <code>InvalidStateError</code>.</p>
           </li>
           <li>
@@ -760,14 +766,17 @@
                   </li>
                   <li>
                     <p>If elements of the SDP were modified, then reject
-                    <var>p</var> with an <code>InvalidModificationError</code>
+                    <var>p</var> with a newly
+                    <a data-link-for="exception" data-lt="create">created</a>
+                    <code>InvalidModificationError</code>
                     and abort these steps.</p>
                   </li>
                   <li>
                     <p>If the <var>description</var>'s <code><a data-for=
                     "RTCSessionDescription">type</a></code> is invalid for the
                     current <a>signaling state</a> of <var>connection</var>,
-                    then reject <var>p</var> with a
+                    then reject <var>p</var> with a newly
+                    <a data-link-for="exception" data-lt="create">created</a>
                     <code>InvalidStateError</code> and abort these steps.</p>
                   </li>
                   <li>
@@ -780,13 +789,15 @@
                   </li>
                   <li>
                     <p>If the content of <var>description</var> is invalid,
-                    then reject <var>p</var> with an
+                    then reject <var>p</var> with a newly
+                    <a data-link-for="exception" data-lt="create">created</a>
                     <code>InvalidAccessError</code> and abort these steps.</p>
                   </li>
                   <li>
                     <p>For all other errors, for example if
                     <var>description</var> cannot be applied at the media
-                    layer, reject <var>p</var> with
+                    layer, reject <var>p</var> with a newly
+                    <a data-link-for="exception" data-lt="create">created</a>
                     <code>OperationError</code>.</p>
                   </li>
                 </ol>
@@ -1443,7 +1454,8 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>If <var>connection</var>'s [[<a>isClosed</a>]] slot is
-                    <code>true</code>, return a promise rejected with an
+                    <code>true</code>, return a promise rejected with a newly
+                    <a data-link-for="exception" data-lt="create">created</a>
                     <code>InvalidStateError</code>.</p>
                   </li>
                   <li>
@@ -1483,10 +1495,9 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>If the identity provider was unable to produce an
-                    identity assertion, reject <var>p</var> with a
-                    <code>DOMException</code> object whose <code>name</code>
-                    attribute has the value <code>NotReadableError</code>, and
-                    abort these steps.</p>
+                    identity assertion, reject <var>p</var> with a newly
+                    <a data-link-for="exception" data-lt="create">created</a>
+                    <code>NotReadableError</code> and abort these steps.</p>
                   </li>
                   <li>
                     <p>If <var>connection</var> was not constructed with a set
@@ -1501,9 +1512,9 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>If this inspection failed for any reason, reject
-                    <var>p</var> with a <code>DOMException</code> object whose
-                    <code>name</code> attribute has the value
-                    <code>OperationError</code>, and abort these steps.</p>
+                    <var>p</var> with a newly
+                    <a data-link-for="exception" data-lt="create">created</a>
+                    <code>OperationError</code> and abort these steps.</p>
                   </li>
                   <li>
                     <p>Queue a task that runs the <a>final steps to create an
@@ -1622,7 +1633,8 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>If <var>connection</var>'s [[<a>isClosed</a>]] slot is
-                    <code>true</code>, return a promise rejected with an
+                    <code>true</code>, return a promise rejected with a newly
+                    <a data-link-for="exception" data-lt="create">created</a>
                     <code>InvalidStateError</code>.</p>
                   </li>
                   <li>
@@ -1641,8 +1653,9 @@ interface RTCPeerConnection : EventTarget  {
                       <li>
                         <p>If <var>connection</var>'s <code><a data-for=
                         "RTCPeerConnection">remoteDescription</a></code> is
-                        <code>null</code> return a promise rejected with an
-                        <code>InvalidStateError</code>.</p>
+                        <code>null</code> return a promise rejected with a newly
+                        <a data-link-for="exception" data-lt="create">created
+                        </a> <code>InvalidStateError</code>.</p>
                       </li>
                       <li>
                         <p>Let <var>p</var> be a new promise.</p>
@@ -1668,10 +1681,9 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>If the identity provider was unable to produce an
-                    identity assertion, reject <var>p</var> with a
-                    <code>DOMException</code> object whose <code>name</code>
-                    attribute has the value <code>NotReadableError</code>, and
-                    abort these steps.</p>
+                    identity assertion, reject <var>p</var> with a newly
+                    <a data-link-for="exception" data-lt="create">created</a>
+                    <code>NotReadableError</code> and abort these steps.</p>
                   </li>
                   <li>
                     <p>If <var>connection</var> was not constructed with a set
@@ -1686,9 +1698,9 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>If this inspection failed for any reason, reject
-                    <var>p</var> with a <code>DOMException</code> object whose
-                    <code>name</code> attribute has the value
-                    <code>OperationError</code>, and abort these steps.</p>
+                    <var>p</var> with a newly
+                    <a data-link-for="exception" data-lt="create">created</a>
+                    <code>OperationError</code> and abort these steps.</p>
                   </li>
                   <li>
                     <p>Queue a task that runs the <a>final steps to create an
@@ -1804,12 +1816,15 @@ interface RTCPeerConnection : EventTarget  {
                   <li>If <code><var>description</var>.type</code> is
                   <code>offer</code> and <code><var>description</var>.sdp</code>
                   does not match <var>lastOffer</var>,
-                  reject the promise with <code>InvalidModificationError</code>
-                  and abort these steps.</li>
+                  reject the promise with a newly
+                  <a data-link-for="exception" data-lt="create">created</a>
+                  <code>InvalidModificationError</code> and abort these steps.
+                  </li>
                   <li>If <code><var>description</var>.type</code> is
                   <code>answer</code> or <code>pranswer</code> and
                   <code><var>description</var>.sdp</code> does not
-                  match <var>lastAnswer</var>, reject the promise with
+                  match <var>lastAnswer</var>, reject the promise with a newly
+                  <a data-link-for="exception" data-lt="create">created</a>
                   <code>InvalidModificationError</code> and abort these steps.</li>               
                   <li>Return the result of <a href="#set-description">setting
                   the RTCSessionDescription</a> indicated by the method's first
@@ -1869,7 +1884,8 @@ interface RTCPeerConnection : EventTarget  {
                 establishes a <a>target peer identity</a>.</p>
                 <p>The <a>target peer identity</a> cannot be changed once set.
                 Once set, if a different value is provided, the user agent MUST
-                reject the returned promise with
+                reject the returned promise with a newly
+                <a data-link-for="exception" data-lt="create">created</a>
                 <code>InvalidModificationError</code> and abort this operation.
                 The <code><a>RTCPeerConnection</a></code> MUST be closed if the
                 validated peer identity does not match the <a>target peer
@@ -1929,7 +1945,8 @@ interface RTCPeerConnection : EventTarget  {
                   <li>
                     <p>If <var>candidate</var> is not <code>null</code> and
                     both <var>sdpMid</var> and <var>sdpMLineIndex</var> are
-                    <code>null</code>, return a promise rejected with
+                    <code>null</code>, return a promise rejected with a newly
+                    <a data-link-for="exception" data-lt="create">created</a>
                     <code>TypeError</code>.</p>
                   </li>
                   <li>
@@ -1940,8 +1957,9 @@ interface RTCPeerConnection : EventTarget  {
                       <li>
                         <p>If <code><a data-for=
                         "RTCPeerConnection">remoteDescription</a></code> is
-                        <code>null</code> return a promise rejected with an
-                        <code>InvalidStateError</code>.</p>
+                        <code>null</code> return a promise rejected with a newly
+                        <a data-link-for="exception" data-lt="create">created
+                        </a> <code>InvalidStateError</code>.</p>
                       </li>
                       <li>
                         <p>Let <var>p</var> be a new promise.</p>
@@ -1955,11 +1973,10 @@ interface RTCPeerConnection : EventTarget  {
                             the mid of any media description in
                             <code><a data-for=
                             "RTCPeerConnection">remoteDescription</a></code>,
-                            reject <var>p</var> with a
-                            <code>DOMException</code> object whose
-                            <code>name</code> attribute has the value
-                            <code>OperationError</code> and stop processing any
-                            more steps.</p>
+                            reject <var>p</var> with a newly
+                            <a data-link-for="exception" data-lt="create">
+                            created</a> <code>OperationError</code> and abort
+                            these steps.</p>
                           </li>
                         </ol>
                       </li>
@@ -1972,11 +1989,10 @@ interface RTCPeerConnection : EventTarget  {
                             to or larger than the number of media descriptions
                             in <code><a data-for=
                             "RTCPeerConnection">remoteDescription</a></code>,
-                            reject <var>p</var> with a
-                            <code>DOMException</code> object whose
-                            <code>name</code> attribute has the value
-                            <code>OperationError</code> and stop processing any
-                            more steps.</p>
+                            reject <var>p</var> with a newly
+                            <a data-link-for="exception" data-lt="create">
+                            created</a> <code>OperationError</code> and abort
+                            these steps.</p>
                           </li>
                         </ol>
                       </li>
@@ -1985,8 +2001,10 @@ interface RTCPeerConnection : EventTarget  {
                         <code>undefined</code> nor <code>null</code>, and is not
                         equal to any ufrag present in the corresponding
                         <a>media description</a> of an applied remote
-                        description, reject <var>p</var> with an
-                        <code>OperationError</code> and abort these steps.</p>
+                        description, reject <var>p</var> with a newly
+                        <a data-link-for="exception" data-lt="create">created
+                        </a> <code>OperationError</code> and abort these steps.
+                        </p>
                       </li>
                       <li>
                         <p>In parallel, add the ICE candidate
@@ -2116,8 +2134,8 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>If <var>connection</var>'s [[<a>isClosed</a>]] slot is
-                    <code>true</code>, throw an <code>InvalidStateError</code>
-                    exception and abort these steps.</p>
+                    <code>true</code>, <a>throw</a> an
+                    <code>InvalidStateError</code>.</p>
                   </li>
                 </ol>
                 <p>To <dfn data-lt="set the configuration" id=
@@ -2131,26 +2149,26 @@ interface RTCPeerConnection : EventTarget  {
                   <code><a>RTCPeerConnection</a></code> object.</li>
                   <li>If <code><var>configuration</var>.peerIdentity</code> is
                   set and its value differs from the <a>target peer
-                  identity</a>, throw an <code>InvalidModificationError</code>.
+                  identity</a>, <a>throw</a> an <code>InvalidModificationError</code>.
                   </li>
                   <li>If <code><var>configuration</var>.certificates</code> is
                   set and the set of certificates differs from the ones used
-                  when <var>connection</var> was constructed, throw an
+                  when <var>connection</var> was constructed, <a>throw</a> an
                   <code>InvalidModificationError</code>.</li>
                   <li>If <code><var>configuration</var>.<a data-for=
                   "RTCConfiguration">bundlePolicy</a></code> is set and its
                   value differs from the <var>connection</var>'s bundle policy,
-                  throw an <code>InvalidModificationError</code>.</li>
+                  <a>throw</a> an <code>InvalidModificationError</code>.</li>
                   <li>If <code><var>configuration</var>.<a data-for=
                   "RTCConfiguration">rtcpMuxPolicy</a></code> is set and its
                   value differs from the <var>connection</var>'s rtcpMux
-                  policy, throw an <code>InvalidModificationError</code>.</li>
+                  policy, <a>throw</a> an <code>InvalidModificationError</code>.</li>
                   <li>If <code><var>configuration</var>.<a data-for=
                   "RTCConfiguration">iceCandidatePoolSize</a></code> is set and
                   its value differs from the <var>connection</var>'s previously
                   set <code>iceCandidatePoolSize</code>, and <code><a data-for=
                   "RTCPeerConnection">setLocalDescription</a></code> has
-                  already been called, throw an
+                  already been called, <a>throw</a> an
                   <code>InvalidModificationError</code>.</li>
                   <li>
                     <p>Set the <a>ICE Agent</a>'s <dfn id=
@@ -2198,16 +2216,15 @@ interface RTCPeerConnection : EventTarget  {
                         <var>url</var> and obtain <var>scheme name</var>. If
                         the <var>scheme name</var> is not implemented by the
                         browser, or if parsing based on the syntax defined in
-                        [[!RFC7064]] and [[!RFC7065]] fails, throw a
-                        <code>SyntaxError</code> and abort these steps.</p>
+                        [[!RFC7064]] and [[!RFC7065]] fails, <a>throw</a> a
+                        <code>SyntaxError</code>.</p>
                       </li>
                       <li>
                         <p>If <var>scheme name</var> is <code>turn</code> or
                         <code>turns</code>, and either of
                         <code><var>server</var>.username</code> or
                         <code><var>server</var>.credential</code> are omitted,
-                        then throw an <code>InvalidAccessError</code> and abort
-                        these steps.</p>
+                        then <a>throw</a> an <code>InvalidAccessError</code>.</p>
                       </li>
                       <li>
                         <p>Append <var>server</var> to
@@ -3537,7 +3554,7 @@ interface RTCIceCandidate {
                 "idlType"><code>RTCIceCandidate</code></a> object. When run, if
                 both the <code><a>sdpMid</a></code> and
                 <code><a>sdpMLineIndex</a></code> dictionary members are
-                <code>null</code>, throw a <code>TypeError</code>.
+                <code>null</code>, <a>throw</a> a <code>TypeError</code>.
                 <table class="parameters">
                   <tbody>
                     <tr>
@@ -4255,7 +4272,8 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             attempts to convert the object into a
             <code><a>RTCCertificateExpiration</a></code>. If this is
             unsuccessful, immediately return a promise that is rejected with a
-            <code><a>TypeError</a></code> and abort processing.</p>
+            newly <a data-link-for="exception" data-lt="create">created</a>
+            <code>TypeError</code> and abort processing.</p>
             <p>A <a>user agent</a> generates a certificate that has an
             expiration date set to the current time plus the value of the
             <code>expires</code> attribute. The <a data-for=
@@ -4581,16 +4599,15 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 </li>
                 <li>
                   <p>If <var>connection</var>'s [[<a>isClosed</a>]] slot is
-                  <code>true</code>, throw an <code>InvalidStateError</code>
-                  exception and abort these steps.</p>
+                  <code>true</code>, <a>throw</a> an
+                  <code>InvalidStateError</code>.</p>
                 </li>
                 <li>
                   <p>Let <var>senders</var> be the result of executing the
                   <code><a>CollectSenders</a></code> algorithm. If an
                   <code><a>RTCRtpSender</a></code> for <var>track</var> already
-                  exists in <var>senders</var>, throw an
-                  <code>InvalidAccessError</code> exception and abort these
-                  steps.</p>
+                  exists in <var>senders</var>, <a>throw</a> an
+                  <code>InvalidAccessError</code>.</p>
                 </li>
                 <li>
                   <p>The steps below describe how to determine if an existing
@@ -4752,14 +4769,13 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 </li>
                 <li>
                   <p>If <var>connection</var>'s [[<a>isClosed</a>]] slot is
-                  <code>true</code>, throw an <code>InvalidStateError</code>
-                  exception and abort these steps.</p>
+                  <code>true</code>, <a>throw</a> an
+                  <code>InvalidStateError</code>.</p>
                 </li>
                 <li>
                   <p>If <var>sender</var> was not created by
-                  <var>connection</var> , throw an
-                  <code>InvalidAccessError</code> exception and abort these
-                  steps.</p>
+                  <var>connection</var>, <a>throw</a> an
+                  <code>InvalidAccessError</code>.</p>
                 </li>
                 <li>
                   <p>Let <var>senders</var> be the result of executing the
@@ -4861,8 +4877,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                     <li>
                       <p>If <var>kind</var> is not a legal
                       <code><a>MediaStreamTrack</a></code> <code>kind</code>,
-                      throw a <code>TypeError</code> and abort these, and all
-                      further steps.</p>
+                      <a>throw</a> a <code>TypeError</code>.</p>
                     </li>
                     <li>
                       <p>Let <var>track</var> be <code>null</code>.</p>
@@ -5261,7 +5276,9 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 parallel.</li>
                 <li>If <code><var>transceiver</var>.stopped</code> is
                 <code>true</code>, abort these steps and return a promise
-                rejected with <code>InvalidStateError</code>.</li>
+                rejected with a newly
+                <a data-link-for="exception" data-lt="create">created</a>
+                <code>InvalidStateError</code>.</li>
                 <li>If <code><var>parameters</var>.encodings.length</code>
                 is different from <var>N</var>, or if
                 any parameter in the <var>parameters</var> argument,
@@ -5269,12 +5286,14 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 different from the corresponding parameter value returned from
                 <code><a data-link-for=
                 "RTCRtpSender"><var>sender</var>.getParameters()</a></code>,
-                abort these steps and return a promise rejected with
+                abort these steps and return a promise rejected with a newly
+                <a data-link-for="exception" data-lt="create">created</a>
                 <code>InvalidModificationError</code>. Note that this also
                 applies to <var>transactionId</var>.</li>
                 <li>If the <code>scaleResolutionDownBy</code> parameter in the
                 <var>parameters</var> argument has a value less than 1.0, abort
-                these steps and return a promise rejected with
+                these steps and return a promise rejected with a newly
+                <a data-link-for="exception" data-lt="create">created</a>
                 <code>RangeError</code>.</li>
                 <li>Set the <code><a>RTCRtpSender</a></code>'s internal
                 <var>transactionId</var> slot to a previously unused
@@ -5372,13 +5391,15 @@ sender.setParameters(params)
                 </li>
                 <li>
                   <p>If <var>connection</var>'s [[<a>isClosed</a>]] slot is
-                  <code>true</code>, return a promise rejected with an
+                  <code>true</code>, return a promise rejected with a newly
+                  <a data-link-for="exception" data-lt="create">created</a>
                   <code>InvalidStateError</code> and abort these steps.</p>
                 </li>
                 <li>
                   <p>If <code><var>transceiver</var>.stopped</code> is
                   <code>true</code>, return a promise rejected
-                  with an <code>InvalidStateError</code>.</p>
+                  with a newly <a data-link-for="exception" data-lt="create">
+                  created</a> <code>InvalidStateError</code>.</p>
                 </li>
                 <li>
                   <p>Let <var>withTrack</var> be the argument to this
@@ -5388,7 +5409,9 @@ sender.setParameters(params)
                   <p>If <code><var>withTrack</var></code> is non-null and
                   <code><var>withTrack</var>.kind</code> differs from the
                   <a>transceiver kind</a> of <var>transceiver</var>, return a
-                  promise rejected with a <code>TypeError</code>.</p>
+                  promise rejected with a newly
+                  <a data-link-for="exception" data-lt="create">created</a>
+                  <code>TypeError</code>.</p>
                 </li>
                 <li>
                   <p>If <var>transceiver</var> is not yet associated with a
@@ -5414,7 +5437,8 @@ sender.setParameters(params)
                       muted). Ignore which <code>MediaStream</code> the track
                       resides in and the <code>id</code> attribute of the track
                       in this determination. If negotiation is needed, then
-                      reject <var>p</var> with
+                      reject <var>p</var> with a newly
+                      <a data-link-for="exception" data-lt="create">created</a>
                       <code>InvalidModificationError</code> and abort these
                       steps.</p>
                     </li>
@@ -6415,8 +6439,7 @@ sender.setParameters(params)
                   <p>If <var>newDirection</var> has a value other
                   than <code>sendrecv</code>, <code>sendonly</code>,
                   <code>recvonly</code> or <code>inactive</code>,
-                  throw an <code>InvalidModificationError</code>
-                  and abort these steps.</p>
+                  <a>throw</a> an <code>InvalidModificationError</code>.</p>
                 </li>
                 <li>
                   <p>Set <code><var>transceiver</var>.direction</code>
@@ -6488,8 +6511,8 @@ sender.setParameters(params)
                 </li>
                 <li>
                   <p>If <var>connection</var>'s [[<a>isClosed</a>]] slot is
-                  <code>true</code>, throw an <code>InvalidStateError</code>
-                  exception and abort these steps.</p>
+                  <code>true</code>, <a>throw</a> an
+                  <code>InvalidStateError</code>.</p>
                 </li>
                 <li>
                   <p>Let <var>sender</var> be <code><var>transceiver</var>.sender</code>.</p>
@@ -6568,8 +6591,7 @@ sender.setParameters(params)
               <code>RTCRtpTransceiver</code> on which the method is called.
               Additionally, the <code>RTCRtpCodecParameters</code> dictionary
               members cannot be modified. If <code>codecs</code> does not
-              fulfill these requirements, the user agent MUST <a
-                href="http://heycam.github.io/webidl/#dfn-throw">throw</a> an
+              fulfill these requirements, the user agent MUST <a>throw</a> an
               InvalidAccessError.</p>
 
               <table class="parameters">
@@ -7611,8 +7633,8 @@ interface RTCTrackEvent : Event {
                 </li>
                 <li>
                   <p>If <var>connection</var>'s [[<a>isClosed</a>]] slot is
-                  <code>true</code>, throw an <code>InvalidStateError</code>
-                  exception and abort these steps.</p>
+                  <code>true</code>, <a>throw</a> an
+                  <code>InvalidStateError</code>.</p>
                 </li>
                 <li>
                   <p>Let <var>channel</var> be a newly created
@@ -7637,21 +7659,19 @@ interface RTCTrackEvent : Event {
                   present in the dictionary).</p>
                 </li>
                 <li>If <code>negotiated</code> is false and <code>label</code>
-                is longer than 65535 bytes long, <a href=
-                "http://heycam.github.io/webidl/#dfn-throw">throw</a> a
+                is longer than 65535 bytes long, <a>throw</a> a
                 <code>TypeError</code>.
                 </li>
                 <li>If <code>negotiated</code> is false and
                 <code>protocol</code> is longer than 65535 bytes long,
-                  <a href="http://heycam.github.io/webidl/#dfn-throw">throw</a>
-                  a <code>TypeError</code>.
+                <a>throw</a> a <code>TypeError</code>.
                 </li>
                 <li>
                   <p>If both the <code><a data-for=
                   "RTCDataChannel">maxPacketLifeTime</a></code> and
                   <code><a data-for="RTCDataChannel">maxRetransmits</a></code>
-                  attributes are set (not null), then throw a
-                  <code>SyntaxError</code> exception and abort these steps.</p>
+                  attributes are set (not null), <a>throw</a> a
+                  <code>SyntaxError</code>.</p>
                 </li>
                 <li>
                   <p>If an attribute, either <code><a data-for=
@@ -7665,8 +7685,8 @@ interface RTCTrackEvent : Event {
                   <p>If <code><a data-for="RTCDataChannel">id</a></code> is
                   equal to 65535, which is greater than the maximum allowed ID
                   of 65534 but still qualifies as an <span class=
-                  "idlMemberType"><a>unsigned short</a></span>, throw a
-                  <code>TypeError</code> exception and abort these steps.</p>
+                  "idlMemberType"><a>unsigned short</a></span>, <a>throw</a> a
+                  <code>TypeError</code>.</p>
                 </li>
                 <li>
                   <p>If the <code><a data-for="RTCDataChannel">id</a></code>
@@ -7678,8 +7698,7 @@ interface RTCTrackEvent : Event {
                   the next step. If no available id could be generated, or if
                   the value of the <code>id</code> member of the dictionary
                   is taken by an existing <code><a>RTCDataChannel</a></code>,
-                  throw a <code>ResourceInUse</code> exception and abort these
-                  steps.</p>
+                  <a>throw</a> a <code>ResourceInUse</code> exception.</p>
                 </li>
                 <li>
                   <p>Return <var>channel</var> and continue the following steps
@@ -8390,8 +8409,8 @@ interface RTCTrackEvent : Event {
         <li>
           <p>If <var>channel</var>'s <a data-for=
           "RTCDataChannel"><code>readyState</code></a> attribute is
-          <code>connecting</code>, throw an <code>InvalidStateError</code>
-          exception and abort these steps.</p>
+          <code>connecting</code>, <a>throw</a> an
+          <code>InvalidStateError</code>.</p>
         </li>
         <li>
           <p>Execute the sub step that corresponds to the type of the methods
@@ -8717,15 +8736,14 @@ interface RTCDTMFSender : EventTarget {
                   <var>sender</var>.</p>
                 </li>
                 <li>If <code><var>transceiver</var>.stopped</code> is
-                <code>true</code>, throw an <code>InvalidStateError</code>
-                exception.</li>
+                <code>true</code>, <a>throw</a> an
+                <code>InvalidStateError</code>.</li>
                 <li>If <code><var>transceiver</var>.currentDirection</code>
                 is <code>recvonly</code> or <code>inactive</code>,
-                throw an <code>InvalidStateError</code> exception.</li>
+                <a>throw</a> an <code>InvalidStateError</code>.</li>
                 <li>Let <var>tones</var> be the method's first argument.</li>
                 <li>If <var>tones</var> contains any <a>unrecognized</a>
-                characters, throw an <code>InvalidCharacterError</code>
-                exception and abort these steps.
+                characters, <a>throw</a> an <code>InvalidCharacterError</code>.
                 </li>
                 <li>Set the object's <code><a data-for=
                 "RTCDTMFSender">toneBuffer</a></code> attribute to
@@ -8970,7 +8988,8 @@ interface RTCDTMFToneChangeEvent : Event {
                 <li>
                   <p>If <var>selectorArg</var> is neither <code>null</code> nor
                   a valid <a>selector</a>, return a promise rejected with a
-                  <code>TypeError</code>.</p>
+                  newly <a data-link-for="exception" data-lt="create">created
+                  </a> <code>TypeError</code>.</p>
                 </li>
                 <li>
                   <p>Let <var>p</var> be a new promise.</p>
@@ -9637,8 +9656,8 @@ interface RTCIdentityProviderRegistrar {
         </li>
       </ol>
       <p>If assertion generation fails, then the promise for the corresponding
-      function call is rejected with a <code>DOMException</code> that has the
-      name <code>OperationError</code>.</p>
+      function call is rejected with a newly <a data-link-for="exception"
+      data-lt="create">created</a> <code>OperationError</code>.</p>
       <section>
         <h4 id="sec.idp-loginneeded">User Login Procedure</h4>
         <p>An IdP MAY reject an attempt to generate an identity assertion if it
@@ -9763,7 +9782,7 @@ interface RTCIdentityProviderRegistrar {
       </ol>
       <p>If identity validation fails, the <code><a data-for=
       "RTCPeerConnection">peerIdentity</a></code> promise is rejected with a
-      <code>DOMException</code> that has a name of
+      newly <a data-link-for="exception" data-lt="create">created</a>
       <code>OperationError</code>.</p>
       <p>If identity validation fails and there is a <a>target peer
       identity</a> for the <code>RTCPeerConnection</code>, the promise returned
@@ -9913,9 +9932,8 @@ interface RTCIdentityProviderRegistrar {
               <ol>
                 <li>
                   <p>If the <code><a>RTCPeerConnection</a></code> object's
-                  [[<a>isClosed</a>]] slot is <code>true</code>, throw an
-                  <code>InvalidStateError</code> exception and abort these
-                  steps.</p>
+                  [[<a>isClosed</a>]] slot is <code>true</code>, <a>throw</a> an
+                  <code>InvalidStateError</code>.</p>
                 </li>
                 <li>
                   <p>Set the current identity provider values to the tuple
@@ -9980,9 +9998,8 @@ interface RTCIdentityProviderRegistrar {
               <ol>
                 <li>
                   <p>If the <code><a>RTCPeerConnection</a></code> object's
-                  [[<a>isClosed</a>]] slot is <code>true</code>, throw an
-                  <code>InvalidStateError</code> exception and abort these
-                  steps.</p>
+                  [[<a>isClosed</a>]] slot is <code>true</code>, <a>throw</a> an
+                  <code>InvalidStateError</code>.</p>
                 </li>
                 <li>
                   <p><a href="#sec.identity-proxy-assertion-request">Request an


### PR DESCRIPTION
Fixes #845.

Throwing exceptions will use the phrase "throw a FooError", which
implies that the current steps will be aborted, making it unnecessary
to clarify that.

Rejecting a promise with an exception will use the phrase "reject p
with a newly created FooError and abort these steps."

Each place where these phrases are used links to the "Terminology"
section, which links to where these terms are defined in WebIDL.