### PR TITLE
Add getStats() to sender and receiver.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5169,6 +5169,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
     Promise&lt;void&gt;             setParameters (optional RTCRtpParameters parameters);
     RTCRtpParameters          getParameters ();
     Promise&lt;void&gt;             replaceTrack (MediaStreamTrack withTrack);
+    Promise&lt;RTCStatsReport&gt;   getStats();
 };</pre>
         <section>
           <h2>Attributes</h2>
@@ -5502,6 +5503,47 @@ sender.setParameters(params)
               </table>
               <div>
                 <em>Return type:</em> <code>Promise&lt;void&gt;</code>
+              </div>
+            </dd>
+            <dt><code>getStats</code></dt>
+            <dd>
+              <p>Gathers stats for this sender only and reports the result
+              asynchronously.</p>
+              <p>When the <dfn id=
+              "widl-RTCRtpSender-getStats-Promise-RTCStatsReport">
+              <code>getStats()</code></dfn> method is invoked, the user
+              agent MUST run the following steps:</p>
+              <ol>
+                <li>
+                  <p>Let <var>selector</var> be the
+                  <code><a>RTCRtpSender</a></code> object on which the method
+                  was invoked.</p>
+                </li>
+                <li>
+                  <p>Let <var>p</var> be a new promise, and run the following
+                  steps in parallel:</p>
+                  <ol>
+                    <li>
+                      <p>Gather the stats indicated by <var>selector</var>
+                      according to the <a>stats selection algorithm</a>.</p>
+                    </li>
+                    <li>
+                      <p>Resolve <var>p</var> with the resulting
+                      <code><a>RTCStatsReport</a></code> object, containing
+                      the gathered stats.</p>
+                    </li>
+                  </ol>
+                </li>
+                <li>
+                  <p>Return <var>p</var>.</p>
+                </li>
+              </ol>
+              <div>
+                <em>No parameters.</em>
+              </div>
+              <div>
+                <em>Return type:</em>
+                <code>Promise&lt;RTCStatsReport&gt;</code>
               </div>
             </dd>
           </dl>
@@ -6099,6 +6141,7 @@ sender.setParameters(params)
     static RTCRtpCapabilities          getCapabilities (DOMString kind);
     RTCRtpParameters                   getParameters ();
     sequence&lt;RTCRtpContributingSource&gt; getContributingSources ();
+    Promise&lt;RTCStatsReport&gt;   getStats();
 };</pre>
         <section>
           <h2>Attributes</h2>
@@ -6212,6 +6255,47 @@ sender.setParameters(params)
               <div>
                 <em>Return type:</em>
                 <code>sequence&lt;RTCRtpContributingSource&gt;</code>
+              </div>
+            </dd>
+            <dt><code>getStats</code></dt>
+            <dd>
+              <p>Gathers stats for this receiver only and reports the result
+              asynchronously.</p>
+              <p>When the <dfn id=
+              "widl-RTCRtpReceiver-getStats-Promise-RTCStatsReport">
+              <code>getStats()</code></dfn> method is invoked, the user
+              agent MUST run the following steps:</p>
+              <ol>
+                <li>
+                  <p>Let <var>selector</var> be the
+                  <code><a>RTCRtpReceiver</a></code> object on which the method
+                  was invoked.</p>
+                </li>
+                <li>
+                  <p>Let <var>p</var> be a new promise, and run the following
+                  steps in parallel:</p>
+                  <ol>
+                    <li>
+                      <p>Gather the stats indicated by <var>selector</var>
+                      according to the <a>stats selection algorithm</a>.</p>
+                    </li>
+                    <li>
+                      <p>Resolve <var>p</var> with the resulting
+                      <code><a>RTCStatsReport</a></code> object, containing
+                      the gathered stats.</p>
+                    </li>
+                  </ol>
+                </li>
+                <li>
+                  <p>Return <var>p</var>.</p>
+                </li>
+              </ol>
+              <div>
+                <em>No parameters.</em>
+              </div>
+              <div>
+                <em>Return type:</em>
+                <code>Promise&lt;RTCStatsReport&gt;</code>
               </div>
             </dd>
           </dl>


### PR DESCRIPTION
Fix for https://github.com/w3c/webrtc-pc/issues/1075.

Last interim we decided we preferred `sender.getStats()` and `receiver.getStats()` over `pc.getStats(sender)` and `pc.getStats(receiver)`. This PR adds that.