### PR TITLE
Clarify which "candidate" is referred to in addIceCandidate description.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1924,8 +1924,8 @@ interface RTCPeerConnection : EventTarget  {
                 "dom-peerconnection-addicecandidate"><code>addIceCandidate()</code></dfn>
                 method provides a remote candidate to the <a>ICE Agent</a>.
                 This method can also be used to indicate the end of remote
-                candidates when called with an empty string for <code><a
-                data-for="RTCIceCandidate">candidate</a></code>. The only
+                candidates when called with an empty string for the <code><a
+                data-for="RTCIceCandidate">candidate</a></code> member. The only
                 members of the argument used by this method are <code><a data-for=
                 "RTCIceCandidate">candidate</a></code>, <code><a data-for=
                 "RTCIceCandidate">sdpMid</a></code>, <code><a data-for=


### PR DESCRIPTION
Fixes #1077.

"candidate" here is referring to the "candidate" member within the
RTCIceCandidate or RTCIceCandidateInit, and not the argument to the
method which is unfortunately also named "candidate".