### PR TITLE
Make "candidate" non-nullable in addIceCandidate parameter table.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2143,8 +2143,7 @@ interface RTCPeerConnection : EventTarget  {
                     method was invoked.</p>
                   </li>
                   <li>
-                    <p>If <var>candidate</var> is not <code>null</code> and
-                    both <var>sdpMid</var> and <var>sdpMLineIndex</var> are
+                    <p>If both <var>sdpMid</var> and <var>sdpMLineIndex</var> are
                     <code>null</code>, return a promise rejected with a newly
                     <a data-link-for="exception" data-lt="create">created</a>
                     <code>TypeError</code>.</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -2288,8 +2288,8 @@ interface RTCPeerConnection : EventTarget  {
                       <td class="prmName">candidate</td>
                       <td class="prmType"><code>(RTCIceCandidateInit or
                       RTCIceCandidate)</code></td>
-                      <td class="prmNullTrue"><span role="img" aria-label=
-                      "True">&#10004;</span></td>
+                      <td class="prmNullFalse"><span role="img" aria-label=
+                      "False">&#10008;</span></td>
                       <td class="prmOptFalse"><span role="img" aria-label=
                       "False">&#10008;</span></td>
                       <td class="prmDesc"></td>


### PR DESCRIPTION
Fixes #1077.

It's non-nullable everywhere else, but we forgot to update this table.