### PR TITLE
Always update the RTCRtpContributingSource for SSRCs.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6565,12 +6565,11 @@ sender.setParameters(params)
       time a packet was received from the source. The browser MUST keep
       information from RTP packets received in the previous 10 seconds. Each
       time an RTP packet is received, the
-      <code><a>RTCRtpContributingSource</a></code> objects are updated. If the
-      RTP packet contains CSRCs, then the
-      <code><a>RTCRtpContributingSource</a></code> objects corresponding to
-      those CSRCs are updated. If the RTP packet contains no CSRCs, then the
+      <code><a>RTCRtpContributingSource</a></code> objects are updated. The
       <code><a>RTCRtpContributingSource</a></code> object corresponding to the
-      SSRC is updated.</p>
+      SSRC is always updated, and if the RTP packet contains CSRCs, then the
+      <code><a>RTCRtpContributingSource</a></code> objects corresponding to
+      those CSRCs are also updated.</p>
       <div>
         <pre class="idl">interface RTCRtpContributingSource {
     readonly        attribute DOMHighResTimeStamp timestamp;


### PR DESCRIPTION
Fixes #1091.

As described in the issue, there may be cases where an application
wants to know the SSRC audio level, even when a CSRC is present in the
packet.