### PR TITLE
Clarify when RTCRtpContributingSource.audioLevel can be null.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6599,16 +6599,19 @@ sender.setParameters(params)
             "idlAttrType"><a>byte</a></span>, readonly , nullable</dt>
             <dd>
               <p>The audio level contained in the last RTP packet received from
-              this source. If the source was set from an SSRC, this will be the
-              level value defined in [[!RFC6464]]. If an RFC 6464 extension
-              header is not present, the browser will compute the value as if
-              it had come from RFC 6464 and use that. If the source was set
-              from a CSRC, this will be the level value defined in
-              [[!RFC6465]]. RFC 6464 and 6465 define the level as a integral
-              value from 0 to 127 representing the audio level in negative
-              decibels relative to the loudest signal that they system could
-              possibly encode. Thus, 0 represents the loudest signal the system
-              could possibly encode, and 127 represents silence.</p>
+              this source. If the source corresponds to an SSRC,
+              <code>audioLevel</code> will be the level value defined in
+              [[!RFC6464]], if the RFC 6464 header extension is present. If the
+              RFC 6464 extension header is not present, the browser will
+              compute a value for <code>audioLevel</code> as if it had come
+              from RFC 6464. If the source corresponds to a CSRC,
+              <code>audioLevel</code> will be the level value defined in
+              [[!RFC6465]] if the RFC 6465 header extension is present, and
+              otherwise <code>null</code>. RFC 6464 and 6465 define the level
+              as a integral value from 0 to 127 representing the audio level in
+              negative decibels relative to the loudest signal that they system
+              could possibly encode. Thus, 0 represents the loudest signal the
+              system could possibly encode, and 127 represents silence.</p>
             </dd>
             <dt><dfn><code>voiceActivityFlag</code></dfn> of type <span class=
             "idlAttrType"><a>boolean</a></span>, readonly , nullable</dt>


### PR DESCRIPTION
Fixes #1090.

audioLevel is only null if the RTCRtpContributingSource object
corresponds to a CSRC, and the RFC 6465 header extension wasn't used.