### PR TITLE
Don't link function names to legacy section (unless intended)

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1988,7 +1988,7 @@ interface RTCPeerConnection : EventTarget  {
               <dt><code>setLocalDescription</code></dt>
               <dd>
                 <p>The <dfn id=
-                "dom-peerconnection-setlocaldescription"><code>setLocalDescription()</code></dfn>
+                "dom-peerconnection-setlocaldescription"><code>setLocalDescription</code></dfn>
                 method instructs the <code><a>RTCPeerConnection</a></code> to
                 apply the supplied
                 <code><a>RTCSessionDescriptionInit</a></code> as the local
@@ -2130,10 +2130,10 @@ interface RTCPeerConnection : EventTarget  {
                   <em>Return type:</em> <code>Promise&lt;void&gt;</code>
                 </div>
               </dd>
-              <dt><dfn><code>addIceCandidate</code></dfn></dt>
+              <dt><code>addIceCandidate</code></dt>
               <dd>
                 <p>The <dfn id=
-                "dom-peerconnection-addicecandidate"><code>addIceCandidate()</code></dfn>
+                "dom-peerconnection-addicecandidate"><code>addIceCandidate</code></dfn>
                 method provides a remote candidate to the <a>ICE Agent</a>.
                 This method can also be used to indicate the end of remote
                 candidates when called with an empty string for the <code><a
@@ -2959,7 +2959,7 @@ interface RTCPeerConnection : EventTarget  {
               </dd>
               <dt><code>addIceCandidate</code></dt>
               <dd>
-                <p>When the <dfn data-lt="addIceCandidate!overload-1" data-lt-nodefault>addIceCandidate</dfn> method is called, the
+                <p>When the <dfn data-lt="addIceCandidate!overload-1" data-lt-nodefault="true"><code>addIceCandidate</code></dfn> method is called, the
                 user agent MUST run the following steps:</p>
                 <ol>
                   <li>
@@ -7686,7 +7686,8 @@ sender.setParameters(params)
       </div>
       <p>The <code>failed</code> and <code>completed</code> states require an
       indication that there are no additional remote candidates. This can be
-      indicated by calling <code><a>addIceCandidate</a></code> with
+      indicated by calling <code><a href=
+      "#dom-rtcpeerconnection-addicecandidate">addIceCandidate</a></code> with
       a candidate value whose <code>candidate</code> property is set
       to an empty string or by <a data-link-for=
       "RTCPeerConnection">canTrickleIceCandidates</a> being set to


### PR DESCRIPTION
Fixes #1095 

setLocalDescription and addIceCandidate has some bad links.