### PR TITLE
Adding configurable "ptime" member of RTCRtpEncodingParameters.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5883,6 +5883,7 @@ sender.setParameters(params)
              RTCDtxStatus        dtx;
              boolean             active;
              RTCPriorityType     priority;
+             unsigned long       ptime;
              unsigned long       maxBitrate;
              unsigned long       maxFramerate;
              DOMString           rid;
@@ -5938,6 +5939,20 @@ sender.setParameters(params)
             <dd>
               <p>Indicates the priority of this encoding. It is specified in
               [[!RTCWEB-TRANSPORT]], Section 4.</p>
+            </dd>
+            <dt><dfn><code>ptime</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned long</a></span></dt>
+            <dd>
+              <p>For an <code><a>RTCRtpSender</a></code>, indicates the
+              preferred duration of media represented by a packet in
+              milliseconds for this encoding. The user agent MUST use this
+              duration if possible, and otherwise use the closest available
+              duration. This value MUST take precedence over any "ptime"
+              attribute in the remote description, whose processing is
+              described in <span data-jsep=
+              "applying-a-remote-desc">[[!JSEP]]</span>. Note that the user
+              agent MUST still respect the limit imposed by any "maxptime"
+              attribute, as defined in [[!RFC4566]], Section 6.</p>
             </dd>
             <dt><dfn><code>maxBitrate</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long</a></span></dt>
@@ -6023,6 +6038,12 @@ sender.setParameters(params)
               <tr id="def-priority*">
                 <td><dfn>priority</dfn></td>
                 <td><code><a>RTCPriorityType</a></code></td>
+                <td>Sender</td>
+                <td>Read/Write</td>
+              </tr>
+              <tr id="def-ptime*">
+                <td><dfn>ptime</dfn></td>
+                <td><code>unsigned long</code></td>
                 <td>Sender</td>
                 <td>Read/Write</td>
               </tr>

--- a/webrtc.html
+++ b/webrtc.html
@@ -5945,14 +5945,14 @@ sender.setParameters(params)
             <dd>
               <p>For an <code><a>RTCRtpSender</a></code>, indicates the
               preferred duration of media represented by a packet in
-              milliseconds for this encoding. The user agent MUST use this
-              duration if possible, and otherwise use the closest available
-              duration. This value MUST take precedence over any "ptime"
-              attribute in the remote description, whose processing is
-              described in <span data-jsep=
-              "applying-a-remote-desc">[[!JSEP]]</span>. Note that the user
-              agent MUST still respect the limit imposed by any "maxptime"
-              attribute, as defined in [[!RFC4566]], Section 6.</p>
+              milliseconds for this encoding. Typically, this is only relevant
+              for audio encoding. The user agent MUST use this duration if
+              possible, and otherwise use the closest available duration. This
+              value MUST take precedence over any "ptime" attribute in the
+              remote description, whose processing is described in <span
+              data-jsep= "applying-a-remote-desc">[[!JSEP]]</span>. Note that
+              the user agent MUST still respect the limit imposed by any
+              "maxptime" attribute, as defined in [[!RFC4566]], Section 6.</p>
             </dd>
             <dt><dfn><code>maxBitrate</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long</a></span></dt>


### PR DESCRIPTION
Fixes #1021.

Behaves just like the "ptime" attribute in a remote description, as
described in JSEP. If both are present, the one in the encoding
parameters takes precedence.