### PR TITLE
Clarify that configuration.certificates remains undefined in the RTCPeerConnection constructor.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -729,7 +729,7 @@
             <code>InvalidAccessError</code>; otherwise, store the certificates.
             If no <code>certificates</code> value was specified, one or more
             new <code>RTCCertificate</code> instances are generated for use
-            with this <code>RTCPeerConnection</code> instance. This happens
+            with this <code>RTCPeerConnection</code> instance. This MAY happen
             asynchronously and the value of <code>certificates</code> remains
             undefined for the subsequent steps.</p>
           </li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -729,7 +729,9 @@
             <code>InvalidAccessError</code>; otherwise, store the certificates.
             If no <code>certificates</code> value was specified, one or more
             new <code>RTCCertificate</code> instances are generated for use
-            with this <code>RTCPeerConnection</code> instance.</p>
+            with this <code>RTCPeerConnection</code> instance. This happens
+            asynchronously and the value of <code>certificates</code> remains
+            undefined for the subsequent steps.</p>
           </li>
           <li>
             <p>If <code><var>configuration</var>.<a data-for=
@@ -2052,7 +2054,7 @@ interface RTCPeerConnection : EventTarget  {
                   <code><var>description</var>.sdp</code> does not
                   match <var>lastAnswer</var>, reject the promise with a newly
                   <a data-link-for="exception" data-lt="create">created</a>
-                  <code>InvalidModificationError</code> and abort these steps.</li>               
+                  <code>InvalidModificationError</code> and abort these steps.</li>
                   <li>Return the result of <a href="#set-description">setting
                   the RTCSessionDescription</a> indicated by the method's first
                   argument.</li>
@@ -4565,7 +4567,7 @@ interface RTCCertificate {
     readonly        attribute DOMTimeStamp expires;
     readonly        attribute FrozenArray&lt;RTCDtlsFingerprint&gt; fingerprints;
     // At risk due to lack of implementers' interest.
-    AlgorithmIdentifier getAlgorithm (); 
+    AlgorithmIdentifier getAlgorithm ();
 };</pre>
           <section>
             <h2>Attributes</h2>
@@ -4663,7 +4665,7 @@ interface RTCCertificate {
     is managed through objects called <code><a>RTCRtpSender</a></code>s.
     Similarly, the reception and decoding of <code>MediaStreamTrack</code>s is
     managed through objects called <code><a>RTCRtpReceiver</a></code>s. Each
-    <code><a>RTCRtpSender</a></code> is associated with at most one track, 
+    <code><a>RTCRtpSender</a></code> is associated with at most one track,
     and each track to be received is associated with exactly
     one <code><a>RTCRtpReceiver</a></code>.</p>
     <p>The encoding and transmission of each <code>MediaStreamTrack</code>
@@ -4707,7 +4709,7 @@ interface RTCCertificate {
       using different <code><a>RTCRtpParameters</a></code> with different
       <code><a>RTCRtpSender</a></code>s) to be sent several times
       simultaneously. Doing this implies that at the receiving end of
-      the peer-to-peer connection there are several 
+      the peer-to-peer connection there are several
       <code>MediaStreamTrack</code>s with an identical
       <code>id</code>.</p>
     </div>
@@ -5396,7 +5398,7 @@ interface RTCCertificate {
       is designed to minimize occurrence of images with with letter
       box or or pillow boxing. The media MUST NOT be upscaled to
       create fake data that did not occur in the input source. </p>
-        
+
       <p>To <dfn>create an RTCRtpSender</dfn> with a
       <code><a>MediaStreamTrack</a></code>, <var>track</var>, a list of
       <code><a>MediaStream</a></code> objects, <var>streams</var>, and
@@ -8544,7 +8546,7 @@ interface RTCTrackEvent : Event {
             <dt><dfn><code>onerror</code></dfn> of type <span class=
             "idlAttrType"><a>EventHandler</a></span></dt>
             <dd>
-              <p>The event type of this event handler is <code><a 
+              <p>The event type of this event handler is <code><a
               data-for="RTCDataChannel">RTCErrorEvent</a></code>.
               <code>errorDetail</code> contains "sctp-failure",
               <code>sctpCauseCode</code> contains the SCTP
@@ -10350,8 +10352,8 @@ interface RTCIdentityProviderRegistrar {
     void               setIdentityProvider (DOMString provider, optional RTCIdentityProviderOptions options);
     Promise&lt;DOMString&gt; getIdentityAssertion ();
     readonly        attribute Promise&lt;RTCIdentityAssertion&gt; peerIdentity;
-    readonly        attribute DOMString?                    idpLoginUrl; 
-    readonly        attribute DOMString?                    idpErrorInfo; 
+    readonly        attribute DOMString?                    idpLoginUrl;
+    readonly        attribute DOMString?                    idpErrorInfo;
 };</pre>
         <section>
           <h2>Attributes</h2>
@@ -10687,7 +10689,7 @@ interface RTCIdentityAssertion {
       by an <code><a>RTCPeerConnection</a></code> is removed (either
       due to reception of a BYE or via timeout), it MUST <a>update
       the muted state</a> of the corresponding
-      <code><a>MediaStreamTrack</a></code> with the value     
+      <code><a>MediaStreamTrack</a></code> with the value
       <code>true</code>. If and when packets are received again,
       the <a data-lt="update the muted state">muted state MUST be
       updated</a> with the value <code>false</code>.</p>
@@ -11651,7 +11653,7 @@ if (sender.dtmf) {
               "idp-token-invalid",
               "sctp-failure",
               "sdp-syntax-error"
-          };</pre> 
+          };</pre>
           <table data-link-for="RTCErrorDetailType" data-dfn-for=
           "RTCErrorDetailType" class="simple">
             <tbody>
@@ -11704,7 +11706,7 @@ if (sender.dtmf) {
               <tr>
                 <td><dfn><code>sctp-failure</code></dfn></td>
                 <td>The SCTP negotiation has failed or the connection
-                has been terminated with a fatal error. The 
+                has been terminated with a fatal error. The
                 <code>sdpCauseCode</code> attribute is set to the
                 SCTP cause code.</td>
               </tr>
@@ -11804,7 +11806,7 @@ if (sender.dtmf) {
         </section>
         <section>
           <h2>RTCError.prototype.sctpCauseCode</h2>
-          <p>The initial value of the <code>sctpCauseCode</code> property of the prototype for 
+          <p>The initial value of the <code>sctpCauseCode</code> property of the prototype for
           the <code><a>RTCError</a></code> constructor is 0.</p>
         </section>
         <section>


### PR DESCRIPTION
Fixes #1120.