### PR TITLE
Drop [TreatNullAs=EmptyString] for USVString

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7989,7 +7989,7 @@ interface RTCTrackEvent : Event {
       <div>
         <pre class="idl">partial interface RTCPeerConnection {
     readonly        attribute RTCSctpTransport? sctp;
-    RTCDataChannel createDataChannel ([TreatNullAs=EmptyString] USVString label, optional RTCDataChannelInit dataChannelDict);
+    RTCDataChannel createDataChannel (USVString label, optional RTCDataChannelInit dataChannelDict);
                     attribute EventHandler      ondatachannel;
 };</pre>
         <section>


### PR DESCRIPTION
Gecko does not use [TreatNullAs=EmptyString] here:
https://github.com/mozilla/gecko-dev/blob/9c9e0b6c604a8bbdca122f3557c600f138438550/dom/webidl/RTCPeerConnection.webidl#L138

Blink doesn't support [TreatNullAs=EmptyString] for USVString:
https://bugs.chromium.org/p/chromium/issues/detail?id=667901

Fixes https://github.com/w3c/webrtc-pc/issues/1118