### PR TITLE
Add more detail about how getParameters and setParameters work.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1255,7 +1255,9 @@
                         <p>Set <var>transceiver</var>'s <code><a data-for=
                         "RTCRtpTransceiver">mid</a></code> value to the mid of
                         the corresponding media description. If the media
-                        description has no mid, generate a random value as
+                        description has no MID, and <var>transceiver</var>'s
+                        <code><a data-for="RTCRtpTransceiver">mid</a></code>
+                        is unset, generate a random value as
                         described in <span data-jsep=
                         "applying-a-remote-desc">[[!JSEP]]</span>.</p>
                       </li>
@@ -5133,6 +5135,14 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <code><a>RTCSessionDescription</a></code> may change it to a
               non-null value, as defined in <span data-jsep=
               "processing-a-local-desc processing-a-remote-desc">[[!JSEP]]</span>.</p>
+              <p>The <code>sendEncodings</code> argument can be used to
+              specify the number of offered simulcast encodings, and
+              optionally their RIDs and encoding parameters. Aside from
+              <code><a data-link-for="RTCRtpEncodingParameters">rid</a></code>,
+              all <a data-lt="read-only parameter">read-only parameters</a> in
+              the <code><a>RTCRtpEncodingParameters</a></code> dictionaries,
+              such as <code><a data-link-for="RTCRtpEncodingParameters">ssrc</a></code>,
+              will be ignored, and treated as <code>undefined</code> even if set.</p>
               <p>When this method is invoked, the user agent MUST run the
               following steps:</p>
               <ol>
@@ -5629,7 +5639,19 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <p>The <dfn>getParameters()</dfn> method
               returns the <code><a>RTCRtpSender</a></code> object's current
               parameters for how <code>track</code> is encoded and transmitted
-              to a remote <code><a>RTCRtpReceiver</a></code>. It may used with
+              to a remote <code><a>RTCRtpReceiver</a></code>. If a remote
+              description for this sender has not yet been set,
+              <code>getParameters</code> will return an
+              <code><a>RTCRtpParameters</a></code> dictionary with <code><a
+              data-link-for="RTCRtpParameters">encodings</a></code> set to
+              the value of the [[<a>send encodings</a>]] internal slot, and all
+              other members <code>undefined</code>. If a remote description for
+              the sender has been set, <code>getParameters</code> will
+              return the current parameters being used for sending, determined
+              by the contents of the remote description, the
+              [[<a>send encodings</a>]] internal slot, and completed calls to
+              <code>setParameters</code>.</p>
+              <p><code>getParameters</code> may be used with
               <code>setParameters</code> to change the parameters in the
               following way:</p>
               <pre class="example highlight">

--- a/webrtc.html
+++ b/webrtc.html
@@ -5437,13 +5437,21 @@ interface RTCPeerConnectionIceErrorEvent : Event {
         <li>
           <p>Let <var>sender</var> have a [[<dfn>send encodings</dfn>]]
           internal slot, representing a list of
-          <code><a>RTCRtpEncodingParameters</a></code> objects, initialized to
-          an empty list.</p>
+          <code><a>RTCRtpEncodingParameters</a></code> dictionaries.</p>
         </li>
         <li>
           <p>If <var>sendEncodings</var> is given as input to this algorithm,
           set the [[<a>send encodings</a>]] slot to
-          <var>sendEncodings</var>.</p>
+          <var>sendEncodings</var>. Otherwise, set it to a list containing a
+          single <code><a>RTCRtpEncodingParameters</a></code> with
+          <code><a data-link-for="RTCRtpEncodingParameters">active</a></code>
+          set to <code>true</code>.</p>
+
+          <div class="note">Providing a single, default
+          <code><a>RTCRtpEncodingParameters</a></code> allows the application
+          to set encoding parameters using
+          <code><a data-link-for="RTCRtpSender">setParameters</a></code>, even
+          when simulcast isn't used.</div>
         </li>
         <li>
           <p>Return <var>sender</var>.</p>
@@ -5559,8 +5567,10 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <li>Let <var>transceiver</var> be the
                 <code><a>RTCRtpTransceiver</a></code> object associated
                 with <var>sender</var>.</li>
-                <li>Let <var>N</var> be the value of
-                <code><var>sender</var>.getParameters().encodings.length</code>.</li>
+                <li>Let <var>N</var> be the number of
+                <code><a>RTCRtpEncodingParameters</a></code> stored in
+                <var>sender</var>'s internal [[<a>send encodings</a>]]
+                slot.</li>
                 <li>Let <var>p</var> be a new promise.</li>
                 <li>Return <var>p</var>, performing the next steps in
                 parallel.</li>
@@ -5585,7 +5595,9 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 these steps and return a promise rejected with a newly
                 <a data-link-for="exception" data-lt="create">created</a>
                 <code>RangeError</code>.</li>
-                <li>Set the <code><a>RTCRtpSender</a></code>'s internal
+                <li>Set <var>sender</var>'s internal [[<a>send encodings</a>]]
+                slot to <code><var>parameters</var>.encodings</code>.</li>
+                <li>Set <var>sender</var>'s internal
                 <var>transactionId</var> slot to a previously unused
                 value.</li>
                 <li>Resolve <var>p</var> with <code>undefined</code>.</li>
@@ -5639,18 +5651,21 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <p>The <dfn>getParameters()</dfn> method
               returns the <code><a>RTCRtpSender</a></code> object's current
               parameters for how <code>track</code> is encoded and transmitted
-              to a remote <code><a>RTCRtpReceiver</a></code>. If a remote
-              description for this sender has not yet been set,
+              to a remote <code><a>RTCRtpReceiver</a></code>.</p>
+
+              <p>If a remote description for this sender has not yet been set,
               <code>getParameters</code> will return an
               <code><a>RTCRtpParameters</a></code> dictionary with <code><a
               data-link-for="RTCRtpParameters">encodings</a></code> set to
-              the value of the [[<a>send encodings</a>]] internal slot, and all
-              other members <code>undefined</code>. If a remote description for
-              the sender has been set, <code>getParameters</code> will
-              return the current parameters being used for sending, determined
-              by the contents of the remote description, the
-              [[<a>send encodings</a>]] internal slot, and completed calls to
-              <code>setParameters</code>.</p>
+              the value of the [[<a>send encodings</a>]] internal slot, and
+              all other members <code>undefined</code>. If a remote
+              description for the sender has been set,
+              <code>getParameters</code> will also return
+              <code><a>RTCRtpCodecParameters</a></code> and
+              <code><a>RTCRtpHeaderExtensionParameters</a></code> from the
+              parsed remote description, for each codec and header extension
+              that the implementation supports.</p>
+
               <p><code>getParameters</code> may be used with
               <code>setParameters</code> to change the parameters in the
               following way:</p>
@@ -5660,6 +5675,10 @@ interface RTCPeerConnectionIceErrorEvent : Event {
 params.encodings[0].active = false;
 sender.setParameters(params)
             </pre>
+
+              <p>After a completed call to <code>setParameters</code>,
+              subsequent calls to <code>getParameters</code> will return the
+              modified set of parameters.</p>
               <div>
                 <em>No parameters.</em>
               </div>
@@ -6570,14 +6589,35 @@ sender.setParameters(params)
             </dd>
             <dt><code>getParameters</code></dt>
             <dd>
-              <p>The <dfn>getParameters()</dfn> method
-              returns the <code>RTCRtpReceiver</code> object's current parameters
-              for how <code>track</code> is decoded.</p>
+              <p>The <dfn>getParameters()</dfn> method returns the
+              <code>RTCRtpReceiver</code> object's current parameters for how
+              <code>track</code> is decoded.</p>
+
+              <p>The receiver's parameters are determined by the applied local
+              and remote descriptions; the
+              <code><a>RTCRtpCodecParameters</a></code> and
+              <code><a>RTCRtpHeaderExtensionParameters</a></code> are
+              determined by the local description, and the SSRCs in the
+              <code><a>RTCRtpEncodingParameters</a></code> may be populated
+              from the remote description, if SSRCs are signaled. A remote
+              description may also cause offered codecs/header extensions to be
+              removed. For example, if three codecs are offered, and the remote
+              endpoint only answers with two, the absent codec will be
+              removed from the receiver's parameters, as the receiver no longer
+              needs to be prepared to receive it.</p>
+
+              <p>Note that the receiver's parameters are determined solely by
+              the applied local and remote descriptions. This means that, for
+              instance, if SSRCs are unsignaled, the <code><a
+              data-link-for="RTCRtpEncodingParameters">ssrc</a></code>
+              member of the <code><a>RTCRtpEncodingParameters</a></code> will
+              be undefined, even after packets are received and an internal
+              SSRC/receiver mapping is created.</p>
               <div>
                 <em>No parameters.</em>
               </div>
               <div>
-                <em>Return type:</em> <code>RTCRtpParameters</code>
+                <em>Return type:</em> <code><a>RTCRtpParameters</a></code>
               </div>
             </dd>
             <dt><dfn><code>getContributingSources</code></dfn></dt>

--- a/webrtc.html
+++ b/webrtc.html
@@ -5142,7 +5142,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               all <a data-lt="read-only parameter">read-only parameters</a> in
               the <code><a>RTCRtpEncodingParameters</a></code> dictionaries,
               such as <code><a data-link-for="RTCRtpEncodingParameters">ssrc</a></code>,
-              will be ignored, and treated as <code>undefined</code> even if set.</p>
+              must be left unset, or an error will be thrown.</p>
               <p>When this method is invoked, the user agent MUST run the
               following steps:</p>
               <ol>
@@ -5180,6 +5180,20 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   <var>track.kind</var>.</p>
                 </li>
                 <li>
+                  <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">rid</a></code>
+                  value in <var>sendEncodings</var> is composed only of
+                  case-sensitive alphanumeric characters (a-z, A-Z, 0-9) up to
+                  a maximum of 16 characters. If one of the RIDs does not meet
+                  these requirements, <a>throw</a> a <code>TypeError</code>.</p>
+                </li>
+                <li>
+                  <p>If any <code><a>RTCRtpEncodingParameters</a></code>
+                  dictionary in <var>sendEncodings</var> contains a
+                  <a>read-only parameter</a> other than
+                  <code><a data-link-for="RTCRtpEncodingParameters">rid</a></code>,
+                  <a>throw</a> an <code>InvalidAccessError</code>.</p>
+                </li>
+                <li>
                   <p><a>Create an RTCRtpSender</a> with <var>track</var>,
                   <var>streams</var> and <var>sendEncodings</var> and let
                   <var>sender</var> be the result.</p>
@@ -5195,10 +5209,6 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   encodings and the parameters retrieved via the transceiver's
                   <code>sender.getParameters()</code> will reflect the
                   encodings negotiated.</p>
-                  <p>RID values passed into <code>init.sendEncodings</code>
-                  must be composed only of case-sensitive alphanumeric
-                  characters (a-z, A-Z, 0-9) up to a maximum of 16
-                  characters.</p>
                 </li>
                 <li>
                   <p><a>Create an RTCRtpReceiver</a> with <var>kind</var> and
@@ -5441,7 +5451,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
         </li>
         <li>
           <p>If <var>sendEncodings</var> is given as input to this algorithm,
-          set the [[<a>send encodings</a>]] slot to
+          and is non-empty, set the [[<a>send encodings</a>]] slot to
           <var>sendEncodings</var>. Otherwise, set it to a list containing a
           single <code><a>RTCRtpEncodingParameters</a></code> with
           <code><a data-link-for="RTCRtpEncodingParameters">active</a></code>

--- a/webrtc.html
+++ b/webrtc.html
@@ -5663,19 +5663,53 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               parameters for how <code>track</code> is encoded and transmitted
               to a remote <code><a>RTCRtpReceiver</a></code>.</p>
 
-              <p>If a remote description for this sender has not yet been set,
-              <code>getParameters</code> will return an
-              <code><a>RTCRtpParameters</a></code> dictionary with <code><a
-              data-link-for="RTCRtpParameters">encodings</a></code> set to
-              the value of the [[<a>send encodings</a>]] internal slot, and
-              all other members <code>undefined</code>. If a remote
-              description for the sender has been set,
-              <code>getParameters</code> will also return
-              <code><a>RTCRtpCodecParameters</a></code> and
-              <code><a>RTCRtpHeaderExtensionParameters</a></code> from the
-              parsed remote description, for each codec and header extension
-              that the implementation supports.</p>
-
+              <p>When <code>getParameters</code> is called, the
+              <code><a>RTCRtpParameters</a></code> dictionary is
+              constructed as follows:</p>
+              <ul>
+                <li>
+                  <code><a data-link-for="RTCRtpParameters">transactionId</a></code>
+                  is set to a new unique identifier, used to match this
+                  <code>getParameters</code> call to a
+                  <code>setParameters</code> call that may occur later.
+                </li>
+                <li>
+                  <code><a data-link-for="RTCRtpParameters">encodings</a></code>
+                  is set to the value of the [[<a>send encodings</a>]] internal
+                  slot.
+                </li>
+                <li>
+                  The <code><a data-link-for="RTCRtpParameters">headerExtensions</a></code>
+                  sequence is populated based on the header extensions that
+                  have been negotiated for sending.
+                </li>
+                <li>
+                  The <code><a data-link-for="RTCRtpParameters">codecs</a></code>
+                  sequence is populated based on the codecs that have been
+                  negotiated for sending, and which the user agent is currently
+                  capable of sending. If <code>setParameters</code> has
+                  removed or reordered codecs, <code>getParameters</code> MUST
+                  return the shortened/reordered list. However, every time
+                  codecs are renegotiated by a new offer/answer exchange, the
+                  list of codecs MUST be restored to the full negotiated set,
+                  in the priority order indicated by the remote description, in
+                  effect discarding the effects of <code>setParameters</code>.
+                </li>
+                <li>
+                  <code><a data-link-for="RTCRtpParameters">rtcp</a>.cname</code>
+                  is set to the CNAME of the associated
+                  <code><a>RTCPeerConnection</a></code>.
+                  <code><a data-link-for="RTCRtpParameters">rtcp</a>.reducedSize</code>
+                  is set to <code>true</code> if reduced-size RTCP has been negotiated
+                  for sending, and <code>false</code> otherwise.
+                </li>
+                <li>
+                  <code><a data-link-for="RTCRtpParameters">degradationPreference</a></code>
+                  is set to the last value passed into <code>setParameters</code>, or
+                  the default value of "balanced" if <code>setParameters</code> hasn't
+                  been called.
+                </li>
+              </ul>
               <p><code>getParameters</code> may be used with
               <code>setParameters</code> to change the parameters in the
               following way:</p>
@@ -6603,26 +6637,54 @@ sender.setParameters(params)
               <code>RTCRtpReceiver</code> object's current parameters for how
               <code>track</code> is decoded.</p>
 
-              <p>The receiver's parameters are determined by the applied local
-              and remote descriptions; the
-              <code><a>RTCRtpCodecParameters</a></code> and
-              <code><a>RTCRtpHeaderExtensionParameters</a></code> are
-              determined by the local description, and the SSRCs in the
-              <code><a>RTCRtpEncodingParameters</a></code> may be populated
-              from the remote description, if SSRCs are signaled. A remote
-              description may also cause offered codecs/header extensions to be
-              removed. For example, if three codecs are offered, and the remote
-              endpoint only answers with two, the absent codec will be
-              removed from the receiver's parameters, as the receiver no longer
-              needs to be prepared to receive it.</p>
-
-              <p>Note that the receiver's parameters are determined solely by
-              the applied local and remote descriptions. This means that, for
-              instance, if SSRCs are unsignaled, the <code><a
-              data-link-for="RTCRtpEncodingParameters">ssrc</a></code>
-              member of the <code><a>RTCRtpEncodingParameters</a></code> will
-              be undefined, even after packets are received and an internal
-              SSRC/receiver mapping is created.</p>
+              <p>When <code>getParameters</code> is called, the
+              <code><a>RTCRtpParameters</a></code> dictionary is
+              constructed as follows:</p>
+              <ul>
+                <li>
+                  <p><code><a data-link-for="RTCRtpParameters">encodings</a></code>
+                  is populated based on SSRCs and RIDs present in the current
+                  remote description, including SSRCs used for RTX and FEC, if
+                  signaled. Every member of the
+                  <code><a>RTCRtpEncodingParameters</a></code> dictionaries
+                  other than the SSRC and RID fields is left
+                  <code>undefined</code>.</p>
+                  <div class="note">This means that if SSRCs are unsignaled,
+                  the SSRC members will be <code>undefined</code>, even after
+                  a packet is received and an internal SSRC/receiver mapping is
+                  created.</div>
+                </li>
+                <li>
+                  The <code><a data-link-for="RTCRtpParameters">headerExtensions</a></code>
+                  sequence is populated based on the header extensions that the
+                  receiver is currently prepared to receive.
+                </li>
+                <li>
+                  <p>The <code><a data-link-for="RTCRtpParameters">codecs</a></code>
+                  sequence is populated based on the codecs that the receiver
+                  is currently prepared to receive.</p>
+                  <div class="note">Both the local and remote description may
+                  affect this list of codecs. For example, if three codecs are
+                  offered, the receiver will be prepared to receive each of
+                  them and will return them all from
+                  <code>getParameters</code>. But if the remote endpoint only
+                  answers with two, the absent codec will no longer be returned
+                  by <code>getParameters</code> as the receiver no longer needs
+                  to be prepared to receive it.</div>
+                </li>
+                <li>
+                  <code><a data-link-for="RTCRtpParameters">rtcp</a>.reducedSize</code>
+                  is set to <code>true</code> if the receiver is currently prepared to
+                  receive reduced-size RTCP packets, and <code>false</code> otherwise.
+                  <code><a data-link-for="RTCRtpParameters">rtcp</a>.cname</code> is
+                  left <code>undefined</code>.
+                </li>
+                <li>
+                  <code><a data-link-for="RTCRtpParameters">transactionId</a></code> and
+                  <code><a data-link-for="RTCRtpParameters">degradationPreference</a></code>
+                  are left <code>undefined</code>.
+                </li>
+              </ul>
               <div>
                 <em>No parameters.</em>
               </div>


### PR DESCRIPTION
Fixes #1073 and #1116.

With regards to `sendEncodings`, all read-write parameters and `rid`
can be set, but the rest are ignored, as decided in the April virtual
interim.

Also adding some detail to the `getParameters` descriptions. For an
`RTCRtpSender`, `getParameters` should return the previously
provided `sendEncodings` even if `setRemoteDescription`
hasn't been called yet.

I'm not yet addressing the simulcast error point that arose in the
discussion of #1073. We can address that after we finish fleshing
out how simulcast errors will be handled in the first place.

There may still be some ambiguity remaining. But I think this is
a step in the right direction.