### PR TITLE
Fire the "track" event from a queued task.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5374,7 +5374,7 @@ interface RTCCertificate {
             at each MediaStream as described in [[!GETUSERMEDIA]].</p>
           </li>
           <li>
-            <p>Fire an event named <code title=
+            <p>Queue a task to fire an event named <code title=
             "event-track"><a>track</a></code> with <var>transceiver</var>,
             <var>track</var>, and <var>streams</var> at the
             <var>connection</var> object.</p>


### PR DESCRIPTION
Fixes #1135.

This ensures that by the time the event is fired, the stream in the
event has a full list of tracks.