### PR TITLE
Call RTCDtlsFingerprint a dictionary, not an object

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7189,9 +7189,9 @@ sender.setParameters(params)
         </table>
       </div>
       <section id="rtcdtlsfingerprint*">
-        <h3>The RTCDtlsFingerprint Object</h3>
-        <p>The <dfn><code>RTCDtlsFingerprint</code></dfn> object includes the
-        hash function algorithm and certificate fingerprint as described in
+        <h3>The RTCDtlsFingerprint Dictionary</h3>
+        <p>The <dfn><code>RTCDtlsFingerprint</code></dfn> dictionary includes
+        the hash function algorithm and certificate fingerprint as described in
         [[!RFC4572]].</p>
         <div>
           <pre class="idl">dictionary RTCDtlsFingerprint {


### PR DESCRIPTION
RTCDtlsFingerprint is a dictionary. Web IDL says that "IDL dictionary type
values are represented by ECMAScript Object values", but they are not the same:
https://heycam.github.io/webidl/#es-dictionary