### PR TITLE
Add a link to web-platform-tests to the top of the spec

### DIFF
--- a/webrtc.js
+++ b/webrtc.js
@@ -85,6 +85,7 @@ var respecConfig = {
   // Team Contact.
   wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/47318/status",
   issueBase: "https://github.com/w3c/webrtc-pc/issues/",
+  testSuiteURI: "https://github.com/w3c/web-platform-tests/tree/master/webrtc",
   otherLinks: [
     {
       key: "Participate",


### PR DESCRIPTION
A few other specs that have something similar:
https://fetch.spec.whatwg.org/
https://w3c.github.io/IndexedDB/
https://notifications.spec.whatwg.org/
https://w3c.github.io/ServiceWorker/
https://webaudio.github.io/web-audio-api/
https://xhr.spec.whatwg.org/