### PR TITLE
Add paragraph about RtpContributingSources being updated simultaneously.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6628,7 +6628,7 @@ sender.setParameters(params)
       <code><a>RTCRtpSynchronizationSource</a></code> objects based on the
       contents of the packet. The
       <code><a>RTCRtpSynchronizationSource</a></code> object corresponding to
-      the SSRC identifier is always updated, and if the RTP packet contains
+      the SSRC identifier is updated each time, and if the RTP packet contains
       CSRC identifiers, then the <code><a>RTCRtpContributingSource</a></code>
       objects corresponding to those CSRC identifiers are also updated.</p>
       <div class="note">As stated in the <a href="#conformance">conformance

--- a/webrtc.html
+++ b/webrtc.html
@@ -6623,19 +6623,23 @@ sender.setParameters(params)
       keep information from RTP packets received in the previous 10 seconds.
       When the first audio frame contained in an RTP packet is delivered to the
       <code><a>RTCRtpReceiver</a></code>'s <code><a>MediaStreamTrack</a></code>
-      for playout, the relevant <code><a>RTCRtpContributingSource</a></code>
-      and <code><a>RTCRtpSynchronizationSource</a></code> objects are updated. The
-      <code><a>RTCRtpSynchronizationSource</a></code> object corresponding to the
-      SSRC identifier is always updated, and if the RTP packet contains CSRC
-      identifiers, then the <code><a>RTCRtpContributingSource</a></code>
+      for playout, the user agent MUST queue a task to update the relevant
+      <code><a>RTCRtpContributingSource</a></code> and
+      <code><a>RTCRtpSynchronizationSource</a></code> objects based on the
+      contents of the packet. The
+      <code><a>RTCRtpSynchronizationSource</a></code> object corresponding to
+      the SSRC identifier is always updated, and if the RTP packet contains
+      CSRC identifiers, then the <code><a>RTCRtpContributingSource</a></code>
       objects corresponding to those CSRC identifiers are also updated.</p>
-      <p>All of the <code><a>RTCRtpContributingSource</a></code> objects that
-      correspond to the same <code><a>RTCRtpReceiver</a></code> MUST be
-      updated at the same time within the same microtask checkpoint, or updated
-      in a different but indistinguishable manner. This is necessary so that an
-      application can compare <code><a>RTCRtpContributingSource</a></code>
-      objects with each other, with the guarantee that they all return
-      information from the same point in time.</p>
+      <div class="note">As stated in the <a href="#conformance">conformance
+      section</a>, requirements phrased as algorithms may be implemented in
+      any manner so long as the end result is equivalent. So, an
+      implementaion does not need to literally queue a task for every
+      packet, as long as the end result is that within a single event loop task
+      execution, all <code><a>RTCRtpSynchronizationSource</a></code> and
+      <code><a>RTCRtpContributingSource</a></code> objects for a particular
+      <code><a>RTCRtpReceiver</a></code> return information from a single point
+      in the RTP stream.</div>
       <div>
         <pre class="idl">interface RTCRtpContributingSource {
     readonly        attribute DOMHighResTimeStamp timestamp;

--- a/webrtc.html
+++ b/webrtc.html
@@ -6629,6 +6629,13 @@ sender.setParameters(params)
       SSRC identifier is always updated, and if the RTP packet contains CSRC
       identifiers, then the <code><a>RTCRtpContributingSource</a></code>
       objects corresponding to those CSRC identifiers are also updated.</p>
+      <p>All of the <code><a>RTCRtpContributingSource</a></code> objects that
+      correspond to the same <code><a>RTCRtpReceiver</a></code> MUST be
+      updated at the same time within the same microtask checkpoint, or updated
+      in a different but indistinguishable manner. This is necessary so that an
+      application can compare <code><a>RTCRtpContributingSource</a></code>
+      objects with each other, with the guarantee that they all return
+      information from the same point in time.</p>
       <div>
         <pre class="idl">interface RTCRtpContributingSource {
     readonly        attribute DOMHighResTimeStamp timestamp;


### PR DESCRIPTION
Fixes #1124.

The intent of this PR is to ensure that if an application reads the
attributes of multiple `RTCRtpContributingSource`s, the values are all
taken from the same point in time, so they're comparable.

For example, an application may compare timestamps to see which
contributing source(s) are actively contributing (have the most recent
timestamp), or see which one is loudest. Without the guarantee this PR
attempts to add, a browser might return values from different points in
time for different `RTCRtpContributingSource`s, making such comparisons
unreliable.