### PR TITLE
Constructor for RTCIceCandidate should accept optional argument

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3770,7 +3770,7 @@ interface RTCSessionDescription {
         <p>This interface describes an ICE candidate.</p>
         <div>
           <pre class="idl">
-          [ Constructor (RTCIceCandidateInit candidateInitDict)]
+          [ Constructor (optional RTCIceCandidateInit candidateInitDict)]
 interface RTCIceCandidate {
     readonly        attribute DOMString               candidate;
     readonly        attribute DOMString?              sdpMid;
@@ -3814,8 +3814,8 @@ interface RTCIceCandidate {
                       <td class="prmType"><code>RTCIceCandidateInit</code></td>
                       <td class="prmNullFalse"><span role="img" aria-label=
                       "False">&#10008;</span></td>
-                      <td class="prmOptFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
+                      <td class="prmOptTrue"><span role="img" aria-label=
+                      "True">&#10004;</span></td>
                       <td class="prmDesc"></td>
                     </tr>
                   </tbody>


### PR DESCRIPTION
I am working on web-platform-tests and is trying to figure if it is valid to construct `RTCIceCandidate` with the expression `new RTCIceCandidate()`, or is the minimum requirement be `new RTCIceCandidate({})`.

According to WebIDL, the argument `RTCIceCandidateInit` must be optional because all its dictionary members are optional.

[Source](https://www.w3.org/TR/WebIDL-1/#idl-operations): 
> If the type of an argument is a dictionary type or a union type that has a dictionary type as one of its flattened member types, and that dictionary type and its ancestors have no required members, and the argument is either the final argument or is followed only by optional arguments, then the argument must be specified as optional. Such arguments are always considered to have a default value of an empty dictionary, unless otherwise specified.

From the constructor description I understand that if both `sdpMid` and `sdpMLineIndex` are null, a TypeError is thrown. However that is outside the scope of WebIDL, and thus should produce different error from passing invalid argument to the method.