### PR TITLE
Fix optional indicator for RTCPeerConnectionIceEventInit argument

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4125,8 +4125,8 @@ interface RTCPeerConnectionIceEvent : Event {
                       <code>RTCPeerConnectionIceEventInit</code></td>
                       <td class="prmNullFalse"><span role="img" aria-label=
                       "False">&#10008;</span></td>
-                      <td class="prmOptFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
+                      <td class="prmOptTrue"><span role="img" aria-label=
+                      "True">&#10004;</span></td>
                       <td class="prmDesc"></td>
                     </tr>
                   </tbody>


### PR DESCRIPTION
From the WebIDL definition of the constructor, the argument `RTCPeerConnectionIceEventInit` is optional. But in the argument table it is shown as non-optional.

```
[Constructor(DOMString type, optional RTCPeerConnectionIceEventInit eventInitDict)]
```

![rtcpeerconnectioniceevent](https://cloud.githubusercontent.com/assets/97665/25648607/4b38559a-3000-11e7-850c-63f42cfdc42a.png)
