### PR TITLE
Update RTCCertificate ref to get serializer from WebIDL

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4549,7 +4549,7 @@ interface RTCCertificate {
     readonly        attribute DOMTimeStamp expires;
     sequence&lt;RTCDtlsFingerprint&gt; getFingerprints ();
     // At risk due to lack of implementers' interest.
-          AlgorithmIdentifier getAlgorithm ();
+    AlgorithmIdentifier getAlgorithm ();
 };</pre>
           <section>
             <h2>Attributes</h2>

--- a/webrtc.html
+++ b/webrtc.html
@@ -79,13 +79,13 @@
     handlers</a></dfn> and <dfn><a href=
     "http://dev.w3.org/html5/spec/webappapis.html#event-handler-event-type">event
     handler event types</a></dfn> are defined in [[!HTML5]].</p>
-    <p>The terms <dfn><a href=
-    "https://html.spec.whatwg.org/multipage/infrastructure.html#serializable-objects">
-    serializable objects</a></dfn>, <dfn><a href=
-    "https://html.spec.whatwg.org/multipage/infrastructure.html#serialization-steps">
-    serialization steps</a></dfn>, and <dfn><a href=
-    "https://html.spec.whatwg.org/multipage/infrastructure.html#deserialization-steps">
-    deserialization steps</a></dfn> are defined in [[!HTML]].</p>
+    <p>The terms <dfn><a
+    href="https://www.w3.org/TR/2016/REC-WebIDL-1-20161215/#dfn-serializer">
+    serializer</a></dfn>, <dfn><a
+    href="https://www.w3.org/TR/2016/REC-WebIDL-1-20161215/#dfn-serializable-type">
+    serializable type</a></dfn>, and <dfn><a
+    href="https://www.w3.org/TR/2016/REC-WebIDL-1-20161215/#dfn-serialization-behavior">
+    serialization behavior</a></dfn> are defined in [[!WEBIDL-1]].</p>
     <p>The terms <dfn>MediaStream</dfn>, <dfn>MediaStreamTrack</dfn>, and
     <dfn>MediaStreamConstraints</dfn> are defined in [[!GETUSERMEDIA]].</p>
     <p>The term <dfn>Blob</dfn> is defined in [[!FILEAPI]].</p>
@@ -4544,12 +4544,12 @@ interface RTCPeerConnectionIceErrorEvent : Event {
         "RTCCertificate-certificate">certificate</dfn>]]) that
         <code>RTCPeerConnection</code> uses to authenticate with a peer.</p>
         <div>
-          <pre class="idl">[Serializable]
+          <pre class="idl">
 interface RTCCertificate {
     readonly        attribute DOMTimeStamp expires;
     sequence&lt;RTCDtlsFingerprint&gt; getFingerprints ();
     // At risk due to lack of implementers' interest.
-    AlgorithmIdentifier getAlgorithm ();
+          AlgorithmIdentifier getAlgorithm ();
 };</pre>
           <section>
             <h2>Attributes</h2>
@@ -4609,8 +4609,8 @@ interface RTCCertificate {
         <p>Note that a <code>RTCCertificate</code> might not directly hold
         private keying material, this might be stored in a secure module.</p>
 
-        <p><code>RTCCertificate</code> objects are <a>serializable objects</a>
-        [[!HTML]]. Their <a>serialization steps</a>, given <var>value</var> and
+        <p><code>RTCCertificate</code> objects are <a>serializable type</a>s
+        [[!WEBIDL-1]]. Their <a>serialization behavior</a>, given <var>value</var> and
         <var>serialized</var>, are:</p>
 
         <ol>
@@ -4626,7 +4626,7 @@ interface RTCCertificate {
           <var>value</var>.[[<a>handle</a>]].</li>
         </ol>
 
-        <p>Their <a>deserialization steps</a>, given <var>serialized</var> and
+        <p>Their deserialization steps, given <var>serialized</var> and
         <var>value</var>, are:</p>
 
         <ol>


### PR DESCRIPTION

We have several objects that in this spec that are serialized used the patters in WebIDL-1.  When the RTCCert got added, it used the pattern from what WG but our IDL does not even cover the syntax used. I made a few changes to terminology but no change to how it works to bring in line with rest of spec. 

