### PR TITLE
Remove paragraph about removeTrack causing track to be ended remotely.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5018,9 +5018,6 @@ interface RTCCertificate {
               as <code>recvonly</code> or <code>inactive</code>,
               as defined in <span data-jsep="subsequent-offers">
               [[!JSEP]]</span>. <!-- onended --></p>
-              <p>When the other peer stops sending a track in this manner, an
-              <code title="event-MediaStreamTrack-ended">ended</code> event is
-              fired at the <code><a>MediaStreamTrack</a></code> object.</p>
               <p>When the <dfn><code>removeTrack</code></dfn> method is
               invoked, the user agent MUST run the following steps:</p>
               <ol>


### PR DESCRIPTION
This no longer happens, because you can still call replaceTrack on the
RTCRtpSender, and thus the track tied to the RTCRtpReceiver on the
remote side is not fully dead yet. The remote track is never actually
ended unless the transceiver is stopped/m= section rejected, since
that's the only irreversible change.

This paragraph dates back to before we had transceivers/RtpSenders, so
I believe it's just obsolete and hasn't been noticed until now.