### PR TITLE
Adding note about legacy `createAnswer` not supporting options dict.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2828,6 +2828,11 @@ interface RTCPeerConnection : EventTarget  {
               <dt><dfn data-lt="createAnswer!overload-1" data-lt-nodefault=
               "true"><code>createAnswer</code></dfn></dt>
               <dd>
+                <div class="note">The legacy <code>createAnswer</code> method
+                does not take an <code><a>RTCAnswerOptions</a></code>
+                parameter, since no known legacy <code>createAnswer</code>
+                implementation ever supported it.</div>
+
                 <p>When the <code>createAnswer</code> method is called, the
                 user agent MUST run the following steps:</p>
                 <ol>


### PR DESCRIPTION
Fixes #1152.