### PR TITLE
Expanding RTCPeerConnection introduction.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -101,10 +101,12 @@
     <h2>Peer-to-peer connections</h2>
     <section>
       <h3>Introduction</h3>
-      <p>An <code><a>RTCPeerConnection</a></code> instance allows to establish
-      peer to peer communications. Communications are coordinated via a
-      signaling channel which is provided by unspecified means, but generally
-      by a script in the page via the server, e.g. using
+      <p>An <code><a>RTCPeerConnection</a></code> instance allows an
+      application to establish peer-to-peer communications with another
+      <code><a>RTCPeerConnection</a></code> instance in another browser, or to
+      another endpoint implementing the required protocols. Communications are
+      coordinated via a signaling channel which is provided by unspecified
+      means, but generally by a script in the page via the server, e.g. using
       <code>XMLHttpRequest</code> [[XMLHttpRequest]] or Web Sockets
       [[WEBSOCKETS-API]].</p>
     </section>
@@ -113,7 +115,7 @@
       <section>
         <h4>RTCConfiguration Dictionary</h4>
         <p>The <dfn><code>RTCConfiguration</code></dfn> defines a set of parameters to
-        configure how the peer to peer communication established via
+        configure how the peer-to-peer communication established via
         <code><a>RTCPeerConnection</a></code> is established or
         re-established.</p>
         <div>


### PR DESCRIPTION
The first sentence contained a grammatical error, so I fixed it and
expanded on it a bit. Also, changed "peer to peer" to "peer-to-peer"
since the latter is used more consistently.