### PR TITLE
Adding more detail to RTCIceTransportPolicy enum descriptions.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -509,17 +509,33 @@
               <tr>
                 <td><dfn><code>relay</code></dfn></td>
                 <td>
-                  The <a>ICE Agent</a> MUST only use media relay candidates
-                  such as candidates passing through a TURN server. This can be
-                  used to reduce leakage of IP addresses in certain use cases.
+                  <p>
+                    The <a>ICE Agent</a> MUST only use media relay candidates
+                    such as candidates passing through a TURN server.
+                  </p>
+                  <div class="note">
+                    This can be used to prevent the remote endpoint from learning
+                    the user's IP addresses, which may be desired in certain
+                    use cases. For example, in a "call"-based application, the
+                    application may want to prevent an unknown caller from
+                    learning the callee's IP addresses until the callee has
+                    consented in some way.
+                  </div>
                 </td>
               </tr>
               <tr>
                 <td><dfn><code>all</code></dfn></td>
                 <td>
-                  The <a>ICE Agent</a> MAY use any type of candidates when this
-                  value is specified. This will not include addresses that have
-                  been filtered by the browser.
+                  <p>
+                    The <a>ICE Agent</a> MAY use any type of candidate when
+                    this value is specified.
+                  </p>
+                  <div class="note">
+                    The implementation may still use its own candidate
+                    filtering policy in order to limit the IP addresses exposed
+                    to the application, as noted in the description of
+                    <code>RTCIceCandidate.<a data-link-for="RTCIceCandidate">ip</a></code>.
+                  </div>
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
The last sentence of the description for each enum value was somewhat
vague. And not really normative either. So I expanded each of them and
moved them into notes.