### PR TITLE
Invalid RTCRtpTransceiverDirection already throws TypeError.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6895,12 +6895,6 @@ sender.setParameters(params)
                   abort these steps.</p>
                 </li>
                 <li>
-                  <p>If <var>newDirection</var> has a value other
-                  than <code>sendrecv</code>, <code>sendonly</code>,
-                  <code>recvonly</code> or <code>inactive</code>,
-                  <a>throw</a> an <code>InvalidModificationError</code>.</p>
-                </li>
-                <li>
                   <p>Set <code><var>transceiver</var>.direction</code>
                   to <var>newDirection</var>.</p>
                 </li>


### PR DESCRIPTION
Remove redundant step. setDirection throws `TypeError` in [WebIDL](https://heycam.github.io/webidl/#es-enumeration), not `InvalidModificationError`.