### PR TITLE
Add bufferSize attribute to RTCDataChannel.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8457,6 +8457,7 @@ interface RTCTrackEvent : Event {
     readonly        attribute unsigned short?     id;
     readonly        attribute RTCPriorityType     priority;
     readonly        attribute RTCDataChannelState readyState;
+    readonly        attribute unsigned long       bufferSize;
     readonly        attribute unsigned long       bufferedAmount;
                     attribute unsigned long       bufferedAmountLowThreshold;
                     attribute EventHandler        onopen;
@@ -8575,6 +8576,20 @@ interface RTCTrackEvent : Event {
               attribute represents the state of the <code>RTCDataChannel</code>
               object. It MUST return the value to which the user agent last set
               it (as defined by the processing model algorithms).</p>
+            </dd>
+            <dt><code>bufferSize</code> of type <span class=
+            "idlAttrType"><a>unsigned long</a></span>, readonly</dt>
+            <dd>
+              <p>The <code><dfn>bufferSize</dfn></code> attribute returns the
+              size of the buffer used to queue application data, in bytes. This
+              size MUST not change during the lifetime of the
+              <code>RTCDataChannel</code>.</p>
+
+              <div class="note">When a call to <code><a data-for=
+              "RTCDataChannel">send()</a></code> fills the buffer, the data
+              channel is closed abruptly. So, an application can use this size
+              along with <code><a>bufferedAmount</a></code> to ensure the buffer
+              is never filled.</div>
             </dd>
             <dt><code>bufferedAmount</code> of type <span class=
             "idlAttrType"><a>unsigned long</a></span>, readonly</dt>


### PR DESCRIPTION
Fixes #1148.

This is option 1 for fixing the issue. An application can read this
bufferSize attribute, and check "messageSize + bufferedAmount <=
bufferSize" before sending data to ensure it won't abruptly close the
data channel.