### PR TITLE
Throw error if data channel's buffer is filled, rather than closing.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8941,11 +8941,16 @@ interface RTCTrackEvent : Event {
           started, then abort these steps.</p>
         </li>
         <li>
+          <p>If the size of <var>data</var> exceeds the value of <code><a
+          data-link-for="RTCSctpTransport">maxMessageSize</a></code> on
+          <var>channel</var>'s associated <code>RTCSctpTransport</code>,
+          <a>throw</a> an <code>InvalidAccessError</code>.</p>
+        </li>
+        <li>
           <p>Attempt to send <var>data</var> on <var>channel</var>'s
-          <a>underlying data transport</a>; if the data cannot be sent, e.g.
-          because it would need to be buffered but the buffer is full, the user
-          agent MUST abruptly <a>close</a> <var>channel</var>'s <a>underlying
-          data transport</a> <a>with an error</a>.</p>
+          <a>underlying data transport</a>. If the data cannot be sent, buffer
+          it, and if this is not possible because the buffer is full,
+          <a>throw</a> an <code>OperationError</code>.</p>
         </li>
       </ol>
       <div>

--- a/webrtc.html
+++ b/webrtc.html
@@ -8949,8 +8949,8 @@ interface RTCTrackEvent : Event {
         <li>
           <p>Queue <var>data</var> for transmission on <var>channel</var>'s
           <a>underlying data transport</a>. If queuing <var>data</var> is not
-          possible because no more buffer space is available, <a>throw</a> an
-          <code>OperationError</code>.</p>
+          possible because not enough buffer space is available, <a>throw</a>
+          an <code>OperationError</code>.</p>
           <div class="note">The actual transmission of data occurs in
           parallel. If sending data leads to an SCTP-level error, the
           application will be notified asynchronously through <code><a

--- a/webrtc.html
+++ b/webrtc.html
@@ -8894,8 +8894,8 @@ interface RTCTrackEvent : Event {
         </li>
         <li>
           <p>If <var>channel</var>'s <a data-for=
-          "RTCDataChannel"><code>readyState</code></a> attribute is
-          <code>connecting</code>, <a>throw</a> an
+          "RTCDataChannel"><code>readyState</code></a> attribute is not
+          <code>open</code>, <a>throw</a> an
           <code>InvalidStateError</code>.</p>
         </li>
         <li>
@@ -8947,10 +8947,14 @@ interface RTCTrackEvent : Event {
           <a>throw</a> an <code>InvalidAccessError</code>.</p>
         </li>
         <li>
-          <p>Attempt to send <var>data</var> on <var>channel</var>'s
-          <a>underlying data transport</a>. If the data cannot be sent, buffer
-          it, and if this is not possible because the buffer is full,
-          <a>throw</a> an <code>OperationError</code>.</p>
+          <p>Queue <var>data</var> for transmission on <var>channel</var>'s
+          <a>underlying data transport</a>. If queuing <var>data</var> is not
+          possible because no more buffer space is available, <a>throw</a> an
+          <code>OperationError</code>.</p>
+          <div class="note">The actual transmission of data occurs in
+          parallel. If sending data leads to an SCTP-level error, the
+          application will be notified asynchronously through <code><a
+          data-link-for="RTCDataChannel">onerror</a></code>.</div>
         </li>
       </ol>
       <div>

--- a/webrtc.html
+++ b/webrtc.html
@@ -8944,7 +8944,7 @@ interface RTCTrackEvent : Event {
           <p>If the size of <var>data</var> exceeds the value of <code><a
           data-link-for="RTCSctpTransport">maxMessageSize</a></code> on
           <var>channel</var>'s associated <code>RTCSctpTransport</code>,
-          <a>throw</a> an <code>InvalidAccessError</code>.</p>
+          <a>throw</a> a <code>TypeError</code>.</p>
         </li>
         <li>
           <p>Queue <var>data</var> for transmission on <var>channel</var>'s


### PR DESCRIPTION
Fixes #1148.

Option 2 for fixing the issue. The application doesn't need to know the
buffer's size ahead of time, because filling the buffer is no longer an
irrecoverable error. If it doesn't care about latency, an application
could send until an exception is thrown, then wait for the
"bufferedamountlow" event until it can send again, similar to a
non-blocking socket.

Note that this is deliberately different than how WebSockets work,
because the circumstances are slightly different: with WebSockets, it
was expected that applications had code to handle them being closed
unexpectedly. But this isn't true of WebRTC DataChannels, because before
an SCTP-level timeout can occur, the application would have done an ICE
restart and repaired the problem.