### PR TITLE
operation: add subsections

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -728,6 +728,11 @@
         representation of an <code><a>RTCIceTransport</a></code> changes, as
         described in <a href= "#rtcicetransport"></a>.</p>
 
+        <p>The task source for the tasks listed in this section is the
+        <a>networking task source</a>.</p>
+
+        <section>
+        <h4>Constructor</h4>
         <p>When the <dfn id=
         "dom-peerconnection"><code>RTCPeerConnection()</code></dfn> constructor
         is invoked, the user agent MUST run the following steps:</p>
@@ -814,7 +819,11 @@
         call is still not settled, they are added to the queue and executed
         when all the previous calls have finished executing and their promises
         have settled.</p>
-        <p>To <dfn id="enqueue-an-operation">enqueue an operation</dfn>, run
+        </section>
+
+        <section>
+        <h4>Enqueue an operation</h4>
+        <p>To <dfn>enqueue an operation</dfn>, run
         the following steps:</p>
         <ol>
           <li>
@@ -881,6 +890,10 @@
             <p>Return <var>p</var>.</p>
           </li>
         </ol>
+        </section>
+
+        <section>
+        <h4>Update the connection state</h4>
         <p>An <code><a>RTCPeerConnection</a></code> object has an aggregated
         <a>connection state</a>. Whenever the state of an
         <code><a>RTCDtlsTransport</a></code> or
@@ -912,6 +925,10 @@
             <var>connection</var>.</p>
           </li>
         </ol>
+        </section>
+
+        <section>
+        <h4>Update the ICE gathering state</h4>
         <p>To <dfn id="update-ice-gathering-state">update the <a>ICE gathering
         state</a></dfn> of an <code><a>RTCPeerConnection</a></code> instance
         <var>connection</var>, the user agent MUST queue a task that runs the
@@ -945,6 +962,10 @@
             <var>connection</var>.</p>
           </li>
         </ol>
+        </section>
+
+        <section>
+        <h4>Update the ICE connection state</h4>
         <p>To <dfn id="update-ice-connection-state">update the <a>ICE
         connection state</a></dfn> of an <code><a>RTCPeerConnection</a></code>
         instance <var>connection</var>, the user agent MUST queue a task that
@@ -973,6 +994,10 @@
             <var>connection</var>.</p>
           </li>
         </ol>
+        </section>
+
+        <section>
+        <h4>Set the RTCSessionSessionDescription</h4>
         <p>To <dfn id="set-description" data-lt=
         "set the RTCSessionDescription">set an RTCSessionDescription</dfn>
         <var>description</var> on an <code><a>RTCPeerConnection</a></code>
@@ -1341,8 +1366,7 @@
             <p>Return <var>p</var>.</p>
           </li>
         </ol>
-        <p>The task source for the tasks listed in this section is the
-        <a>networking task source</a>.</p>
+        </section>
       </section>
       <section>
         <h3>Interface Definition</h3>


### PR DESCRIPTION
adds subsections to the RTCPeerConnection operations description
to make the individial operations linkable.

fixes #1190 

Also moved the last paragraph about the task source to the top.
Sticking to h4 (respec doesn't really care) and not reindenting for easier review.
@burnburn