### PR TITLE
Removing WebIDL defaults for various RTP parameters.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5929,8 +5929,8 @@ sender.setParameters(params)
               preferred. If unset, the <code><a>RtpSender</a></code> defaults to
               the <code>balanced</code> policy.</p>
               <p>For an <code><a>RtpReceiver</a></code>,
-              <code>degradationPreference</code> is inapplicable will always be
-              <code>undefined</code>.</p>
+              <code>degradationPreference</code> is inapplicable and will
+              always be <code>undefined</code>.</p>
             </dd>
           </dl>
         </section>
@@ -6050,7 +6050,8 @@ sender.setParameters(params)
               will be scaled down by a factor of 2 in each dimension, resulting
               in sending a video of one quarter the size. If the value is 1.0,
               the video will not be affected. The value must be greater than or
-              equal to 1.0.</p>
+              equal to 1.0. By default, the sender will not apply any scaling,
+              (i.e., <code>scaleResolutionDownBy</code> will be 1.0).</p>
             </dd>
           </dl>
           <p>Usage of the attributes is defined in the table below:</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -5871,7 +5871,7 @@ sender.setParameters(params)
              sequence&lt;RTCRtpHeaderExtensionParameters&gt; headerExtensions;
              RTCRtcpParameters                         rtcp;
              sequence&lt;RTCRtpCodecParameters&gt;           codecs;
-             RTCDegradationPreference                  degradationPreference = "balanced";
+             RTCDegradationPreference                  degradationPreference;
 };</pre>
         <section>
           <h2>Dictionary <dfn>RTCRtpParameters</dfn> Members</h2>
@@ -5920,14 +5920,17 @@ sender.setParameters(params)
               modified.</p>
             </dd>
             <dt><dfn><code>degradationPreference</code></dfn> of type
-            <span class="idlMemberType"><a>RTCDegradationPreference</a></span>,
-            defaulting to <code>"balanced"</code></dt>
+            <span class="idlMemberType"><a>RTCDegradationPreference</a></span></dt>
             <dd>
               <p>When bandwidth is constrained and the
               <code><a>RtpSender</a></code> needs to choose between degrading
               resolution or degrading framerate,
               <code>degradationPreference</code> indicates which is
-              preferred.</p>
+              preferred. If unset, the <code><a>RtpSender</a></code> defaults to
+              the <code>balanced</code> policy.</p>
+              <p>For an <code><a>RtpReceiver</a></code>,
+              <code>degradationPreference</code> is inapplicable will always be
+              <code>undefined</code>.</p>
             </dd>
           </dl>
         </section>
@@ -5944,7 +5947,7 @@ sender.setParameters(params)
              unsigned long       maxBitrate;
              double              maxFramerate;
              DOMString           rid;
-             double              scaleResolutionDownBy = 1.0;
+             double              scaleResolutionDownBy;
 };</pre>
         <section>
           <h2>Dictionary <dfn>RTCRtpEncodingParameters</dfn>
@@ -6039,8 +6042,7 @@ sender.setParameters(params)
               <code>addTransceiver</code>.</p>
             </dd>
             <dt><dfn><code>scaleResolutionDownBy</code></dfn> of type
-            <span class="idlMemberType"><a>double</a></span>, defaulting to
-            <code>1.0</code></dt>
+            <span class="idlMemberType"><a>double</a></span></dt>
             <dd>
               <p>If the sender's <code>kind</code> is "video", the video's
               resolution will be scaled down in each dimension by the given
@@ -6289,7 +6291,7 @@ sender.setParameters(params)
              unsigned short payloadType;
              DOMString      mimeType;
              unsigned long  clockRate;
-             unsigned short channels = 1;
+             unsigned short channels;
              DOMString      sdpFmtpLine;
 };</pre>
         <section>
@@ -6315,8 +6317,7 @@ sender.setParameters(params)
               <p>The codec clock rate expressed in Hertz.</p>
             </dd>
             <dt><dfn><code>channels</code></dfn> of type <span class=
-            "idlMemberType"><a>unsigned short</a></span>, defaulting to
-            <code>1</code></dt>
+            "idlMemberType"><a>unsigned short</a></span></dt>
             <dd>
               <p>The number of channels (mono=1, stereo=2).</p>
             </dd>
@@ -6363,7 +6364,7 @@ sender.setParameters(params)
         <pre class="idl">dictionary RTCRtpCodecCapability {
              DOMString mimeType;
              unsigned long  clockRate;
-             unsigned short channels = 1;
+             unsigned short channels;
              DOMString      sdpFmtpLine;
 };</pre>
         <section>
@@ -6392,8 +6393,7 @@ sender.setParameters(params)
               <p>The codec clock rate expressed in Hertz.</p>
             </dd>
             <dt><dfn><code>channels</code></dfn> of type <span class=
-            "idlMemberType"><a>unsigned short</a></span>, defaulting to
-            <code>1</code></dt>
+            "idlMemberType"><a>unsigned short</a></span></dt>
             <dd>
               <p>The maximum number of channels (mono=1, stereo=2).</p>
             </dd>

--- a/webrtc.html
+++ b/webrtc.html
@@ -6303,24 +6303,27 @@ sender.setParameters(params)
             <dt><dfn><code>payloadType</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned short</a></span></dt>
             <dd>
-              <p>The RTP payload type. This value can be set to control which
-              codec should be used to send a given encoding.</p>
+              <p>The RTP payload type used to identify this codec. <a>Read-only
+              parameter</a>.</p>
             </dd>
             <dt><dfn><code>mimeType</code></dfn> of type <span class=
             "idlMemberType"><a>DOMString</a></span></dt>
             <dd>
               <p>The codec MIME media type/subtype. Valid media types and
-              subtypes are listed in [[IANA-RTP-2]].</p>
+              subtypes are listed in [[IANA-RTP-2]]. <a>Read-only
+              parameter</a>.</p>
             </dd>
             <dt><dfn><code>clockRate</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long</a></span></dt>
             <dd>
-              <p>The codec clock rate expressed in Hertz.</p>
+              <p>The codec clock rate expressed in Hertz. <a>Read-only
+              parameter</a>.</p>
             </dd>
             <dt><dfn><code>channels</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned short</a></span></dt>
             <dd>
-              <p>The number of channels (mono=1, stereo=2).</p>
+              <p>The number of channels (mono=1, stereo=2). <a>Read-only
+              parameter</a>.</p>
             </dd>
             <dt><dfn><code>sdpFmtpLine</code></dfn> of type <span class=
             "idlMemberType"><a>DOMString</a></span></dt>
@@ -6331,7 +6334,7 @@ sender.setParameters(params)
               <a><code>RTCRtpSender</code></a>, these parameters come from the
               remote description, and for an
               <a><code>RTCRtpReceiver</code></a>, they come from the local
-              description.</p>
+              description. <a>Read-only parameter</a>.</p>
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
Fixes #1173.

`setParameters` is only expected to be called with a result of
`getParameters` (enforced by the `transactionId` field). So, these
WebIDL defaults serve no purpose. If a parameter has a default value,
`getParameters` will have already returned it.