### PR TITLE
Add detailed steps for constructing RTCIceCandidate

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3851,18 +3851,49 @@ interface RTCIceCandidate {
     serializer = {candidate, sdpMid, sdpMLineIndex, ufrag};
 };</pre>
           <section>
-            <h2>Constructors</h2>
+            <h2>Constructor</h2>
             <dl data-link-for="RTCIceCandidate" data-dfn-for="RTCIceCandidate"
             class="constructors">
               <dt><code>RTCIceCandidate</code></dt>
               <dd>
-                The <dfn><code>RTCIceCandidate()</code></dfn> constructor takes
+                <p>The <dfn><code>RTCIceCandidate()</code></dfn> constructor takes
                 a dictionary argument, <var>candidateInitDict</var>, whose
                 content is used to initialize the new <a class=
-                "idlType"><code>RTCIceCandidate</code></a> object. When run, if
-                both the <code><a>sdpMid</a></code> and
-                <code><a>sdpMLineIndex</a></code> dictionary members are
-                <code>null</code>, <a>throw</a> a <code>TypeError</code>.
+                "idlType"><code>RTCIceCandidate</code></a> object.</p>
+                <p>When invoked, run the following steps:</p>
+                <ol>
+                  <li>If both the <code><a>sdpMid</a></code> and <code>
+                  <a>sdpMLineIndex</a></code> dictionary members in
+                  <var>candidateInitDict</var> are <code>null</code>, <a>throw</a>
+                  a <code>TypeError</code>.</li>
+                  <li>Let <var>iceCandidate</var> be a newly created
+                  <code>RTCIceCandidate</code> object.</li>
+                  <li>Set the corresponding attributes in <var>iceCandidate</var>
+                  with the dictionary member values of <var>candidateInitDict</var></li>
+                  <li>Let <var>candidate</var> be the <code><a>candidate</a></code>
+                  dictionary member of <var>candidateInitDict</var>. If
+                  <var>candidate</var> is not an empty string, run the following steps:
+                  <ol>
+                    <li>Parse <var>candidate</var> using the grammar for
+                    <code>candidate-attribute</code> as defined in section 15.1 of
+                    [[!ICE]], together with the grammar extension for ICE TCP as
+                    defined in section 4.5 of [[!RFC6544]].</li>
+                    <li>If parsing of <code>candidate-attribute</code> is successful,
+                    set the corresponding attributes in <var>iceCandidate</var> to
+                    the field values of the parse result.</li>
+                  </ol></li>
+                  <li>Return <var>iceCandidate</var></li>
+                </ol>
+                <div class="note">
+                  The validation for members in <var>candidateInitDict</var>
+                  is not done in the constructor for <code>RTCIceCandidate</code>.
+                  Instead, validation is done when calling <code><a data-for=
+                  "RTCPeerConnection">addIceCandidate()</a></code>. To maintain
+                  backward compatibility, if the <var>candidate</var> member do not
+                  match the grammar for <code>candidate-attribute</code>, the value
+                  remain set in the <code>candidate</code> attribute with the other
+                  derivative fields set to <code>null</code>
+                </div>
                 <table class="parameters">
                   <tbody>
                     <tr>
@@ -3925,7 +3956,9 @@ interface RTCIceCandidate {
               <dt><dfn><code>ip</code></dfn> of type <span class=
               "idlAttrType"><a>DOMString</a></span>, readonly, nullable</dt>
               <dd>
-                <p>The IP address of the candidate.</p>
+                <p>The IP address of the candidate. This corresponds to the
+                <code>connection-address</code> field in
+                <code>candidate-attribute</code></p>
                 <div class="note">
                   <p>The IP addresses exposed in candidates gathered via ICE
                   and made visibile to the application in
@@ -3955,33 +3988,38 @@ interface RTCIceCandidate {
               <dt><dfn><code>protocol</code></dfn> of type <span class=
               "idlAttrType"><a>RTCIceProtocol</a></span>, readonly, nullable</dt>
               <dd>The protocol of the candidate
-              (<code>udp</code>/<code>tcp</code>).</dd>
+              (<code>udp</code>/<code>tcp</code>). This corresponds to the
+              <code>transport</code> field in <code>candidate-attribute</code>.</dd>
               <dt><dfn><code>port</code></dfn> of type <span class=
               "idlAttrType"><a>unsigned short</a></span>, readonly, nullable</dt>
               <dd>The port of the candidate.</dd>
               <dt><dfn><code>type</code></dfn> of type <span class=
               "idlAttrType"><a>RTCIceCandidateType</a></span>, readonly, nullable</dt>
-              <dd>The type of the candidate.</dd>
+              <dd>The type of the candidate. This corresponds to the
+              <code>candidate-types</code> field in <code>candidate-attribute</code></dd>
               <dt><dfn><code>tcpType</code></dfn> of type <span class=
               "idlAttrType"><a>RTCIceTcpCandidateType</a></span>, readonly,
               nullable</dt>
               <dd>If <code>protocol</code> is <code>tcp</code>,
               <code>tcpType</code> represents the type of TCP candidate.
-              Otherwise, <code>tcpType</code> is <code>null</code>.</dd>
+              Otherwise, <code>tcpType</code> is <code>null</code>. This corresponds
+              to the <code>tcp-type</code> in <code>candidate-attribute</code></dd>
               <dt><code>relatedAddress</code> of type <span class=
               "idlAttrType"><a>DOMString</a></span>, readonly, nullable</dt>
               <dd>For a candidate that is derived from another, such as a relay
               or reflexive candidate, the <dfn>relatedAddress</dfn> is the IP
               address of the candidate that it is derived from. For host
               candidates, the <code>relatedAddress</code> is
-              <code>null</code>.</dd>
+              <code>null</code>. This corresponds to the <code>rel-address</code>
+              field in <code>candidate-attribute</code></dd>
               <dt><code>relatedPort</code> of type <span class=
               "idlAttrType"><a>unsigned short</a></span>, readonly,
               nullable</dt>
               <dd>For a candidate that is derived from another, such as a relay
               or reflexive candidate, the <dfn>relatedPort</dfn> is the port of
               the candidate that it is derived from. For host candidates, the
-              <code>relatedPort</code> is <code>null</code>.</dd>
+              <code>relatedPort</code> is <code>null</code>. This corresponds to
+              the <code>rel-port</code> field in <code>candidate-attribute</code></dd>
               <dt><code><dfn>ufrag</dfn></code> of type <span class=
               "idlAttrType"><a>DOMString</a></span>, readonly, nullable</dt>
               <dd>This carries the <code>ufrag</code> as defined in section

--- a/webrtc.html
+++ b/webrtc.html
@@ -3874,8 +3874,17 @@ interface RTCIceCandidate {
                   <code>null</code>, <a>throw</a> a <code>TypeError</code>.</li>
                   <li>Let <var>iceCandidate</var> be a newly created
                   <code>RTCIceCandidate</code> object.</li>
-                  <li>Set the corresponding attributes in <var>iceCandidate</var>
-                  with the dictionary member values of <var>candidateInitDict</var>.</li>
+                  <li>Initialize the following attributes of <var>iceCandidate</var> to
+                  <code>null</code>: <a><code>foundation</code></a>,
+                  <a><code>component</code></a>, <a><code>priority</code></a>,
+                  <a><code>ip</code></a>, <a><code>protocol</code></a>,
+                  <a><code>port</code></a>, <a><code>type</code></a>,
+                  <a><code>tcpType</code></a>, <a><code>relatedAddress</code></a>,
+                  and <a><code>relatedPort</code></a>.</li>
+                  <li>Set the <a><code>candidate</code></a>, <a><code>sdpMid</code></a>,
+                  <a><code>sdpMLineIndex</code></a>, <a><code>ufrag</code></a> attributes
+                  of <var>iceCandidate</var> with the corresponding dictionary member values
+                  of <var>candidateInitDict</var>.</li>
                   <li>Let <var>candidate</var> be the <code>
                   <a data-dfn-for="idl-def-rtcicecandidateinit-candidate">candidate</a></code>
                   dictionary member of <var>candidateInitDict</var>. If
@@ -3894,11 +3903,11 @@ interface RTCIceCandidate {
                 </ol>
                 <div class="note">
                   <p>The constructor for <code>RTCIceCandidate</code> only does basic
-                  type checking for the dictionary members in <var>candidateInitDict</var>.
-                  Detailed validation on the well-formedness of <code>candidate</code>,
-                  <code>sdpMid</code>, <code>sdpMLineIndex</code>, <code>ufrag</code>
-                  with the corresponding session description is done when passing
-                  the <code>RTCIceCandidate</code> object to <a>
+                  parsing and type checking for the dictionary members in
+                  <var>candidateInitDict</var>. Detailed validation on the well-formedness
+                  of <code>candidate</code>, <code>sdpMid</code>, <code>sdpMLineIndex</code>,
+                  <code>ufrag</code> with the corresponding session description is done
+                  when passing the <code>RTCIceCandidate</code> object to <a>
                   <code>addIceCandidate()</code></a>.</p>
 
                   <p>To maintain backward compatibility, any error on parsing the
@@ -3907,8 +3916,7 @@ interface RTCIceCandidate {
                   <a data-dfn-for="idl-def-rtcicecandidateinit-candidate">
                   <code>candidate</code></a> string given in <var>candidateInitDict</var>,
                   but derivative attributes such as <a><code>foundation</code></a>,
-                  <a><code>priority</code></a>, etc are set to their default value,
-                  which is <code>null</code>.</p>
+                  <a><code>priority</code></a>, etc are set to <code>null</code>.</p>
                 </div>
                 <table class="parameters">
                   <tbody>

--- a/webrtc.html
+++ b/webrtc.html
@@ -3883,8 +3883,11 @@ interface RTCIceCandidate {
                   <ol>
                     <li>Parse <var>candidate</var> using the <a><code>candidate-attribute</code>
                     </a> grammar.</li>
-                    <li>If parsing of <a><code>candidate-attribute</code></a> is successful,
-                    set the corresponding attributes in <var>iceCandidate</var> to
+                    <li>If parsing of <a><code>candidate-attribute</code></a> has failed, abort
+                    these steps.</li>
+                    <li>If any field in the parse result represents an invalid value for the
+                    corresponding attribute in <var>iceCandidate</var>, abort these steps.</li>
+                    <li>Set the corresponding attributes in <var>iceCandidate</var> to
                     the field values of the parsed result.</li>
                   </ol></li>
                   <li>Return <var>iceCandidate</var>.</li>
@@ -3962,7 +3965,10 @@ interface RTCIceCandidate {
               <dt><dfn><code>component</code></dfn> of type <span class=
               "idlAttrType"><a>RTCIceComponent</a></span>, readonly, nullable</dt>
               <dd>The assigned network component of the candidate
-              (<code>rtp</code> or <code>rtcp</code>).</dd>
+              (<code>rtp</code> or <code>rtcp</code>). This corresponds to the
+              <code>component-id</code> field in <a><code>candidate-attribute</code></a>,
+              decoded to the string representation as defined in
+              <a><code>RTCIceComponent</code></a>.</dd>
               <dt><dfn><code>priority</code></dfn> of type <span class=
               "idlAttrType"><a>unsigned long</a></span>, readonly, nullable</dt>
               <dd>The assigned priority of the candidate.</dd>
@@ -4016,7 +4022,7 @@ interface RTCIceCandidate {
               <dd>If <code>protocol</code> is <code>tcp</code>,
               <code>tcpType</code> represents the type of TCP candidate.
               Otherwise, <code>tcpType</code> is <code>null</code>. This corresponds
-              to the <code>tcp-type</code> in <a><code>candidate-attribute</code></a>.</dd>
+              to the <code>tcp-type</code> field in <a><code>candidate-attribute</code></a>.</dd>
               <dt><code>relatedAddress</code> of type <span class=
               "idlAttrType"><a>DOMString</a></span>, readonly, nullable</dt>
               <dd>For a candidate that is derived from another, such as a relay
@@ -8095,12 +8101,16 @@ sender.setParameters(params)
               <td><dfn><code>rtp</code></dfn></td>
               <td>The ICE Transport is used for RTP (or RTCP multiplexing),
               as defined in [[!ICE]], Section 4.1.1.1. Protocols multiplexed
-              with RTP (e.g. data channel) share its component ID.</td>
+              with RTP (e.g. data channel) share its component ID. This represents
+              the <code>component-id</code> value <code>1</code> when encoded
+              in <a><code>candidate-attribute</code></a>.</td>
             </tr>
             <tr>
               <td><dfn><code>rtcp</code></dfn></td>
               <td>The ICE Transport is used for RTCP as defined by [[!ICE]],
-              Section 4.1.1.1.</td>
+              Section 4.1.1.1. This represents the <code>component-id</code>
+              value <code>2</code> when encoded in
+              <a><code>candidate-attribute</code></a>.</td>
             </tr>
           </tbody>
         </table>

--- a/webrtc.html
+++ b/webrtc.html
@@ -3862,23 +3862,25 @@ interface RTCIceCandidate {
                 "idlType"><code>RTCIceCandidate</code></a> object.</p>
                 <p>When invoked, run the following steps:</p>
                 <ol>
-                  <li>If both the <code><a>sdpMid</a></code> and <code>
-                  <a>sdpMLineIndex</a></code> dictionary members in
-                  <var>candidateInitDict</var> are <code>null</code>, <a>throw</a>
-                  a <code>TypeError</code>.</li>
+                  <li>If both the <code>
+                  <a href="#idl-def-rtcicecandidateinit-sdpmid">sdpMid</a></code> and <code>
+                  <a href="#idl-def-rtcicecandidateinit-sdpmlineindex">sdpMLineIndex</a>
+                  </code> dictionary members in <var>candidateInitDict</var> are
+                  <code>null</code>, <a>throw</a> a <code>TypeError</code>.</li>
                   <li>Let <var>iceCandidate</var> be a newly created
                   <code>RTCIceCandidate</code> object.</li>
                   <li>Set the corresponding attributes in <var>iceCandidate</var>
                   with the dictionary member values of <var>candidateInitDict</var>.</li>
-                  <li>Let <var>candidate</var> be the <code><a>candidate</a></code>
+                  <li>Let <var>candidate</var> be the <code>
+                  <a href="#idl-def-rtcicecandidateinit-candidate">candidate</a></code>
                   dictionary member of <var>candidateInitDict</var>. If
                   <var>candidate</var> is not an empty string, run the following steps:
                   <ol>
                     <li>Parse <var>candidate</var> using the grammar for
-                    <code>candidate-attribute</code> as defined in section 15.1 of
+                    <dfn><code>candidate-attribute</code></dfn> as defined in section 15.1 of
                     [[!ICE]], together with the grammar extension for ICE TCP as
                     defined in section 4.5 of [[!RFC6544]].</li>
-                    <li>If parsing of <code>candidate-attribute</code> is successful,
+                    <li>If parsing of <a><code>candidate-attribute</code></a> is successful,
                     set the corresponding attributes in <var>iceCandidate</var> to
                     the field values of the parsed result.</li>
                   </ol></li>
@@ -3890,7 +3892,7 @@ interface RTCIceCandidate {
                   Instead, validation is done when calling <code><a data-for=
                   "RTCPeerConnection">addIceCandidate()</a></code>. To maintain
                   backward compatibility, if the <var>candidate</var> member does not
-                  match the grammar for <code>candidate-attribute</code>, the value
+                  match the grammar for <a><code>candidate-attribute</code></a>, the value
                   remain set in the <code>candidate</code> attribute with the other
                   derivative fields set to <code>null</code>
                 </div>
@@ -3924,7 +3926,7 @@ interface RTCIceCandidate {
             class="attributes">
               <dt><dfn><code>candidate</code></dfn> of type <span class=
               "idlAttrType"><a>DOMString</a></span>, readonly</dt>
-              <dd>This carries the <code>candidate-attribute</code> as defined
+              <dd>This carries the <a><code>candidate-attribute</code></a> as defined
               in section 15.1 of [[!ICE]]. If this <code>RTCIceCandidate</code>
               represents an end-of-candidates indication,
               <code>candidate</code> is an empty string.</dd>
@@ -3958,7 +3960,7 @@ interface RTCIceCandidate {
               <dd>
                 <p>The IP address of the candidate. This corresponds to the
                 <code>connection-address</code> field in
-                <code>candidate-attribute</code></p>
+                <a><code>candidate-attribute</code></a>.</p>
                 <div class="note">
                   <p>The IP addresses exposed in candidates gathered via ICE
                   and made visibile to the application in
@@ -3989,21 +3991,24 @@ interface RTCIceCandidate {
               "idlAttrType"><a>RTCIceProtocol</a></span>, readonly, nullable</dt>
               <dd>The protocol of the candidate
               (<code>udp</code>/<code>tcp</code>). This corresponds to the
-              <code>transport</code> field in <code>candidate-attribute</code>.</dd>
+              <code>transport</code> field in <a><code>candidate-attribute</code>
+              </a>.</dd>
               <dt><dfn><code>port</code></dfn> of type <span class=
               "idlAttrType"><a>unsigned short</a></span>, readonly, nullable</dt>
               <dd>The port of the candidate.</dd>
               <dt><dfn><code>type</code></dfn> of type <span class=
               "idlAttrType"><a>RTCIceCandidateType</a></span>, readonly, nullable</dt>
               <dd>The type of the candidate. This corresponds to the
-              <code>candidate-types</code> field in <code>candidate-attribute</code></dd>
+              <code>candidate-types</code> field in <a><code>candidate-attribute</code>
+              </a>.</dd>
               <dt><dfn><code>tcpType</code></dfn> of type <span class=
               "idlAttrType"><a>RTCIceTcpCandidateType</a></span>, readonly,
               nullable</dt>
               <dd>If <code>protocol</code> is <code>tcp</code>,
               <code>tcpType</code> represents the type of TCP candidate.
               Otherwise, <code>tcpType</code> is <code>null</code>. This corresponds
-              to the <code>tcp-type</code> in <code>candidate-attribute</code></dd>
+              to the <code>tcp-type</code> in <a><code>candidate-attribute</code>
+              </a>.</dd>
               <dt><code>relatedAddress</code> of type <span class=
               "idlAttrType"><a>DOMString</a></span>, readonly, nullable</dt>
               <dd>For a candidate that is derived from another, such as a relay
@@ -4011,7 +4016,7 @@ interface RTCIceCandidate {
               address of the candidate that it is derived from. For host
               candidates, the <code>relatedAddress</code> is
               <code>null</code>. This corresponds to the <code>rel-address</code>
-              field in <code>candidate-attribute</code></dd>
+              field in <a><code>candidate-attribute</code></a>.</dd>
               <dt><code>relatedPort</code> of type <span class=
               "idlAttrType"><a>unsigned short</a></span>, readonly,
               nullable</dt>
@@ -4019,7 +4024,8 @@ interface RTCIceCandidate {
               or reflexive candidate, the <dfn>relatedPort</dfn> is the port of
               the candidate that it is derived from. For host candidates, the
               <code>relatedPort</code> is <code>null</code>. This corresponds to
-              the <code>rel-port</code> field in <code>candidate-attribute</code></dd>
+              the <code>rel-port</code> field in <a><code>candidate-attribute</code>
+              </a>.</dd>
               <dt><code><dfn>ufrag</dfn></code> of type <span class=
               "idlAttrType"><a>DOMString</a></span>, readonly, nullable</dt>
               <dd>This carries the <code>ufrag</code> as defined in section

--- a/webrtc.html
+++ b/webrtc.html
@@ -3869,7 +3869,7 @@ interface RTCIceCandidate {
                   <li>Let <var>iceCandidate</var> be a newly created
                   <code>RTCIceCandidate</code> object.</li>
                   <li>Set the corresponding attributes in <var>iceCandidate</var>
-                  with the dictionary member values of <var>candidateInitDict</var></li>
+                  with the dictionary member values of <var>candidateInitDict</var>.</li>
                   <li>Let <var>candidate</var> be the <code><a>candidate</a></code>
                   dictionary member of <var>candidateInitDict</var>. If
                   <var>candidate</var> is not an empty string, run the following steps:
@@ -3880,16 +3880,16 @@ interface RTCIceCandidate {
                     defined in section 4.5 of [[!RFC6544]].</li>
                     <li>If parsing of <code>candidate-attribute</code> is successful,
                     set the corresponding attributes in <var>iceCandidate</var> to
-                    the field values of the parse result.</li>
+                    the field values of the parsed result.</li>
                   </ol></li>
-                  <li>Return <var>iceCandidate</var></li>
+                  <li>Return <var>iceCandidate</var>.</li>
                 </ol>
                 <div class="note">
                   The validation for members in <var>candidateInitDict</var>
                   is not done in the constructor for <code>RTCIceCandidate</code>.
                   Instead, validation is done when calling <code><a data-for=
                   "RTCPeerConnection">addIceCandidate()</a></code>. To maintain
-                  backward compatibility, if the <var>candidate</var> member do not
+                  backward compatibility, if the <var>candidate</var> member does not
                   match the grammar for <code>candidate-attribute</code>, the value
                   remain set in the <code>candidate</code> attribute with the other
                   derivative fields set to <code>null</code>

--- a/webrtc.html
+++ b/webrtc.html
@@ -3829,7 +3829,12 @@ interface RTCSessionDescription {
       <h3>Interfaces for Connectivity Establishment</h3>
       <section>
         <h4><dfn>RTCIceCandidate</dfn> Interface</h4>
-        <p>This interface describes an ICE candidate.</p>
+        <p>This interface describes an ICE candidate. Other than
+        <code>candidate</code>, <code>sdpMid</code>,
+        <code>sdpMLineIndex</code>, and <code>ufrag</code>,
+        the remaining attributes are derived from parsing the
+        <code>candidate</code> member in <var>candidateInitDict</var>,
+        if it is well formed.</p>
         <div>
           <pre class="idl">
           [ Constructor (optional RTCIceCandidateInit candidateInitDict)]
@@ -3863,8 +3868,8 @@ interface RTCIceCandidate {
                 <p>When invoked, run the following steps:</p>
                 <ol>
                   <li>If both the <code>
-                  <a href="#idl-def-rtcicecandidateinit-sdpmid">sdpMid</a></code> and <code>
-                  <a href="#idl-def-rtcicecandidateinit-sdpmlineindex">sdpMLineIndex</a>
+                  <a data-dfn-for="idl-def-rtcicecandidateinit-sdpmid">sdpMid</a></code> and <code>
+                  <a data-dfn-for="idl-def-rtcicecandidateinit-sdpmlineindex">sdpMLineIndex</a>
                   </code> dictionary members in <var>candidateInitDict</var> are
                   <code>null</code>, <a>throw</a> a <code>TypeError</code>.</li>
                   <li>Let <var>iceCandidate</var> be a newly created
@@ -3872,14 +3877,12 @@ interface RTCIceCandidate {
                   <li>Set the corresponding attributes in <var>iceCandidate</var>
                   with the dictionary member values of <var>candidateInitDict</var>.</li>
                   <li>Let <var>candidate</var> be the <code>
-                  <a href="#idl-def-rtcicecandidateinit-candidate">candidate</a></code>
+                  <a data-dfn-for="idl-def-rtcicecandidateinit-candidate">candidate</a></code>
                   dictionary member of <var>candidateInitDict</var>. If
                   <var>candidate</var> is not an empty string, run the following steps:
                   <ol>
-                    <li>Parse <var>candidate</var> using the grammar for
-                    <dfn><code>candidate-attribute</code></dfn> as defined in section 15.1 of
-                    [[!ICE]], together with the grammar extension for ICE TCP as
-                    defined in section 4.5 of [[!RFC6544]].</li>
+                    <li>Parse <var>candidate</var> using the <a><code>candidate-attribute</code>
+                    </a> grammar.</li>
                     <li>If parsing of <a><code>candidate-attribute</code></a> is successful,
                     set the corresponding attributes in <var>iceCandidate</var> to
                     the field values of the parsed result.</li>
@@ -3887,14 +3890,22 @@ interface RTCIceCandidate {
                   <li>Return <var>iceCandidate</var>.</li>
                 </ol>
                 <div class="note">
-                  The validation for members in <var>candidateInitDict</var>
-                  is not done in the constructor for <code>RTCIceCandidate</code>.
-                  Instead, validation is done when calling <code><a data-for=
-                  "RTCPeerConnection">addIceCandidate()</a></code>. To maintain
-                  backward compatibility, if the <var>candidate</var> member does not
-                  match the grammar for <a><code>candidate-attribute</code></a>, the value
-                  remain set in the <code>candidate</code> attribute with the other
-                  derivative fields set to <code>null</code>
+                  <p>The constructor for <code>RTCIceCandidate</code> only does basic
+                  type checking for the dictionary members in <var>candidateInitDict</var>.
+                  Detailed validation on the well-formedness of <code>candidate</code>,
+                  <code>sdpMid</code>, <code>sdpMLineIndex</code>, <code>ufrag</code>
+                  with the corresponding session description is done when passing
+                  the <code>RTCIceCandidate</code> object to <a>
+                  <code>addIceCandidate()</code></a>.</p>
+
+                  <p>To maintain backward compatibility, any error on parsing the
+                  <var>candidate</var> attribute is ignored. In such case, the
+                  <a><code>candidate</code></a> attribute holds the raw
+                  <a data-dfn-for="idl-def-rtcicecandidateinit-candidate">
+                  <code>candidate</code></a> string given in <var>candidateInitDict</var>,
+                  but derivative attributes such as <a><code>foundation</code></a>,
+                  <a><code>priority</code></a>, etc are set to their default value,
+                  which is <code>null</code>.</p>
                 </div>
                 <table class="parameters">
                   <tbody>
@@ -3991,24 +4002,21 @@ interface RTCIceCandidate {
               "idlAttrType"><a>RTCIceProtocol</a></span>, readonly, nullable</dt>
               <dd>The protocol of the candidate
               (<code>udp</code>/<code>tcp</code>). This corresponds to the
-              <code>transport</code> field in <a><code>candidate-attribute</code>
-              </a>.</dd>
+              <code>transport</code> field in <a><code>candidate-attribute</code></a>.</dd>
               <dt><dfn><code>port</code></dfn> of type <span class=
               "idlAttrType"><a>unsigned short</a></span>, readonly, nullable</dt>
               <dd>The port of the candidate.</dd>
               <dt><dfn><code>type</code></dfn> of type <span class=
               "idlAttrType"><a>RTCIceCandidateType</a></span>, readonly, nullable</dt>
               <dd>The type of the candidate. This corresponds to the
-              <code>candidate-types</code> field in <a><code>candidate-attribute</code>
-              </a>.</dd>
+              <code>candidate-types</code> field in <a><code>candidate-attribute</code></a>.</dd>
               <dt><dfn><code>tcpType</code></dfn> of type <span class=
               "idlAttrType"><a>RTCIceTcpCandidateType</a></span>, readonly,
-              nullable</dt>
+               nullable</dt>
               <dd>If <code>protocol</code> is <code>tcp</code>,
               <code>tcpType</code> represents the type of TCP candidate.
               Otherwise, <code>tcpType</code> is <code>null</code>. This corresponds
-              to the <code>tcp-type</code> in <a><code>candidate-attribute</code>
-              </a>.</dd>
+              to the <code>tcp-type</code> in <a><code>candidate-attribute</code></a>.</dd>
               <dt><code>relatedAddress</code> of type <span class=
               "idlAttrType"><a>DOMString</a></span>, readonly, nullable</dt>
               <dd>For a candidate that is derived from another, such as a relay
@@ -4024,8 +4032,7 @@ interface RTCIceCandidate {
               or reflexive candidate, the <dfn>relatedPort</dfn> is the port of
               the candidate that it is derived from. For host candidates, the
               <code>relatedPort</code> is <code>null</code>. This corresponds to
-              the <code>rel-port</code> field in <a><code>candidate-attribute</code>
-              </a>.</dd>
+              the <code>rel-port</code> field in <a><code>candidate-attribute</code></a>.</dd>
               <dt><code><dfn>ufrag</dfn></code> of type <span class=
               "idlAttrType"><a>DOMString</a></span>, readonly, nullable</dt>
               <dd>This carries the <code>ufrag</code> as defined in section
@@ -4071,6 +4078,19 @@ interface RTCIceCandidate {
             </dl>
           </section>
         </div>
+        <section>
+          <h4><dfn><code>candidate-attribute</code></dfn> Grammar</h4>
+          <p>The <code>candidate-attribute</code> grammar is used to parse
+          the <a href="#idl-def-rtcicecandidateinit-candidate">
+          <code>candidate</code></a> member of <var>candidateInitDict</var>
+          in the <a><code>RTCIceCandidate()</code></a> constructor.</p>
+          <p>The primary grammar for <code>candidate-attribute</code>
+          is defined in section 15.1 of [[!ICE]]. In addition, the browser
+          MUST support the grammar extension for ICE TCP as defined in
+          section 4.5 of [[!RFC6544]].</p>
+          <p>The browser MAY support other grammar extensions for
+          <code>candidate-attribute</code> as defined in other RFCs.</p>
+        </section>
         <section>
           <h4>RTCIceProtocol Enum</h4>
           <p>The <dfn>RTCIceProtocol</dfn> represents the protocol of the ICE


### PR DESCRIPTION
This PR address the issues in #1165 and #1224. It is also needed to have complete test coverage for `RTCIceCandidate()` in w3c/web-platform-tests#5917.

I am not very sure of the details for editing the spec, so this is a first cut draft that attempt to explain the changes to be made.

The main change is to add detailed steps for the `RTCIceCandidate` constructor to parse the candidate string, referencing the relevant specs, and populating the attributes with the parse result. 

To maintain backward compatibility, any parsing error is ignored and the derivative attributes are simply set with the default `null` value. This might not be the best approach, but I am not sure if we can make it throw an error since current browser implementations do not have the derivative attributes and have not done any parsing on the candidate string.