### PR TITLE
Use data-cite for RTCStatsType

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -84,6 +84,7 @@
     <p>The term <dfn>Blob</dfn> is defined in [[!FILEAPI]].</p>
     <p>The term <dfn>media description</dfn> is defined in [[!RFC4566]].</p>
     <p>The term <dfn>generation</dfn> is defined in [[!TRICKLE-ICE]] Section 2.</p>
+    <p>The term <dfn data-cite="!WEBRTC-STATS#dom-rtcstatstype">RTCStatsType</dfn> is defined in [[!WEBRTC-STATS]].
     <p>When referring to exceptions, the terms <dfn><a
     href="https://www.w3.org/TR/WebIDL-1/#dfn-throw">throw</a></dfn> and
     <dfn data-dfn-for="exception"><a href=
@@ -9658,11 +9659,7 @@ interface RTCDTMFToneChangeEvent : Event {
           </dl>
         </section>
       </div>
-      <div>
-        <pre class="idl">enum RTCStatsType {
-};</pre>
-      </div>
-      <p>The set of valid values for <dfn>RTCStatsType</dfn>, and the dictionaries derived
+      <p>The set of valid values for <code><a>RTCStatsType</a></code>, and the dictionaries derived
       from RTCStats that they indicate, are documented in
       [[!WEBRTC-STATS]].</p>
     </section>


### PR DESCRIPTION
...which is explained [on ReSpec wiki](https://github.com/w3c/respec/wiki/data--cite) and [mailing list](https://lists.w3.org/Archives/Public/spec-prod/2017JanMar/0011.html). Should fix #1212.