### PR TITLE
RTCIceConnectionEventInit: url is nullable

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4229,8 +4229,10 @@ interface RTCPeerConnectionIceEvent : Event {
                 <code>RTCPeerConnectionIceEvent</code> interface</a>.</p>
               </dd>
               <dt><dfn><code>url</code></dfn> of type <span class=
-              "idlMemberType"><a>DOMString</a></span></dt>
-              <dd></dd>
+              "idlMemberType"><a>DOMString</a></span>, nullable</dt>
+              <dd>The <code>url</code> attribute is the STUN or TURN URL that
+              identifies the STUN or TURN server used to gather this
+              candidate.</dd>
             </dl>
           </section>
         </div>


### PR DESCRIPTION
describes the url as nullable as it is done in the idl definition.

Description is missing too. ORTC has "The URL of the server from which the candidate was obtained." shall I steal that (with @aboba's permission)?