### PR TITLE
RTP/RTCP mux -> RTCP mux

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7533,7 +7533,7 @@ sender.setParameters(params)
               <p>The <dfn id=
               "dom-icetransport-component"><code>component</code></dfn>
               attribute MUST return the ICE component of the transport. When
-              RTP/RTCP mux is used, a single
+              RTCP mux is used, a single
               <code><a>RTCIceTransport</a></code> transports both RTP and RTCP
               and <code>component</code> is set to "RTP".</p>
             </dd>
@@ -7891,7 +7891,7 @@ sender.setParameters(params)
             </tr>
             <tr>
               <td><dfn><code>rtp</code></dfn></td>
-              <td>The ICE Transport is used for RTP (or RTP/RTCP-multiplexing),
+              <td>The ICE Transport is used for RTP (or RTCP multiplexing),
               as defined in [[!ICE]], Section 4.1.1.1. Protocols multiplexed
               with RTP (e.g. data channel) share its component ID.</td>
             </tr>


### PR DESCRIPTION
replace single use of RTP/RTCP mux with just RTCP mux for consitency with
other uses

We also don't define "RTCP mux" anywhere and don't have a reference to RFC 5763. Should we?