### PR TITLE
clean up logic to support removal of RTCP mux "negotiated" value

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -757,8 +757,8 @@
           <li>
             <p>If <code><var>configuration</var>.<a data-for=
             "RTCConfiguration">rtcpMuxPolicy</a></code> is
-            <code>negotiate</code>, and the user agent does not implement
-            non-muxed RTCP, <a>throw</a> a <code>NotSupportedError</code>.</p>
+            a value the user agent does not support,
+            <a>throw</a> a <code>NotSupportedError</code>.</p>
           <li>
             <p>Initialize <var>connection</var>'s <a>ICE Agent</a>.</p>
           </li>


### PR DESCRIPTION
This PR makes it easier to remove this at risk value and at the same times makes the text better for future extensions that define new values. 

