### PR TITLE
pc.close() sets pc.signalingState to "closed"

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2675,7 +2675,7 @@ interface RTCPeerConnection : EventTarget  {
                     <code>true</code>.</p>
                   </li>
                   <li>
-                    <p>Set <var>connection</var>'s <code><a>signalingState</a></code> attribute to
+                    <p>Set <var>connection</var>'s <a>signaling state</a> to 
                     <code>closed</code>.</p>
                   </li>
                 </ol>

--- a/webrtc.html
+++ b/webrtc.html
@@ -2674,6 +2674,10 @@ interface RTCPeerConnection : EventTarget  {
                     <p>Set <var>connection</var>'s [[<a>isClosed</a>]] slot to
                     <code>true</code>.</p>
                   </li>
+                  <li>
+                    <p>Set <var>connection</var>'s <code><a>signalingState</a></code> attribute to
+                    <code>closed</code>.</p>
+                  </li>
                 </ol>
                 <div>
                   <em>No parameters.</em>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/1367