### PR TITLE
Remove condition "If channel's underlying data transport is not established yet, then abort these steps" from send()

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9270,10 +9270,10 @@ interface RTCTrackEvent : Event {
             </li>
           </ul>
         </li>
+
         <li>
-          <p>If <var>channel</var>'s <a>underlying data transport</a> is not
-          established yet, or if the <code><a>closing procedure</a></code> has
-          started, then abort these steps.</p>
+          <p>If the <code><a>closing procedure</a></code> for
+          <var>channel</var> has started, then abort these steps.</p>
         </li>
         <li>
           <p>If the size of <var>data</var> exceeds the value of <code><a


### PR DESCRIPTION
Fixes #1396.