### PR TITLE
close all DtlsTransports in pc.close() (including sctp.transport)

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2903,36 +2903,11 @@ interface RTCPeerConnection : EventTarget  {
                     "RTCIceTransportState">closed</a></code>.</p>
                   </li>
                   <li>
-                    <p>Set the <var>connection</var>'s
-                    <code>sctp.transport.state</code>
+                    <p>Set the <code><a data-link-for=
+                    "RTCDtlsTransport">state</a></code> of each of
+                    <var>connection</var>'s <code><a>RTCDtlsTransport</a></code>s
                     to <code><a data-link-for=
                     "RTCDtlsTransportState">closed</a></code>.</p>
-                  </li>
-                  <li>
-                    <p>Let <var>senders</var> be the result of executing the
-                    <code><a>CollectSenders</a></code> algorithm. For every
-                    <code><a>RTCRtpSender</a></code> <var>sender</var> in
-                    <var>senders</var>, set
-                    <code><var>sender.transport.state</var></code> and
-                    <code><var>sender.transport.transport.state</var></code> to
-                    "closed". If <code><var>sender.rtcpTransport</var></code>
-                    is set, set
-                    <code><var>sender.rtcpTransport.state</var></code> and
-                    <code><var>sender.rtcpTransport.transport.state</var></code>
-                    to "closed".</p>
-                  </li>
-                  <li>
-                    <p>Let <var>receivers</var> be the result of executing the
-                    <code><a>CollectReceivers</a></code> algorithm. For every
-                    <code><a>RTCRtpReceiver</a></code> <var>receiver</var> in
-                    <var>receivers</var>, set
-                    <code><var>receiver.transport.state</var></code> and
-                    <code><var>receiver.transport.transport.state</var></code>
-                    to "closed". If
-                    <code><var>receiver.rtcpTransport</var></code> is set, set
-                    <code><var>receiver.rtcpTransport.state</var></code> and
-                    <code><var>receiver.rtcpTransport.transport.state</var></code>
-                    to "closed".</p>
                   </li>
                   <li>
                     <p>Let <var>transceivers</var> be the result of executing the

--- a/webrtc.html
+++ b/webrtc.html
@@ -2903,6 +2903,12 @@ interface RTCPeerConnection : EventTarget  {
                     "RTCIceTransportState">closed</a></code>.</p>
                   </li>
                   <li>
+                    <p>Set the <var>connection</var>'s
+                    <code>sctp.transport.state</code>
+                    to <code><a data-link-for=
+                    "RTCDtlsTransportState">closed</a></code>.</p>
+                  </li>
+                  <li>
                     <p>Let <var>senders</var> be the result of executing the
                     <code><a>CollectSenders</a></code> algorithm. For every
                     <code><a>RTCRtpSender</a></code> <var>sender</var> in


### PR DESCRIPTION
Work-in-progress, do not merge.

Fix for Issue https://github.com/w3c/webrtc-pc/issues/1381


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/issue-1381-patch.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/0b0db47...5322655.html)