### PR TITLE
Add/remove remote tracks from msid streams based on direction (rebased)

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5609,7 +5609,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           </li>
           <li>
             <p>Let <var>streams</var> be <var>transceiver.receiver</var>'s
-            [[<a>associated remote MediaStreams</a>]] slot.
+            <a>[[\AssociatedRemoteMediaStreams]]</a> slot.
             </p>
           </li>
           <li>
@@ -5665,7 +5665,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           </li>
           <li>
             <p>For each <var>stream</var> in <var>receiver</var>'s
-            [[<a>associated remote MediaStreams</a>]] that is not present in
+            <a>[[\AssociatedRemoteMediaStreams]]</a> that is not present in
             <var>streams</var>, remove <var>track</var> from <var>stream</var>.
             </p>
             <p class="note">This will result in a removetrack event being fired
@@ -5674,14 +5674,14 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           <li>
             <p>For each <var>stream</var> in
             <var>streams</var> that is not present in <var>receiver</var>'s
-            [[<a>associated remote MediaStreams</a>]], add <var>track</var> to
+            <a>[[\AssociatedRemoteMediaStreams]]</a>, add <var>track</var> to
             <var>stream</var>.</p>
             <p class="note">This will result in an addtrack event being fired
             at each MediaStream as described in [[!GETUSERMEDIA]].</p>
           </li>
           <li>
             <p>Set <var>receiver</var>'s
-            [[<a>associated remote MediaStreams</a>]] slot to
+            <a>[[\AssociatedRemoteMediaStreams]]</a> slot to
             <var>streams</var>.
             </p>
           </li>
@@ -6813,9 +6813,9 @@ sender.setParameters(params)
           <p>Set <var>receiver.track</var> to <var>track</var>.</p>
         </li>
         <li>
-          <p>Let <var>receiver</var> have an [[<dfn>associated remote
-          MediaStreams</dfn>]] internal slot, representing a list of
-          <code><a>MediaStream</a></code> objects that the
+          <p>Let <var>receiver</var> have an
+          <a>[[\AssociatedRemoteMediaStreams]]</a> internal slot, representing a
+          list of <code><a>MediaStream</a></code> objects that the
           <code><a>MediaStreamTrack</a></code> object of this receiver is
           associated with, and initialized to an empty list.</p>
         </li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1584,9 +1584,19 @@
                       <li>
                         <p>If the direction of the media description is
                         <code>sendrecv</code> or <code>sendonly</code>, and
-                        <code>transceiver.receiver.track</code> has not yet
-                        been fired in a <code title="event-track"><a>track
-                        </a></code> event, <a>process the remote track</a> for
+                        <var>transceiver</var>'s
+                        [[<a href="#direction-slot">Direction</a>]] slot is
+                        neither "sendrecv" nor "sendonly",
+                        <a>process the addition of a remote track</a> for
+                        the media description, given <var>transceiver</var>.</p>
+                      </li>
+                      <li>
+                        <p>If the direction of the media description is
+                        <code>recvonly</code> or <code>inactive</code>, and
+                        <var>transceiver</var>'s
+                        [[<a href="#direction-slot">Direction</a>]] slot is
+                        neither "recvonly" nor "inactive",
+                        <a>process the removal of a remote track</a> for
                         the media description, given <var>transceiver</var>.</p>
                       </li>
                       <li>
@@ -5570,35 +5580,101 @@ interface RTCPeerConnectionIceErrorEvent : Event {
       </div>
       <section>
         <h4>Processing Remote MediaStreamTracks</h4>
-        <p>An application can reject incoming <code><a>MediaStreamTrack</a></code>
-        objects by calling <code><a>RTCRtpTransceiver</a>.stop()</code>.</p>
-        <p>To <dfn id="process-remote-track">process the remote track</dfn> for
+        <p>An application can reject incoming media descriptions by calling
+        <code><a>RTCRtpTransceiver</a>.stop()</code>.</p>
+        <p>To <dfn id="process-remote-track-addition">
+        process the addition of a remote track</dfn> for
         an incoming media description <span data-jsep=
         "applying-a-remote-desc">[[!JSEP]]</span> given
         <code>RTCRtpTransceiver</code> <var>transceiver</var>, the user agent
         MUST run the following steps:</p>
         <ol>
           <li>
-            <p>Let <var>connection</var> be the
-            <code><a>RTCPeerConnection</a></code> object associated with
-            <var>transceiver</var>.</p>
+            <p>Let <var>track</var> be <var>transceiver.receiver.track</var>.
+            </p>
           </li>
           <li>
-            <p>Let <var>streams</var> be a list of
-            <code><a>MediaStream</a></code> objects that the media description
-            indicates the <code><a>MediaStreamTrack</a></code> belongs to.</p>
+            <p><a>Set the associated remote streams</a> given
+            <var>transceiver.receiver</var> and a list of the MSIDs that the
+            media description indicates <var>track</var> is to be associated
+            with.</p>
           </li>
           <li>
-            <p>Add <var>track</var> to all <code><a>MediaStream</a></code>
-            objects in <var>streams</var>.</p>
-            <p class="note">This will result in an addtrack event being fired
-            at each MediaStream as described in [[!GETUSERMEDIA]].</p>
+            <p>Let <var>streams</var> be <var>transceiver.receiver</var>'s
+            [[<a>associated remote MediaStreams</a>]] slot.
+            </p>
           </li>
           <li>
             <p>Queue a task to fire an event named <code title=
             "event-track"><a>track</a></code> with <var>transceiver</var>,
             <var>track</var>, and <var>streams</var> at the
             <var>connection</var> object.</p>
+          </li>
+        </ol>
+        <p>To <dfn id="process-remote-track-removal">
+        process the removal of a remote track</dfn> for
+        an incoming media description <span data-jsep=
+        "applying-a-remote-desc">[[!JSEP]]</span> given
+        <code>RTCRtpTransceiver</code> <var>transceiver</var>, the user agent
+        MUST run the following steps:</p>
+        <ol>
+          <li>
+            <p>Let <var>track</var> be <var>transceiver.receiver.track</var>.
+            </p>
+          </li>
+          <li>
+            <p><a>Set the associated remote streams</a> for the media
+            description, given <var>transceiver.receiver</var> and an empty
+            list.</p>
+          </li>
+          <li>
+            <p>Queue a task, that if <var>track.muted</var> is
+            <code>false</code>, will <a>update the muted state</a>
+            of <var>track</var> with the value <code>true</code>.</p>
+          </li>
+        </ol>
+        <p>To <dfn id="set-associated-remote-streams">set the associated remote streams</dfn> given
+        <code>RTCRtpReceiver</code> <var>receiver</var> and a list
+        <var>msids</var>, the user agent MUST run the following steps:</p>
+        <ol>
+          <li>
+            <p>Let <var>connection</var> be the
+            <code><a>RTCPeerConnection</a></code> object associated with
+            <var>receiver</var>.</p>
+          </li>
+          <li>
+            <p>For each MSID in <var>msids</var>, unless a
+            <code><a>MediaStream</a></code> object has previously been created
+            with that <code>id</code> for this <var>connection</var>, create a
+            <code><a>MediaStream</a></code> object with that
+            <code>id</code>.</p>
+          </li>
+          <li>
+            <p>Let <var>streams</var> be a list of the
+            <code><a>MediaStream</a></code> objects created for this
+            <var>connection</var> with the <code>id</code>s corresponding to
+            <var>msids<var>.</p>
+          </li>
+          <li>
+            <p>For each <var>stream</var> in <var>receiver</var>'s
+            [[<a>associated remote MediaStreams</a>]] that is not present in
+            <var>streams</var>, remove <var>track</var> from <var>stream</var>.
+            <p class="note">This will result in a removetrack event being fired
+            at each MediaStream as described in [[!GETUSERMEDIA]].</p>
+          </li>
+          <li>
+            <p>For each <var>stream</var> in
+            <var>streams</var> that is not present in <var>receiver</var>'s
+            [[<a>associated remote MediaStreams</a>]], add <var>track</var> to
+            <var>stream</var>.
+            <p class="note">This will result in an addtrack event being fired
+            at each MediaStream as described in [[!GETUSERMEDIA]].</p>
+          </li>
+          <li>
+            <p>Set <var>receiver</var>'s
+            [[<a>associated remote MediaStreams</a>]] slot to
+            <var>streams</var>.
+            </p>
           </li>
         </ol>
       </section>
@@ -6726,6 +6802,13 @@ sender.setParameters(params)
         </li>
         <li>
           <p>Set <var>receiver.track</var> to <var>track</var>.</p>
+        </li>
+        <li>
+          <p>Let <var>receiver</var> have an [[<dfn>associated remote
+          MediaStreams</dfn>]] internal slot, representing a list of
+          <code><a>MediaStream</a></code> objects that the
+          <code><a>MediaStreamTrack</a></code> object of this receiver is
+          associated with, and initialized to an empty list.</p>
         </li>
         <li>
           <p>Return <var>receiver</var>.</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1581,7 +1581,7 @@
                         <span data-jsep="applying-a-remote-desc">[[!JSEP]]</span>
                         is <code>sendrecv</code> or <code>sendonly</code>, and
                         <var>transceiver</var>'s
-                        [[<a href="#direction-slot">CurrentDirection</a>]] slot
+                        [[<a>CurrentDirection</a>]] slot
                         is neither "sendrecv" nor "sendonly",
                         <a>process the addition of a remote track</a> for
                         the media description, given <var>transceiver</var>.</p>
@@ -1590,7 +1590,7 @@
                         <p>If the direction of the media description is
                         <code>recvonly</code> or <code>inactive</code>, and
                         <var>transceiver</var>'s
-                        [[<a href="#direction-slot">CurrentDirection</a>]] slot
+                        [[<a>CurrentDirection</a>]] slot
                         is neither "recvonly" nor "inactive",
                         <a>process the removal of a remote track</a> for
                         the media description, given <var>transceiver</var>.</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1576,22 +1576,20 @@
                         "applying-a-remote-desc">[[!JSEP]]</span>.</p>
                       </li>
                       <li>
-                        <p>If the direction of the media description as defined
-                        in
-                        <span data-jsep="applying-a-remote-desc">[[!JSEP]]</span>
-                        is <code>sendrecv</code> or <code>sendonly</code>, and
+                        <p>If <var>direction</var> is <code>sendrecv</code> or
+                        <code>recvonly</code>, and
                         <var>transceiver</var>'s
                         [[<a>CurrentDirection</a>]] slot
-                        is neither "sendrecv" nor "sendonly",
+                        is neither "sendrecv" nor "recvonly",
                         <a>process the addition of a remote track</a> for
                         the media description, given <var>transceiver</var>.</p>
                       </li>
                       <li>
-                        <p>If the direction of the media description is
-                        <code>recvonly</code> or <code>inactive</code>, and
+                        <p>If <var>direction</var> is
+                        <code>sendonly</code> or <code>inactive</code>, and
                         <var>transceiver</var>'s
                         [[<a>CurrentDirection</a>]] slot
-                        is neither "recvonly" nor "inactive",
+                        is neither "sendonly" nor "inactive",
                         <a>process the removal of a remote track</a> for
                         the media description, given <var>transceiver</var>.</p>
                       </li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -5589,7 +5589,9 @@ interface RTCPeerConnectionIceErrorEvent : Event {
       <section>
         <h4>Processing Remote MediaStreamTracks</h4>
         <p>An application can reject incoming media descriptions by calling
-        <code><a>RTCRtpTransceiver</a>.stop()</code>.</p>
+        <code><a>RTCRtpTransceiver</a>.stop()</code> to stop both directions,
+        or set the transceiver's direction to "sendonly" to reject only the
+        incoming side.</p>
         <p>To <dfn id="process-remote-track-addition">
         process the addition of a remote track</dfn> for
         an incoming media description <span data-jsep=

--- a/webrtc.html
+++ b/webrtc.html
@@ -1576,17 +1576,13 @@
                         "applying-a-remote-desc">[[!JSEP]]</span>.</p>
                       </li>
                       <li>
-                        <p>If <var>description</var> is of type
-                        <code>"answer"</code> or <code>"pranswer"</code>, set
-                        <var>transceiver</var>'s <a>[[\CurrentDirection]]</a> slot
-                        to <var>direction</var>.</p>
-                      </li>
-                      <li>
-                        <p>If the direction of the media description is
-                        <code>sendrecv</code> or <code>sendonly</code>, and
+                        <p>If the direction of the media description as defined
+                        in
+                        <span data-jsep="applying-a-remote-desc">[[!JSEP]]</span>
+                        is <code>sendrecv</code> or <code>sendonly</code>, and
                         <var>transceiver</var>'s
-                        [[<a href="#direction-slot">Direction</a>]] slot is
-                        neither "sendrecv" nor "sendonly",
+                        [[<a href="#direction-slot">CurrentDirection</a>]] slot
+                        is neither "sendrecv" nor "sendonly",
                         <a>process the addition of a remote track</a> for
                         the media description, given <var>transceiver</var>.</p>
                       </li>
@@ -1594,10 +1590,16 @@
                         <p>If the direction of the media description is
                         <code>recvonly</code> or <code>inactive</code>, and
                         <var>transceiver</var>'s
-                        [[<a href="#direction-slot">Direction</a>]] slot is
-                        neither "recvonly" nor "inactive",
+                        [[<a href="#direction-slot">CurrentDirection</a>]] slot
+                        is neither "recvonly" nor "inactive",
                         <a>process the removal of a remote track</a> for
                         the media description, given <var>transceiver</var>.</p>
+                      </li>
+                      <li>
+                        <p>If <var>description</var> is of type
+                        <code>"answer"</code> or <code>"pranswer"</code>, set
+                        <var>transceiver</var>'s <a>[[\CurrentDirection]]</a> slot
+                        to <var>direction</var>.</p>
                       </li>
                       <li>
                         <p>If the media description is rejected, and
@@ -5252,6 +5254,12 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               as <code>recvonly</code> or <code>inactive</code>,
               as defined in <span data-jsep="subsequent-offers">
               [[!JSEP]]</span>. <!-- onended --></p>
+              <p>When the other peer stops sending a track in this manner, the
+              track is removed from any remote <code><a>MediaStream</a></code>s
+              that were initially revealed in the <code>track</code> event, and
+              if the <code><a>MediaStreamTrack</a></code> is not already muted,
+              a <code title="event-MediaStreamTrack-muted">muted</code> event is
+              fired at the track.</p>
               <p>When the <dfn><code>removeTrack</code></dfn> method is
               invoked, the user agent MUST run the following steps:</p>
               <ol>
@@ -5653,7 +5661,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             <p>Let <var>streams</var> be a list of the
             <code><a>MediaStream</a></code> objects created for this
             <var>connection</var> with the <code>id</code>s corresponding to
-            <var>msids<var>.</p>
+            <var>msids</var>.</p>
           </li>
           <li>
             <p>For each <var>stream</var> in <var>receiver</var>'s

--- a/webrtc.html
+++ b/webrtc.html
@@ -5667,6 +5667,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             <p>For each <var>stream</var> in <var>receiver</var>'s
             [[<a>associated remote MediaStreams</a>]] that is not present in
             <var>streams</var>, remove <var>track</var> from <var>stream</var>.
+            </p>
             <p class="note">This will result in a removetrack event being fired
             at each MediaStream as described in [[!GETUSERMEDIA]].</p>
           </li>
@@ -5674,7 +5675,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             <p>For each <var>stream</var> in
             <var>streams</var> that is not present in <var>receiver</var>'s
             [[<a>associated remote MediaStreams</a>]], add <var>track</var> to
-            <var>stream</var>.
+            <var>stream</var>.</p>
             <p class="note">This will result in an addtrack event being fired
             at each MediaStream as described in [[!GETUSERMEDIA]].</p>
           </li>


### PR DESCRIPTION
Rebase of https://github.com/w3c/webrtc-pc/pull/1377.
Fix for https://github.com/w3c/webrtc-pc/issues/1181.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/jan-ivar/webrtc-pc/removeremote2.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/a12bf47...jan-ivar:f13a05e.html)