### PR TITLE
when voiceActivityDetection is false browser sends media

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6208,7 +6208,7 @@ sender.setParameters(params)
               CN codec); if it was not negotiated (such as when setting
               <code>voiceActivityDetection</code> to <code>false</code>),
               then discontinuous operation will be turned off regardless of the
-              value of <code>dtx</code>, and media will sent even when silence
+              value of <code>dtx</code>, and media will be sent even when silence
               is detected. This attribute is ignored by a receiver or video
               sender.</p>
             </dd>

--- a/webrtc.html
+++ b/webrtc.html
@@ -6205,12 +6205,12 @@ sender.setParameters(params)
               turned off. Setting it to <code>enabled</code> causes
               discontinuous transmission to be turned on if it was negotiated
               (either via a codec-specific parameter or via negotiation of the
-              CN codec). This attribute is ignored by a video sender.
-              If it was not negotiated (such as when setting
-              <code>voiceActivityDetection</code> to <code>false</code> in
-              <code>RTCOfferOptions</code>), then discontinuous operation will
-              be turned off regardless of the value of <code>dtx</code>,
-              and media will sent even when silence is detected.</p>
+              CN codec); if it was not negotiated (such as when setting
+              <code>voiceActivityDetection</code> to <code>false</code>),
+              then discontinuous operation will be turned off regardless of the
+              value of <code>dtx</code>, and media will sent even when silence
+              is detected. This attribute is ignored by a receiver or video
+              sender.</p>
             </dd>
             <dt><dfn><code>active</code></dfn> of type <span class=
             "idlMemberType"><a>boolean</a></span></dt>

--- a/webrtc.html
+++ b/webrtc.html
@@ -6205,7 +6205,12 @@ sender.setParameters(params)
               turned off. Setting it to <code>enabled</code> causes
               discontinuous transmission to be turned on if it was negotiated
               (either via a codec-specific parameter or via negotiation of the
-              CN codec). This attribute is ignored by a video sender.</p>
+              CN codec). This attribute is ignored by a video sender.
+              If it was not negotiated (such as when setting
+              <code>voiceActivityDetection</code> to <code>false</code> in
+              <code>RTCOfferOptions</code>), then discontinuous operation will
+              be turned off regardless of the value of <code>dtx</code>,
+              and media will sent even when silence is detected.</p>
             </dd>
             <dt><dfn><code>active</code></dfn> of type <span class=
             "idlMemberType"><a>boolean</a></span></dt>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/1308


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/issue-1308-patch.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/0b0db47...91594ef.html)