### PR TITLE
Section 4.8.3: Editorial fixes

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4469,7 +4469,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <p>The <code>errorCode</code> attribute is the numeric STUN
                 error code returned by the STUN or TURN server
                 [[STUN-PARAMETERS]].</p>
-                <p class="note">If no host candidate can reach the server,
+                <p>If no host candidate can reach the server,
                 <code>errorCode</code> will be set to the value 701 which is
                 outside the STUN error code range. This error is only fired
                 once per server URL while in the

--- a/webrtc.html
+++ b/webrtc.html
@@ -4503,16 +4503,28 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             "dictionary-members">
               <dt><dfn><code>hostCandidate</code></dfn> of type <span class=
               "idlMemberType"><a>DOMString</a></span></dt>
-              <dd>DOMString url</dd>
+              <dd>
+                <p>The local IP address and port used to communicate
+                 with the STUN or TURN server.</p>
+              </dd>
               <dt><dfn><code>url</code></dfn> of type <span class=
               "idlMemberType"><a>DOMString</a></span></dt>
-              <dd>unsigned short errorCode</dd>
+              <dd>
+                <p>tThe STUN or TURN URL that identifies the STUN
+                or TURN server for which the failure occurred.</p>
+              </dd>
               <dt><dfn><code>errorCode</code></dfn> of type <span class=
               "idlMemberType"><a>unsigned short</a></span>, required</dt>
-              <dd>USVString statusText</dd>
+              <dd>
+                <p>The numeric STUN error code returned by the STUN
+                or TURN server.</p>
+              </dd>
               <dt><dfn><code>statusText</code></dfn> of type <span class=
               "idlMemberType"><a>USVString</a></span></dt>
-              <dd></dd>
+              <dd>
+                <p>The STUN reason text returned by the STUN
+                or TURN server.</p>
+              </dd>
             </dl>
           </section>
         </div>

--- a/webrtc.html
+++ b/webrtc.html
@@ -4473,7 +4473,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <code>errorCode</code> will be set to the value 701 which is
                 outside the STUN error code range. This error is only fired
                 once per server URL while in the
-                <code>RTCIceGatheringState</code> of <code>gathering</code>.</p>
+                <code>RTCIceGatheringState</code> of "gathering".</p>
               </dd>
               <dt><dfn><code>errorText</code></dfn> of type <span class=
               "idlAttrType"><a>USVString</a></span>, readonly</dt>
@@ -4510,7 +4510,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <dt><dfn><code>url</code></dfn> of type <span class=
               "idlMemberType"><a>DOMString</a></span></dt>
               <dd>
-                <p>tThe STUN or TURN URL that identifies the STUN
+                <p>The STUN or TURN URL that identifies the STUN
                 or TURN server for which the failure occurred.</p>
               </dd>
               <dt><dfn><code>errorCode</code></dfn> of type <span class=

--- a/webrtc.html
+++ b/webrtc.html
@@ -4469,11 +4469,11 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <p>The <code>errorCode</code> attribute is the numeric STUN
                 error code returned by the STUN or TURN server
                 [[STUN-PARAMETERS]].</p>
-                <p>If no host candidate can reach the server,
+                <p class="note">If no host candidate can reach the server,
                 <code>errorCode</code> will be set to the value 701 which is
                 outside the STUN error code range. This error is only fired
                 once per server URL while in the
-                <code>RTCIceGatheringState</code> of "gathering".</p>
+                <code>RTCIceGatheringState</code> of <code>gathering</code>.</p>
               </dd>
               <dt><dfn><code>errorText</code></dfn> of type <span class=
               "idlAttrType"><a>USVString</a></span>, readonly</dt>


### PR DESCRIPTION
Fixes problems with RTCPeerConnectionIceErrorEventInit dictionary descriptions.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/issue-1281-patch.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/cc8d80f...178ae11.html)