### PR TITLE
rtcsessiondescription: attributes are not mutable

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3602,8 +3602,7 @@ interface RTCPeerConnection : EventTarget  {
         <h4><dfn>RTCSessionDescription</dfn> Class</h4>
         <p>The <code>RTCSessionDescription</code> class is used by
         <code><a>RTCPeerConnection</a></code> to expose local and remote
-        session descriptions. Attributes on this interface are mutable for
-        legacy reasons.</p>
+        session descriptions.</p>
         <div>
           <pre class="idl">
           [ Constructor (RTCSessionDescriptionInit descriptionInitDict)]


### PR DESCRIPTION
removes text which claims the attributes were mutable for legacy reasons.

Fixes https://github.com/w3c/webrtc-pc/issues/1242