### PR TITLE
addTranscevier: Assume default dictionary

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5304,23 +5304,19 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               following steps:</p>
               <ol>
                 <li>
-                  <p>If the dictionary argument is present, and it has a
-                  <code>streams</code> member, let <var>streams</var> be that
-                  list of <code><a>MediaStream</a></code> objects, or an empty
-                  list otherwise.</p>
+                  <p>Let <var>init</var> be the second argument.</p>
                 </li>
                 <li>
-                  <p>If the dictionary argument is present, and it has a
-                  <code>sendEncodings</code> member, let
-                  <var>sendEncodings</var> be that list of
-                  <code><a>RTCRtpEncodingParameters</a></code> objects, or an
-                  empty list otherwise.</p>
+                  <p>Let <var>streams</var> be <var>init</var>'s
+                  <code>streams</code> member.</p>
                 </li>
                 <li>
-                  <p>If the dictionary argument is present, let
-                  <var>direction</var> be the value of the
-                  <code>direction</code> member. Otherwise let
-                  <var>direction</var> be <code>sendrecv</code>.</p>
+                  <p>Let <var>sendEncodings</var> be <var>init</var>'s
+                  <code>sendEncodings</code> member.</p>
+                </li>
+                <li>
+                  <p>Let <var>direction</var> be <var>init</var>'s
+                  <code>direction</code> member.</p>
                 </li>
                 <li>
                   <p>If the first argument is a string, let it be
@@ -5443,8 +5439,8 @@ interface RTCPeerConnectionIceErrorEvent : Event {
       <div>
         <pre class="idl">dictionary RTCRtpTransceiverInit {
              RTCRtpTransceiverDirection         direction = "sendrecv";
-             sequence&lt;MediaStream&gt;              streams;
-             sequence&lt;RTCRtpEncodingParameters&gt; sendEncodings;
+             sequence&lt;MediaStream&gt;              streams = [];
+             sequence&lt;RTCRtpEncodingParameters&gt; sendEncodings = [];
 };</pre>
         <section>
           <h2>Dictionary <dfn>RTCRtpTransceiverInit</dfn>


### PR DESCRIPTION
Fixes #1369 

Adds default values to members of RTCRtpTransceiverInit to avoid writing the same thing in prose.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/default-dict.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/cc8d80f...76b7466.html)