### PR TITLE
RTCRtpTransceiver: Set currentDirection to null when stopping

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7310,6 +7310,11 @@ sender.setParameters(params)
                   <p>Set <code><var>transceiver</var>.stopped</code> to <code>true</code>.</p>
                 </li>
                 <li>
+                  <p>Set <var>transceiver</var>'s [[<a href=
+                  "#curr-direction-slot">CurrentDirection</a>]] slot to
+                  <code>null</code>.</p>
+                </li>
+                <li>
                   <p><a>Update the negotiation-needed flag</a> for
                   <var>connection</var>.</p>
                 </li>


### PR DESCRIPTION
Fixes half of #1417


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/curr-direction-stop.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/c602d52...8b18a5e.html)