### PR TITLE
Set [[CurrentDirection]] for provisional answers.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1525,7 +1525,8 @@
                         the corresponding media description.</p>
                       </li>
                       <li>
-                        <p>If <var>description</var> is of type "answer", then
+                        <p>If <var>description</var> is of type
+                        <code>"answer"</code> or <code>"pranswer"</code>, then
                         set <var>transceiver</var>'s <a>[[\CurrentDirection]]</a> slot
                         to an <code><a>RTCRtpTransceiverDirection</a></code>
                         value representing the direction of the corresponding
@@ -1585,7 +1586,8 @@
                         "applying-a-remote-desc">[[!JSEP]]</span>.</p>
                       </li>
                       <li>
-                        <p>If <var>description</var> is of type "answer", set
+                        <p>If <var>description</var> is of type
+                        <code>"answer"</code> or <code>"pranswer"</code>, set
                         <var>transceiver</var>'s <a>[[\CurrentDirection]]</a> slot
                         to <var>direction</var>.</p>
                       </li>


### PR DESCRIPTION
Fixes #1394.

This matches JSEP (at least, as I interpret it) and makes the logic
that uses [[CurrentDirection]] work correctly. `currentDirection` is
meant to represent "direction in effect", which the application may
want to know about. And applying a pranswer does allow
sending/receiving media based on the directional attribute.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/taylor-b/webrtc-pc/issue_1394_pranswer_currentdirection.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/c232b6e...taylor-b:b55d70f.html)