### PR TITLE
Editorial: Add 'Style Conventions' section to contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,3 +28,20 @@ Section aliases, to be used as data-jsep values, are found in [jsep-mapping/map.
 
 ### Refactoring: Moving Text
 If your PR needs to both move a section of text and update it, please do these operations in two separate commits (or even PRs). That will make the review process simpler.
+
+### Style Conventions
+
+**Strings**. Use quotes and enclose in code tags (to distinguish strings literals from quoted prose).
+Example: `<code>"String literal"</code>`
+
+**Booleans**. Enclose booleans in code tags (without quotes).\
+Example: `<code>true</code>`
+
+**Enum Values**. See **Strings**.
+
+**Notes**. Use div tags for notes.\
+Example: `<div class='note'>FYI</div>`
+
+**Internal Slots**. Use upper camel case (initial upper case letter) with a leading backslash and enclosed by two brackets. The leading backslash prevents your slot name from colliding with other definitions such as attribute names. If a slot name is very general, like "Id", it might be useful to add more information to it to avoid name collisions and make it easier to identify its owning entity. For example, "Id" could be extended to "ComponentId".\
+Example (defining): `<dfn>[[\FooBar]]</dfn>`\
+Example (referencing): `<a>[[\FooBar]]</a>`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,6 @@ Example: `<code>true</code>`
 **Notes**. Use div tags for notes.\
 Example: `<div class='note'>FYI</div>`
 
-**Internal Slots**. Use upper camel case (initial upper case letter) with a leading backslash and enclosed by two brackets. The leading backslash prevents your slot name from colliding with other definitions such as attribute names. If a slot name is very general, like "Id", it might be useful to add more information to it to avoid name collisions and make it easier to identify its owning entity. For example, "Id" could be extended to "ComponentId".\
+**Internal Slots**. Use upper camel case (initial upper case letter) with a leading backslash and enclosed by two brackets. The leading backslash prevents the text in double brackets from being interpreted as a reference. If a slot name is very general, like "Id", it might be useful to add more information to it to avoid name collisions and make it easier to identify its owning entity. For example, "Id" could be extended to "ComponentId".\
 Example (defining): `<dfn>[[\FooBar]]</dfn>`\
 Example (referencing): `<a>[[\FooBar]]</a>`


### PR DESCRIPTION
This is a first stab at a set of 'Style Conventions'. We need to work out the details. My guess is that there might be some controversy around strings and enums.