### PR TITLE
Replace serializers by toJSON definitions

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3620,7 +3620,7 @@ interface RTCPeerConnection : EventTarget  {
 interface RTCSessionDescription {
     readonly        attribute RTCSdpType type;
     readonly        attribute DOMString  sdp;
-    serializer = {attribute};
+    [Default] object toJSON();
 };</pre>
           <section>
             <h2>Constructors</h2>
@@ -3907,7 +3907,7 @@ interface RTCIceCandidate {
     readonly        attribute DOMString?              relatedAddress;
     readonly        attribute unsigned short?         relatedPort;
     readonly        attribute DOMString?              ufrag;
-    serializer = {candidate, sdpMid, sdpMLineIndex, ufrag};
+    RTCIceCandidateInit toJSON();
 };</pre>
           <section>
             <h2>Constructor</h2>
@@ -4108,12 +4108,20 @@ interface RTCIceCandidate {
             </dl>
           </section>
           <section>
-            <h2><dfn data-dfn-for="RTCIceCandidate">Serializer</dfn></h2>
-            <div>
-              <p>Instances of this interface are serialized as a map with
-              entries for the following attributes: candidate, sdpMid,
-              sdpMLineIndex, ufrag.</p>
-            </div>
+            <h2>Methods</h2>
+            <dl data-dfn-for="RTCIceCandidate">
+              <dt><dfn>toJSON</dfn></dt>
+              <dd>To invoke the <code>toJSON()</code> operation of the <code>RTCIceCandidate</code> interface, run the following steps:
+                <ol>
+                  <li>Let <var>json</var> be a new <code>RTCIceCandidateInit</code> dictionary.</li>
+                  <li>For each attribute identifier <var>attr</var> in "candidate", "sdpMid", "sdpMLineIndex", "description":
+                    <ol>
+                      <li>Let <var>value</var> be the result of getting the underlying value of the attribute identified by <var>attr</var>, given this <code>RTCIceCandidate</code> object.</li>
+                      <li>Set <var>json</var>[<var>attr</var>] to <var>value</var>.</li>
+                    </ol>
+                  </li>
+                  <li>Return <var>json</var>.</li>
+                </ol></dd>
           </section>
         </div>
         <div>

--- a/webrtc.html
+++ b/webrtc.html
@@ -4107,10 +4107,10 @@ interface RTCIceCandidate {
               <dd>To invoke the <code>toJSON()</code> operation of the <code>RTCIceCandidate</code> interface, run the following steps:
                 <ol>
                   <li>Let <var>json</var> be a new <code>RTCIceCandidateInit</code> dictionary.</li>
-                  <li>For each attribute identifier <var>attr</var> in "candidate", "sdpMid", "sdpMLineIndex", "description":
+                  <li>For each attribute identifier <var>attr</var> in «"candidate", "sdpMid", "sdpMLineIndex", "description"»:
                     <ol>
                       <li>Let <var>value</var> be the result of getting the underlying value of the attribute identified by <var>attr</var>, given this <code>RTCIceCandidate</code> object.</li>
-                      <li>Set <var>json</var>[<var>attr</var>] to <var>value</var>.</li>
+                      <li>Set <code><var>json</var>[<var>attr</var>]</code> to <var>value</var>.</li>
                     </ol>
                   </li>
                   <li>Return <var>json</var>.</li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -3671,13 +3671,6 @@ interface RTCSessionDescription {
               <dd>The string representation of the SDP [[!SDP]].</dd>
             </dl>
           </section>
-          <section>
-            <h2><dfn data-dfn-for="RTCSessionDescription">Serializer</dfn></h2>
-            <div>
-              <p>Instances of this interface are serialized as a map with
-              entries for each of the serializable attributes.</p>
-            </div>
-          </section>
         </div>
         <div>
           <pre class="idl">dictionary RTCSessionDescriptionInit {
@@ -4121,7 +4114,8 @@ interface RTCIceCandidate {
                     </ol>
                   </li>
                   <li>Return <var>json</var>.</li>
-                </ol></dd>
+              </ol></dd>
+              </dl>
           </section>
         </div>
         <div>


### PR DESCRIPTION
Using [Default] for RTCSessionDescription
Using algorithm inspired by [WebIDL example](https://heycam.github.io/webidl/#tojson-example) for RTCIceCandidate

This currently creates a warning in ReSpec, but [I don't think it should](https://github.com/w3c/respec/issues/1309)
Also, this (implicitly) creates a dependency on WebIDL level 2

close #1419


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/tojson.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/3345dad...acdd237.html)