### PR TITLE
Remove duplicate info on method parameters

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1876,26 +1876,6 @@ interface RTCPeerConnection : EventTarget  {
               <dd>
                 See the <a data-lt="RTCPeerConnection()">RTCPeerConnection
                 constructor algorithm</a>.
-                <table class="parameters">
-                  <tbody>
-                    <tr>
-                      <th>Parameter</th>
-                      <th>Type</th>
-                      <th>Nullable</th>
-                      <th>Optional</th>
-                      <th>Description</th>
-                    </tr>
-                    <tr>
-                      <td class="prmName">configuration</td>
-                      <td class="prmType"><code>RTCConfiguration</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptTrue"><span role="img" aria-label=
-                      "True">&#10004;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                  </tbody>
-                </table>
               </dd>
             </dl>
           </section>
@@ -2276,30 +2256,6 @@ interface RTCPeerConnection : EventTarget  {
                     <p>Resolve <var>p</var> with <var>offer</var>.</p>
                   </li>
                 </ol>
-                <table class="parameters">
-                  <tbody>
-                    <tr>
-                      <th>Parameter</th>
-                      <th>Type</th>
-                      <th>Nullable</th>
-                      <th>Optional</th>
-                      <th>Description</th>
-                    </tr>
-                    <tr>
-                      <td class="prmName">options</td>
-                      <td class="prmType"><code>RTCOfferOptions</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptTrue"><span role="img" aria-label=
-                      "True">&#10004;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                  </tbody>
-                </table>
-                <div>
-                  <em>Return type:</em>
-                  <code>Promise&lt;RTCSessionDescriptionInit&gt;</code>
-                </div>
               </dd>
               <dt><dfn><code>createAnswer</code></dfn></dt>
               <dd>
@@ -2474,30 +2430,6 @@ interface RTCPeerConnection : EventTarget  {
                     <p>Resolve <var>p</var> with <var>answer</var>.</p>
                   </li>
                 </ol>
-                <table class="parameters">
-                  <tbody>
-                    <tr>
-                      <th>Parameter</th>
-                      <th>Type</th>
-                      <th>Nullable</th>
-                      <th>Optional</th>
-                      <th>Description</th>
-                    </tr>
-                    <tr>
-                      <td class="prmName">options</td>
-                      <td class="prmType"><code>RTCAnswerOptions</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptTrue"><span role="img" aria-label=
-                      "True">&#10004;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                  </tbody>
-                </table>
-                <div>
-                  <em>Return type:</em>
-                  <code>Promise&lt;RTCSessionDescriptionInit&gt;</code>
-                </div>
               </dd>
               <dt><code>setLocalDescription</code></dt>
               <dd>
@@ -2548,30 +2480,6 @@ interface RTCPeerConnection : EventTarget  {
                   calling this method may trigger the ICE candidate gathering process
                   by the <a>ICE Agent</a>.</p>
                 </div>
-                <table class="parameters">
-                  <tbody>
-                    <tr>
-                      <th>Parameter</th>
-                      <th>Type</th>
-                      <th>Nullable</th>
-                      <th>Optional</th>
-                      <th>Description</th>
-                    </tr>
-                    <tr>
-                      <td class="prmName">description</td>
-                      <td class="prmType">
-                      <code>RTCSessionDescriptionInit</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                  </tbody>
-                </table>
-                <div>
-                  <em>Return type:</em> <code>Promise&lt;void&gt;</code>
-                </div>
               </dd>
               <dt><code>setRemoteDescription</code></dt>
               <dd>
@@ -2611,30 +2519,6 @@ interface RTCPeerConnection : EventTarget  {
                 <p>If there is no <a>target peer identity</a>, then
                 <code>setRemoteDescription</code> does not await the completion
                 of identity validation.</p>
-                <table class="parameters">
-                  <tbody>
-                    <tr>
-                      <th>Parameter</th>
-                      <th>Type</th>
-                      <th>Nullable</th>
-                      <th>Optional</th>
-                      <th>Description</th>
-                    </tr>
-                    <tr>
-                      <td class="prmName">description</td>
-                      <td class="prmType">
-                      <code>RTCSessionDescriptionInit</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                  </tbody>
-                </table>
-                <div>
-                  <em>Return type:</em> <code>Promise&lt;void&gt;</code>
-                </div>
               </dd>
               <dt><code>addIceCandidate</code></dt>
               <dd>
@@ -2792,30 +2676,6 @@ interface RTCPeerConnection : EventTarget  {
                     </ol>
                   </li>
                 </ol>
-                <table class="parameters">
-                  <tbody>
-                    <tr>
-                      <th>Parameter</th>
-                      <th>Type</th>
-                      <th>Nullable</th>
-                      <th>Optional</th>
-                      <th>Description</th>
-                    </tr>
-                    <tr>
-                      <td class="prmName">candidate</td>
-                      <td class="prmType"><code>(RTCIceCandidateInit or
-                      RTCIceCandidate)</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                  </tbody>
-                </table>
-                <div>
-                  <em>Return type:</em> <code>Promise&lt;void&gt;</code>
-                </div>
               </dd>
               <dt><dfn><code>getDefaultIceServers</code></dfn></dt>
               <dd>
@@ -2833,12 +2693,6 @@ interface RTCPeerConnection : EventTarget  {
                 the discretion of application developers, configuring a user
                 agent with these defaults does not per se increase a user's
                 ability to limit the exposure of their IP addresses.</p>
-                <div>
-                  <em>No parameters.</em>
-                </div>
-                <div>
-                  <em>Return type:</em> <code>sequence&lt;RTCIceServer&gt;</code>
-                </div>
               </dd>
               <dt><dfn><code>getConfiguration</code></dfn></dt>
               <dd>
@@ -2848,12 +2702,6 @@ interface RTCPeerConnection : EventTarget  {
                 <p>When this method is called, the user agent MUST return the
                 <code><a>RTCConfiguration</a></code> object stored in the
                 <a>[[\Configuration]]</a> internal slot.</p>
-                <div>
-                  <em>No parameters.</em>
-                </div>
-                <div>
-                  <em>Return type:</em> <code>RTCConfiguration</code>
-                </div>
               </dd>
               <dt><code>setConfiguration</code></dt>
               <dd>
@@ -2882,29 +2730,6 @@ interface RTCPeerConnection : EventTarget  {
                     <var>configuration</var>.</p>
                   </li>
                 </ol>
-                <table class="parameters">
-                  <tbody>
-                    <tr>
-                      <th>Parameter</th>
-                      <th>Type</th>
-                      <th>Nullable</th>
-                      <th>Optional</th>
-                      <th>Description</th>
-                    </tr>
-                    <tr>
-                      <td class="prmName">configuration</td>
-                      <td class="prmType"><code>RTCConfiguration</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                  </tbody>
-                </table>
-                <div>
-                  <em>Return type:</em> <code>void</code>
-                </div>
               </dd>
               <dt><code>close</code></dt>
               <dd>
@@ -3002,12 +2827,6 @@ interface RTCPeerConnection : EventTarget  {
                     <code>"closed"</code>.</p>
                   </li>
                 </ol>
-                <div>
-                  <em>No parameters.</em>
-                </div>
-                <div>
-                  <em>Return type:</em> <code>void</code>
-                </div>
               </dd>
             </dl>
           </section>
@@ -3079,49 +2898,6 @@ interface RTCPeerConnection : EventTarget  {
                     <code>undefined</code>.</p>
                   </li>
                 </ol>
-                <table class="parameters">
-                  <tbody>
-                    <tr>
-                      <th>Parameter</th>
-                      <th>Type</th>
-                      <th>Nullable</th>
-                      <th>Optional</th>
-                      <th>Description</th>
-                    </tr>
-                    <tr>
-                      <td class="prmName">successCallback</td>
-                      <td class="prmType">
-                      <code>RTCSessionDescriptionCallback</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                    <tr>
-                      <td class="prmName">failureCallback</td>
-                      <td class="prmType">
-                      <code>RTCPeerConnectionErrorCallback</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                    <tr>
-                      <td class="prmName">options</td>
-                      <td class="prmType"><code>RTCOfferOptions</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptTrue"><span role="img" aria-label=
-                      "True">&#10004;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                  </tbody>
-                </table>
-                <div>
-                  <em>Return type:</em> <code>Promise&lt;void&gt;</code>
-                </div>
               </dd>
               <dt><dfn data-lt="setLocalDescription!overload-1"
               data-lt-nodefault=
@@ -3164,49 +2940,6 @@ interface RTCPeerConnection : EventTarget  {
                     <code>undefined</code>.</p>
                   </li>
                 </ol>
-                <table class="parameters">
-                  <tbody>
-                    <tr>
-                      <th>Parameter</th>
-                      <th>Type</th>
-                      <th>Nullable</th>
-                      <th>Optional</th>
-                      <th>Description</th>
-                    </tr>
-                    <tr>
-                      <td class="prmName">description</td>
-                      <td class="prmType">
-                      <code>RTCSessionDescriptionInit</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                    <tr>
-                      <td class="prmName">successCallback</td>
-                      <td class="prmType"><code>VoidFunction</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                    <tr>
-                      <td class="prmName">failureCallback</td>
-                      <td class="prmType">
-                      <code>RTCPeerConnectionErrorCallback</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                  </tbody>
-                </table>
-                <div>
-                  <em>Return type:</em> <code>Promise&lt;void&gt;</code>
-                </div>
               </dd>
               <dt><dfn data-lt="createAnswer!overload-1" data-lt-nodefault=
               "true"><code>createAnswer</code></dfn></dt>
@@ -3249,40 +2982,6 @@ interface RTCPeerConnection : EventTarget  {
                     <code>undefined</code>.</p>
                   </li>
                 </ol>
-                <table class="parameters">
-                  <tbody>
-                    <tr>
-                      <th>Parameter</th>
-                      <th>Type</th>
-                      <th>Nullable</th>
-                      <th>Optional</th>
-                      <th>Description</th>
-                    </tr>
-                    <tr>
-                      <td class="prmName">successCallback</td>
-                      <td class="prmType">
-                      <code>RTCSessionDescriptionCallback</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                    <tr>
-                      <td class="prmName">failureCallback</td>
-                      <td class="prmType">
-                      <code>RTCPeerConnectionErrorCallback</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                  </tbody>
-                </table>
-                <div>
-                  <em>Return type:</em> <code>Promise&lt;void&gt;</code>
-                </div>
               </dd>
               <dt><dfn data-lt="setRemoteDescription!overload-1"
               data-lt-nodefault=
@@ -3325,49 +3024,6 @@ interface RTCPeerConnection : EventTarget  {
                     <code>undefined</code>.</p>
                   </li>
                 </ol>
-                <table class="parameters">
-                  <tbody>
-                    <tr>
-                      <th>Parameter</th>
-                      <th>Type</th>
-                      <th>Nullable</th>
-                      <th>Optional</th>
-                      <th>Description</th>
-                    </tr>
-                    <tr>
-                      <td class="prmName">description</td>
-                      <td class="prmType">
-                      <code>RTCSessionDescriptionInit</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                    <tr>
-                      <td class="prmName">successCallback</td>
-                      <td class="prmType"><code>VoidFunction</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                    <tr>
-                      <td class="prmName">failureCallback</td>
-                      <td class="prmType">
-                      <code>RTCPeerConnectionErrorCallback</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                  </tbody>
-                </table>
-                <div>
-                  <em>Return type:</em> <code>Promise&lt;void&gt;</code>
-                </div>
               </dd>
               <dt><code>addIceCandidate</code></dt>
               <dd>
@@ -3408,49 +3064,6 @@ interface RTCPeerConnection : EventTarget  {
                     <code>undefined</code>.</p>
                   </li>
                 </ol>
-                <table class="parameters">
-                  <tbody>
-                    <tr>
-                      <th>Parameter</th>
-                      <th>Type</th>
-                      <th>Nullable</th>
-                      <th>Optional</th>
-                      <th>Description</th>
-                    </tr>
-                    <tr>
-                      <td class="prmName">candidate</td>
-                      <td class="prmType"><code>(RTCIceCandidateInit or
-                      RTCIceCandidate)</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                    <tr>
-                      <td class="prmName">successCallback</td>
-                      <td class="prmType"><code>VoidFunction</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                    <tr>
-                      <td class="prmName">failureCallback</td>
-                      <td class="prmType">
-                      <code>RTCPeerConnectionErrorCallback</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                  </tbody>
-                </table>
-                <div>
-                  <em>Return type:</em> <code>Promise&lt;void&gt;</code>
-                </div>
               </dd>
             </dl>
             <h4>Callback Definitions</h4>
@@ -3654,27 +3267,6 @@ interface RTCSessionDescription {
                 initialize the new <code><a>RTCSessionDescription</a></code>
                 object. This constructor is deprecated; it exists for legacy
                 compatibility reasons only.
-                <table class="parameters">
-                  <tbody>
-                    <tr>
-                      <th>Parameter</th>
-                      <th>Type</th>
-                      <th>Nullable</th>
-                      <th>Optional</th>
-                      <th>Description</th>
-                    </tr>
-                    <tr>
-                      <td class="prmName">descriptionInitDict</td>
-                      <td class="prmType">
-                      <code>RTCSessionDescriptionInit</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                  </tbody>
-                </table>
               </dd>
             </dl>
           </section>
@@ -3982,26 +3574,6 @@ interface RTCIceCandidate {
                   but derivative attributes such as <a><code>foundation</code></a>,
                   <a><code>priority</code></a>, etc are set to <code>null</code>.</p>
                 </div>
-                <table class="parameters">
-                  <tbody>
-                    <tr>
-                      <th>Parameter</th>
-                      <th>Type</th>
-                      <th>Nullable</th>
-                      <th>Optional</th>
-                      <th>Description</th>
-                    </tr>
-                    <tr>
-                      <td class="prmName">candidateInitDict</td>
-                      <td class="prmType"><code>RTCIceCandidateInit</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptTrue"><span role="img" aria-label=
-                      "True">&#10004;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                  </tbody>
-                </table>
               </dd>
             </dl>
           </section>
@@ -4330,36 +3902,6 @@ interface RTCPeerConnectionIceEvent : Event {
             "RTCPeerConnectionIceEvent" class="constructors">
               <dt><code>RTCPeerConnectionIceEvent</code></dt>
               <dd>
-                <table class="parameters">
-                  <tbody>
-                    <tr>
-                      <th>Parameter</th>
-                      <th>Type</th>
-                      <th>Nullable</th>
-                      <th>Optional</th>
-                      <th>Description</th>
-                    </tr>
-                    <tr>
-                      <td class="prmName">type</td>
-                      <td class="prmType"><code>DOMString</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                    <tr>
-                      <td class="prmName">eventInitDict</td>
-                      <td class="prmType">
-                      <code>RTCPeerConnectionIceEventInit</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptTrue"><span role="img" aria-label=
-                      "True">&#10004;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                  </tbody>
-                </table>
               </dd>
             </dl>
           </section>
@@ -4439,37 +3981,6 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             "RTCPeerConnectionIceErrorEvent" class="constructors">
               <dt><code>RTCPeerConnectionIceErrorEvent</code></dt>
               <dd>
-                readonly attribute DOMString hostCandidate
-                <table class="parameters">
-                  <tbody>
-                    <tr>
-                      <th>Parameter</th>
-                      <th>Type</th>
-                      <th>Nullable</th>
-                      <th>Optional</th>
-                      <th>Description</th>
-                    </tr>
-                    <tr>
-                      <td class="prmName">type</td>
-                      <td class="prmType"><code>DOMString</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                    <tr>
-                      <td class="prmName">eventInitDict</td>
-                      <td class="prmType">
-                      <code>RTCPeerConnectionIceErrorEventInit</code></td>
-                      <td class="prmNullFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmOptFalse"><span role="img" aria-label=
-                      "False">&#10008;</span></td>
-                      <td class="prmDesc"></td>
-                    </tr>
-                  </tbody>
-                </table>
               </dd>
             </dl>
           </section>
@@ -4707,30 +4218,6 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               }</code>.</p>
               <p class="note">It is expected that a <a>user agent</a> will have
               a small or even fixed set of values that it will accept.</p>
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>Parameter</th>
-                    <th>Type</th>
-                    <th>Nullable</th>
-                    <th>Optional</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">keygenAlgorithm</td>
-                    <td class="prmType"><code>AlgorithmIdentifier</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
-              <div>
-                <em>Return type:</em>
-                <code>Promise&lt;RTCCertificate&gt;</code>
-              </div>
             </dd>
           </dl>
         </section>
@@ -4812,12 +4299,6 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <p>Returns the list of certificate fingerprints, one of which is
                 computed with the digest algorithm used in the certificate
                 signature.</p>
-                <div>
-                  <em>No parameters.</em>
-                </div>
-                <div>
-                  <em>Return type:</em> <code>sequence&lt;RTCDtlsFingerprint&gt;</code>
-                </div>
               </dd>
             </dl>
           </section>
@@ -4988,12 +4469,6 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 to be stable between calls.</li>
                 <li>Return <var>senders</var>.</li>
               </ol>
-              <div>
-                <em>No parameters.</em>
-              </div>
-              <div>
-                <em>Return type:</em> <code>sequence&lt;RTCRtpSender&gt;</code>
-              </div>
             </dd>
             <dt><code>getReceivers</code></dt>
             <dd>
@@ -5026,13 +4501,6 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 have to be stable between calls.</li>
                 <li>Return <var>receivers</var>.</li>
               </ol>
-              <div>
-                <em>No parameters.</em>
-              </div>
-              <div>
-                <em>Return type:</em>
-                <code>sequence&lt;RTCRtpReceiver&gt;</code>
-              </div>
             </dd>
             <dt><code>getTransceivers</code></dt>
             <dd>
@@ -5058,13 +4526,6 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 </li>
                 <li>Return <var>transceivers</var>.</li>
               </ol>
-              <div>
-                <em>No parameters.</em>
-              </div>
-              <div>
-                <em>Return type:</em>
-                <code>sequence&lt;RTCRtpTransceiver&gt;</code>
-              </div>
             </dd>
             <dt><code>addTrack</code></dt>
             <dd>
@@ -5214,38 +4675,6 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   <p>Return <var>sender</var>.</p>
                 </li>
               </ol>
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>Parameter</th>
-                    <th>Type</th>
-                    <th>Nullable</th>
-                    <th>Optional</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">track</td>
-                    <td class="prmType"><code>MediaStreamTrack</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                  <tr>
-                    <td class="prmName">streams</td>
-                    <td class="prmType"><code>MediaStream</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
-              <div>
-                <em>Return type:</em> <code>RTCRtpSender</code>
-              </div>
             </dd>
             <dt><code>removeTrack</code></dt>
             <dd>
@@ -5322,29 +4751,6 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   negotiation-needed flag</a> for <var>connection</var>.</p>
                 </li>
               </ol>
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>Parameter</th>
-                    <th>Type</th>
-                    <th>Nullable</th>
-                    <th>Optional</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">sender</td>
-                    <td class="prmType"><code>RTCRtpSender</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
-              <div>
-                <em>Return type:</em> <code>void</code>
-              </div>
             </dd>
             <dt><dfn><code>addTransceiver</code></dfn></dt>
             <dd>
@@ -5467,39 +4873,6 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   <p>Return <var>transceiver</var>.</p>
                 </li>
               </ol>
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>Parameter</th>
-                    <th>Type</th>
-                    <th>Nullable</th>
-                    <th>Optional</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">trackOrKind</td>
-                    <td class="prmType"><code>(MediaStreamTrack or
-                    DOMString)</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                  <tr>
-                    <td class="prmName">init</td>
-                    <td class="prmType"><code>RTCRtpTransceiverInit</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptTrue"><span role="img" aria-label=
-                    "True">&#10004;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
-              <div>
-                <em>Return type:</em> <code>RTCRtpTransceiver</code>
-              </div>
             </dd>
           </dl>
         </section>
@@ -5826,29 +5199,6 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               increases the fingerprinting surface of the application. In
               privacy-sensitive contexts, browsers can consider mitigations
               such as reporting only a common subset of the capabilities.</p>
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>Parameter</th>
-                    <th>Type</th>
-                    <th>Nullable</th>
-                    <th>Optional</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">kind</td>
-                    <td class="prmType"><code>DOMString</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
-              <div>
-                <em>Return type:</em> <code>RTCRtpCapabilities</code>
-              </div>
             </dd>
             <dt><dfn><code>setParameters</code></dfn></dt>
             <dd>
@@ -5920,29 +5270,6 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <code>maxBitrate</code>, while at the same time making sure it
               satisfies constraints on bitrate specified in other places such
               as the SDP.</p>
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>Parameter</th>
-                    <th>Type</th>
-                    <th>Nullable</th>
-                    <th>Optional</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">parameters</td>
-                    <td class="prmType"><code>RTCRtpParameters</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptTrue"><span role="img" aria-label=
-                    "True">&#10004;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
-              <div>
-                <em>Return type:</em> <code>Promise&lt;void&gt;</code>
-              </div>
             </dd>
             <dt><code>getParameters</code></dt>
             <dd>
@@ -6016,12 +5343,6 @@ sender.setParameters(params)
               <p>After a completed call to <code>setParameters</code>,
               subsequent calls to <code>getParameters</code> will return the
               modified set of parameters.</p>
-              <div>
-                <em>No parameters.</em>
-              </div>
-              <div>
-                <em>Return type:</em> <code>RTCRtpParameters</code>
-              </div>
             </dd>
             <dt><code>replaceTrack</code></dt>
             <dd>
@@ -6149,29 +5470,6 @@ sender.setParameters(params)
                   negotiated for an encoding source.</li>
                 </ol>
               </div>
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>Parameter</th>
-                    <th>Type</th>
-                    <th>Nullable</th>
-                    <th>Optional</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">withTrack</td>
-                    <td class="prmType"><code>MediaStreamTrack</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "True">&#10004;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
-              <div>
-                <em>Return type:</em> <code>Promise&lt;void&gt;</code>
-              </div>
             </dd>
             <dt><code>getStats</code></dt>
             <dd>
@@ -6206,13 +5504,6 @@ sender.setParameters(params)
                   <p>Return <var>p</var>.</p>
                 </li>
               </ol>
-              <div>
-                <em>No parameters.</em>
-              </div>
-              <div>
-                <em>Return type:</em>
-                <code>Promise&lt;RTCStatsReport&gt;</code>
-              </div>
             </dd>
           </dl>
         </section>
@@ -6842,29 +6133,6 @@ sender.setParameters(params)
               increases the fingerprinting surface of the application. In
               privacy-sensitive contexts, browsers can consider mitigations
               such as reporting only a common subset of the capabilities.</p>
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>Parameter</th>
-                    <th>Type</th>
-                    <th>Nullable</th>
-                    <th>Optional</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">kind</td>
-                    <td class="prmType"><code>DOMString</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
-              <div>
-                <em>Return type:</em> <code>RTCRtpCapabilities</code>
-              </div>
             </dd>
             <dt><code>getParameters</code></dt>
             <dd>
@@ -6915,38 +6183,18 @@ sender.setParameters(params)
                   are left <code>undefined</code>.
                 </li>
               </ul>
-              <div>
-                <em>No parameters.</em>
-              </div>
-              <div>
-                <em>Return type:</em> <code><a>RTCRtpParameters</a></code>
-              </div>
             </dd>
             <dt><dfn><code>getContributingSources</code></dfn></dt>
             <dd>
               <p>Returns an <code><a>RTCRtpContributingSource</a></code> for
               each unique CSRC identifier received by this RTCRtpReceiver in
               the last 10 seconds.</p>
-              <div>
-                <em>No parameters.</em>
-              </div>
-              <div>
-                <em>Return type:</em>
-                <code>sequence&lt;RTCRtpContributingSource&gt;</code>
-              </div>
             </dd>
             <dt><dfn><code>getSynchronizationSources</code></dfn></dt>
             <dd>
               <p>Returns an <code><a>RTCRtpSynchronizationSource</a></code> for
               each unique SSRC identifier received by this RTCRtpReceiver in
               the last 10 seconds.</p>
-              <div>
-                <em>No parameters.</em>
-              </div>
-              <div>
-                <em>Return type:</em>
-                <code>sequence&lt;RTCRtpSynchronizationSource&gt;</code>
-              </div>
             </dd>
             <dt><code>getStats</code></dt>
             <dd>
@@ -6981,13 +6229,6 @@ sender.setParameters(params)
                   <p>Return <var>p</var>.</p>
                 </li>
               </ol>
-              <div>
-                <em>No parameters.</em>
-              </div>
-              <div>
-                <em>Return type:</em>
-                <code>Promise&lt;RTCStatsReport&gt;</code>
-              </div>
             </dd>
           </dl>
         </section>
@@ -7294,30 +6535,6 @@ sender.setParameters(params)
                     <var>connection</var>.</p>
                 </li>
               </ol>
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>Parameter</th>
-                    <th>Type</th>
-                    <th>Nullable</th>
-                    <th>Optional</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">direction</td>
-                    <td class="prmType">
-                    <code>RTCRtpTransceiverDirection</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
-              <div>
-                <em>Return type:</em> <code>void</code>
-              </div>
             </dd>
             <dt><code>stop</code></dt>
             <dd>
@@ -7396,12 +6613,6 @@ sender.setParameters(params)
               has ended, the steps described in <code><a href=
               "https://www.w3.org/TR/mediacapture-streams/#track-ended">track ended</a></code>
               MUST be followed.</p>
-              <div>
-                <em>No parameters.</em>
-              </div>
-              <div>
-                <em>Return type:</em> <code>void</code>
-              </div>
             </dd>
             <dt><dfn><code>setCodecPreferences</code></dfn></dt>
             <dd>
@@ -7435,30 +6646,6 @@ sender.setParameters(params)
               fulfill these requirements, the user agent MUST <a>throw</a> an
               InvalidAccessError.</p>
 
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>Parameter</th>
-                    <th>Type</th>
-                    <th>Nullable</th>
-                    <th>Optional</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">codecs</td>
-                    <td class="prmType">
-                    <code>sequence&lt;RTCRtpCodecCapability&gt;</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
-              <div>
-                <em>Return type:</em> <code>void</code>
-              </div>
             </dd>
           </dl>
         </section>
@@ -7576,12 +6763,6 @@ sender.setParameters(params)
               will be completed by the time
               <code><a>RTCDtlsTransportState</a></code> transitions to
               "connected".</p>
-              <div>
-                <em>No parameters.</em>
-              </div>
-              <div>
-                <em>Return type:</em> <code>sequence&lt;ArrayBuffer&gt;</code>
-              </div>
             </dd>
           </dl>
         </section>
@@ -7950,13 +7131,6 @@ sender.setParameters(params)
               gathered for this <code><a>RTCIceTransport</a></code> and sent in
               <code><a data-for=
               "RTCPeerConnection">onicecandidate</a></code></p>
-              <div>
-                <em>No parameters.</em>
-              </div>
-              <div>
-                <em>Return type:</em>
-                <code>sequence&lt;RTCIceCandidate&gt;</code>
-              </div>
             </dd>
             <dt><dfn><code>getRemoteCandidates</code></dfn></dt>
             <dd>
@@ -7964,25 +7138,11 @@ sender.setParameters(params)
               received by this <code><a>RTCIceTransport</a></code> via
               <code><a data-for=
               "RTCPeerConnection">addIceCandidate()</a></code></p>
-              <div>
-                <em>No parameters.</em>
-              </div>
-              <div>
-                <em>Return type:</em>
-                <code>sequence&lt;RTCIceCandidate&gt;</code>
-              </div>
             </dd>
             <dt><dfn><code>getSelectedCandidatePair</code></dfn></dt>
             <dd>
               <p>Returns the selected candidate pair on which packets are sent,
               or <code>null</code> if there is no such pair.</p>
-              <div>
-                <em>No parameters.</em>
-              </div>
-              <div>
-                <em>Return type:</em> <code>RTCIceCandidatePair</code>,
-                nullable
-              </div>
             </dd>
             <dt><dfn><code>getLocalParameters</code></dfn></dt>
             <dd>
@@ -7991,12 +7151,6 @@ sender.setParameters(params)
               "RTCPeerConnection">setLocalDescription</a></code>, or
               <code>null</code> if the parameters have not yet been
               received.</p>
-              <div>
-                <em>No parameters.</em>
-              </div>
-              <div>
-                <em>Return type:</em> <code>RTCIceParameters</code>, nullable
-              </div>
             </dd>
             <dt><dfn><code>getRemoteParameters</code></dfn></dt>
             <dd>
@@ -8005,12 +7159,6 @@ sender.setParameters(params)
               "RTCPeerConnection">setRemoteDescription</a></code> or
               <code>null</code> if the parameters have not yet been
               received.</p>
-              <div>
-                <em>No parameters.</em>
-              </div>
-              <div>
-                <em>Return type:</em> <code>RTCIceParameters</code>, nullable
-              </div>
             </dd>
           </dl>
         </section>
@@ -8306,36 +7454,6 @@ interface RTCTrackEvent : Event {
           "constructors">
             <dt><code>RTCTrackEvent</code></dt>
             <dd>
-              readonly attribute RTCRtpReceiver receiver
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>Parameter</th>
-                    <th>Type</th>
-                    <th>Nullable</th>
-                    <th>Optional</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">type</td>
-                    <td class="prmType"><code>DOMString</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                  <tr>
-                    <td class="prmName">eventInitDict</td>
-                    <td class="prmType"><code>RTCTrackEventInit</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
             </dd>
           </dl>
         </section>
@@ -8602,38 +7720,6 @@ interface RTCTrackEvent : Event {
                   flag</a> for <var>connection</var>.</p>
                 </li>
               </ol>
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>Parameter</th>
-                    <th>Type</th>
-                    <th>Nullable</th>
-                    <th>Optional</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">label</td>
-                    <td class="prmType"><code>USVString</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                  <tr>
-                    <td class="prmName">dataChannelDict</td>
-                    <td class="prmType"><code>RTCDataChannelInit</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptTrue"><span role="img" aria-label=
-                    "True">&#10004;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
-              <div>
-                <em>Return type:</em> <code>RTCDataChannel</code>
-              </div>
             </dd>
           </dl>
         </section>
@@ -9115,41 +8201,12 @@ interface RTCTrackEvent : Event {
                   started yet, start it.</p>
                 </li>
               </ol>
-              <div>
-                <em>No parameters.</em>
-              </div>
-              <div>
-                <em>Return type:</em> <code>void</code>
-              </div>
             </dd>
             <dt><dfn><code>send</code></dfn></dt>
             <dd>
               <p>Run the steps described by the <code><a data-for=
               "RTCDataChannel">send()</a></code> algorithm with argument type
               <code>string</code> object.</p>
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>Parameter</th>
-                    <th>Type</th>
-                    <th>Nullable</th>
-                    <th>Optional</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">data</td>
-                    <td class="prmType"><code>USVString</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
-              <div>
-                <em>Return type:</em> <code>void</code>
-              </div>
             </dd>
             <dt><dfn data-lt="send!overload-1" data-lt-nodefault=
             "true"><code>send</code></dfn></dt>
@@ -9157,29 +8214,6 @@ interface RTCTrackEvent : Event {
               <p>Run the steps described by the <code><a data-for=
               "RTCDataChannel">send()</a></code> algorithm with argument type
               <code>Blob</code> object.</p>
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>Parameter</th>
-                    <th>Type</th>
-                    <th>Nullable</th>
-                    <th>Optional</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">data</td>
-                    <td class="prmType"><code>Blob</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
-              <div>
-                <em>Return type:</em> <code>void</code>
-              </div>
             </dd>
             <dt><dfn data-lt="send!overload-2" data-lt-nodefault=
             "true"><code>send</code></dfn></dt>
@@ -9187,29 +8221,6 @@ interface RTCTrackEvent : Event {
               <p>Run the steps described by the <code><a data-for=
               "RTCDataChannel">send()</a></code> algorithm with argument type
               <code>ArrayBuffer</code> object.</p>
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>Parameter</th>
-                    <th>Type</th>
-                    <th>Nullable</th>
-                    <th>Optional</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">data</td>
-                    <td class="prmType"><code>ArrayBuffer</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
-              <div>
-                <em>Return type:</em> <code>void</code>
-              </div>
             </dd>
             <dt><dfn data-lt="send!overload-3" data-lt-nodefault=
             "true"><code>send</code></dfn></dt>
@@ -9217,29 +8228,6 @@ interface RTCTrackEvent : Event {
               <p>Run the steps described by the <code><a data-for=
               "RTCDataChannel">send()</a></code> algorithm with argument type
               <code>ArrayBufferView</code> object.</p>
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>Parameter</th>
-                    <th>Type</th>
-                    <th>Nullable</th>
-                    <th>Optional</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">data</td>
-                    <td class="prmType"><code>ArrayBufferView</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
-              <div>
-                <em>Return type:</em> <code>void</code>
-              </div>
             </dd>
           </dl>
         </section>
@@ -9458,37 +8446,6 @@ interface RTCDataChannelEvent : Event {
           "RTCDataChannelEvent" class="constructors">
             <dt><code>RTCDataChannelEvent</code></dt>
             <dd>
-              readonly attribute RTCDataChannel channel
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>Parameter</th>
-                    <th>Type</th>
-                    <th>Nullable</th>
-                    <th>Optional</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">type</td>
-                    <td class="prmType"><code>DOMString</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                  <tr>
-                    <td class="prmName">eventInitDict</td>
-                    <td class="prmType">
-                    <code>RTCDataChannelEventInit</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
             </dd>
           </dl>
         </section>
@@ -9723,47 +8680,6 @@ interface RTCDTMFSender : EventTarget {
               "RTCDTMFSender">insertDTMF</a></code> with an empty tones
               parameter can be used to cancel all tones queued to play after
               the currently playing tone.</p>
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>Parameter</th>
-                    <th>Type</th>
-                    <th>Nullable</th>
-                    <th>Optional</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">tones</td>
-                    <td class="prmType"><code>DOMString</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                  <tr>
-                    <td class="prmName">duration</td>
-                    <td class="prmType"><code>unsigned long = 100</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptTrue"><span role="img" aria-label=
-                    "True">&#10004;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                  <tr>
-                    <td class="prmName">interToneGap</td>
-                    <td class="prmType"><code>unsigned long = 70</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptTrue"><span role="img" aria-label=
-                    "True">&#10004;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
-              <div>
-                <em>Return type:</em> <code>void</code>
-              </div>
             </dd>
           </dl>
         </section>
@@ -9794,37 +8710,6 @@ interface RTCDTMFToneChangeEvent : Event {
           "RTCDTMFToneChangeEvent" class="constructors">
             <dt><code>RTCDTMFToneChangeEvent</code></dt>
             <dd>
-              readonly attribute DOMString tone
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>Parameter</th>
-                    <th>Type</th>
-                    <th>Nullable</th>
-                    <th>Optional</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">type</td>
-                    <td class="prmType"><code>DOMString</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                  <tr>
-                    <td class="prmName">eventInitDict</td>
-                    <td class="prmType">
-                    <code>RTCDTMFToneChangeEventInit</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
             </dd>
           </dl>
         </section>
@@ -9963,31 +8848,6 @@ interface RTCDTMFToneChangeEvent : Event {
                   <p>Return <var>p</var>.</p>
                 </li>
               </ol>
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>Parameter</th>
-                    <th>Type</th>
-                    <th>Nullable</th>
-                    <th>Optional</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">selector</td>
-                    <td class="prmType"><code>MediaStreamTrack =
-                    null</code></td>
-                    <td class="prmNullTrue"><span role="img" aria-label=
-                    "True">&#10004;</span></td>
-                    <td class="prmOptTrue"><span role="img" aria-label=
-                    "True">&#10004;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
-              <div>
-                <em>Return type:</em>
-                <code>Promise&lt;RTCStatsReport&gt;</code>
-              </div>
             </dd>
           </dl>
         </section>
@@ -10365,29 +9225,6 @@ interface RTCIdentityProviderRegistrar {
               <p>This method is invoked by the IdP when its script is first
               executed. This registers <code><a>RTCIdentityProvider</a></code>
               methods with the user agent.</p>
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>Parameter</th>
-                    <th>Type</th>
-                    <th>Nullable</th>
-                    <th>Optional</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">idp</td>
-                    <td class="prmType"><code>RTCIdentityProvider</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
-              <div>
-                <em>Return type:</em> <code>void</code>
-              </div>
             </dd>
           </dl>
         </section>
@@ -10944,39 +9781,6 @@ interface RTCIdentityProviderRegistrar {
               <code>getIdentityAssertion</code>, or a session description is
               requested with a call to either <code>createOffer</code> or
               <code>createAnswer</code>.</p>
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>Parameter</th>
-                    <th>Type</th>
-                    <th>Nullable</th>
-                    <th>Optional</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">provider</td>
-                    <td class="prmType"><code>DOMString</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                  <tr>
-                    <td class="prmName">options</td>
-                    <td class="prmType">
-                    <code>RTCIdentityProviderOptions</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptTrue"><span role="img" aria-label=
-                    "True">&#10004;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
-              <div>
-                <em>Return type:</em> <code>void</code>
-              </div>
             </dd>
             <dt><dfn><code>getIdentityAssertion</code></dfn></dt>
             <dd>
@@ -11005,12 +9809,6 @@ interface RTCIdentityProviderRegistrar {
                   assertion.</p>
                 </li>
               </ol>
-              <div>
-                <em>No parameters.</em>
-              </div>
-              <div>
-                <em>Return type:</em> <code>Promise&lt;DOMString&gt;</code>
-              </div>
             </dd>
           </dl>
         </section>
@@ -12416,36 +11214,6 @@ interface RTCErrorEvent : Event {
             <dd>
               <p>Constructs a new
               <code><a>RTCErrorEvent</a></code>.</p>
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>Parameter</th>
-                    <th>Type</th>
-                    <th>Nullable</th>
-                    <th>Optional</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">type</td>
-                    <td class="prmType"><code>DOMString</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">✘</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">✘</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                  <tr>
-                    <td class="prmName">eventInitDict</td>
-                    <td class="prmType">
-                    <code>RTCErrorEventInit</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">✘</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">✘</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
These were inherited from the previous respec WebIDL format, but they now represent a maintenance footgun


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/noparamtables.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/cdf9e75...b0ac6f1.html)