### PR TITLE
Removing text talking about key shortening that was incorrect.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -278,21 +278,10 @@
                 <p>However, this specification uses a simplified <a>alg</a>
                 approach. The length of the HMAC key
                 (<code>RTCOAuthCredential.macKey</code>) MAY be any multiple of
-                bytes greater than 20 (160 bits). When the <a>ICE Agent</a>
-                computes the message integrity attributes it supports, it will
-                shorten the key to the length required by each algorithm,
-                according to [[!RFC7635]]. For example, a 256-bit key can be
-                used to compute both the HMAC-SHA-1 and HMAC-SHA-256 message
-                integrity attributes, shortening the key to 160 bits in the
-                case of HMAC-SHA-1. This negates the need to query the HMAC
+                bytes greater than 20 (160 bits). This negates the need to query the HMAC
                 Algorithm capabilities of the <a>ICE Agent</a>, and still
                 allows for hash agility as described by [[STUN-BIS]], Section
                 15.3.</p>
-                <div class="note">[[!RFC7635]] doesn't explicitly define
-                how keys are shortened; there is only a brief reference to this
-                in Appendix B. This needs to be adressed in the IETF TRAM
-                working group.
-                </div>
                 <div class="note">According to [[!RFC7635]] Section 4.1, the
                 HMAC key MUST be a symmetric key.
                 </div>

--- a/webrtc.html
+++ b/webrtc.html
@@ -277,7 +277,7 @@
                 </p>
                 <p>However, this specification uses a simplified <a>alg</a>
                 approach. The length of the HMAC key
-                (<code>RTCOAuthCredential.macKey</code>) MAY be any multiple of
+                (<code>RTCOAuthCredential.macKey</code>) MAY be any integer number of
                 bytes greater than 20 (160 bits). This negates the need to query the HMAC
                 Algorithm capabilities of the <a>ICE Agent</a>, and still
                 allows for hash agility as described by [[STUN-BIS]], Section


### PR DESCRIPTION
Fixes #1156.

The HMAC algorithm itself accepts *any* key size. So all we have to say
here is that WebRTC allows any key size 20 bytes or greater (even if the
implementation has transitioned to HMAC-SHA-256, and would prefer a
32-byte key for the added security).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/taylor-b/webrtc-pc/issue_1156_key_shortening.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/3345dad...taylor-b:52ca510.html)