### PR TITLE
label/protocol length restriction

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8428,6 +8428,10 @@ interface RTCTrackEvent : Event {
                   <p>Let <var>channel</var> have a <dfn>[[\DataChannelLabel]]</dfn> internal slot initialized to the
                   value of the first argument.</p>
                 </li>
+                <li>If <a>[[\DataChannelLabel]]</a>
+                is longer than 65535 bytes, <a>throw</a> a
+                <code>TypeError</code>.
+                </li>
                 <li>
                   <p>Let <var>options</var> be the second argument.</p>
                 </li>
@@ -8456,6 +8460,9 @@ interface RTCTrackEvent : Event {
                   <p>Let <var>channel</var> have a <dfn>[[\DataChannelProtocol]]</dfn> internal slot initialized to
                   <var>option</var>'s <code>protocol</code> member.</p>
                 </li>
+                <li>If <a>[[\DataChannelProtocol]]</a> is longer than
+                65535 bytes long, <a>throw</a> a <code>TypeError</code>.
+                </li>
                 <li>
                   <p>Let <var>channel</var> have a <dfn>[[\Negotiated]]</dfn> internal slot initialized
                   to <var>option</var>'s <code>negotiated</code> member.</p>
@@ -8464,16 +8471,6 @@ interface RTCTrackEvent : Event {
                   <p>Let <var>channel</var> have an
                   <dfn>[[\DataChannelPriority]]</dfn> internal slot initialized
                   to <var>option</var>'s <code>priority</code> member.</p>
-                </li>
-                <li>
-                If <a>[[\Negotiated]]</a> is false and
-                <a>[[\DataChannelLabel]]</a>
-                is longer than 65535 bytes, <a>throw</a> a
-                <code>TypeError</code>.
-                </li>
-                <li>If <a>[[\Negotiated]]</a> is false
-                and <a>[[\DataChannelProtocol]]</a> is longer than
-                65535 bytes long, <a>throw</a> a <code>TypeError</code>.
                 </li>
                 <li>
                   <p>If both <a>[[\MaxPacketLifeTime]]</a> and


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/1286


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/issue-1286-patchv2.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/3345dad...e1c26cb.html)