### PR TITLE
Remove "is set" text

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1683,18 +1683,18 @@
             set and the set of certificates differs from the ones used
             when <var>connection</var> was constructed, <a>throw</a> an
             <code>InvalidModificationError</code>.</li>
-            <li>If <code><var>configuration</var>.<a data-for=
-            "RTCConfiguration">bundlePolicy</a></code> is set and its
-            value differs from the <var>connection</var>'s bundle policy,
-            <a>throw</a> an <code>InvalidModificationError</code>.</li>
-            <li>If <code><var>configuration</var>.<a data-for=
-            "RTCConfiguration">rtcpMuxPolicy</a></code> is set and its
-            value differs from the <var>connection</var>'s rtcpMux
-            policy, <a>throw</a> an <code>InvalidModificationError</code>.</li>
-            <li>If <code><var>configuration</var>.<a data-for=
-            "RTCConfiguration">iceCandidatePoolSize</a></code> is set and
-            its value differs from the <var>connection</var>'s previously
-            set <code>iceCandidatePoolSize</code>, and <code><a data-for=
+            <li>If the value of <code><var>configuration</var>.<a data-for=
+            "RTCConfiguration">bundlePolicy</a></code> differs from the
+            <var>connection</var>'s bundle policy, <a>throw</a>
+            an <code>InvalidModificationError</code>.</li>
+            <li>If the value of <code><var>configuration</var>.<a data-for=
+            "RTCConfiguration">rtcpMuxPolicy</a></code> differs from the
+            <var>connection</var>'s rtcpMux policy, <a>throw</a> an
+            <code>InvalidModificationError</code>.</li>
+            <li>If the value of <code><var>configuration</var>.<a data-for=
+            "RTCConfiguration">iceCandidatePoolSize</a></code> differs from
+            the <var>connection</var>'s previously set
+            <code>iceCandidatePoolSize</code>, and <code><a data-for=
             "RTCPeerConnection">setLocalDescription</a></code> has
             already been called, <a>throw</a> an
             <code>InvalidModificationError</code>.</li>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/1447


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/issue-1447-patchv3.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/7ba8467...bd2797a.html)