### PR TITLE
Examples with dictionaries shouldn't use quotes around member names

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -468,7 +468,7 @@
                        macKey: "WmtzanB3ZW9peFhtdm42NzUzNG0=",
                        accessToken: "AAwg3kPHWPfvk9bDFL936wYvkoctMADzQ5VhNDgeMR3+ZlZ35byg972fW8QjpEl7bx91YLBPFsIhsxloWcXPhA=="
                      },
-       credentialType: "oauth" },
+       credentialType: "oauth" }
      }
 ]</code></pre>
       </section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -380,8 +380,8 @@
         </div>
         <p>An example of an RTCOAuthCredential dictionary is:</p>
         <pre class="example highlight"><code>{
-    "macKey": "WmtzanB3ZW9peFhtdm42NzUzNG0=",
-    "accessToken": "AAwg3kPHWPfvk9bDFL936wYvkoctMADzQ5VhNDgeMR3+ZlZ35byg972fW8QjpEl7bx91YLBPFsIhsxloWcXPhA=="
+    macKey: "WmtzanB3ZW9peFhtdm42NzUzNG0=",
+    accessToken: "AAwg3kPHWPfvk9bDFL936wYvkoctMADzQ5VhNDgeMR3+ZlZ35byg972fW8QjpEl7bx91YLBPFsIhsxloWcXPhA=="
 }</code></pre>
       </section>
       <section>
@@ -457,18 +457,18 @@
         </div>
         <p>An example array of RTCIceServer objects is:</p>
         <pre class="example highlight"><code>[
-     { "urls": "stun:stun1.example.net" },
-     { "urls": ["turns:turn.example.org", "turn:turn.example.net"],
-       "username": "user",
-       "credential": "myPassword",
-       "credentialType": "password" },
-     { "urls": "turns:turn2.example.net",
-       "username": "22BIjxU93h/IgwEb",
-       "credential": {
-                       "macKey": "WmtzanB3ZW9peFhtdm42NzUzNG0=",
-                       "accessToken": "AAwg3kPHWPfvk9bDFL936wYvkoctMADzQ5VhNDgeMR3+ZlZ35byg972fW8QjpEl7bx91YLBPFsIhsxloWcXPhA=="
+     { urls: "stun:stun1.example.net" },
+     { urls: ["turns:turn.example.org", "turn:turn.example.net"],
+       username: "user",
+       credential: "myPassword",
+       credentialType: "password" },
+     { urls: "turns:turn2.example.net",
+       username: "22BIjxU93h/IgwEb",
+       credential: {
+                       macKey: "WmtzanB3ZW9peFhtdm42NzUzNG0=",
+                       accessToken: "AAwg3kPHWPfvk9bDFL936wYvkoctMADzQ5VhNDgeMR3+ZlZ35byg972fW8QjpEl7bx91YLBPFsIhsxloWcXPhA=="
                      },
-       "credentialType": "oauth" },
+       credentialType: "oauth" },
      }
 ]</code></pre>
       </section>
@@ -11365,7 +11365,7 @@ interface RTCIdentityAssertion {
         the first place.</p>
         <pre class="example highlight">
 var signalingChannel = new SignalingChannel();
-var configuration = { "iceServers": [{ "urls": "stuns:stun.example.org" }] };
+var configuration = { iceServers: [{ urls: "stuns:stun.example.org" }] };
 var pc;
 
 // call start() to initiate
@@ -11374,7 +11374,7 @@ function start() {
 
     // send any ice candidates to the other peer
     pc.onicecandidate = function (evt) {
-        signalingChannel.send(JSON.stringify({ "candidate": evt.candidate }));
+        signalingChannel.send(JSON.stringify({ candidate: evt.candidate }));
     };
 
     // let the "negotiationneeded" event trigger offer generation
@@ -11384,7 +11384,7 @@ function start() {
         })
         .then(function () {
             // send the offer to the other peer
-            signalingChannel.send(JSON.stringify({ "desc": pc.localDescription }));
+            signalingChannel.send(JSON.stringify({ desc: pc.localDescription }));
         })
         .catch(logError);
     };
@@ -11397,7 +11397,7 @@ function start() {
     };
 
     // get a local stream, show it in a self-view and add it to be sent
-    navigator.mediaDevices.getUserMedia({ "audio": true, "video": true })
+    navigator.mediaDevices.getUserMedia({ audio: true, video: true })
         .then(function (stream) {
             selfView.srcObject = stream;
             pc.addTrack(stream.getAudioTracks()[0], stream);
@@ -11423,7 +11423,7 @@ signalingChannel.onmessage = function (evt) {
                 return pc.setLocalDescription(answer);
             })
             .then(function () {
-                var str = JSON.stringify({ "desc": pc.localDescription });
+                var str = JSON.stringify({ desc: pc.localDescription });
                 signalingChannel.send(str);
             })
             .catch(logError);
@@ -11452,7 +11452,7 @@ function logError(error) {
         both go through these steps.</p>
         <pre class="example highlight">
 var signalingChannel = new SignalingChannel();
-var configuration = { "iceServers": [{ "urls": "stuns:stun.example.org" }] };
+var configuration = { iceServers: [{ urls: "stuns:stun.example.org" }] };
 var pc;
 var audio = null;
 var audioSendTrack = null;
@@ -11470,7 +11470,7 @@ function warmup(answerer) {
 
     // send any ice candidates to the other peer
     pc.onicecandidate = function (evt) {
-        signalingChannel.send(JSON.stringify({ "candidate": evt.candidate }));
+        signalingChannel.send(JSON.stringify({ candidate: evt.candidate }));
     };
 
     // let the "negotiationneeded" event trigger offer generation
@@ -11480,7 +11480,7 @@ function warmup(answerer) {
         })
         .then(function () {
             // send the offer to the other peer
-            signalingChannel.send(JSON.stringify({ "desc": pc.localDescription }));
+            signalingChannel.send(JSON.stringify({ desc: pc.localDescription }));
         })
         .catch(logError);
     };
@@ -11510,7 +11510,7 @@ function warmup(answerer) {
     };
 
     // get a local stream, show it in a self-view and add it to be sent
-    navigator.mediaDevices.getUserMedia({ "audio": true, "video": true })
+    navigator.mediaDevices.getUserMedia({ audio: true, video: true })
       .then(function (stream) {
         selfView.srcObject = stream;
         audioSendTrack = stream.getAudioTracks()[0];
@@ -11528,7 +11528,7 @@ function warmup(answerer) {
 // Call start() to start sending media.
 function start() {
   started = true;
-  signalingChannel.send(JSON.stringify({ "start": true }));
+  signalingChannel.send(JSON.stringify({ start: true }));
 }
 
 signalingChannel.onmessage = function (evt) {
@@ -11548,7 +11548,7 @@ signalingChannel.onmessage = function (evt) {
                 return pc.setLocalDescription(answer);
             })
             .then(function () {
-                var str = JSON.stringify({ "desc": pc.localDescription });
+                var str = JSON.stringify({ desc: pc.localDescription });
                 signalingChannel.send(str);
             })
             .catch(logError);
@@ -11581,7 +11581,7 @@ function logError(error) {
         arrives.</p>
         <pre class="example highlight">
 var signalingChannel = new SignalingChannel();
-var configuration = { "iceServers": [{ "urls": "stuns:stun.example.org" }] };
+var configuration = { iceServers: [{ urls: "stuns:stun.example.org" }] };
 var pc;
 
 // call start() to initiate
@@ -11590,7 +11590,7 @@ function start() {
 
     // send any ice candidates to the other peer
     pc.onicecandidate = function (evt) {
-        signalingChannel.send(JSON.stringify({ "candidate": evt.candidate }));
+        signalingChannel.send(JSON.stringify({ candidate: evt.candidate }));
     };
 
     // let the "negotiationneeded" event trigger offer generation
@@ -11600,13 +11600,13 @@ function start() {
         })
         .then(function () {
             // send the offer to the other peer
-            signalingChannel.send(JSON.stringify({ "desc": pc.localDescription }));
+            signalingChannel.send(JSON.stringify({ desc: pc.localDescription }));
         })
         .catch(logError);
     };
 
     // get a local stream, show it in a self-view and add it to be sent
-    navigator.mediaDevices.getUserMedia({ "audio": true, "video": true })
+    navigator.mediaDevices.getUserMedia({ audio: true, video: true })
         .then(function (stream) {
             selfView.srcObject = stream;
             var remoteStream = new MediaStream();
@@ -11641,7 +11641,7 @@ signalingChannel.onmessage = function (evt) {
                 return pc.setLocalDescription(answer);
             })
             .then(function () {
-                var str = JSON.stringify({ "desc": pc.localDescription });
+                var str = JSON.stringify({ desc: pc.localDescription });
                 signalingChannel.send(str);
             })
             .catch(logError);
@@ -11679,13 +11679,13 @@ function start() {
         })
         .then(function () {
             // send the offer to the other peer
-            signalingChannel.send(JSON.stringify({ "desc": pc.localDescription }));
+            signalingChannel.send(JSON.stringify({ desc: pc.localDescription }));
         })
         .catch(logError);
     };
 
     // get a local stream, show it in a self-view and add it to be sent
-    navigator.mediaDevices.getUserMedia({ "audio": true, "video": true })
+    navigator.mediaDevices.getUserMedia({ audio: true, video: true })
         .then(function (stream) {
             selfView.srcObject = stream;
             pc.addTransceiver(stream.getAudioTracks()[0], {direction: "sendonly"});
@@ -11735,7 +11735,7 @@ function logError(error) {
         is ready, messages are received and when the channel is closed.</p>
         <pre class="example highlight">
 var signalingChannel = new SignalingChannel();
-var configuration = { "iceServers": [{ "urls": "stuns:stun.example.org" }] };
+var configuration = { iceServers: [{ urls: "stuns:stun.example.org" }] };
 var pc;
 var channel;
 
@@ -11745,7 +11745,7 @@ function start(isInitiator) {
 
     // send any ice candidates to the other peer
     pc.onicecandidate = function (evt) {
-        signalingChannel.send(JSON.stringify({ "candidate": evt.candidate }));
+        signalingChannel.send(JSON.stringify({ candidate: evt.candidate }));
     };
 
     // let the "negotiationneeded" event trigger offer generation
@@ -11755,7 +11755,7 @@ function start(isInitiator) {
         })
         .then(function () {
             // send the offer to the other peer
-            signalingChannel.send(JSON.stringify({ "desc": pc.localDescription }));
+            signalingChannel.send(JSON.stringify({ desc: pc.localDescription }));
         })
         .catch(logError);
     };
@@ -11790,7 +11790,7 @@ signalingChannel.onmessage = function (evt) {
                 return pc.setLocalDescription(answer);
             })
             .then(function () {
-                var str = JSON.stringify({ "desc": pc.localDescription });
+                var str = JSON.stringify({ desc: pc.localDescription });
                 signalingChannel.send(str);
             })
             .catch(logError);
@@ -11824,10 +11824,10 @@ function logError(error) {
     <p>This simple example shows how configure two RTCDataChannel objects for different purposes.</p>
 <p><pre   class='example highlight'>
 // the chat channel is reliable and not as prioritized as game data
-var chatChan = peerConn.createDataChannel("chat", { "priority": 1 });
+var chatChan = peerConn.createDataChannel("chat", { priority: 1 });
 
 // the game data channel is prioritized and unreliable low latency channel for high performance
-var gameDataChan = peerConn.createDataChannel("data", { "reliable": false, "priority": 10 });
+var gameDataChan = peerConn.createDataChannel("data", { reliable: false, priority: 10 });
     </pre></p>
   </div-->
     </section>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/1444


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/issue-1444-patch.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/7ba8467...67d20a4.html)