### PR TITLE
setConfiguration({ peerIdentity }) when there is no initial peerIdentity

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1679,6 +1679,9 @@
             set and <a>[[\Configuration]]</a>.<code>peerIdentity</code> is
             not set, <a>throw</a> an <code>InvalidModificationError</code>.
             </li>
+            <li>If <code><var>configuration</var>.peerIdentity</code> is
+            set and its value differs from the <a>target peer
+            identity</a>, <a>throw</a> an <code>InvalidModificationError</code>.
             <li>If <code><var>configuration</var>.certificates</code> is
             set and the set of certificates differs from the ones used
             when <var>connection</var> was constructed, <a>throw</a> an

--- a/webrtc.html
+++ b/webrtc.html
@@ -1679,9 +1679,6 @@
             set and <a>[[\Configuration]]</a>.<code>peerIdentity</code> is
             not set, <a>throw</a> an <code>InvalidModificationError</code>.
             </li>
-            <li>If <code><var>configuration</var>.peerIdentity</code> is
-            set and its value differs from the <a>target peer
-            identity</a>, <a>throw</a> an <code>InvalidModificationError</code>.
             <li>If <code><var>configuration</var>.certificates</code> is
             set and the set of certificates differs from the ones used
             when <var>connection</var> was constructed, <a>throw</a> an

--- a/webrtc.html
+++ b/webrtc.html
@@ -1676,8 +1676,8 @@
             <li>Let <var>connection</var> be the target
             <code><a>RTCPeerConnection</a></code> object.</li>
             <li>If <code><var>configuration</var>.peerIdentity</code> is
-            set and its value differs from the <a>target peer
-            identity</a>, <a>throw</a> an <code>InvalidModificationError</code>.
+            set and <a>[[\Configuration]]</a>.<code>peerIdentity</code> is
+            not set, <a>throw</a> an <code>InvalidModificationError</code>.
             </li>
             <li>If <code><var>configuration</var>.certificates</code> is
             set and the set of certificates differs from the ones used


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/1456


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/issue-1456-patch.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/7ba8467...0b011a6.html)