### PR TITLE
Cover legacy sendonly using {offerToReceiveAudio/Video: false}.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3484,7 +3484,13 @@ interface RTCPeerConnection : EventTarget  {
                   prior to the createOffer() call.
                 </p>
                 <p>
-                  In all other situations, it will be disregarded.
+                  Whenever this is given a false value, and the
+                  <code><a>RTCPeerConnection</a></code> has a non-stopped
+                  "sendrecv" audio transceiver, createOffer() MUST as its first
+                  step set that transceiver's
+                  [[<a href="#direction-slot">Direction</a>]] slot
+                  to "sendonly", and then proceed with createOffer()'s regular
+                  steps.
                 </p>
               </dd>
               <dt><dfn>offerToReceiveVideo</dfn> of type <span class="idlMemberType"><a>boolean</a></span></dt>
@@ -3498,7 +3504,13 @@ interface RTCPeerConnection : EventTarget  {
                   to the createOffer() call.
                 </p>
                 <p>
-                  In all other situations, it will be disregarded.
+                  Whenever this is given a false value, and the
+                  <code><a>RTCPeerConnection</a></code> has a non-stopped
+                  "sendrecv" video transceiver, createOffer() MUST as its first
+                  step set that transceiver's
+                  [[<a href="#direction-slot">Direction</a>]] slot
+                  to "sendonly", and then proceed with createOffer()'s regular
+                  steps.
                 </p>
               </dd>
             </dl>

--- a/webrtc.html
+++ b/webrtc.html
@@ -3485,11 +3485,11 @@ interface RTCPeerConnection : EventTarget  {
                 </p>
                 <p>
                   Whenever this is given a false value, and the
-                  <code><a>RTCPeerConnection</a></code> has a non-stopped
-                  "sendrecv" audio transceiver, createOffer() MUST as its first
-                  step set that transceiver's
-                  [[<a href="#direction-slot">Direction</a>]] slot
-                  to "sendonly", and then proceed with createOffer()'s regular
+                  <code><a>RTCPeerConnection</a></code> has one or more
+                  non-stopped "sendrecv" or "recvonly" audio transceivers,
+                  createOffer() MUST as its first step set those transceivers'
+                  <a>[[\Direction]]</a> slot to "sendonly" or "inactive"
+                  respectively, and then proceed with createOffer()'s normal
                   steps.
                 </p>
               </dd>
@@ -3505,11 +3505,11 @@ interface RTCPeerConnection : EventTarget  {
                 </p>
                 <p>
                   Whenever this is given a false value, and the
-                  <code><a>RTCPeerConnection</a></code> has a non-stopped
-                  "sendrecv" video transceiver, createOffer() MUST as its first
-                  step set that transceiver's
-                  [[<a href="#direction-slot">Direction</a>]] slot
-                  to "sendonly", and then proceed with createOffer()'s regular
+                  <code><a>RTCPeerConnection</a></code> has one or more
+                  non-stopped "sendrecv" or "recvonly" video transceivers,
+                  createOffer() MUST as its first step set those transceivers'
+                  <a>[[\Direction]]</a> slot to "sendonly" or "inactive"
+                  respectively, and then proceed with createOffer()'s normal
                   steps.
                 </p>
               </dd>


### PR DESCRIPTION
Fix for https://github.com/w3c/webrtc-pc/issues/1461.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/jan-ivar/webrtc-pc/offertoreceivefalse.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/cc8d80f...jan-ivar:eef2557.html)