### PR TITLE
move rescale paragraph

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4847,6 +4847,20 @@ interface RTCPeerConnectionIceErrorEvent : Event {
     added to a <code>RTCPeerConnection</code>, result in signaling; when this
     signaling is forwarded to a remote peer, it causes corresponding tracks to
     be created on the remote side.</p>
+    <p>When sending media, the sender may need to rescale or
+    resample the media to meet various requirements including the
+    envelope negotiated by SDP. When resizing video, the source
+    video is first centered relative to the desired video then
+    scaled down the minimum amount such that the video fully covers
+    the desired size, then finally cropped to the destination
+    size. The video remains centered while scaling and cropping. For
+    example, if the source video was 1280 by 720, and the max size
+    that could be sent was 640 by 480, the video would be scaled
+    down by 1.5 and 160 columns of pixels on both the right and left
+    sides of the source video would be cropped off. This algorithm
+    is designed to minimize occurrence of images with with letter
+    box or or pillow boxing. The media MUST NOT be upscaled to
+    create fake data that did not occur in the input source.</p>
     <p>The actual encoding and transmission of <code>MediaStreamTrack</code>s
     is managed through objects called <code><a>RTCRtpSender</a></code>s.
     Similarly, the reception and decoding of <code>MediaStreamTrack</code>s is
@@ -5586,21 +5600,6 @@ interface RTCPeerConnectionIceErrorEvent : Event {
       encoded and transmitted to a remote peer. When <code>setParameters</code>
       is called on an <code><a>RTCRtpSender</a></code> object, the encoding is
       changed appropriately.</p>
-
-      <p>When sending media, the sender may need to rescale or
-      resample the media to meet various requirements including the
-      envelope negotiated by SDP. When resizing video, the source
-      video is first centered relative to the desired video then
-      scaled down the minimum amount such that the video fully covers
-      the desired size, then finally cropped to the destination
-      size. The video remains centered while scaling and cropping. For
-      example, if the source video was 1280 by 720, and the max size
-      that could be sent was 640 by 480, the video would be scaled
-      down by 1.5 and 160 columns of pixels on both the right and left
-      sides of the source video would be cropped off. This algorithm
-      is designed to minimize occurrence of images with with letter
-      box or or pillow boxing. The media MUST NOT be upscaled to
-      create fake data that did not occur in the input source. </p>
 
       <p>To <dfn>create an RTCRtpSender</dfn> with a
       <code><a>MediaStreamTrack</a></code>, <var>track</var>, a list of


### PR DESCRIPTION
moves the paragraph that explains cropping to the beginning
of the media api section.

Fixes #1243

just moving stuff, but I actually fixed a dangling whitespace at the end ;-)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/fippo/webrtc-pc/issue-1243.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/7ba8467...fippo:a7d868d.html)