### PR TITLE
rename ufrag to usernameFragment

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2637,7 +2637,7 @@ interface RTCPeerConnection : EventTarget  {
                 "RTCIceCandidate">candidate</a></code>, <code><a data-for=
                 "RTCIceCandidate">sdpMid</a></code>, <code><a data-for=
                 "RTCIceCandidate">sdpMLineIndex</a></code>, and
-                <code><a data-for="RTCIceCandidate">ufrag</a></code>; the rest
+                <code><a data-for="RTCIceCandidate">usernameFragment</a></code>; the rest
                 are ignored. When the method is invoked, the user agent MUST
                 run the following steps:</p>
                 <ol>
@@ -2703,9 +2703,9 @@ interface RTCPeerConnection : EventTarget  {
                         </ol>
                       </li>
                       <li>
-                        <p>If <code><var>candidate</var>.ufrag</code> is neither
+                        <p>If <code><var>candidate</var>.usernameFragment</code> is neither
                         <code>undefined</code> nor <code>null</code>, and is not
-                        equal to any ufrag present in the corresponding
+                        equal to any usernameFragment present in the corresponding
                         <a>media description</a> of an applied remote
                         description, reject <var>p</var> with a newly
                         <a data-link-for="exception" data-lt="create">created
@@ -2716,8 +2716,8 @@ interface RTCPeerConnection : EventTarget  {
                         <p>In parallel, add the ICE candidate
                         <var>candidate</var> as described in <span data-jsep=
                         "addicecandidate">[[!JSEP]]</span>. Use
-                        <code><var>candidate</var>.ufrag</code> to identify the
-                        ICE <a>generation</a>; if the ufrag is null, process the
+                        <code><var>candidate</var>.usernameFragment</code> to identify the
+                        ICE <a>generation</a>; if the usernameFragment is null, process the
                         <var>candidate</var> for the most recent ICE
                         <a>generation</a>. If
                         <code><var>candidate</var>.candidate</code> is an empty
@@ -3890,7 +3890,7 @@ interface RTCSessionDescription {
         <p>This interface describes an ICE candidate, described in
         [[!ICE]] Section 2. Other than
         <code>candidate</code>, <code>sdpMid</code>,
-        <code>sdpMLineIndex</code>, and <code>ufrag</code>,
+        <code>sdpMLineIndex</code>, and <code>usernameFragment</code>,
         the remaining attributes are derived from parsing the
         <code>candidate</code> member in <var>candidateInitDict</var>,
         if it is well formed.</p>
@@ -3911,7 +3911,7 @@ interface RTCIceCandidate {
     readonly        attribute RTCIceTcpCandidateType? tcpType;
     readonly        attribute DOMString?              relatedAddress;
     readonly        attribute unsigned short?         relatedPort;
-    readonly        attribute DOMString?              ufrag;
+    readonly        attribute DOMString?              usernameFragment;
     RTCIceCandidateInit toJSON();
 };</pre>
           <section>
@@ -3941,7 +3941,7 @@ interface RTCIceCandidate {
                   <a><code>tcpType</code></a>, <a><code>relatedAddress</code></a>,
                   and <a><code>relatedPort</code></a>.</li>
                   <li>Set the <a><code>candidate</code></a>, <a><code>sdpMid</code></a>,
-                  <a><code>sdpMLineIndex</code></a>, <a><code>ufrag</code></a> attributes
+                  <a><code>sdpMLineIndex</code></a>, <a><code>usernameFragment</code></a> attributes
                   of <var>iceCandidate</var> with the corresponding dictionary member values
                   of <var>candidateInitDict</var>.</li>
                   <li>Let <var>candidate</var> be the <code>
@@ -3965,7 +3965,7 @@ interface RTCIceCandidate {
                   parsing and type checking for the dictionary members in
                   <var>candidateInitDict</var>. Detailed validation on the well-formedness
                   of <code>candidate</code>, <code>sdpMid</code>, <code>sdpMLineIndex</code>,
-                  <code>ufrag</code> with the corresponding session description is done
+                  <code>usernameFragment</code> with the corresponding session description is done
                   when passing the <code>RTCIceCandidate</code> object to <a>
                   <code>addIceCandidate()</code></a>.</p>
 
@@ -4106,7 +4106,7 @@ interface RTCIceCandidate {
               the candidate that it is derived from. For host candidates, the
               <code>relatedPort</code> is <code>null</code>. This corresponds to
               the <code>rel-port</code> field in <a><code>candidate-attribute</code></a>.</dd>
-              <dt><code><dfn>ufrag</dfn></code> of type <span class=
+              <dt><code><dfn>usernameFragment</dfn></code> of type <span class=
               "idlAttrType"><a>DOMString</a></span>, readonly, nullable</dt>
               <dd>This carries the <code>ufrag</code> as defined in section
               15.4 of [[!ICE]].</dd>
@@ -4135,7 +4135,7 @@ interface RTCIceCandidate {
              DOMString       candidate = "";
              DOMString?      sdpMid = null;
              unsigned short? sdpMLineIndex = null;
-             DOMString       ufrag;
+             DOMString       usernameFragment;
 };</pre>
           <section>
             <h2>Dictionary <dfn>RTCIceCandidateInit</dfn>
@@ -4161,7 +4161,7 @@ interface RTCIceCandidate {
               <dd>If not <code>null</code>, this indicates the index (starting at
               zero) of the <a>media description</a> in the SDP this candidate
               is associated with.</dd>
-              <dt><dfn><code>ufrag</code></dfn> of type <span class=
+              <dt><dfn><code>usernameFragment</code></dfn> of type <span class=
               "idlMemberType"><a>DOMString</a></span></dt>
               <dd>This carries the <code>ufrag</code> as defined in section
               15.4 of [[!ICE]].</dd>
@@ -7687,7 +7687,7 @@ sender.setParameters(params)
           <code><a data-for="RTCIceCandidate">sdpMLineIndex</a></code>
           set to the values associated with this
           <code><a>RTCIceTransport</a></code>, with
-          <code><a data-for="RTCIceCandidate">ufrag</a></code> set to the ufrag
+          <code><a data-for="RTCIceCandidate">usernameFragment</a></code> set to the usernameFragment
           of the <a>generation</a> of candidates for which gathering finished, with
           <code><a data-for="RTCIceCandidate">candidate</a></code> set to an
           empty string, and with all other nullable members set to null.</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -2121,8 +2121,7 @@ interface RTCPeerConnection : EventTarget  {
                 any additional capabilities that could be negotiated in an
                 updated offer.</p>
                 <p>The generated SDP will also contain the <a>ICE agent</a>'s
-                <a data-link-for="RTCIceParameters">
-                  ment</a>,
+                <a data-link-for="RTCIceParameters">usernameFragment</a>,
                 <a data-link-for="RTCIceParameters">password</a> and
                 ICE options (as defined in [[!ICE]], Section 14) and may also contain
                 any local candidates that have been gathered by the agent.</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -2121,7 +2121,8 @@ interface RTCPeerConnection : EventTarget  {
                 any additional capabilities that could be negotiated in an
                 updated offer.</p>
                 <p>The generated SDP will also contain the <a>ICE agent</a>'s
-                <a data-link-for="RTCIceParameters">usernameFragment</a>,
+                <a data-link-for="RTCIceParameters">
+                  ment</a>,
                 <a data-link-for="RTCIceParameters">password</a> and
                 ICE options (as defined in [[!ICE]], Section 14) and may also contain
                 any local candidates that have been gathered by the agent.</p>
@@ -2705,7 +2706,7 @@ interface RTCPeerConnection : EventTarget  {
                       <li>
                         <p>If <code><var>candidate</var>.usernameFragment</code> is neither
                         <code>undefined</code> nor <code>null</code>, and is not
-                        equal to any usernameFragment present in the corresponding
+                        equal to any username fragment present in the corresponding
                         <a>media description</a> of an applied remote
                         description, reject <var>p</var> with a newly
                         <a data-link-for="exception" data-lt="create">created
@@ -2717,7 +2718,7 @@ interface RTCPeerConnection : EventTarget  {
                         <var>candidate</var> as described in <span data-jsep=
                         "addicecandidate">[[!JSEP]]</span>. Use
                         <code><var>candidate</var>.usernameFragment</code> to identify the
-                        ICE <a>generation</a>; if the usernameFragment is null, process the
+                          ICE <a>generation</a>; if <code>usernameFragment</code> is null, process the
                         <var>candidate</var> for the most recent ICE
                         <a>generation</a>. If
                         <code><var>candidate</var>.candidate</code> is an empty
@@ -7687,7 +7688,7 @@ sender.setParameters(params)
           <code><a data-for="RTCIceCandidate">sdpMLineIndex</a></code>
           set to the values associated with this
           <code><a>RTCIceTransport</a></code>, with
-          <code><a data-for="RTCIceCandidate">usernameFragment</a></code> set to the usernameFragment
+          <code><a data-for="RTCIceCandidate">usernameFragment</a></code> set to the username fragment
           of the <a>generation</a> of candidates for which gathering finished, with
           <code><a data-for="RTCIceCandidate">candidate</a></code> set to an
           empty string, and with all other nullable members set to null.</p>


### PR DESCRIPTION
renames the ICE ufrag to usernameFragment for consistency.
Fixes #1210


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/fippo/webrtc-pc/ufrag.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/a12bf47...fippo:0060df4.html)