### PR TITLE
Update mandatory stats to reflect rtp refactor in webrtc-stats.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -10075,14 +10075,23 @@ interface RTCDTMFToneChangeEvent : Event {
       types when the corresponding objects exist on a PeerConnection, with the
       attributes that are listed when they are valid for that object:</p>
       <ul>
-        <li>RTCRTPStreamStats, with attributes ssrc, associateStatsId,
-        isRemote, mediaType, mediaTrackId, transportId, codecId, nackCount</li>
-        <li>RTCInboundRTPStreamStats, with all required attributes from
-        RTCRTPStreamStats, and also attributes packetsReceived, bytesReceived,
-        packetsLost, jitter, packetsDiscarded</li>
-        <li>RTCOutboundRTPStreamStats, with all required attributes from
-        RTCRTPStreamStats, and also attributes packetsSent, bytesSent,
+        <li>RTCRTPStreamStats, with attributes ssrc, mediaType, trackId,
+        transportId, codecId, nackCount</li>
+        <li>RTCReceivedRTPStreamStats, with all required attributes from its
+        inherited dictionaries, and also attributes packetsReceived,
+        bytesReceived, packetsLost, jitter, packetsDiscarded</li>
+        <li>RTCInboundRTPStreamStats, with all required attributes from its
+        inherited dictionaries, and also attributes remoteId, framesDecoded</li>
+        <li>RTCRemoteInboundRTPStreamStats, with all required attributes from
+        its inherited dictionaries, and also attributes localId,
         roundTripTime</li>
+        <li>RTCSentRTPStreamStats, with all required attributes from its
+        inherited dictionaries, and also attributes packetsSent, bytesSent</li>
+        <li>RTCOutboundRTPStreamStats, with all required attributes from its
+        inherited dictionaries, and also attributes remoteId, framesEncoded</li>
+        <li>RTCRemoteOutboundRTPStreamStats, with all required attributes from
+        its inherited dictionaries, and also attributes localId, remoteTimestamp
+        </li>
         <li>RTCPeerConnectionStats, with attributes dataChannelsOpened,
         dataChannelsClosed</li>
         <li>RTCDataChannelStats, with attributes label, protocol,


### PR DESCRIPTION
Partial fix for https://github.com/w3c/webrtc-pc/issues/1474.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/jan-ivar/webrtc-pc/conformance.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/a12bf47...jan-ivar:6388d8a.html)