### PR TITLE
Direction of newly created transceiver in setRemoteDescription

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1560,8 +1560,8 @@
                           <li>
                             <p><a>Create an RTCRtpTransceiver</a> with
                             <var>sender</var>, <var>receiver</var> and
-                            <var>direction</var>, and let
-                            <var>transceiver</var> be the result.</p>
+                            <var>direction</var> set to <code>"recvonly"</code>,
+                            and let <var>transceiver</var> be the result.</p>
                           </li>
                         </ol>
                       </li>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/1473


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/issue-1473-patch.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/a12bf47...505aa44.html)