### PR TITLE
Validating scaleResolutionDownBy parameter in addTransceiver

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5400,6 +5400,12 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   <a>throw</a> an <code>InvalidAccessError</code>.</p>
                 </li>
                 <li>
+                  <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">scaleResolutionDownBy</a></code>
+                  value in <var>sendEncodings</var> is more than or equal to 1.0. If
+                  one of the <code>scaleResolutionDownBy</code> values does not meet
+                  this requirement, <a>throw</a> a <code>RangeError</code>.</p>
+                </li>
+                <li>
                   <p><a>Create an RTCRtpSender</a> with <var>track</var>,
                   <var>streams</var> and <var>sendEncodings</var> and let
                   <var>sender</var> be the result.</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -5401,7 +5401,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 </li>
                 <li>
                   <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">scaleResolutionDownBy</a></code>
-                  value in <var>sendEncodings</var> is more than or equal to 1.0. If
+                  value in <var>sendEncodings</var> is greater than or equal to 1.0. If
                   one of the <code>scaleResolutionDownBy</code> values does not meet
                   this requirement, <a>throw</a> a <code>RangeError</code>.</p>
                 </li>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/1478


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/issue-1478-patch.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/a12bf47...755dc67.html)