### PR TITLE
setDirection():  throw InvalidStateError if transceiver is stopped or…

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7228,6 +7228,21 @@ sender.setParameters(params)
                   invoked.</p>
                 </li>
                 <li>
+                  <p>Let <var>connection</var> be the
+                  <code><a>RTCPeerConnection</a></code> object
+                  associated with <var>transceiver</var>.</p>
+                </li>
+                <li>
+                  <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+                  <code>true</code>, <a>throw</a> an
+                  <code>InvalidStateError</code>.</p>
+                </li>                
+                <li>
+                  <p>If <code><var>transceiver</var>.stopped</code> is
+                  <code>true</code>, <a>throw</a> an
+                  <code>InvalidStateError</code>.</p>
+                </li>
+                <li>
                   <p>Let <var>newDirection</var> be the
                   argument to <code>setDirection</code>.</p>
                 </li>
@@ -7238,11 +7253,6 @@ sender.setParameters(params)
                 <li>
                   <p>Set <var>transceiver</var>'s <a>[[\Direction]]</a> slot
                   to <var>newDirection</var>.</p>
-                </li>
-                <li>
-                  <p>Let <var>connection</var> be the
-                  <code><a>RTCPeerConnection</a></code> object
-                  associated with <var>transceiver</var>.</p>
                 </li>
                 <li>
                   <p><a>Update the negotiation-needed flag</a> for


### PR DESCRIPTION
… connection is closed

Fix for Issue https://github.com/w3c/webrtc-pc/issues/1418


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/issue-1418-patch.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/a12bf47...ce0aeec.html)