### PR TITLE
setLocalDescription() with null sdp is not applicable

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2529,13 +2529,13 @@ interface RTCPeerConnection : EventTarget  {
                   last call to <code>createOffer</code>.</li>
                   <li>Let <var>lastAnswer</var> be the result returned by the
                   last call to <code>createAnswer</code>.</li>
-                  <li>If <code><var>description</var>.sdp</code> is
-                  <code>null</code> and <code><var>description</var>.type</code>
+                  <li>If <code><var>description</var>.sdp</code> is the
+                  empty string and <code><var>description</var>.type</code>
                   is <code>"answer"</code> or <code>"pranswer"</code>,
                   set <code><var>description</var>.sdp</code> to
                   <var>lastAnswer</var>.</li>
-                  <li>If <code><var>description</var>.sdp</code> is
-                  <code>null</code> and <code><var>description</var>.type</code>
+                  <li>If <code><var>description</var>.sdp</code> is the
+                  empty string and <code><var>description</var>.type</code>
                   is <code>"offer"</code>, set <code><var>description</var>.sdp</code>
                   to <var>lastOffer</var>.</li>
                   <li>Return the result of <a href="#set-description">setting


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/1465

Rebase of PR https://github.com/w3c/webrtc-pc/pull/1482


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/issue-1465-patchv3.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/df9ae7d...d19d140.html)