### PR TITLE
Specify how data channel priority enum is initialized from priority integer

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8835,15 +8835,43 @@ interface RTCTrackEvent : Event {
           Protocol specification [[!RTCWEB-DATA-PROTOCOL]].</p>
         </li>
         <li>
-          <p>Initialize <var>channel</var>'s <code><a data-for=
-          "RTCDataChannel">label</a></code>, <code><a data-for=
-          "RTCDataChannel">ordered</a></code>, <code><a data-for=
-          "RTCDataChannel">maxPacketLifeTime</a></code>, <code><a data-for=
-          "RTCDataChannel">maxRetransmits</a></code>, <code><a data-for=
-          "RTCDataChannel">protocol</a></code>, <code><a data-for=
-          "RTCDataChannel">negotiated</a></code> and <code><a data-for=
-          "RTCDataChannel">id</a></code> attributes to their corresponding
+          <p>Initialize <var>channel</var>'s <a>[[\DataChannelLabel]]</a>,
+          <a>[[\Ordered]]</a>, <a>[[\MaxPacketLifeTime]]</a>,
+          <a>[[\MaxRetransmits]]</a>, <a>[[\DataChannelProtocol]]</a>,
+          and <a>[[\DataChannelId]]</a> internal slots to the corresponding
           values in <var>configuration</var>.</p>
+        </li>
+        <li>
+          <p>Initialize <var>channel</var>'s <a>[[\Negotiated]]</a> internal
+          slot to <code>false</code>.</p>
+        </li>
+        <li>
+          <p>Initialize <var>channel</var>'s <a>[[\DataChannelPriority]]</a>
+          internal slot based on the integer priority value in
+          <var>configuration</var>, according to the following mapping:
+          </p>
+          <table class="simple">
+            <tr>
+              <th><var>configuration</var> priority value</th>
+              <th><code><a>RTCPriorityType</a></code> value</th>
+            </tr>
+            <tr>
+              <td>0 to 128</td>
+              <td><code><a data-link-for="RTCPriorityType">very-low</a></code></td>
+            </tr>
+            <tr>
+              <td>129 to 256</td>
+              <td><code><a data-link-for="RTCPriorityType">low</a></code></td>
+            </tr>
+            <tr>
+              <td>257 to 512</td>
+              <td><code><a data-link-for="RTCPriorityType">medium</a></code></td>
+            </tr>
+            <tr>
+              <td>513 and greater</td>
+              <td><code><a data-link-for="RTCPriorityType">high</a></code></td>
+            </tr>
+          </table>
         </li>
         <li>
           <p>Set <var>channel</var>'s <code><a data-for=


### PR DESCRIPTION
Fixes #1423.

The priority value from the data channel "OPEN" message is a two-byte
integer, whereas the priority on the RTCDataChannel object is an enum.
The integer has four recommended values in rtcweb-transport, but that
recommendation is only a "SHOULD", so technically any value from 0 to
65535 is possible. So something needs to define how these integer values
are mapped to the enum values.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/taylor-b/webrtc-pc/issue_1423_datachannel_priority.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/226d9af...taylor-b:27f1ecf.html)