### PR TITLE
Reference [[Direction]] internal slot from addTrack/removeTrack.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5150,9 +5150,19 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                       to <var>streams</var>.</p>
                     </li>
                     <li>
-                      <p>Enable sending direction on the
+                      <p>Let <var>transceiver</var> be the
                       <code><a>RTCRtpTransceiver</a></code> associated with
-                      <var>sender</var> by updating its <a>[[\Direction]]</a> slot accordingly.</p>
+                      <var>sender</var>.</p>
+                    </li>
+                    <li>
+                      <p>If <var>transceiver</var>'s <a>[[\Direction]]</a> slot is
+                      <code>recvonly</code>, set <var>transceiver</var>'s
+                      <a>[[\Direction]]</a> slot to <code>sendrecv</code>.</p>
+                    </li>
+                    <li>
+                      <p>If <var>transceiver</var>'s <a>[[\Direction]]</a> slot
+                      is <code>inactive</code>, set <var>transceiver</var>'s
+                      <a>[[\Direction]]</a> slot to <code>sendonly</code>.</p>
                     </li>
                   </ol>
                 </li>
@@ -5304,19 +5314,14 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   to <var>sender</var>.</p>
                 </li>
                 <li>
-                  <p>If <var>transceiver</var>'s <a>[[\CurrentDirection]]</a> slot is
-                  <code>recvonly</code> or <code>inactive</code>, then abort
-                  these steps.</p>
-                </li>
-                <li>
-                  <p>If <var>transceiver</var>'s <a>[[\CurrentDirection]]</a> slot is
-                  <code>sendrecv</code> set <var>transceiver</var>'s
+                  <p>If <var>transceiver</var>'s <a>[[\Direction]]</a> slot is
+                  <code>sendrecv</code>, set <var>transceiver</var>'s
                   <a>[[\Direction]]</a> slot to <code>recvonly</code>.</p>
                 </li>
                 <li>
-                  <p>If <var>transceiver</var>'s <a>[[\CurrentDirection]]</a> slot
-                  is <code>sendonly</code> <var>transceiver</var>'s <a>[[\Direction]]</a> slot to
-                  <code>inactive</code>.</p>
+                  <p>If <var>transceiver</var>'s <a>[[\Direction]]</a> slot
+                  is <code>sendonly</code>, set <var>transceiver</var>'s
+                  <a>[[\Direction]]</a> slot to <code>inactive</code>.</p>
                 </li>
                 <li>
                   <p><a data-lt="update the negotiation-needed flag">Update the


### PR DESCRIPTION
Fixes #1204 and fixes #1390.

This replaces text that previously just said "enable sending direction"
(in addTrack), and which incorrectly used [[CurrentDirection]]  (in
removeTrack).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/taylor-b/webrtc-pc/issue_1204_transceiver_direction_slots.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/226d9af...taylor-b:684caa0.html)