### PR TITLE
Update paragraph that introduces senders/receivers/transceivers.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4898,7 +4898,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
     there may be <code><a>RTCRtpSender</a></code> settings applied that
     instruct the implementation to act differently.</p>
     <p>
-      A <code><a>RTCPeerConnection</a></code> object contains a <dfn id=
+      An <code><a>RTCPeerConnection</a></code> object contains a <dfn id=
       "transceivers-set" data-lt="set of transceivers">set of
       <code><a>RTCRtpTransceiver</a></code>s</dfn>, representing the paired
       senders and receivers with some shared state. This set is initialized to

--- a/webrtc.html
+++ b/webrtc.html
@@ -4906,7 +4906,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
       created. <code><a>RTCRtpSender</a></code>s and
       <code><a>RTCRtpReceiver</a></code>s are always created at the same time
       as an <code><a>RTCRtpTransceiver</a></code>, which they will remain
-      attached to for their entire lifetime.
+      attached to for their lifetime.
       <code><a>RTCRtpTransceiver</a></code>s are created implicitly when the
       application attaches a <code>MediaStreamTrack</code> to an
       <code><a>RTCPeerConnection</a></code> via the <code>addTrack</code>

--- a/webrtc.html
+++ b/webrtc.html
@@ -4897,22 +4897,27 @@ interface RTCPeerConnectionIceErrorEvent : Event {
     example be resource constraints at either endpoint or in the network or
     there may be <code><a>RTCRtpSender</a></code> settings applied that
     instruct the implementation to act differently.</p>
-    <p><code><a>RTCRtpSender</a></code>s are created when the application
-    attaches a <code>MediaStreamTrack</code> to a
-    <code><a>RTCPeerConnection</a></code>, via the <code>addTrack</code>
-    method. <code><a>RTCRtpReceiver</a></code>s, on the other hand, are created
-    when remote signaling indicates new tracks are available, and each new
-    <code>MediaStreamTrack</code> and its associated
-    <code><a>RTCRtpReceiver</a></code> are surfaced to the application via the
-    <code>ontrack</code> event. Both <code><a>RTCRtpSender</a></code> and
-    <code><a>RTCRtpReceiver</a></code> objects are created by the
-    <code>addTransceiver</code> method.</p>
-    <p>A <code><a>RTCPeerConnection</a></code> object contains a <dfn id=
-    "transceivers-set" data-lt="set of transceivers">set of
-    <code><a>RTCRtpTransceiver</a></code>s</dfn>, representing the paired
-    senders and receivers with some shared state. This set is initialized to
-    the empty set when the <code><a>RTCPeerConnection</a></code> object is
-    created.</p>
+    <p>
+      A <code><a>RTCPeerConnection</a></code> object contains a <dfn id=
+      "transceivers-set" data-lt="set of transceivers">set of
+      <code><a>RTCRtpTransceiver</a></code>s</dfn>, representing the paired
+      senders and receivers with some shared state. This set is initialized to
+      the empty set when the <code><a>RTCPeerConnection</a></code> object is
+      created. <code><a>RTCRtpSender</a></code>s and
+      <code><a>RTCRtpReceiver</a></code>s are always created at the same time
+      as an <code><a>RTCRtpTransceiver</a></code>, which they will remain
+      attached to for their entire lifetime.
+      <code><a>RTCRtpTransceiver</a></code>s are created implicitly when the
+      application attaches a <code>MediaStreamTrack</code> to an
+      <code><a>RTCPeerConnection</a></code> via the <code>addTrack</code>
+      method, or explicitly when the application uses the
+      <code>addTransceiver</code> method. They are also created when a remote
+      description is applied that includes a new media description.
+      Additionally, when a remote description is applied that indicates the
+      remote endpoint has media to send, the relevant
+      <code>MediaStreamTrack</code> and <code><a>RTCRtpReceiver</a></code> are
+      surfaced to the application via the <code><a>track</a></code> event.
+    </p>
     <div class="note">
       <p>There are several ways to initiate the sending of a
       <code>MediaStreamTrack</code> over a peer-to-peer connection.


### PR DESCRIPTION
Fixes #1241.

This paragraph hasn't been updated much since the transceiver model came
about (aside from basic find/replace), so it was a bit out of date. It
was implying that receivers could be created independently from
transceivers, which is not the case.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/taylor-b/webrtc-pc/issue_1241_sender_receiver_creation.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/226d9af...taylor-b:67c38db.html)