### PR TITLE
Clarify that ICE states should be "new" if there are no transports.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -830,7 +830,8 @@
                 <code>"new"</code> state and none of the transports are in the
                 <code>"connecting"</code>, <code>"checking"</code>,
                 <code>"failed"</code> or <code>"disconnected"</code> state, or all
-                transports are in the <code>"closed"</code> state.</td>
+                transports are in the <code>"closed"</code> state, or there are
+                no transports.</td>
               </tr>
               <tr>
                 <td><dfn><code>connecting</code></dfn></td>
@@ -897,7 +898,7 @@
                 <code>"checking"</code>, <code>"failed"</code> or
                 <code>"disconnected"</code> state, or all
                 <code><a>RTCIceTransport</a></code>s are in the
-                <code>"closed"</code> state.</td>
+                <code>"closed"</code> state, or there are no transports.</td>
               </tr>
               <tr>
                 <td><dfn><code>checking</code></dfn></td>


### PR DESCRIPTION
Fixes #1305.

This was always the intention, and was somewhat implied, but this PR
makes it more explicit. Note that this was already stated explicitly for
RTCIceGatheringState, but not the other aggregate states.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/taylor-b/webrtc-pc/issue_1305_ice_state_for_0_transports.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/226d9af...taylor-b:b01e887.html)