### PR TITLE
Define what an "associated" transceiver is.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1501,7 +1501,7 @@
                   <li>
                     <p>If <var>description</var> is set as a local description,
                     then run the following steps for each media description
-                    in <var>description</var> that is not yet associated with
+                    in <var>description</var> that is not yet <a>associated</a> with
                     an <code><a>RTCRtpTransceiver</a></code> object:</p>
                     <ol>
                       <li>
@@ -3750,7 +3750,7 @@ interface RTCSessionDescription {
         <code><a>RTCDataChannel</a></code>s that currently exist on the
         <code><a>RTCPeerConnection</a></code>. Specifically, this means that all
         non-<a data-for="RTCRtpTransceiver">stopped</a> transceivers have an
-        associated section in the local description with matching properties,
+        <a>associated</a> section in the local description with matching properties,
         and, if any data channels have been created, a data section exists in
         the local description.</p>
         <p>Note that the exact procedures for <a data-lt="update the
@@ -3834,20 +3834,18 @@ interface RTCSessionDescription {
             <ul>
               <li>
                 <p>If <var>t</var> isn't <a data-for="RTCRtpTransceiver">
-                stopped</a> and isn't yet associated with an m= section
-                according to <span data-jsep="rtptransceivers">[[!JSEP]]</span>,
+                stopped</a> and isn't yet <a>associated</a> with an m= section,
                 return <code>true</code>.</p>
               </li>
               <li>
                 <p>If <var>t</var> isn't <a data-for="RTCRtpTransceiver">
-                stopped</a> and is associated with an m= section
-                according to <span data-jsep="rtptransceivers">[[!JSEP]]</span>,
+                stopped</a> and is <a>associated</a> with an m= section
                 then perform the following checks:</p>
                 <ul>
                   <li>
                     <p>If <var>t</var>'s <a>[[\Direction]]</a> slot is
                     <code>"sendrecv"</code> or <code>"sendonly"</code>,
-                    and the associated m= section in
+                    and the <a>associated</a> m= section in
                     <var>connection</var>'s <code><a data-for=
                     "RTCPeerConnection">currentLocalDescription</a></code>
                     doesn't contain an "a=msid" line, return <code>true</code>.
@@ -3856,7 +3854,7 @@ interface RTCSessionDescription {
                   <li>
                     <p>If <var>connection</var>'s <code><a data-for=
                     "RTCPeerConnection">currentLocalDescription</a></code> is of
-                    type <code>"offer"</code>, and the direction of the associated m=
+                    type <code>"offer"</code>, and the direction of the <a>associated</a> m=
                     section in neither the offer nor answer matches
                     <var>t</var>'s <a>[[\Direction]]</a>
                     slot, return <code>true</code>.</p>
@@ -3864,7 +3862,7 @@ interface RTCSessionDescription {
                   <li>
                     <p>If <var>connection</var>'s <code><a data-for=
                     "RTCPeerConnection">currentLocalDescription</a></code> is of
-                    type <code>"answer"</code>, and the direction of the associated m=
+                    type <code>"answer"</code>, and the direction of the <a>associated</a> m=
                     section in the answer does not match <var>t</var>'s
                     <a>[[\Direction]]</a> slot intersected with
                     the offered direction (as described in <span data-jsep=
@@ -3875,8 +3873,7 @@ interface RTCSessionDescription {
               </li>
               <li>
                 <p>If <var>t</var> is <a data-for="RTCRtpTransceiver">
-                stopped</a> and is associated with an m= section according to
-                <span data-jsep="rtptransceivers">[[!JSEP]]</span>, but the
+                stopped</a> and is <a>associated</a> with an m= section, but the
                 associated m= section is not yet rejected in
                 <var>connection</var>'s <code><a data-for=
                 "RTCPeerConnection">currentLocalDescription</a></code> or
@@ -6066,9 +6063,8 @@ sender.setParameters(params)
                   <code>TypeError</code>.</p>
                 </li>
                 <li>
-                  <p>If <var>transceiver</var> is not yet associated with a
-                  <a>media description</a> <span data-jsep=
-                  "rtptransceivers">[[!JSEP]]</span>, then set
+                  <p>If <var>transceiver</var> is not yet <a>associated</a> with a
+                  <a>media description</a>, then set
                   <var>sender</var>'s <code><a data-for=
                   "RTCRtpSender">track</a></code> attribute to
                   <var>withTrack</var>, and return a promise resolved with
@@ -7182,7 +7178,12 @@ sender.setParameters(params)
       <p>The <a><code>RTCRtpTransceiver</code></a> interface represents a
       combination of an <a><code>RTCRtpSender</code></a> and an
       <a><code>RTCRtpReceiver</code></a> that share a common
-      <code>mid</code>.</p>
+      <code>mid</code>. As defined in <span data-jsep="rtptransceivers">[[!JSEP]]</span>,
+      an <a><code>RTCRtpTransceiver</code></a> is said to be <dfn>associated</dfn> with
+      a <a>media description</a> if its <code><a data-link-for=RTCRtpTransceiver>mid</a></code>
+      property is non-null; otherwise it is said to be disassociated. Conceptually, an
+      <a>associated</a> transceiver is one that's represented in the last applied session
+      description.</p>
       <p>The <dfn>transceiver kind</dfn> of an
       <code><a>RTCRtpTransceiver</a></code> is defined by the kind of the
       associated <code><a>RTCRtpReceiver</a></code>'s


### PR DESCRIPTION
Fixes #1393.

This references/restates the definition in JSEP, and expands on it a
bit in more human-readable language. I also looked through every
instance of the word "associated" and linked to this definition where
applicable.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/taylor-b/webrtc-pc/issue_1393_transceiver_associated.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/226d9af...taylor-b:33f9e41.html)