### PR TITLE
Adding defaults for RTCRtpEncodingParameters.active and priority

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6289,8 +6289,8 @@ sender.setParameters(params)
              RTCRtpRtxParameters rtx;
              RTCRtpFecParameters fec;
              RTCDtxStatus        dtx;
-             boolean             active;
-             RTCPriorityType     priority;
+             boolean             active = true;
+             RTCPriorityType     priority = "low";
              unsigned long       ptime;
              unsigned long       maxBitrate;
              double              maxFramerate;
@@ -6337,7 +6337,8 @@ sender.setParameters(params)
               sender.</p>
             </dd>
             <dt><dfn><code>active</code></dfn> of type <span class=
-            "idlMemberType"><a>boolean</a></span></dt>
+            "idlMemberType"><a>boolean</a></span>, defaulting to
+            <code>true</code></dt>
             <dd>
               <p>For an <code><a>RTCRtpSender</a></code>, indicates that this
               encoding is actively being sent. Setting it to <code>false</code>
@@ -6348,7 +6349,8 @@ sender.setParameters(params)
               decoded.</p>
             </dd>
             <dt><dfn><code>priority</code></dfn> of type <span class=
-            "idlMemberType"><a>RTCPriorityType</a></span></dt>
+            "idlMemberType"><a>RTCPriorityType</a></span>, defaulting to
+            <code>"low"</code></dt>
             <dd>
               <p>Indicates the priority of this encoding. It is specified in
               [[!RTCWEB-TRANSPORT]], Section 4.</p>


### PR DESCRIPTION
Fixes #1491.

The rest of the encoding parameters (`ptime`, `maxBitrate`,
`maxFramerate`, etc.) are optional, but `active` and `priority` need
default values in case they aren't specified in the `sendEncodings`
passed into `addTransceiver`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/taylor-b/webrtc-pc/issue_1491_rtpencodingparameters_defaults.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/226d9af...taylor-b:453ba4f.html)