### PR TITLE
Remove event.receiver.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8279,14 +8279,14 @@ sender.setParameters(params)
       <code><a>RTCTrackEvent</a></code> interface.</p>
       <p><dfn id="fire-track-event" data-lt="fire track event">Firing an
       RTCTrackEvent event named <var>e</var></dfn> with an
-      <code><a>RTCRtpReceiver</a></code> <var>receiver</var>, a
+      <code><a>RTCRtpTransceiver</a></code> <var>transceiver</var>, a
       <code><a>MediaStreamTrack</a></code> <var>track</var> and a
       <code>MediaStream</code>[] <var>streams</var>, means that an event with
       the name <var>e</var>, which does not bubble (except where otherwise
       stated) and is not cancelable (except where otherwise stated), and which
       uses the <code><a>RTCTrackEvent</a></code> interface with the
-      <code><a data-for="RTCTrackEvent">receiver</a></code> attribute set to
-      <var>receiver</var>, <code><a data-for="RTCTrackEvent">track</a></code>
+      <code><a data-for="RTCTrackEvent">transceiver</a></code> attribute set to
+      <var>transceiver</var>, <code><a data-for="RTCTrackEvent">track</a></code>
       attribute set to <var>track</var>, <code><a data-for=
       "RTCTrackEvent">streams</a></code> attribute set to <var>streams</var>,
       MUST be created and dispatched at the given target.</p>
@@ -8294,7 +8294,6 @@ sender.setParameters(params)
         <pre class="idl">
         [ Constructor (DOMString type, RTCTrackEventInit eventInitDict)]
 interface RTCTrackEvent : Event {
-    readonly        attribute RTCRtpReceiver           receiver;
     readonly        attribute MediaStreamTrack         track;
     [SameObject]
     readonly        attribute FrozenArray&lt;MediaStream&gt; streams;
@@ -8306,7 +8305,6 @@ interface RTCTrackEvent : Event {
           "constructors">
             <dt><code>RTCTrackEvent</code></dt>
             <dd>
-              readonly attribute RTCRtpReceiver receiver
               <table class="parameters">
                 <tbody>
                   <tr>
@@ -8343,21 +8341,13 @@ interface RTCTrackEvent : Event {
           <h2>Attributes</h2>
           <dl data-link-for="RTCTrackEvent" data-dfn-for="RTCTrackEvent" class=
           "attributes">
-            <dt><code>receiver</code> of type <span class=
-            "idlAttrType"><a>RTCRtpReceiver</a></span>, readonly</dt>
-            <dd>
-              <p>The <dfn id=
-              "dom-trackevent-receiver"><code>receiver</code></dfn> attribute
-              represents the <code><a>RTCRtpReceiver</a></code> object
-              associated with the event.</p>
-            </dd>
             <dt><dfn><code>track</code></dfn> of type <span class=
             "idlAttrType"><a>MediaStreamTrack</a></span>, readonly</dt>
             <dd>
               <p>The <code>track</code> attribute represents the
               <code><a>MediaStreamTrack</a></code> object that is associated
               with the <code><a>RTCRtpReceiver</a></code> identified by
-              <code>receiver</code>.</p>
+              <code>transceiver.receiver</code>.</p>
             </dd>
             <dt><code>streams</code> of type <span class=
             "idlAttrType">FrozenArray&lt;<a>MediaStream</a>&gt;</span>,
@@ -8381,7 +8371,6 @@ interface RTCTrackEvent : Event {
       </div>
       <div>
         <pre class="idl">dictionary RTCTrackEventInit : EventInit {
-    required RTCRtpReceiver        receiver;
     required MediaStreamTrack      track;
              sequence&lt;MediaStream&gt; streams = [];
     required RTCRtpTransceiver     transceiver;
@@ -8390,20 +8379,13 @@ interface RTCTrackEvent : Event {
           <h2>Dictionary <dfn>RTCTrackEventInit</dfn> Members</h2>
           <dl data-link-for="RTCTrackEventInit" data-dfn-for=
           "RTCTrackEventInit" class="dictionary-members">
-            <dt><dfn><code>receiver</code></dfn> of type <span class=
-            "idlMemberType"><a>RTCRtpReceiver</a></span>, required</dt>
-            <dd>
-              <p>The <code>receiver</code> attribute represents the
-              <code><a>RTCRtpReceiver</a></code> object associated with the
-              event.</p>
-            </dd>
             <dt><dfn><code>track</code></dfn> of type <span class=
             "idlMemberType"><a>MediaStreamTrack</a></span>, required</dt>
             <dd>
               <p>The <code>track</code> attribute represents the
               <code><a>MediaStreamTrack</a></code> object that is associated
               with the <code><a>RTCRtpReceiver</a></code> identified by
-              <code>receiver</code>.</p>
+              <code>transceiver.receiver</code>.</p>
             </dd>
             <dt><dfn><code>streams</code></dfn> of type <span class=
             "idlMemberType">sequence&lt;<a>MediaStream</a>&gt;</span>,


### PR DESCRIPTION
Fix for https://github.com/w3c/webrtc-pc/issues/1499.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/jan-ivar/webrtc-pc/noreceiver.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/cdf9e75...jan-ivar:f29a0b1.html)