### PR TITLE
Change ResourceInUse to OperationError

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1486,8 +1486,8 @@
                           </li>
                           <li>
                             <p>Fire an event named <code><a data-for=
-                            "RTCDataChannel">error</a></code > with a
-                            <code>ResourceInUse</code> exception at
+                            "RTCDataChannel">error</a></code > with an
+                            <code>OperationError</code> exception at
                             <var>channel</var>.</p>
                           </li>
                           <li>
@@ -8577,7 +8577,7 @@ interface RTCTrackEvent : Event {
                   the next step. If no available ID could be generated, or if
                   the value of the <a>[[\DataChannelId]]</a> slot
                   is being used by an existing <code><a>RTCDataChannel</a></code>,
-                  <a>throw</a> a <code>ResourceInUse</code> exception.</p>
+                  <a>throw</a> an <code>OperationError</code> exception.</p>
                   <div class="note">
                     If the <a>[[\DataChannelId]]</a>
                     slot is <code>null</code> after this step, it will be


### PR DESCRIPTION
Fixes Issue #1412.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/burnburn/webrtc-pc/ResourceInUse.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/cdf9e75...burnburn:8c322e2.html)