### PR TITLE
protocol can only contain characters legal in a URI

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9388,7 +9388,8 @@ interface RTCIdentityProviderRegistrar {
               "idlMemberType"><a>DOMString</a></span>, defaulting to
               <code>"default"</code></dt>
               <dd>
-                <p>The protocol parameter used for the IdP.</p>
+                <p>The protocol parameter used for the IdP. This attribute MUST
+                contain only ASCII characters.</p>
               </dd>
             </dl>
           </section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -9389,7 +9389,7 @@ interface RTCIdentityProviderRegistrar {
               <code>"default"</code></dt>
               <dd>
                 <p>The protocol parameter used for the IdP. This attribute MUST
-                contain only ASCII characters.</p>
+                contain only characters legal for inclusion in URIs [[!RFC3986]].</p>
               </dd>
             </dl>
           </section>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/1293


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/issue-1293-patch.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/945b618...d863e68.html)