### PR TITLE
Type checking for selectorArg in getStats is unnecessary

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8806,13 +8806,6 @@ interface RTCDTMFToneChangeEvent : Event {
                   the method was invoked.</p>
                 </li>
                 <li>
-                  <p>If <var>selectorArg</var> is neither <code>null</code> nor
-                  a <a>MediaStreamTrack</a>, return a promise rejected
-                  with a newly
-                  <a data-link-for="exception" data-lt="create">created</a>
-                  <code>TypeError</code>.</p>
-                </li>
-                <li>
                   <p>If <var>selectorArg</var> is <code>null</code>, let
                   <var>selector</var> be <code>null</code>.</p>
                 </li>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/1498


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/issue-1498-patch.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/945b618...b148800.html)