### PR TITLE
getCapabilities behavior with an unsupported value of kind

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5189,11 +5189,13 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             <dt><code>getCapabilities</code>, static</dt>
             <dd>
               <p>The <dfn>getCapabilities()</dfn>
-              method returns the most optimist view on the capabilities of the
+              method returns the most optimistic view of the capabilities of the
               system for sending media of the given kind. It does not reserve
               any resources, ports, or other state but is meant to provide a
               way to discover the types of capabilities of the browser
-              including which codecs may be supported.</p>
+              including which codecs may be supported. If the system has no
+              capabilities corresponding to the value of the <var>kind</var>
+              argument, <code>getCapabilities</code> returns <code>null</code>.</p>
               <p class="fingerprint">These capabilities provide generally
               persistent cross-origin information on the device and thus
               increases the fingerprinting surface of the application. In
@@ -6127,7 +6129,9 @@ sender.setParameters(params)
               the system for receiving media of the given kind. It does not
               reserve any resources, ports, or other state but is meant to
               provide a way to discover the types of capabilities of the
-              browser including which codecs may be supported.</p>
+              browser including which codecs may be supported. If the system has no
+              capabilities corresponding to the value of the <var>kind</var>
+              argument, <code>getCapabilities</code> returns <code>null</code>.</p>
               <p class="fingerprint">These capabilities provide generally
               persistent cross-origin information on the device and thus
               increases the fingerprinting surface of the application. In

--- a/webrtc.html
+++ b/webrtc.html
@@ -5193,8 +5193,10 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               system for sending media of the given kind. It does not reserve
               any resources, ports, or other state but is meant to provide a
               way to discover the types of capabilities of the browser
-              including which codecs may be supported. If the system has no
-              capabilities corresponding to the value of the <var>kind</var>
+              including which codecs may be supported. User agents
+              MUST support <var>kind</var> values of <code>"audio"</code>
+              and <code>"video"</code>. If the system has no capabilities
+              corresponding to the value of the <var>kind</var>
               argument, <code>getCapabilities</code> returns <code>null</code>.</p>
               <p class="fingerprint">These capabilities provide generally
               persistent cross-origin information on the device and thus
@@ -6129,9 +6131,11 @@ sender.setParameters(params)
               the system for receiving media of the given kind. It does not
               reserve any resources, ports, or other state but is meant to
               provide a way to discover the types of capabilities of the
-              browser including which codecs may be supported. If the system has no
-              capabilities corresponding to the value of the <var>kind</var>
-              argument, <code>getCapabilities</code> returns <code>null</code>.</p>
+              browser including which codecs may be supported. User agents
+              MUST support <var>kind</var> values of <code>"audio"</code>
+              and <code>"video"</code>. If the system has no capabilities
+              corresponding to the value of the <var>kind</var> argument,
+              <code>getCapabilities</code> returns <code>null</code>.</p>
               <p class="fingerprint">These capabilities provide generally
               persistent cross-origin information on the device and thus
               increases the fingerprinting surface of the application. In


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/1495


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/issue-1495-patch.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/945b618...f5c3b74.html)