### PR TITLE
Duration, InterToneGap and CanInsertDTMF internal slots of RTCDTMFSender

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8646,17 +8646,26 @@ interface RTCDTMFSender : EventTarget {
                 <li>If <var>tones</var> contains any <a>unrecognized</a>
                 characters, <a>throw</a> an <code>InvalidCharacterError</code>.
                 </li>
-                <li>Set the object's <code><a data-for=
-                "RTCDTMFSender">toneBuffer</a></code> attribute to
-                <var>tones</var>.</li>
+                <li>Set the <code><a data-for="RTCDTMFSender">toneBuffer</a></code>
+                attribute of <var>dtmf</var> to <var>tones</var>.</li>
+                <li>Set the <a>[[\Duration]]</a> slot of <var>dtmf</var>
+                to the value of the <code><a data-for=
+                "RTCDTMFSender">duration</a></code> parameter.</li>
+                <li>Set the <a>[[\InterToneGap]]</a> slot of <var>dtmf</var>
+                to the value of the <code><a data-for=
+                "RTCDTMFSender">interToneGap</a></code> parameter.</li>
                 <li>If the value of the <code><a data-for=
                 "RTCDTMFSender">duration</a></code> parameter is less than 40,
-                set it to 40. If, on the other hand, the value is greater than
-                6000, set it to 6000.</li>
+                set the <a>[[\Duration]]</a> slot of <var>dtmf</var> to 40.</li>
                 <li>If the value of the <code><a data-for=
-                "RTCDTMFSender">interToneGap</a></code> parameter is less than
-                30, set it to 30. If, on the other hand, the value is greater
-                than 6000, set it to 6000.</li>
+                "RTCDTMFSender">duration</a></code> parameter is greater than 6000,
+                set the <a>[[\Duration]]</a> slot of <var>dtmf</var> to 6000.</li>
+                <li>If the value of the <code><a data-for=
+                "RTCDTMFSender">interToneGap</a></code> parameter is less than 30,
+                set the <a>[[\InterToneGap]]</a> slot of <var>dtmf</var> to 30.</li>
+                <li>If the value of the <code><a data-for=
+                "RTCDTMFSender">interToneGap</a></code> parameter is greater than 6000,
+                set the <a>[[\InterToneGap]]</a> slot of <var>dtmf</var> to 6000.</li>
                 <li>If <code><a data-for="RTCDTMFSender">toneBuffer</a></code>
                 is an empty string, abort these steps.</li>
                 <li>If a <em>Playout task</em> is scheduled to be run, abort

--- a/webrtc.html
+++ b/webrtc.html
@@ -8632,9 +8632,8 @@ interface RTCDTMFSender : EventTarget {
                 <code><a>RTCRtpSender</a></code> used to send DTMF.</li>
                 <li>Let <var>dtmf</var> be the <code><a>RTCDTMFSender</a></code>
                 associated with <var>sender</var>.</li>
-                <li>If the <a>[[\CanInsertDTMF]]</a> internal slot of
-                <var>dtmf</var> is <code>false</code>,
-                <a>throw</a> an <code>InvalidStateError</code>.</li>
+                <li>If <var>dtmf</var>'s <a>[[\CanInsertDTMF]]</a> internal slot
+                is <code>false</code>, <a>throw</a> an <code>InvalidStateError</code>.</li>
                 <li>
                   <p>Let <var>transceiver</var> be the
                   <code><a>RTCRtpTransceiver</a></code> object associated with

--- a/webrtc.html
+++ b/webrtc.html
@@ -8543,6 +8543,26 @@ interface RTCDataChannelEvent : Event {
     </section>
     <section>
       <h4><dfn>RTCDTMFSender</dfn></h4>
+      <p>When the <code>RTCDTMFSender</code> is constructed,
+        the user agent MUST run the following steps:</p>
+        <ol>
+          <li>
+            <p>Let <var>sender</var> be a newly created
+            <code><a>RTCDTMFSender</a></code> object.</p>
+          </li>
+          <li>
+            <p>Let <var>sender</var> have an <dfn>[[\CanInsertDTMF]]</dfn>
+            internal slot, initialized to <code>false</code>.</p>
+          </li>
+          <li>
+            <p>Let <var>sender</var> have an <dfn>[[\Duration]]</dfn>
+            internal slot, initialized to <code>100</code>.</p>
+          </li>
+          <li>
+            <p>Let <var>sender</var> have an <dfn>[[\InterToneGap]]</dfn>
+            internal slot, initialized to <code>70</code>.</p>
+          </li>
+       </ol>  
       <div>
         <pre class="idl">
 interface RTCDTMFSender : EventTarget {

--- a/webrtc.html
+++ b/webrtc.html
@@ -8547,19 +8547,19 @@ interface RTCDataChannelEvent : Event {
         the user agent MUST run the following steps:</p>
         <ol>
           <li>
-            <p>Let <var>sender</var> be a newly created
+            <p>Let <var>dtmf</var> be a newly created
             <code><a>RTCDTMFSender</a></code> object.</p>
           </li>
           <li>
-            <p>Let <var>sender</var> have an <dfn>[[\CanInsertDTMF]]</dfn>
+            <p>Let <var>dtmf</var> have an <dfn>[[\CanInsertDTMF]]</dfn>
             internal slot, initialized to <code>false</code>.</p>
           </li>
           <li>
-            <p>Let <var>sender</var> have an <dfn>[[\Duration]]</dfn>
+            <p>Let <var>dtmf</var> have an <dfn>[[\Duration]]</dfn>
             internal slot, initialized to <code>100</code>.</p>
           </li>
           <li>
-            <p>Let <var>sender</var> have an <dfn>[[\InterToneGap]]</dfn>
+            <p>Let <var>dtmf</var> have an <dfn>[[\InterToneGap]]</dfn>
             internal slot, initialized to <code>70</code>.</p>
           </li>
        </ol>  

--- a/webrtc.html
+++ b/webrtc.html
@@ -8658,7 +8658,7 @@ interface RTCDTMFSender : EventTarget {
                 <li>Set <var>dtmf</var>'s <a>[[\InterToneGap]]</a> slot to the
                 value of the <code><a data-for=
                 "RTCDTMFSender">interToneGap</a></code> parameter.</li>
-                <li>If the value of the code><a data-for=
+                <li>If the value of the <code><a data-for=
                 "RTCDTMFSender">duration</a></code> parameter is less than 40 ms,
                 set <var>dtmf</var>'s <a>[[\Duration]]</a> slot to 40 ms.</li>
                 <li>If the value of the <code><a data-for=

--- a/webrtc.html
+++ b/webrtc.html
@@ -8543,24 +8543,28 @@ interface RTCDataChannelEvent : Event {
     </section>
     <section>
       <h4><dfn>RTCDTMFSender</dfn></h4>
-      <p>When the <code>RTCDTMFSender</code> is constructed,
-        the user agent MUST run the following steps:</p>
+      <p>To create an <code>RTCDTMFSender</code>, the user agent MUST
+        run the following steps:</p>
         <ol>
           <li>
             <p>Let <var>dtmf</var> be a newly created
             <code><a>RTCDTMFSender</a></code> object.</p>
           </li>
           <li>
-            <p>Let <var>dtmf</var> have an <dfn>[[\CanInsertDTMF]]</dfn>
+            <p>Let <var>dtmf</var> have a <dfn>[[\CanInsertDtmf]]</dfn>
             internal slot, initialized to <code>false</code>.</p>
           </li>
           <li>
-            <p>Let <var>dtmf</var> have an <dfn>[[\Duration]]</dfn>
-            internal slot, initialized to <code>100</code>.</p>
+            <p>Let <var>dtmf</var> have a <dfn>[[\Duration]]</dfn>
+            internal slot.</p>
           </li>
           <li>
-            <p>Let <var>dtmf</var> have an <dfn>[[\InterToneGap]]</dfn>
-            internal slot, initialized to <code>70</code>.</p>
+            <p>Let <var>dtmf</var> have a <dfn>[[\InterToneGap]]</dfn>
+            internal slot.</p>
+          </li>
+          <li>
+            <p>Let <var>dtmf</var> have a <dfn>[[\ToneBuffer]]</dfn>
+            internal slot.</p>
           </li>
        </ol>  
       <div>

--- a/webrtc.html
+++ b/webrtc.html
@@ -8633,14 +8633,13 @@ interface RTCDTMFSender : EventTarget {
                 <li>Let <var>dtmf</var> be the <code><a>RTCDTMFSender</a></code>
                 associated with <var>sender</var>.</li>
                 <li>If <var>dtmf</var>'s <a>[[\CanInsertDTMF]]</a> internal slot
-                is <code>false</code>, <a>throw</a> a newly created
-                <code>InvalidStateError</code>.</li>
+                is <code>false</code>, <a>throw</a> an <code>InvalidStateError</code>.</li>
                 <li>
                   <p>Let <var>transceiver</var> be the
                   <code><a>RTCRtpTransceiver</a></code> object associated with
                   <var>sender</var>.</p>
                 </li>
-                <li>If <code><var>transceiver</var>.stopped</code> is
+                <li>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot is
                 <code>true</code>, <a>throw</a> an
                 <code>InvalidStateError</code>.</li>
                 <li>If <var>transceiver</var>'s <a>[[\CurrentDirection]]</a> slot
@@ -8648,8 +8647,7 @@ interface RTCDTMFSender : EventTarget {
                 <a>throw</a> an <code>InvalidStateError</code>.</li>
                 <li>Let <var>tones</var> be the method's first argument.</li>
                 <li>If <var>tones</var> contains any <a>unrecognized</a>
-                characters, <a>throw</a> an <code>InvalidCharacterError</code>.
-                </li>
+                characters, <a>throw</a> an <code>InvalidCharacterError</code>.</li>
                 <li>Set the object's <a>[[\ToneBuffer]]</a> slot to
                 <var>tones</var>.</li>
                 <li>Set <var>dtmf</var>'s <a>[[\Duration]]</a> slot to the
@@ -8670,20 +8668,20 @@ interface RTCDTMFSender : EventTarget {
                 <li>If the value of the <code><a data-for=
                 "RTCDTMFSender">interToneGap</a></code> parameter is greater than 6000 ms,
                 set <var>dtmf</var>'s <a>[[\InterToneGap]]</a> slot to 6000 ms.</li>
-                <li>If <code><a data-for="RTCDTMFSender">toneBuffer</a></code>
-                is an empty string, abort these steps.</li>
+                <li>If <a>[[\ToneBuffer]]</a> slot is an empty string,
+                abort these steps.</li>
                 <li>If a <em>Playout task</em> is scheduled to be run, abort
                 these steps; otherwise queue a task that runs the following
                 steps (<em>Playout task</em>):
                   <ol>
-                    <li>If <code><var>transceiver</var>.stopped</code> is
-                    <code>true</code>, abort these steps.</li>
-                    <li>If <var>transceiver</var>'s <a>[[\CurrentDirection]]</a> slot
-                    is <code>recvonly</code> or <code>inactive</code>,
+                    <li>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot
+                    is <code>true</code>, abort these steps.</li>
+                    <li>If <var>transceiver</var>'s <a>[[\CurrentDirection]]</a>
+                    slot is <code>recvonly</code> or <code>inactive</code>,
                     abort these steps.</li>
-                    <li>If the <a>[[\ToneBuffer]]</a> slot contains the empty string,
-                    fire an event named <code><a>tonechange</a></code> with an
-                    empty string at the <code><a>RTCDTMFSender</a></code>
+                    <li>If the <a>[[\ToneBuffer]]</a> slot contains the empty
+                    string, fire an event named <code><a>tonechange</a></code>
+                    with an empty string at the <code><a>RTCDTMFSender</a></code>
                     object and abort these steps.</li>
                     <li>Remove the first character from the <a>[[\ToneBuffer]]</a>
                     slot and let that character be <var>tone</var>.</li>
@@ -8694,12 +8692,10 @@ interface RTCDTMFSender : EventTarget {
                     "RTCDTMFSender">2000</a></code> ms from now that
                     runs the steps labelled <em>Playout task</em>.</li>
                     <li>If <var>tone</var> is not "," start playout of
-                    <var>tone</var> for <code><a data-for=
-                    "RTCDTMFSender">duration</a></code> ms on the associated
+                    <var>tone</var> for <a>[[\Duration]]</a> ms on the associated
                     RTP media stream, using the appropriate codec, then
-                    queue a task to be executed in <code><a data-for=
-                    "RTCDTMFSender">duration</a></code> + <code><a data-for=
-                    "RTCDTMFSender">interToneGap</a></code> ms from now that
+                    queue a task to be executed in <a>[[\Duration]]</a>
+                    + <a>[[\InterToneGap]]</a> ms from now that
                     runs the steps labelled <em>Playout task</em>.</li>
                     <li>Fire an event named <code><a>tonechange</a></code> with
                     a string consisting of <var>tone</var> at the

--- a/webrtc.html
+++ b/webrtc.html
@@ -8651,25 +8651,25 @@ interface RTCDTMFSender : EventTarget {
                 characters, <a>throw</a> an <code>InvalidCharacterError</code>.
                 </li>
                 <li>Set the <code><a data-for="RTCDTMFSender">toneBuffer</a></code>
-                attribute of <var>dtmf</var> to <var>tones</var>.</li>
-                <li>Set the <a>[[\Duration]]</a> slot of <var>dtmf</var>
-                to the value of the <code><a data-for=
+                attribute to <var>tones</var>.</li>
+                <li>Set <var>dtmf</var>'s <a>[[\Duration]]</a> slot to the
+                value of the <code><a data-for=
                 "RTCDTMFSender">duration</a></code> parameter.</li>
-                <li>Set the <a>[[\InterToneGap]]</a> slot of <var>dtmf</var>
-                to the value of the <code><a data-for=
+                <li>Set <var>dtmf</var>'s <a>[[\InterToneGap]]</a> slot to the
+                value of the <code><a data-for=
                 "RTCDTMFSender">interToneGap</a></code> parameter.</li>
+                <li>If the value of the code><a data-for=
+                "RTCDTMFSender">duration</a></code> parameter is less than 40 ms,
+                set <var>dtmf</var>'s <a>[[\Duration]]</a> slot to 40 ms.</li>
                 <li>If the value of the <code><a data-for=
-                "RTCDTMFSender">duration</a></code> parameter is less than 40,
-                set the <a>[[\Duration]]</a> slot of <var>dtmf</var> to 40.</li>
+                "RTCDTMFSender">duration</a></code> parameter is greater than 6000 ms,
+                set <var>dtmf</var>'s <a>[[\Duration]]</a> slot to 6000 ms.</li>
                 <li>If the value of the <code><a data-for=
-                "RTCDTMFSender">duration</a></code> parameter is greater than 6000,
-                set the <a>[[\Duration]]</a> slot of <var>dtmf</var> to 6000.</li>
+                "RTCDTMFSender">interToneGap</a></code> parameter is less than 30 ms,
+                set <var>dtmf</var>'s <a>[[\InterToneGap]]</a> slot to 30 ms.</li>
                 <li>If the value of the <code><a data-for=
-                "RTCDTMFSender">interToneGap</a></code> parameter is less than 30,
-                set the <a>[[\InterToneGap]]</a> slot of <var>dtmf</var> to 30.</li>
-                <li>If the value of the <code><a data-for=
-                "RTCDTMFSender">interToneGap</a></code> parameter is greater than 6000,
-                set the <a>[[\InterToneGap]]</a> slot of <var>dtmf</var> to 6000.</li>
+                "RTCDTMFSender">interToneGap</a></code> parameter is greater than 6000 ms,
+                set <var>dtmf</var>'s <a>[[\InterToneGap]]</a> slot to 6000 ms.</li>
                 <li>If <code><a data-for="RTCDTMFSender">toneBuffer</a></code>
                 is an empty string, abort these steps.</li>
                 <li>If a <em>Playout task</em> is scheduled to be run, abort

--- a/webrtc.html
+++ b/webrtc.html
@@ -8624,6 +8624,8 @@ interface RTCDTMFSender : EventTarget {
               <p>When the <code><a>insertDTMF()</a></code> method is invoked,
               the user agent MUST run the following steps:</p>
               <ol>
+                <li>If the <a>[[\CanInsertDTMF]]</a> internal slot is <code>false</code>,
+                <a>throw</a> an <code>InvalidStateError</code>.</li>
                 <li>let <var>sender</var> be the
                 <code><a>RTCRtpSender</a></code> used to send DTMF.</li>
                 <li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -8633,7 +8633,8 @@ interface RTCDTMFSender : EventTarget {
                 <li>Let <var>dtmf</var> be the <code><a>RTCDTMFSender</a></code>
                 associated with <var>sender</var>.</li>
                 <li>If <var>dtmf</var>'s <a>[[\CanInsertDTMF]]</a> internal slot
-                is <code>false</code>, <a>throw</a> an <code>InvalidStateError</code>.</li>
+                is <code>false</code>, <a>throw</a> a newly created
+                <code>InvalidStateError</code>.</li>
                 <li>
                   <p>Let <var>transceiver</var> be the
                   <code><a>RTCRtpTransceiver</a></code> object associated with
@@ -8649,8 +8650,7 @@ interface RTCDTMFSender : EventTarget {
                 <li>If <var>tones</var> contains any <a>unrecognized</a>
                 characters, <a>throw</a> an <code>InvalidCharacterError</code>.
                 </li>
-                <li>Set the object's <code><a data-for=
-                "RTCDTMFSender">toneBuffer</a></code> attribute to
+                <li>Set the object's <a>[[\ToneBuffer]]</a> slot to
                 <var>tones</var>.</li>
                 <li>Set <var>dtmf</var>'s <a>[[\Duration]]</a> slot to the
                 value of the <code><a data-for=
@@ -8681,14 +8681,12 @@ interface RTCDTMFSender : EventTarget {
                     <li>If <var>transceiver</var>'s <a>[[\CurrentDirection]]</a> slot
                     is <code>recvonly</code> or <code>inactive</code>,
                     abort these steps.</li>
-                    <li>If <code><a data-for=
-                    "RTCDTMFSender">toneBuffer</a></code> is an empty string,
+                    <li>If the <a>[[\ToneBuffer]]</a> slot contains the empty string,
                     fire an event named <code><a>tonechange</a></code> with an
                     empty string at the <code><a>RTCDTMFSender</a></code>
                     object and abort these steps.</li>
-                    <li>Remove the first character from <code><a data-for=
-                    "RTCDTMFSender">toneBuffer</a></code> and let that
-                    character be <var>tone</var>.</li>
+                    <li>Remove the first character from the <a>[[\ToneBuffer]]</a>
+                    slot and let that character be <var>tone</var>.</li>
                     <li>If <var>tone</var> is "," delay sending tones for
                     <code><a data-for="RTCDTMFSender">2000</a></code> ms on
                     the associated RTP media stream, and queue a task to
@@ -8712,8 +8710,8 @@ interface RTCDTMFSender : EventTarget {
               <p>Since <code>insertDTMF</code> replaces the tone
               buffer, in order to add to the DTMF tones being played,
               it is necessary to call <code>insertDTMF</code> with a
-              string containing both the remaining tones (stored in
-              <code>toneBuffer</code>) and the new tones appended
+              string containing both the remaining tones (stored in the
+              <a>[[\ToneBuffer]]</a> slot) and the new tones appended
               together. Calling <code><a data-for=
               "RTCDTMFSender">insertDTMF</a></code> with an empty tones
               parameter can be used to cancel all tones queued to play after
@@ -8761,8 +8759,8 @@ interface RTCDTMFToneChangeEvent : Event {
               <p>The <dfn><code>tone</code></dfn> attribute contains the
               character for the tone (including ",") that has just
               begun playout (see <code><a>insertDTMF</a></code> ). If the
-              value is the empty string, it indicates that the <code><a data-for=
-              "RTCDTMFSender">toneBuffer</a></code> is an empty string and that
+              value is the empty string, it indicates that the 
+              <a>[[\ToneBuffer]]</a> slot is an empty string and that
               the previous tones have completed playback.</p>
             </dd>
           </dl>
@@ -8782,9 +8780,9 @@ interface RTCDTMFToneChangeEvent : Event {
             <dd>
               <p>The <code>tone</code> attribute contains the
               character for the tone (including ",") that has just
-              begun playout (see <code><a>insertDTMF</a></code> ). If the
-              value is the empty string, it indicates that the <code><a data-for=
-              "RTCDTMFSender">toneBuffer</a></code> is an empty string and that
+              begun playout (see <code><a>insertDTMF</a></code> ). If
+              the value is the empty string, it indicates that the
+              <a>[[\ToneBuffer]]</a> slot is an empty string and that
               the previous tones have completed playback.</p>
             </dd>
           </dl>

--- a/webrtc.html
+++ b/webrtc.html
@@ -8624,10 +8624,13 @@ interface RTCDTMFSender : EventTarget {
               <p>When the <code><a>insertDTMF()</a></code> method is invoked,
               the user agent MUST run the following steps:</p>
               <ol>
-                <li>If the <a>[[\CanInsertDTMF]]</a> internal slot is <code>false</code>,
-                <a>throw</a> an <code>InvalidStateError</code>.</li>
                 <li>let <var>sender</var> be the
                 <code><a>RTCRtpSender</a></code> used to send DTMF.</li>
+                <li>Let <var>dtmf</var> be the <code><a>RTCDTMFSender</a></code>
+                associated with <var>sender</var>.</li>
+                <li>If the <a>[[\CanInsertDTMF]]</a> internal slot of
+                <var>dtmf</var> is <code>false</code>,
+                <a>throw</a> an <code>InvalidStateError</code>.</li>
                 <li>
                   <p>Let <var>transceiver</var> be the
                   <code><a>RTCRtpTransceiver</a></code> object associated with

--- a/webrtc.html
+++ b/webrtc.html
@@ -8649,8 +8649,9 @@ interface RTCDTMFSender : EventTarget {
                 <li>If <var>tones</var> contains any <a>unrecognized</a>
                 characters, <a>throw</a> an <code>InvalidCharacterError</code>.
                 </li>
-                <li>Set the <code><a data-for="RTCDTMFSender">toneBuffer</a></code>
-                attribute to <var>tones</var>.</li>
+                <li>Set the object's <code><a data-for=
+                "RTCDTMFSender">toneBuffer</a></code> attribute to
+                <var>tones</var>.</li>
                 <li>Set <var>dtmf</var>'s <a>[[\Duration]]</a> slot to the
                 value of the <code><a data-for=
                 "RTCDTMFSender">duration</a></code> parameter.</li>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/1516


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/issue-1516-patch.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/945b618...3bbf9d4.html)