### PR TITLE
s/outboundrtp/outbound-rtp

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9081,7 +9081,7 @@ pc.getStats(selector).then(function (report) {
 function processStats() {
     // compare the elements from the current report with the baseline
     currentReport.forEach (now =&gt; {
-        if (now.type != "outboundrtp")
+        if (now.type != "outbound-rtp")
             return;
 
         // get the corresponding stats from the baseline report


### PR DESCRIPTION
stat type names are using hyphens now.

@jan-ivar is the example still correct with your recent "remote" change to -stats?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/fippo/webrtc-pc/outbound-fix.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/945b618...fippo:1eb447f.html)