### PR TITLE
Wait for certificate to be generated before identity assertion process

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2179,6 +2179,11 @@ interface RTCPeerConnection : EventTarget  {
                 <var>p</var> are as follows:</p>
                 <ol>
                   <li>
+                    <p>If <var>connection</var> was not constructed with a set
+                    of certificates, and one has not yet been generated, wait
+                    for it to be generated.</p>
+                  </li>
+                  <li>
                     <p>If the need for an identity assertion was identified
                     when <code>createOffer</code> was invoked, wait for
                     <a href="#sec.identity-proxy-assertion-request">the
@@ -2189,11 +2194,6 @@ interface RTCPeerConnection : EventTarget  {
                     identity assertion, reject <var>p</var> with a newly
                     <a data-link-for="exception" data-lt="create">created</a>
                     <code>NotReadableError</code> and abort these steps.</p>
-                  </li>
-                  <li>
-                    <p>If <var>connection</var> was not constructed with a set
-                    of certificates, and one has not yet been generated, wait
-                    for it to be generated.</p>
                   </li>
                   <li>
                     <p>Inspect the system state to determine the currently
@@ -2353,6 +2353,11 @@ interface RTCPeerConnection : EventTarget  {
                 <var>p</var> are as follows:</p>
                 <ol>
                   <li>
+                    <p>If <var>connection</var> was not constructed with a set
+                    of certificates, and one has not yet been generated, wait
+                    for it to be generated.</p>
+                  </li>
+                  <li>
                     <p>If the need for an identity assertion was identified
                     when <code>createAnswer</code> was invoked, wait for
                     <a href="#sec.identity-proxy-assertion-request">the
@@ -2363,11 +2368,6 @@ interface RTCPeerConnection : EventTarget  {
                     identity assertion, reject <var>p</var> with a newly
                     <a data-link-for="exception" data-lt="create">created</a>
                     <code>NotReadableError</code> and abort these steps.</p>
-                  </li>
-                  <li>
-                    <p>If <var>connection</var> was not constructed with a set
-                    of certificates, and one has not yet been generated, wait
-                    for it to be generated.</p>
                   </li>
                   <li>
                     <p>Inspect the system state to determine the currently
@@ -9449,6 +9449,11 @@ interface RTCIdentityProviderRegistrar {
           Provider Selection</a> and <a href="#sec.register-idp">Registering an
           IdP Proxy</a>. If the IdP cannot be loaded, instantiated, or the IdP
           proxy is not registered, this process fails.</p>
+        </li>
+        <li>
+          <p>If the <code>RTCPeerConnection</code> was not constructed with a set
+          of certificates, and one has not yet been generated, wait
+          for it to be generated.</p>
         </li>
         <li>
           <p>The <code>RTCPeerConnection</code> invokes the <code><a data-for=


### PR DESCRIPTION
Fixes #1503.

- The step for waiting for certificate generation is repeated in 9.3 Requesting Identity Assertions.

- The steps for waiting for certificate generation in `createOffer` and `createAnswer` are moved to before waiting for identity assertion process to complete.

The step for waiting for certificate needs to be duplicated, because createOffer/Answer may not request for identity assertion. The additional step is added to 9.3 instead of `getIdentityAssertion`, because createOffer/Answer invokes the identity assertion process synchronously first then only wait for the assertion and certificates to be generated.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/soareschen/webrtc-pc/issue-1503-patch.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/f798246...soareschen:0076edc.html)