### PR TITLE
Add note that IdP must treat contents as opaque

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9296,9 +9296,10 @@ interface RTCIdentityProviderRegistrar {
               <dt><code>contents</code> of type <span class=
               "idlMemberType"><a>DOMString</a></span></dt>
               <dd>The <var>contents</var> parameter includes the information
-              that the user agent wants covered by the identity assertion. A
-              successful validation of the provided assertion MUST produce this
-              string.</dd>
+              that the user agent wants covered by the identity assertion. The
+              IdP MUST treat <code>contents</code> as opaque string. A
+              successful validation of the provided assertion MUST produce the
+              same string.</dd>
               <dt><code>origin</code> of type <span class=
               "idlMemberType"><a>DOMString</a></span></dt>
               <dd>
@@ -9605,6 +9606,14 @@ interface RTCIdentityProviderRegistrar {
           communicate with peers that offer a certificate that doesn't match an
           <code>a=fingerprint</code> line in the negotiated session
           description.</p>
+          <p class="note">The user agent decodes <a data-for=
+          "RTCIdentityValidationResult"></code>contents</code></a> using
+          the format described in [[!RTCWEB-SECURITY-ARCH]] and do not perform
+          string-based comparison with the original <a
+          href="#dom-generateassertioncallback"><code>contents</code></a>.
+          However [[!RTCWEB-SECURITY-ARCH]] mandates that the IdP MUST treat
+          </code>contents</code> as opaque and return the same string to allow
+          for future extensions.</p>
         </li>
         <li>
           <p>The <code>RTCPeerConnection</code> validates that the domain

--- a/webrtc.html
+++ b/webrtc.html
@@ -9607,13 +9607,10 @@ interface RTCIdentityProviderRegistrar {
           <code>a=fingerprint</code> line in the negotiated session
           description.</p>
           <p class="note">The user agent decodes <a data-for=
-          "RTCIdentityValidationResult"></code>contents</code></a> using
-          the format described in [[!RTCWEB-SECURITY-ARCH]] and do not perform
-          string-based comparison with the original <a
-          href="#dom-generateassertioncallback"><code>contents</code></a>.
-          However [[!RTCWEB-SECURITY-ARCH]] mandates that the IdP MUST treat
-          </code>contents</code> as opaque and return the same string to allow
-          for future extensions.</p>
+          "RTCIdentityValidationResult"><code>contents</code></a> using
+          the format described in [[!RTCWEB-SECURITY-ARCH]]. However the IdP
+          MUST treat <code>contents</code> as opaque and return the same string
+          to allow for future extensions.</p>
         </li>
         <li>
           <p>The <code>RTCPeerConnection</code> validates that the domain


### PR DESCRIPTION
Fixes #1505.

This adds note that although `RTCPeerConnection` do not perform string based comparison with the original `contents`, the IdP MUST treat `contents` as opaque and return the same string to conform with rtcweb-security-arch.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/soareschen/webrtc-pc/issue-1505-patch.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/f798246...soareschen:89aeed6.html)