### PR TITLE
Allow createAnswer to be called only in valid signaling state

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2330,11 +2330,12 @@ interface RTCPeerConnection : EventTarget  {
                     steps to <var>connection</var>'s operation queue:</p>
                     <ol>
                       <li>
-                        <p>If <var>connection</var>'s <code><a data-for=
-                        "RTCPeerConnection">remoteDescription</a></code> is
-                        <code>null</code> return a promise rejected with a newly
-                        <a data-link-for="exception" data-lt="create">created
-                        </a> <code>InvalidStateError</code>.</p>
+                        <p>If <var>connection</var>'s <a>signaling stated</a>
+                        is not <code>"have-remote-offer"</code> or
+                        <code>"have-local-pranswer"</code>, return a promise
+                        rejected with a newly <a data-link-for="exception"
+                        data-lt="create">created</a>
+                        <code>InvalidStateError</code>.</p>
                       </li>
                       <li>
                         <p>Let <var>p</var> be a new promise.</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -2330,8 +2330,8 @@ interface RTCPeerConnection : EventTarget  {
                     steps to <var>connection</var>'s operation queue:</p>
                     <ol>
                       <li>
-                        <p>If <var>connection</var>'s <a>signaling stated</a>
-                        is not <code>"have-remote-offer"</code> or
+                        <p>If <var>connection</var>'s <a>signaling state</a>
+                        is neither <code>"have-remote-offer"</code> nor
                         <code>"have-local-pranswer"</code>, return a promise
                         rejected with a newly <a data-link-for="exception"
                         data-lt="create">created</a>
@@ -2824,7 +2824,7 @@ interface RTCPeerConnection : EventTarget  {
                     <code>true</code>.</p>
                   </li>
                   <li>
-                    <p>Set <var>connection</var>'s <a>signaling state</a> to 
+                    <p>Set <var>connection</var>'s <a>signaling state</a> to
                     <code>"closed"</code>.</p>
                   </li>
                 </ol>


### PR DESCRIPTION
Fixes #1183.

This makes createAnswer throw `InvalidStateError` if the signaling state is not `have-remote-offer` or `have-local-pranswer`. Checking signaling state also implicitly assert that `pendingRemoteDescription` is set, so that checking is removed.

There is a breaking change here that existing implementations allow createAnswer to succeed after a call to `setLocalDescription(answer)`. Nevertheless the resulting new answer cannot be applied because the connection have transition  back to stable state. If anyone think it is important not to break this behavior, I am happy to modify the patch to only throw error if `pendingRemoteDescription` is not of type `offer`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/soareschen/webrtc-pc/issue-1183-patch.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/f798246...soareschen:6137d09.html)