### PR TITLE
Validate binaryType value when setting it in RTCDataChannel

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8168,11 +8168,11 @@ interface RTCTrackEvent : Event {
             <dd>
               <p>The <dfn id=
               "dom-datachannel-binarytype"><code>binaryType</code></dfn>
-              attribute MUST, on getting, return the value to which it was last
-              set. On setting, if the new value is either the string
-              "<code>blob</code>" or the string "<code>arraybuffer</code>",
-              then set the IDL attribute to this new value. Otherwise, throw a
-              <code>SyntaxError</code> exception. When a
+              attribute MUST, on getting, return the value to which it was
+              last set. On setting, if the new value is either the string
+              <code>"blob"</code> or the string "<code>"arraybuffer"</code>,
+              then set the IDL attribute to this new value. Otherwise,
+              <a>throw</a> a <code>SyntaxError</code>. When a
               <code><a>RTCDataChannel</a></code> object is
               created, the <code><a data-for=
               "RTCDataChannel">binaryType</a></code> attribute MUST be

--- a/webrtc.html
+++ b/webrtc.html
@@ -8169,8 +8169,11 @@ interface RTCTrackEvent : Event {
               <p>The <dfn id=
               "dom-datachannel-binarytype"><code>binaryType</code></dfn>
               attribute MUST, on getting, return the value to which it was last
-              set. On setting, the user agent MUST set the IDL attribute to the
-              new value. When a <code><a>RTCDataChannel</a></code> object is
+              set. On setting, if the new value is either the string
+              "<code>blob</code>" or the string "<code>arraybuffer</code>",
+              then set the IDL attribute to this new value. Otherwise, throw a
+              <code>SyntaxError</code> exception. When a
+              <code><a>RTCDataChannel</a></code> object is
               created, the <code><a data-for=
               "RTCDataChannel">binaryType</a></code> attribute MUST be
               initialized to the string "<code>blob</code>".</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -8170,7 +8170,7 @@ interface RTCTrackEvent : Event {
               "dom-datachannel-binarytype"><code>binaryType</code></dfn>
               attribute MUST, on getting, return the value to which it was
               last set. On setting, if the new value is either the string
-              <code>"blob"</code> or the string "<code>"arraybuffer"</code>,
+              <code>"blob"</code> or the string <code>"arraybuffer"</code>,
               then set the IDL attribute to this new value. Otherwise,
               <a>throw</a> a <code>SyntaxError</code>. When a
               <code><a>RTCDataChannel</a></code> object is


### PR DESCRIPTION
Fixes #1379.

The new paragraph is directly copied from WebSockets so that minimal changes are introduced.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/soareschen/webrtc-pc/issue-1379-patch.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/f798246...soareschen:96b0beb.html)