### PR TITLE
replace "a RTCsomething" with "an RTCsomething"

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -440,7 +440,7 @@
                 long-term authentication password, as described in
                 [[!RFC5389]], Section 10.2.</p>
                 <p>If <code>credentialType</code> is <code>"oauth"</code>,
-                <code>credential</code> is a <a>RTCOAuthCredential</a>, which
+                <code>credential</code> is an <a>RTCOAuthCredential</a>, which
                 contains the OAuth access token and MAC key.</p>
               </dd>
               <dt><dfn><code>credentialType</code></dfn> of type <span class=
@@ -2709,7 +2709,7 @@ interface RTCPeerConnection : EventTarget  {
               </dd>
               <dt><dfn><code>getConfiguration</code></dfn></dt>
               <dd>
-                <p>Returns a <code><a>RTCConfiguration</a></code> object
+                <p>Returns an <code><a>RTCConfiguration</a></code> object
                 representing the current configuration of this
                 <code><a>RTCPeerConnection</a></code> object.</p>
                 <p>When this method is called, the user agent MUST return the
@@ -3170,7 +3170,7 @@ interface RTCPeerConnection : EventTarget  {
         slot is <code>true</code>, no such event handler can be triggered and
         it is therefore safe to garbage collect the object.</p>
         <p>All <code><a>RTCDataChannel</a></code> and
-        <code><a>MediaStreamTrack</a></code> objects that are connected to a
+        <code><a>MediaStreamTrack</a></code> objects that are connected to an
         <code><a>RTCPeerConnection</a></code> have a strong reference to the
         <code><a>RTCPeerConnection</a></code> object.</p>
       </section>
@@ -3906,7 +3906,7 @@ interface RTCIceCandidate {
         <code>candidate</code> attribute set to the new ICE candidate, MUST be
         created and dispatched at the given target.</p>
         <p>When firing an <code><a>RTCPeerConnectionIceEvent</a></code> event
-        that contains a <code><a>RTCIceCandidate</a></code> object, it MUST
+        that contains an <code><a>RTCIceCandidate</a></code> object, it MUST
         include values for both <a data-for=
         "RTCIceCandidate"><code>sdpMid</code></a> and <a data-for=
         "RTCIceCandidate"><code>sdpMLineIndex</code></a>. If the
@@ -4273,7 +4273,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             <p>When <a data-for=
             "RTCPeerConnection"><code>generateCertificate</code></a> is called
             with an <code><a>object</a></code> argument, the <a>user agent</a>
-            attempts to convert the object into a
+            attempts to convert the object into an
             <code><a>RTCCertificateExpiration</a></code>. If this is
             unsuccessful, immediately return a promise that is rejected with a
             newly <a data-link-for="exception" data-lt="create">created</a>
@@ -4334,17 +4334,17 @@ interface RTCPeerConnectionIceErrorEvent : Event {
         </div>
         <p>For the purposes of this API, the <a>[[\Certificate]]</a> slot
         contains unstructured binary data.</p>
-        <p>Note that a <code>RTCCertificate</code> might not directly hold
+        <p>Note that an <code>RTCCertificate</code> might not directly hold
         private keying material, this might be stored in a secure module.</p>
         <p>The <code>RTCCertificate</code> object can be stored and retrieved
         from persistent storage by an application. When a <a>user agent</a> is
-        required to obtain a structured clone [[!HTML5]] of a
+        required to obtain a structured clone [[!HTML5]] of an
         <code>RTCCertificate</code> object, it performs the following
         steps:</p>
         <ol>
           <li>Let <var>input</var> and <var>memory</var> be the corresponding
           inputs defined by the internal structured cloning algorithm, where
-          <var>input</var> represents a <code>RTCCertificate</code> object to
+          <var>input</var> represents an <code>RTCCertificate</code> object to
           be cloned.</li>
           <li>Let <var>output</var> be a newly constructed
           <code>RTCCertificate</code> object.</li>
@@ -7793,21 +7793,21 @@ interface RTCTrackEvent : Event {
     <section>
       <h3><dfn>RTCDataChannel</dfn></h3>
       <p>The <code><a>RTCDataChannel</a></code> interface represents a
-      bi-directional data channel between two peers. A
+      bi-directional data channel between two peers. An
       <code><a>RTCDataChannel</a></code> is created via a factory method on an
       <code><a>RTCPeerConnection</a></code> object. The messages sent between
       the browsers are described in [[!RTCWEB-DATA]] and
       [[!RTCWEB-DATA-PROTOCOL]].</p>
       <p>There are two ways to establish a connection with
-      <code><a>RTCDataChannel</a></code>. The first way is to simply create a
+      <code><a>RTCDataChannel</a></code>. The first way is to simply create an
       <code><a>RTCDataChannel</a></code> at one of the peers with the
       <code><a data-for="RTCDataChannelInit">negotiated</a></code>
       <code><a>RTCDataChannelInit</a></code> dictionary member unset or set to
       its default value false. This will announce the new channel in-band and
-      trigger a <code><a>RTCDataChannelEvent</a></code> with the corresponding
+      trigger an <code><a>RTCDataChannelEvent</a></code> with the corresponding
       <code><a>RTCDataChannel</a></code> object at the other peer. The second
       way is to let the application negotiate the
-      <code><a>RTCDataChannel</a></code>. To do this, create a
+      <code><a>RTCDataChannel</a></code>. To do this, create an
       <code><a>RTCDataChannel</a></code> object with the <code><a data-for=
       "RTCDataChannelInit">negotiated</a></code>
       <code><a>RTCDataChannelInit</a></code> dictionary member set to true, and
@@ -7829,7 +7829,7 @@ interface RTCTrackEvent : Event {
       is created. The properties of a channel cannot change after the channel
       has been created. The actual wire protocol between the peers is specified
       by the WebRTC DataChannel Protocol specification [[RTCWEB-DATA]].</p>
-      <p>A <code><a>RTCDataChannel</a></code> can be configured to operate in
+      <p>An <code><a>RTCDataChannel</a></code> can be configured to operate in
       different reliability modes. A reliable channel ensures that the data is
       delivered at the other peer through retransmissions. An unreliable
       channel is configured to either limit the number of retransmissions (
@@ -7839,8 +7839,8 @@ interface RTCTrackEvent : Event {
       These properties can not be used simultaneously and an attempt to do so
       will result in an error. Not setting any of these properties results in a
       reliable channel.</p>
-      <p>A <code><a>RTCDataChannel</a></code>, created with <code><a data-for=
-      "RTCPeerConnection">createDataChannel</a></code> or dispatched via a
+      <p>An <code><a>RTCDataChannel</a></code>, created with <code><a data-for=
+      "RTCPeerConnection">createDataChannel</a></code> or dispatched via an
       <code><a>RTCDataChannelEvent</a></code>, MUST initially be in the
       <code>connecting</code> state. When the
       <code><a>RTCDataChannel</a></code> object's <a>underlying data
@@ -7848,7 +7848,7 @@ interface RTCTrackEvent : Event {
       <code>RTCDataChannel</code> as open</a>.</p>
       <p>When the user agent is to <dfn data-lt=
       "announce the rtcdatachannel as open" id=
-      "announce-datachannel-open">announce a <code>RTCDataChannel</code> as
+      "announce-datachannel-open">announce an <code>RTCDataChannel</code> as
       open</dfn>, the user agent MUST queue a task to run the following
       steps:</p>
       <ol>
@@ -7948,7 +7948,7 @@ interface RTCTrackEvent : Event {
       task that sets the object's <code><a data-for=
       "RTCDataChannel">readyState</a></code> attribute to <code>closing</code>.
       This will eventually render the <a>data transport</a> <a>closed</a>.</p>
-      <p>When a <code><a>RTCDataChannel</a></code> object's <a>underlying data
+      <p>When an <code><a>RTCDataChannel</a></code> object's <a>underlying data
       transport</a> has been <dfn id="data-transport-closed">closed</dfn>, the
       user agent MUST queue a task to run the following steps:</p>
       <ol>
@@ -8194,7 +8194,7 @@ interface RTCTrackEvent : Event {
               last set. On setting, if the new value is either the string
               <code>"blob"</code> or the string <code>"arraybuffer"</code>,
               then set the IDL attribute to this new value. Otherwise,
-              <a>throw</a> a <code>SyntaxError</code>. When a
+              <a>throw</a> a <code>SyntaxError</code>. When an
               <code><a>RTCDataChannel</a></code> object is
               created, the <code><a data-for=
               "RTCDataChannel">binaryType</a></code> attribute MUST be
@@ -8320,7 +8320,7 @@ interface RTCTrackEvent : Event {
               the channel in-band and instruct the other peer to dispatch a
               corresponding <code><a>RTCDataChannel</a></code> object. If set
               to true, it is up to the application to negotiate the channel and
-              create a <code><a>RTCDataChannel</a></code> object with the same
+              create an <code><a>RTCDataChannel</a></code> object with the same
               <code><a data-for="RTCDataChannel">id</a></code> at the other
               peer.</p>
             </dd>
@@ -8423,7 +8423,7 @@ interface RTCTrackEvent : Event {
               <td><dfn><code>connecting</code></dfn></td>
               <td>
                 <p>The user agent is attempting to establish the <a>underlying
-                data transport</a>. This is the initial state of a
+                data transport</a>. This is the initial state of an
                 <code><a>RTCDataChannel</a></code> object created with
                 <code><a data-for=
                 "RTCPeerConnection">createDataChannel</a></code>.</p>
@@ -8433,9 +8433,9 @@ interface RTCTrackEvent : Event {
               <td><dfn><code>open</code></dfn></td>
               <td>
                 <p>The <a>underlying data transport</a> is established and
-                communication is possible. This is the initial state of a
+                communication is possible. This is the initial state of an
                 <code><a>RTCDataChannel</a></code> object dispatched as a part
-                of a <code><a>RTCDataChannelEvent</a></code>.</p>
+                of an <code><a>RTCDataChannelEvent</a></code>.</p>
               </td>
             </tr>
             <tr>
@@ -8463,7 +8463,7 @@ interface RTCTrackEvent : Event {
       <code><a>RTCDataChannelEvent</a></code> interface.</p>
       <p><dfn id="fire-a-datachannel-event" data-lt=
       "fire a datachannel event">Firing a datachannel event named
-      <var>e</var></dfn> with a <code><a>RTCDataChannel</a></code>
+      <var>e</var></dfn> with an <code><a>RTCDataChannel</a></code>
       <var>channel</var> means that an event with the name <var>e</var>, which
       does not bubble (except where otherwise stated) and is not cancelable
       (except where otherwise stated), and which uses the
@@ -8522,7 +8522,7 @@ interface RTCDataChannelEvent : Event {
     </section>
     <section>
       <h3>Garbage Collection</h3>
-      <p>A <code><a>RTCDataChannel</a></code> object MUST not be garbage
+      <p>An <code><a>RTCDataChannel</a></code> object MUST not be garbage
       collected if its</p>
       <ul>
         <li>
@@ -8570,7 +8570,7 @@ interface RTCDataChannelEvent : Event {
             <dt><code>dtmf</code> of type <span class=
             "idlAttrType"><a>RTCDTMFSender</a></span>, readonly, nullable</dt>
             <dd>
-              <p>The <dfn>dtmf</dfn> attribute returns a RTCDTMFSender which
+              <p>The <dfn>dtmf</dfn> attribute returns an RTCDTMFSender which
               can be used to send DTMF. The attribute is set when
               <code><a>RTCRtpSender</a>.track.kind</code> is <code>"audio"</code>
               and is <code>null</code> otherwise.</p>
@@ -8855,7 +8855,7 @@ interface RTCDTMFToneChangeEvent : Event {
                 </li>
                 <li>
                   <p>If <var>selectorArg</var> is a <a>MediaStreamTrack</a> 
-                  let <var>selector</var> be a <a>RTCRtpSender</a> or
+                  let <var>selector</var> be an <a>RTCRtpSender</a> or
                   <a>RTCRtpReceiver</a> on <var>connection</var> which
                   <code>track</code> member matches <var>selectorArg</var>.
                   If no such sender or receiver exists, or if more than one
@@ -9684,7 +9684,7 @@ interface RTCIdentityProviderRegistrar {
       <a>target peer identity</a> cause the <code><a data-for=
       "RTCPeerConnection">peerIdentity</a></code> promise to be rejected
       instead.</p>
-      <p>If an error occurs these promises are rejected with a
+      <p>If an error occurs these promises are rejected with an
       <code><a>RTCError</a></code> if an error occurs in interacting with the IdP
       proxy. The following scenarios result in errors:</p>
       <ul>
@@ -9735,7 +9735,7 @@ interface RTCIdentityProviderRegistrar {
         the error set to the URL that can be used to login.</p></li>
         <li><p>Even when the IdP proxy produces a positive result, the
         procedure that uses this information might still fail. Additional
-        validation of a <a>RTCIdentityValidationResult</a> value is still
+        validation of an <a>RTCIdentityValidationResult</a> value is still
         necessary. The procedure for <a
         href="#sec.identity-verify-assertion">validation of identity
         assertions</a> describes additional steps that are required to
@@ -10072,7 +10072,7 @@ interface RTCIdentityAssertion {
         <code>MediaTrackCapabilites</code>, <code>MediaTrackConstraints</code>
         and <code>MediaTrackSettings</code> is outlined in [[!GETUSERMEDIA]].
         However, the <code>MediaTrackSettings</code> for a
-        <code>MediaStreamTrack</code> sourced by a
+        <code>MediaStreamTrack</code> sourced by an
         <code><a>RTCPeerConnection</a></code> will only be populated with
         members to the extent that data is supplied by means of the remote
         <code><a>RTCSessionDescription</a></code> applied via
@@ -10237,7 +10237,7 @@ interface RTCIdentityAssertion {
         <p>Any <code>MediaStreamTrack</code> that has the
         <var>peerIdentity</var> option set causes all tracks sent using the
         same <code><a>RTCPeerConnection</a></code> to be isolated at the
-        receiving peer. All DTLS connections created for a
+        receiving peer. All DTLS connections created for an
         <code><a>RTCPeerConnection</a></code> with isolated local streams MUST
         be negotiated so that media remains isolated at the remote peer. This
         causes non-isolated media to become isolated at the receiving peer if
@@ -10657,7 +10657,7 @@ function logError(error) {
     <section>
       <h3>Peer-to-peer Data Example</h3>
       <div>
-        <p>This example shows how to create a
+        <p>This example shows how to create an
         <code><a>RTCDataChannel</a></code> object and perform the offer/answer
         exchange required to connect the channel to the other peer. The
         <code><a>RTCDataChannel</a></code> is used in the context of a simple
@@ -12392,7 +12392,7 @@ interface RTCErrorEvent : Event {
       code.</li>
       <li>Change maxRetransmits to be an unsigned type.</li>
       <li>Clarify state changes when ICE restarts.</li>
-      <li>Added InvalidStateError exception for operations on a
+      <li>Added InvalidStateError exception for operations on an
       RTCPeerConnection that is closed.</li>
       <li>Major changes to Identity Proxy section.</li>
       <li>(ACTION: 95) Moved IceTransports (constraint) to RTCConfiguration


### PR DESCRIPTION
for consistency


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/fippo/webrtc-pc/arrrr-like-a-pirate.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/7d5b589...fippo:1be6828.html)