### PR TITLE
Update mandatory to implement stats fields to sync with webrtc-stats

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9047,7 +9047,7 @@ interface RTCDTMFToneChangeEvent : Event {
         framesPerSecond, framesSent, framesReceived, framesDecoded,
         framesDropped, framesCorrupted, audioLevel</li>
         <li>RTCCodecStats, with attributes payloadType, codec, clockRate,
-        channels</li>
+        channels, sdpFmtpLine</li>
         <li>RTCTransportStats, with attributes bytesSent, bytesReceived,
         rtcpTransportStatsId, selectedCandidatePairId,
         localCertificateId, remoteCertificateId</li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -9043,17 +9043,17 @@ interface RTCDTMFToneChangeEvent : Event {
         bytesReceived</li>
         <li>RTCMediaStreamStats, with attributes streamIdentifer, trackIds</li>
         <li>RTCMediaStreamTrackStats, with attributes trackIdentifier,
-        remoteSource, ended, detached, ssrcIds, frameWidth, frameHeight,
+        remoteSource, ended, detached, frameWidth, frameHeight,
         framesPerSecond, framesSent, framesReceived, framesDecoded,
         framesDropped, framesCorrupted, audioLevel</li>
         <li>RTCCodecStats, with attributes payloadType, codec, clockRate,
-        channels, parameters</li>
+        channels</li>
         <li>RTCTransportStats, with attributes bytesSent, bytesReceived,
-        rtcpTransportStatsId, activeConnection, selectedCandidatePairId,
+        rtcpTransportStatsId, selectedCandidatePairId,
         localCertificateId, remoteCertificateId</li>
         <li>RTCIceCandidatePairStats, with attributes transportId,
         localCandidateId, remoteCandidateId, state, priority, nominated,
-        writable, readable, bytesSent, bytesReceived, totalRtt, currentRtt</li>
+        bytesSent, bytesReceived, totalRoundTripTime, currentRoundTripTime</li>
         <li>RTCIceCandidateStats, with attributes ip, port, protocol,
         candidateType, priority, url</li>
         <li>RTCCertificateStats, with attributes fingerprint,


### PR DESCRIPTION
Continue #1480 to fix #1474.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/soareschen/webrtc-pc/issue-1474-patch.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/7d0e7ab...soareschen:754a8c2.html)