### PR TITLE
Throw if a DataChannel, negotiated by the script, lacks id

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7672,14 +7672,14 @@ interface RTCTrackEvent : Event {
                   </div>
                 </li>
                 <li>
-                  <p>Let <var>channel</var> have an
-                  <dfn>[[\DataChannelPriority]]</dfn> internal slot initialized
-                  to <var>option</var>'s <code>priority</code> member.</p>
-                </li>
-                <li>
                   <p>If <a>[[\Negotiated]]</a> is <code>true</code> and
                   <a>[[\DataChannelId]]</a> is <code>null</code>, <a>throw</a>
                   a <code>TypeError</code>.</p>
+                </li>
+                <li>
+                  <p>Let <var>channel</var> have an
+                  <dfn>[[\DataChannelPriority]]</dfn> internal slot initialized
+                  to <var>option</var>'s <code>priority</code> member.</p>
                 </li>
                 <li>
                   <p>If both <a>[[\MaxPacketLifeTime]]</a> and

--- a/webrtc.html
+++ b/webrtc.html
@@ -7677,6 +7677,11 @@ interface RTCTrackEvent : Event {
                   to <var>option</var>'s <code>priority</code> member.</p>
                 </li>
                 <li>
+                  <p>If <a>[[\Negotiated]]</a> is <code>true</code> and
+                  <a>[[\DataChannelId]]</a> is <code>null</code>, <a>throw</a>
+                  a <code>TypeError</code>.</p>
+                </li>
+                <li>
                   <p>If both <a>[[\MaxPacketLifeTime]]</a> and
                   <a>[[\MaxRetransmits]]</a>
                   attributes are set (not null), <a>throw</a> a


### PR DESCRIPTION
Fix #1529


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/dc-negotiate-no-id.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/2d424aa...642597a.html)