### PR TITLE
Reference rtcweb-data-channel for RTCPriorityType enum.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4118,19 +4118,23 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               </tr>
               <tr>
                 <td><dfn><code>very-low</code></dfn></td>
-                <td>See [[!RTCWEB-TRANSPORT]], Section 4.</td>
+                <td>See [[!RTCWEB-TRANSPORT]], Section 4. Corresponds to "below
+                normal" as defined in [[!RTCWEB-DATA]].</td>
               </tr>
               <tr>
                 <td><dfn><code>low</code></dfn></td>
-                <td>See [[!RTCWEB-TRANSPORT]], Section 4.</td>
+                <td>See [[!RTCWEB-TRANSPORT]], Section 4. Corresponds to
+                "normal" as defined in [[!RTCWEB-DATA]].</td>
               </tr>
               <tr>
                 <td><dfn><code>medium</code></dfn></td>
-                <td>See [[!RTCWEB-TRANSPORT]], Section 4.</td>
+                <td>See [[!RTCWEB-TRANSPORT]], Section 4. Corresponds to "high"
+                as defined in [[!RTCWEB-DATA]].</td>
               </tr>
               <tr>
                 <td><dfn><code>high</code></dfn></td>
-                <td>See [[!RTCWEB-TRANSPORT]], Section 4.</td>
+                <td>See [[!RTCWEB-TRANSPORT]], Section 4. Corresponds to "extra
+                high" as defined in [[!RTCWEB-DATA]].</td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
Fixes #1439.

This enum is used to determine both the default DSCP marking and the
SCTP priority, if used for a data channel. So it needs to reference both
the relevant standards, and clarify that "very-low" corresponds to
"below normal", and so on.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/taylor-b/webrtc-pc/issue_1439_rtcweb_data_channel_ref.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/7d0e7ab...taylor-b:64f7ffc.html)