### PR TITLE
Clarify which session description to check for if negotiation is needed

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3445,53 +3445,55 @@ interface RTCSessionDescription {
         </ol>
         <p>To <dfn>check if negotiation is needed</dfn> for
         <var>connection</var>, perform the following checks:</p>
-        <ul>
+        <ol>
           <li>
             <p>If any implementation-specific negotiation is required, as
             described at the start of this section, return <code>true</code>.
             </p>
           </li>
+            <li>
+              <p>Let <var>description</var> be <var>connection</var>'s
+              <a data-for="RTCPeerConnection"
+              ><code>currentLocalDescription</code></a>.</p>
+            </li>
           <li>
             <p>If <var>connection</var> has created any
-            <code><a>RTCDataChannel</a></code>s, and no m= section has been
-            negotiated yet for data, return <code>true</code>.</p>
+            <code><a>RTCDataChannel</a></code>s, and no m= section in
+            <var>description</var> has been negotiated yet for data, return
+            <code>true</code>.</p>
           </li>
           <li>
-            <p>For each transceiver <var>t</var> in <var>connection</var>'s
+            <p>For each <var>transceiver</var> in <var>connection</var>'s
             <a>set of transceivers</a>, perform the following checks:</p>
-            <ul>
+            <ol>
               <li>
-                <p>If <var>t</var> isn't <a data-for="RTCRtpTransceiver">
-                stopped</a> and isn't yet <a>associated</a> with an m= section,
-                return <code>true</code>.</p>
+                <p>If <var>transceiver</var> isn't <a data-for="RTCRtpTransceiver">
+                stopped</a> and isn't yet <a>associated</a> with an m= section
+                in <var>description</var>, return <code>true</code>.</p>
               </li>
               <li>
-                <p>If <var>t</var> isn't <a data-for="RTCRtpTransceiver">
+                <p>If <var>transceiver</var> isn't <a data-for="RTCRtpTransceiver">
                 stopped</a> and is <a>associated</a> with an m= section
-                then perform the following checks:</p>
-                <ul>
+                in <var>description</var> then perform the following checks:</p>
+                <ol>
                   <li>
-                    <p>If <var>t</var>'s <a>[[\Direction]]</a> slot is
+                    <p>If <var>transceiver</var>'s <a>[[\Direction]]</a> slot is
                     <code>"sendrecv"</code> or <code>"sendonly"</code>,
-                    and the <a>associated</a> m= section in
-                    <var>connection</var>'s <code><a data-for=
-                    "RTCPeerConnection">currentLocalDescription</a></code>
+                    and the <a>associated</a> m= section in <var>description</var>
                     doesn't contain an "a=msid" line, return <code>true</code>.
                     </p>
                   </li>
                   <li>
-                    <p>If <var>connection</var>'s <code><a data-for=
-                    "RTCPeerConnection">currentLocalDescription</a></code> is of
-                    type <code>"offer"</code>, and the direction of the <a>associated</a> m=
+                    <p>If <var>description</var> is of type <code>"offer"</code>,
+                    and the direction of the <a>associated</a> m=
                     section in neither the offer nor answer matches
-                    <var>t</var>'s <a>[[\Direction]]</a>
+                    <var>transceiver</var>'s <a>[[\Direction]]</a>
                     slot, return <code>true</code>.</p>
                   </li>
                   <li>
-                    <p>If <var>connection</var>'s <code><a data-for=
-                    "RTCPeerConnection">currentLocalDescription</a></code> is of
-                    type <code>"answer"</code>, and the direction of the <a>associated</a> m=
-                    section in the answer does not match <var>t</var>'s
+                    <p>If <var>description</var> is of type <code>"answer"</code>,
+                    and the direction of the <a>associated</a> m=
+                    section in the answer does not match <var>transceiver</var>'s
                     <a>[[\Direction]]</a> slot intersected with
                     the offered direction (as described in <span data-jsep=
                     "initial-answers">[[!JSEP]]</span>), return
@@ -3500,7 +3502,7 @@ interface RTCSessionDescription {
                 </ul>
               </li>
               <li>
-                <p>If <var>t</var> is <a data-for="RTCRtpTransceiver">
+                <p>If <var>transceiver</var> is <a data-for="RTCRtpTransceiver">
                 stopped</a> and is <a>associated</a> with an m= section, but the
                 associated m= section is not yet rejected in
                 <var>connection</var>'s <code><a data-for=

--- a/webrtc.html
+++ b/webrtc.html
@@ -3497,10 +3497,10 @@ interface RTCSessionDescription {
                   <li>
                     <p>If <var>description</var> is of type <code>"answer"</code>,
                     and the direction of the <a>associated</a> m=
-                    section in the answer does not match <var>transceiver</var>'s
-                    <a>[[\Direction]]</a> slot intersected with
-                    the offered direction (as described in <span data-jsep=
-                    "initial-answers">[[!JSEP]]</span>), return
+                    section in the <var>description</var> does not match
+                    <var>transceiver</var>'s <a>[[\Direction]]</a> slot
+                    intersected with the offered direction (as described in
+                    <span data-jsep="initial-answers">[[!JSEP]]</span>), return
                     <code>true</code>.</p>
                   </li>
                 </ol>

--- a/webrtc.html
+++ b/webrtc.html
@@ -3503,7 +3503,7 @@ interface RTCSessionDescription {
                     "initial-answers">[[!JSEP]]</span>), return
                     <code>true</code>.</p>
                   </li>
-                </ul>
+                </ol>
               </li>
               <li>
                 <p>If <var>transceiver</var> is <a data-for="RTCRtpTransceiver">
@@ -3515,14 +3515,14 @@ interface RTCSessionDescription {
                 "RTCPeerConnection">currentRemoteDescription</a></code>,
                 return <code>true</code>.</p>
               </li>
-            </ul>
+            </ol>
           </li>
           <li>
             <p>If all the preceding checks were performed and <code>true</code>
             was not returned, nothing remains to be negotiated; return
             <code>false</code>.</p>
           </li>
-        </ul>
+        </ol>
       </section>
     </section>
     <section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -3486,8 +3486,12 @@ interface RTCSessionDescription {
                   <li>
                     <p>If <var>description</var> is of type <code>"offer"</code>,
                     and the direction of the <a>associated</a> m=
-                    section in neither the offer nor answer matches
-                    <var>transceiver</var>'s <a>[[\Direction]]</a>
+                    section in neither <var>connection</var>'s
+                    <code><a data-for=
+                    "RTCPeerConnection">currentLocalDescription</a></code> nor
+                    <code><a data-for=
+                    "RTCPeerConnection">currentRemoteDescription</a></code>
+                    matches <var>transceiver</var>'s <a>[[\Direction]]</a>
                     slot, return <code>true</code>.</p>
                   </li>
                   <li>


### PR DESCRIPTION
Fixes #1331.

In this patch I clarify checking of the m= sections against `currentLocalDescription` only. But I am not entirely sure if it is correct to check for `currentLocalDescription` only. Would be great if anyone can verify and correct me if I am wrong.

I also done some minor improvements to the formatting to make it more readable.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/soareschen/webrtc-pc/issue-1331-patch.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/48532fb...soareschen:5ba6c78.html)