### PR TITLE
close all DtlsTransports in pc.close() (including sctp.transport)

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2785,14 +2785,14 @@ interface RTCPeerConnection : EventTarget  {
                     "RTCIceTransport">state</a></code> of each of
                     <var>connection</var>'s <code><a>RTCIceTransport</a></code>s
                     to <code><a data-link-for=
-                    "RTCIceTransportState">closed</a></code>.</p>
+                    "RTCIceTransportState">"closed"</a></code>.</p>
                   </li>
                   <li>
                     <p>Set the <code><a data-link-for=
                     "RTCDtlsTransport">state</a></code> of each of
                     <var>connection</var>'s <code><a>RTCDtlsTransport</a></code>s
                     to <code><a data-link-for=
-                    "RTCDtlsTransportState">closed</a></code>.</p>
+                    "RTCDtlsTransportState">"closed"</a></code>.</p>
                   </li>
                   <li>
                     <p>Let <var>transceivers</var> be the result of executing the

--- a/webrtc.html
+++ b/webrtc.html
@@ -2775,6 +2775,14 @@ interface RTCPeerConnection : EventTarget  {
                     <code>true</code>, abort these steps.</p>
                   </li>
                   <li>
+                    <p>Set <var>connection</var>'s <a>[[\IsClosed]]</a> slot to
+                    <code>true</code>.</p>
+                  </li>
+                  <li>
+                    <p>Set <var>connection</var>'s <a>signaling state</a> to
+                    <code>"closed"</code>.</p>
+                  </li>
+                  <li>
                     <p>Let <var>transceivers</var> be the result of executing the
                     <code><a>CollectTransceivers</a></code> algorithm. For every
                     <code><a>RTCRtpTransceiver</a></code> <var>transceiver</var> in
@@ -2827,14 +2835,6 @@ interface RTCPeerConnection : EventTarget  {
                     <var>connection</var>'s <code><a>RTCIceTransport</a></code>s
                     to <code><a data-link-for=
                     "RTCIceTransportState">"closed"</a></code>.</p>
-                  </li>
-                  <li>
-                    <p>Set <var>connection</var>'s <a>[[\IsClosed]]</a> slot to
-                    <code>true</code>.</p>
-                  </li>
-                  <li>
-                    <p>Set <var>connection</var>'s <a>signaling state</a> to
-                    <code>"closed"</code>.</p>
                   </li>
                 </ol>
               </dd>

--- a/webrtc.html
+++ b/webrtc.html
@@ -2788,30 +2788,11 @@ interface RTCPeerConnection : EventTarget  {
                     "RTCIceTransportState">closed</a></code>.</p>
                   </li>
                   <li>
-                    <p>Let <var>senders</var> be the result of executing the
-                    <code><a>CollectSenders</a></code> algorithm. For every
-                    <code><a>RTCRtpSender</a></code> <var>sender</var> in
-                    <var>senders</var>, set
-                    <code><var>sender.transport.state</var></code> and
-                    <code><var>sender.transport.transport.state</var></code> to
-                    <code>"closed"</code>. If <code><var>sender.rtcpTransport</var></code>
-                    is set, set
-                    <code><var>sender.rtcpTransport.state</var></code> and
-                    <code><var>sender.rtcpTransport.transport.state</var></code>
-                    to <code>"closed"</code>.</p>
-                  </li>
-                  <li>
-                    <p>Let <var>receivers</var> be the result of executing the
-                    <code><a>CollectReceivers</a></code> algorithm. For every
-                    <code><a>RTCRtpReceiver</a></code> <var>receiver</var> in
-                    <var>receivers</var>, set
-                    <code><var>receiver.transport.state</var></code> and
-                    <code><var>receiver.transport.transport.state</var></code>
-                    to <code>"closed"</code>. If
-                    <code><var>receiver.rtcpTransport</var></code> is set, set
-                    <code><var>receiver.rtcpTransport.state</var></code> and
-                    <code><var>receiver.rtcpTransport.transport.state</var></code>
-                    to <code>"closed"</code>.</p>
+                    <p>Set the <code><a data-link-for=
+                    "RTCDtlsTransport">state</a></code> of each of
+                    <var>connection</var>'s <code><a>RTCDtlsTransport</a></code>s
+                    to <code><a data-link-for=
+                    "RTCDtlsTransportState">closed</a></code>.</p>
                   </li>
                   <li>
                     <p>Let <var>transceivers</var> be the result of executing the

--- a/webrtc.html
+++ b/webrtc.html
@@ -2775,26 +2775,6 @@ interface RTCPeerConnection : EventTarget  {
                     <code>true</code>, abort these steps.</p>
                   </li>
                   <li>
-                    <p>Destroy <var>connection</var>'s <a>ICE Agent</a>,
-                    abruptly ending any active ICE processing and any active
-                    streaming, and releasing any relevant resources (e.g. TURN
-                    permissions).</p>
-                  </li>
-                  <li>
-                    <p>Set the <code><a data-link-for=
-                    "RTCIceTransport">state</a></code> of each of
-                    <var>connection</var>'s <code><a>RTCIceTransport</a></code>s
-                    to <code><a data-link-for=
-                    "RTCIceTransportState">"closed"</a></code>.</p>
-                  </li>
-                  <li>
-                    <p>Set the <code><a data-link-for=
-                    "RTCDtlsTransport">state</a></code> of each of
-                    <var>connection</var>'s <code><a>RTCDtlsTransport</a></code>s
-                    to <code><a data-link-for=
-                    "RTCDtlsTransportState">"closed"</a></code>.</p>
-                  </li>
-                  <li>
                     <p>Let <var>transceivers</var> be the result of executing the
                     <code><a>CollectTransceivers</a></code> algorithm. For every
                     <code><a>RTCRtpTransceiver</a></code> <var>transceiver</var> in
@@ -2827,6 +2807,26 @@ interface RTCPeerConnection : EventTarget  {
                         <p>Set <code><var>transceiver</var>.stopped</code> to <code>true</code>.</p>
                       </li>
                     </ol>
+                  </li>
+                  <li>
+                    <p>Set the <code><a data-link-for=
+                    "RTCDtlsTransport">state</a></code> of each of
+                    <var>connection</var>'s <code><a>RTCDtlsTransport</a></code>s
+                    to <code><a data-link-for=
+                    "RTCDtlsTransportState">"closed"</a></code>.</p>
+                  </li>
+                  <li>
+                    <p>Destroy <var>connection</var>'s <a>ICE Agent</a>,
+                    abruptly ending any active ICE processing and
+                    releasing any relevant resources (e.g. TURN
+                    permissions).</p>
+                  </li>
+                  <li>
+                    <p>Set the <code><a data-link-for=
+                    "RTCIceTransport">state</a></code> of each of
+                    <var>connection</var>'s <code><a>RTCIceTransport</a></code>s
+                    to <code><a data-link-for=
+                    "RTCIceTransportState">"closed"</a></code>.</p>
                   </li>
                   <li>
                     <p>Set <var>connection</var>'s <a>[[\IsClosed]]</a> slot to


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/1381

Related PR: https://github.com/w3c/webrtc-pc/pull/1414

Rebase of PR https://github.com/w3c/webrtc-pc/pull/1401


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/issue-1381-patchv3.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/48532fb...f1d3184.html)