### PR TITLE
Add a section summarizing different ICE candidate events.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3966,6 +3966,7 @@ interface RTCIceCandidate {
               for backwards compatibility, and this event does not need to be
               signaled to the remote peer.</p>
             </li>
+          </ul>
         </div>
         <div>
           <pre class="idl">

--- a/webrtc.html
+++ b/webrtc.html
@@ -3936,7 +3936,7 @@ interface RTCIceCandidate {
           different types of indications:
           <ul>
             <li>
-              <p>An candidate has been gathered. The <code><a
+              <p>A candidate has been gathered. The <code><a
               data-link-for="RTCPeerConnectionIceEvent">candidate</a></code>
               member of the event will be populated normally. It should be
               signaled to the remote peer and passed into
@@ -3958,13 +3958,16 @@ interface RTCIceCandidate {
             <li>
               <p>All <code><a>RTCIceTransport</a></code>s have finished
               gathering candidates, and the <code><a>RTCPeerConnection</a></code>'s
-              <code><a>RTCIceConnectionState</a></code> has transitioned to
-              <code>"<a data-link-for="RTCIceConnectionState">completed</a>"</code>.
+              <code><a>RTCIceGatheringState</a></code> has transitioned to
+              <code>"<a data-link-for="RTCIceGatheringState">complete</a>"</code>.
               This is indicated by the
               <code><a data-link-for="RTCPeerConnectionIceEvent">candidate</a></code>
-              member of the event being set to <code>null</code>. This only exists
-              for backwards compatibility, and this event does not need to be
-              signaled to the remote peer.</p>
+              member of the event being set to <code>null</code>. This only
+              exists for backwards compatibility, and this event does not need
+              to be signaled to the remote peer. It's equivalent to an
+              <code>"<a>icegatheringstatechange</a>"</code> event with the
+              <code>"<a data-link-for="RTCIceGatheringState">complete</a>"</code>
+              state.</p>
             </li>
           </ul>
         </div>

--- a/webrtc.html
+++ b/webrtc.html
@@ -3930,6 +3930,43 @@ interface RTCIceCandidate {
         type <code>relay</code>, the <code>url</code> property of the event
         MUST be set to the URL of the ICE server from which the candidate was
         obtained.</p>
+
+        <div class="note">
+          The <code><a>icecandidate</a></code> event is used for three
+          different types of indications:
+          <ul>
+            <li>
+              <p>An candidate has been gathered. The <code><a
+              data-link-for="RTCPeerConnectionIceEvent">candidate</a></code>
+              member of the event will be populated normally. It should be
+              signaled to the remote peer and passed into
+              <code><a data-link-for="RTCPeerConnection">addIceCandidate</a></code>.</p>
+            </li>
+            <li>
+              <p>An <code><a>RTCIceTransport</a></code> has finished gathering a
+              <a>generation</a> of candidates, and is providing an end-of-candidates
+              indication as defined by Section 8.2 of [[TRICKLE-ICE]]. This is
+              indicated by <code><a data-link-for="RTCPeerConnectionIceEvent">candidate</a>.<a
+              data-link-for="RTCIceCandidate">candidate</a></code> being set to an
+              empty string. The <code><a
+              data-link-for="RTCPeerConnectionIceEvent">candidate</a></code> object
+              should be signaled to the remote peer and passed into
+              <code><a data-link-for="RTCPeerConnection">addIceCandidate</a></code>
+              like a typical ICE candidate, in order to provide the
+              end-of-candidates indication to the remote peer.</p>
+            </li>
+            <li>
+              <p>All <code><a>RTCIceTransport</a></code>s have finished
+              gathering candidates, and the <code><a>RTCPeerConnection</a></code>'s
+              <code><a>RTCIceConnectionState</a></code> has transitioned to
+              <code>"<a data-link-for="RTCIceConnectionState">completed</a>"</code>.
+              This is indicated by the
+              <code><a data-link-for="RTCPeerConnectionIceEvent">candidate</a></code>
+              member of the event being set to <code>null</code>. This only exists
+              for backwards compatibility, and this event does not need to be
+              signaled to the remote peer.</p>
+            </li>
+        </div>
         <div>
           <pre class="idl">
           [ Constructor (DOMString type, optional RTCPeerConnectionIceEventInit eventInitDict)]


### PR DESCRIPTION
Fixes #1213.

We've ended up with three different types of events that all use the
same "icecandidate" event, and are fired in different places. Which is,
understandably, confusing to most readers of the specification.

This PR adds a note to the RTCPeerConnectionIceEvent section summarizing
the different types of events, describing when they're fired, how
they're represented in the RTCPeerConnectionIceEvent, and what the
application should do with them.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/taylor-b/webrtc-pc/issue_1213_candidate_events.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/48532fb...taylor-b:3ee9539.html)