### PR TITLE
Resizing video (fix for Issue 1283)

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4464,6 +4464,15 @@ interface RTCPeerConnectionIceErrorEvent : Event {
     envelope negotiated by SDP. The rules outlined in
     <span data-jsep="interpreting-imageattr">[[!JSEP]]</span> MUST be followed
     when resizing the video.</p>
+    <div class="note">
+      <p>The procedures outlined in JSEP preserve the aspect ratio if the video
+      is resized. If the video track is rendered in a <code>video</code>
+      element on the receiving side, and that <code>video</code> element
+      has a different aspect ratio than the track, the video will be shown
+      letterboxed or pillarboxed as specified in [[!HTML51]] regardless of
+      whether it has been resized or not.</p>
+    </div>
+
     <p>When video is rescaled, for example for certain combinations
     of width or height and
     <code><a data-link-for="RTCRtpEncodingParameters">

--- a/webrtc.html
+++ b/webrtc.html
@@ -4461,18 +4461,9 @@ interface RTCPeerConnectionIceErrorEvent : Event {
     be created on the remote side.</p>
     <p>When sending media, the sender may need to rescale or
     resample the media to meet various requirements including the
-    envelope negotiated by SDP. When resizing video, the source
-    video is first centered relative to the desired video then
-    scaled down the minimum amount such that the video fully covers
-    the desired size, then finally cropped to the destination
-    size. The video remains centered while scaling and cropping. For
-    example, if the source video was 1280 by 720, and the max size
-    that could be sent was 640 by 480, the video would be scaled
-    down by 1.5 and 160 columns of pixels on both the right and left
-    sides of the source video would be cropped off. This algorithm
-    is designed to minimize occurrence of images with with letter
-    box or or pillow boxing. The media MUST NOT be upscaled to
-    create fake data that did not occur in the input source.</p>
+    envelope negotiated by SDP. The rules outlined in
+    <span data-jsep="interpreting-imageattr">[[!JSEP]]</span> MUST be followed
+    when resizing the video.</p>
     <p>When video is rescaled, for example for certain combinations
     of width or height and
     <code><a data-link-for="RTCRtpEncodingParameters">

--- a/webrtc.html
+++ b/webrtc.html
@@ -4468,9 +4468,9 @@ interface RTCPeerConnectionIceErrorEvent : Event {
       <p>The procedures outlined in JSEP preserve the aspect ratio if the video
       is resized. If the video track is rendered in a <code>video</code>
       element on the receiving side, and that <code>video</code> element
-      has a different aspect ratio than the track, the video will be shown
-      letterboxed or pillarboxed as specified in [[!HTML51]] regardless of
-      whether it has been resized or not.</p>
+      has a different aspect ratio than the track, the default behavior
+      (which can be overridden using CSS) specified in [[!HTML51]] is that
+      video will be shown letterboxed or pillarboxed.</p>
     </div>
 
     <p>When video is rescaled, for example for certain combinations


### PR DESCRIPTION
Fixes #1283


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/stefhak/webrtc-pc/issue-1283-patch.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/35a3a09...stefhak:deb3c6a.html)