### PR TITLE
Editorial: Remove unreferenced [HTML] ref using respec post processing

### DIFF
--- a/webrtc.js
+++ b/webrtc.js
@@ -1,3 +1,11 @@
+// Working around  respec using WHATWG HTML links for EventHandler
+// See also https://github.com/w3c/respec/issues/1372
+function cleanHTMLRef() {
+    [...document.querySelectorAll("a[href='https://html.spec.whatwg.org/multipage/#eventhandler']")].forEach(a => a.href = "https://www.w3.org/TR/html52/webappapis.html#event-handler");
+    document.getElementById('bib-HTML').nextElementSibling.remove();
+    document.getElementById('bib-HTML').remove();
+}
+
 var respecConfig = {
   // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
   specStatus:           "ED",
@@ -180,5 +188,6 @@ var respecConfig = {
             "title": "STUN Error Codes",
             "date": "April 2011"
         }
-    }
+    },
+    postProcess: [cleanHTMLRef]
 };


### PR DESCRIPTION
This is the webrtc-pc equivalent of https://github.com/w3c/mediacapture-main/pull/480