### PR TITLE
Annotate all interfaces with Exposed extended attribute

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1853,7 +1853,7 @@
         objects.</p>
         <div>
           <pre class="idl">
-          [ Constructor (optional RTCConfiguration configuration)]
+          [ Constructor (optional RTCConfiguration configuration), Exposed=Window]
 interface RTCPeerConnection : EventTarget  {
     Promise&lt;RTCSessionDescriptionInit&gt; createOffer (optional RTCOfferOptions options);
     Promise&lt;RTCSessionDescriptionInit&gt; createAnswer (optional RTCAnswerOptions options);
@@ -3289,7 +3289,7 @@ interface RTCPeerConnection : EventTarget  {
         session descriptions.</p>
         <div>
           <pre class="idl">
-          [ Constructor (RTCSessionDescriptionInit descriptionInitDict)]
+          [ Constructor (RTCSessionDescriptionInit descriptionInitDict), Exposed=Window]
 interface RTCSessionDescription {
     readonly        attribute RTCSdpType type;
     readonly        attribute DOMString  sdp;
@@ -3550,7 +3550,7 @@ interface RTCSessionDescription {
         if it is well formed.</p>
         <div>
           <pre class="idl">
-          [ Constructor (optional RTCIceCandidateInit candidateInitDict)]
+          [ Constructor (optional RTCIceCandidateInit candidateInitDict), Exposed=Window]
 interface RTCIceCandidate {
     readonly        attribute DOMString               candidate;
     readonly        attribute DOMString?              sdpMid;
@@ -3991,7 +3991,7 @@ interface RTCIceCandidate {
         </div>
         <div>
           <pre class="idl">
-          [ Constructor (DOMString type, optional RTCPeerConnectionIceEventInit eventInitDict)]
+          [ Constructor (DOMString type, optional RTCPeerConnectionIceEventInit eventInitDict), Exposed=Window]
 interface RTCPeerConnectionIceEvent : Event {
     readonly        attribute RTCIceCandidate? candidate;
     readonly        attribute DOMString?       url;
@@ -4068,7 +4068,7 @@ interface RTCPeerConnectionIceEvent : Event {
         interface.</p>
         <div>
           <pre class="idl">
-          [ Constructor (DOMString type, RTCPeerConnectionIceErrorEventInit eventInitDict)]
+          [ Constructor (DOMString type, RTCPeerConnectionIceErrorEventInit eventInitDict), Exposed=Window]
 interface RTCPeerConnectionIceErrorEvent : Event {
     readonly        attribute DOMString      hostCandidate;
     readonly        attribute DOMString      url;
@@ -4373,7 +4373,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
         (<dfn>[[\Certificate]]</dfn>]]) that <code>RTCPeerConnection</code>
         uses to authenticate with a peer.</p>
         <div>
-          <pre class="idl">interface RTCCertificate {
+          <pre class="idl">[Exposed=Window] interface RTCCertificate {
     readonly        attribute DOMTimeStamp expires;
     sequence&lt;RTCDtlsFingerprint&gt; getFingerprints ();
 };</pre>
@@ -5237,7 +5237,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
         </li>
       </ol>
       <div>
-        <pre class="idl">interface RTCRtpSender {
+        <pre class="idl">[Exposed=Window] interface RTCRtpSender {
     readonly        attribute MediaStreamTrack? track;
     readonly        attribute RTCDtlsTransport?  transport;
     readonly        attribute RTCDtlsTransport? rtcpTransport;  // Feature at risk
@@ -6171,7 +6171,7 @@ sender.setParameters(params)
         </li>
       </ol>
       <div>
-        <pre class="idl">interface RTCRtpReceiver {
+        <pre class="idl">[Exposed=Window] interface RTCRtpReceiver {
     readonly        attribute MediaStreamTrack  track;
     readonly        attribute RTCDtlsTransport? transport;
     readonly        attribute RTCDtlsTransport? rtcpTransport; // Feature at risk
@@ -6376,7 +6376,7 @@ sender.setParameters(params)
       <code><a>RTCRtpReceiver</a></code> return information from a single point
       in the RTP stream.</div>
       <div>
-        <pre class="idl">interface RTCRtpContributingSource {
+        <pre class="idl">[Exposed=Window] interface RTCRtpContributingSource {
     readonly        attribute DOMHighResTimeStamp timestamp;
     readonly        attribute unsigned long       source;
     readonly        attribute byte?               audioLevel;
@@ -6415,7 +6415,7 @@ sender.setParameters(params)
         </section>
       </div>
       <div>
-        <pre class="idl">interface RTCRtpSynchronizationSource {
+        <pre class="idl">[Exposed=Window] interface RTCRtpSynchronizationSource {
     readonly        attribute DOMHighResTimeStamp timestamp;
     readonly        attribute unsigned long       source;
     readonly        attribute byte                audioLevel;
@@ -6510,7 +6510,7 @@ sender.setParameters(params)
         </li>
       </ol>
       <div>
-        <pre class="idl">interface RTCRtpTransceiver {
+        <pre class="idl">[Exposed=Window] interface RTCRtpTransceiver {
     readonly        attribute DOMString?                  mid;
     [SameObject]
     readonly        attribute RTCRtpSender                sender;
@@ -6850,7 +6850,7 @@ sender.setParameters(params)
       of calls to <code>setLocalDescription()</code> and
       <code>setRemoteDescription()</code>.</p>
       <div>
-        <pre class="idl">interface RTCDtlsTransport : EventTarget {
+        <pre class="idl">[Exposed=Window] interface RTCDtlsTransport : EventTarget {
     readonly        attribute RTCIceTransport       transport;
     readonly        attribute RTCDtlsTransportState state;
     sequence&lt;ArrayBuffer&gt; getRemoteCertificates ();
@@ -7188,7 +7188,7 @@ sender.setParameters(params)
         </li>
       </ol>
       <div>
-        <pre class="idl">interface RTCIceTransport : EventTarget {
+        <pre class="idl">[Exposed=Window] interface RTCIceTransport : EventTarget {
     readonly        attribute RTCIceRole           role;
     readonly        attribute RTCIceComponent      component;
     readonly        attribute RTCIceTransportState state;
@@ -7579,7 +7579,7 @@ sender.setParameters(params)
       MUST be created and dispatched at the given target.</p>
       <div>
         <pre class="idl">
-        [ Constructor (DOMString type, RTCTrackEventInit eventInitDict)]
+        [ Constructor (DOMString type, RTCTrackEventInit eventInitDict), Exposed=Window]
 interface RTCTrackEvent : Event {
     readonly        attribute RTCRtpReceiver           receiver;
     readonly        attribute MediaStreamTrack         track;
@@ -7874,7 +7874,7 @@ interface RTCTrackEvent : Event {
         application access to information about the SCTP data channels tied to
         a particular SCTP association.</p>
         <div>
-          <pre class="idl">interface RTCSctpTransport {
+          <pre class="idl">[Exposed=Window] interface RTCSctpTransport {
     readonly        attribute RTCDtlsTransport transport;
     readonly        attribute unsigned long    maxMessageSize;
 };</pre>
@@ -8114,7 +8114,7 @@ interface RTCTrackEvent : Event {
         </li>
       </ol>
       <div>
-        <pre class="idl">interface RTCDataChannel : EventTarget {
+        <pre class="idl">[Exposed=Window] interface RTCDataChannel : EventTarget {
     readonly        attribute USVString           label;
     readonly        attribute boolean             ordered;
     readonly        attribute unsigned short?     maxPacketLifeTime;
@@ -8583,7 +8583,7 @@ interface RTCTrackEvent : Event {
       target.</p>
       <div>
         <pre class="idl">
-        [ Constructor (DOMString type, RTCDataChannelEventInit eventInitDict)]
+        [ Constructor (DOMString type, RTCDataChannelEventInit eventInitDict), Exposed=Window]
 interface RTCDataChannelEvent : Event {
     readonly        attribute RTCDataChannel channel;
 };</pre>
@@ -8693,7 +8693,7 @@ interface RTCDataChannelEvent : Event {
       <h4><dfn>RTCDTMFSender</dfn></h4>
       <div>
         <pre class="idl">
-interface RTCDTMFSender : EventTarget {
+[Exposed=Window] interface RTCDTMFSender : EventTarget {
     void insertDTMF (DOMString tones, optional unsigned long duration = 100, optional unsigned long interToneGap = 70);
                     attribute EventHandler ontonechange;
     readonly        attribute boolean      canInsertDTMF;
@@ -8854,7 +8854,7 @@ interface RTCDTMFSender : EventTarget {
       <var>tone</var>, MUST be created and dispatched at the given target.</p>
       <div>
         <pre class="idl">
-        [ Constructor (DOMString type, RTCDTMFToneChangeEventInit eventInitDict)]
+        [ Constructor (DOMString type, RTCDTMFToneChangeEventInit eventInitDict), Exposed=Window]
 interface RTCDTMFToneChangeEvent : Event {
     readonly        attribute DOMString tone;
 };</pre>
@@ -9020,7 +9020,7 @@ interface RTCDTMFToneChangeEvent : Event {
       <code>RTCStats</code>-derived dictionary per SSRC (which can be
       distinguished by the value of the "ssrc" stats attribute).</p>
       <div>
-        <pre class="idl">interface RTCStatsReport {
+        <pre class="idl">[Exposed=Window] interface RTCStatsReport {
     readonly maplike&lt;DOMString, object&gt;;
 };</pre>
         <p>This interface has "entries", "forEach", "get", "has", "keys",
@@ -10010,7 +10010,7 @@ interface RTCIdentityProviderRegistrar {
         </section>
       </div>
       <div>
-        <pre class="idl">[Constructor(DOMString idp, DOMString name)]
+        <pre class="idl">[Constructor(DOMString idp, DOMString name), Exposed=Window]
 interface RTCIdentityAssertion {
     attribute DOMString idp;
     attribute DOMString name;


### PR DESCRIPTION
WebIDL is moving to making it a required extended attribute https://github.com/heycam/webidl/issues/365


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/exposed.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/a004acc...ec481e2.html)