### PR TITLE
Editorial: Link to 'Firing a something event' definitions

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1212,7 +1212,7 @@
             <var>connection</var>.</p>
           </li>
           <li>
-            <p>If <var>newState</var> is <code>"completed"</code>, fire an event
+            <p>If <var>newState</var> is <code>"completed"</code>, <a>fire an ice candidate event</a>
             named <code><a>icecandidate</a></code> with <code>null</code> at
             <var>connection</var>.</p>
           </li>
@@ -3931,7 +3931,7 @@ interface RTCIceCandidate {
         <p>The <code>icecandidate</code> event of the RTCPeerConnection uses
         the <code><a>RTCPeerConnectionIceEvent</a></code> interface.</p>
         <p><dfn data-lt="Fire an ice candidate event">Firing an
-        <code><a>RTCPeerConnectionIceEvent</a></code> event named
+        ice candidate event named
         <var>e</var></dfn> with an <code><a>RTCIceCandidate</a></code>
         <var>candidate</var> means that an event with the name <var>e</var>,
         which does not bubble (except where otherwise stated) and is not
@@ -5100,7 +5100,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             </p>
           </li>
           <li>
-            <p>Queue a task to fire an event named <code title=
+            <p>Queue a task to <a>fire a track event</a> named <code title=
             "event-track"><a>track</a></code> with <var>transceiver</var>,
             <var>track</var>, and <var>streams</var> at the
             <var>connection</var> object.</p>
@@ -7054,7 +7054,7 @@ sender.setParameters(params)
           empty string, and with all other nullable members set to null.</p>
         </li>
         <li>
-          <p>Fire an event named <code><a>icecandidate</a></code> with
+          <p><a>Fire an ice candidate event</a> named <code><a>icecandidate</a></code> with
           <var>newCandidate</var> at <var>connection</var>.</p>
         </li>
         <li>
@@ -7111,7 +7111,7 @@ sender.setParameters(params)
           candidates.</p>
         </li>
         <li>
-          <p>Fire an event named <code><a>icecandidate</a></code> with
+          <p><a>Fire an ice candidate event</a> named <code><a>icecandidate</a></code> with
           <var>newCandidate</var> at <var>connection</var>.</p>
         </li>
       </ol>
@@ -7564,8 +7564,8 @@ sender.setParameters(params)
       <h3><dfn>RTCTrackEvent</dfn></h3>
       <p>The <code><a>track</a></code> event uses the
       <code><a>RTCTrackEvent</a></code> interface.</p>
-      <p><dfn id="fire-track-event" data-lt="fire track event">Firing an
-      RTCTrackEvent event named <var>e</var></dfn> with an
+      <p><dfn id="fire-track-event" data-lt="fire a track event">Firing a
+      track event named <var>e</var></dfn> with an
       <code><a>RTCRtpReceiver</a></code> <var>receiver</var>, a
       <code><a>MediaStreamTrack</a></code> <var>track</var> and a
       <code>MediaStream</code>[] <var>streams</var>, means that an event with
@@ -8799,7 +8799,7 @@ interface RTCDTMFSender : EventTarget {
                     abort these steps.</li>
                     <li>If <code><a data-for=
                     "RTCDTMFSender">toneBuffer</a></code> is an empty string,
-                    fire an event named <code><a>tonechange</a></code> with an
+                    <a>fire a tonechange event</a> named <code><a>tonechange</a></code> with an
                     empty string at the <code><a>RTCDTMFSender</a></code>
                     object and abort these steps.</li>
                     <li>Remove the first character from <code><a data-for=
@@ -8819,7 +8819,7 @@ interface RTCDTMFSender : EventTarget {
                     "RTCDTMFSender">duration</a></code> + <code><a data-for=
                     "RTCDTMFSender">interToneGap</a></code> ms from now that
                     runs the steps labelled <em>Playout task</em>.</li>
-                    <li>Fire an event named <code><a>tonechange</a></code> with
+                    <li><a>Fire a tonechange event</a> named <code><a>tonechange</a></code> with
                     a string consisting of <var>tone</var> at the
                     <code><a>RTCDTMFSender</a></code> object.</li>
                   </ol>


### PR DESCRIPTION
We have a paragraph for each type of event that describes how it should be fired. We should link to those sections when we fire events. There's currently only one such link.

Fix #1141


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/link-fire-event.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/a004acc...730cd40.html)