### PR TITLE
scaleResolutionDownBy: Specify how the User Agent should behave when scaling video

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4465,8 +4465,8 @@ interface RTCPeerConnectionIceErrorEvent : Event {
     of width or height and
     <code><a data-link-for="RTCRtpEncodingParameters">
     scaleResolutionDownBy</a></code> values, situations when the result must
-    be rounded may occur. In such situations the user agent is allowed to
-    round as suitable.</p>
+    be rounded to obtain an integer result may occur. In such situations the
+    user agent MUST round up to the nearest integer value.</p>
     <p>The actual encoding and transmission of <code>MediaStreamTrack</code>s
     is managed through objects called <code><a>RTCRtpSender</a></code>s.
     Similarly, the reception and decoding of <code>MediaStreamTrack</code>s is

--- a/webrtc.html
+++ b/webrtc.html
@@ -4461,6 +4461,12 @@ interface RTCPeerConnectionIceErrorEvent : Event {
     is designed to minimize occurrence of images with with letter
     box or or pillow boxing. The media MUST NOT be upscaled to
     create fake data that did not occur in the input source.</p>
+    <p>When video is rescaled, for example for certain combinations
+    of width or height and
+    <code><a data-link-for="RTCRtpEncodingParameters">
+    scaleResolutionDownBy</a></code> values, situations when the result must
+    be rounded may occur. In such situations the user agent is allowed to
+    round as suitable.</p>
     <p>The actual encoding and transmission of <code>MediaStreamTrack</code>s
     is managed through objects called <code><a>RTCRtpSender</a></code>s.
     Similarly, the reception and decoding of <code>MediaStreamTrack</code>s is

--- a/webrtc.html
+++ b/webrtc.html
@@ -4467,7 +4467,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
     scaleResolutionDownBy</a></code> values, situations when the resulting width
     or height is not an integer may occur. In such situations the
     user agent MUST use the integer part of the result (
-    https://tc39.github.io/ecma262/#eqn-floor). How to act if the integer
+    https://tc39.github.io/ecma262/#eqn-floor). What to transmit if the integer
     part of the scaled width or height is zero is implementation-specific.</p>
     <p>The actual encoding and transmission of <code>MediaStreamTrack</code>s
     is managed through objects called <code><a>RTCRtpSender</a></code>s.

--- a/webrtc.html
+++ b/webrtc.html
@@ -4464,9 +4464,11 @@ interface RTCPeerConnectionIceErrorEvent : Event {
     <p>When video is rescaled, for example for certain combinations
     of width or height and
     <code><a data-link-for="RTCRtpEncodingParameters">
-    scaleResolutionDownBy</a></code> values, situations when the result must
-    be rounded to obtain an integer result may occur. In such situations the
-    user agent MUST round up to the nearest integer value.</p>
+    scaleResolutionDownBy</a></code> values, situations when the resulting width
+    or height is not an integer may occur. In such situations the
+    user agent MUST use the integer part of the result (
+    https://tc39.github.io/ecma262/#eqn-floor). How to act if the integer
+    part of the scaled width or height is zero is implementation-specific.</p>
     <p>The actual encoding and transmission of <code>MediaStreamTrack</code>s
     is managed through objects called <code><a>RTCRtpSender</a></code>s.
     Similarly, the reception and decoding of <code>MediaStreamTrack</code>s is


### PR DESCRIPTION
Would fix #1564 if we agree this is the way to go.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/stefhak/webrtc-pc/patch-issue-1564.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/a004acc...stefhak:9caf541.html)