### PR TITLE
Fixed spelling of scaleResolutionDownBy in example.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -10741,11 +10741,11 @@ function start() {
                     },
                     {
                       rid: "h",
-                      scaleDownResolutionBy: 2.0
+                      scaleResolutionDownBy: 2.0
                     },
                     {
                       rid: "q",
-                      scaleDownResolutionBy: 4.0
+                      scaleResolutionDownBy: 4.0
                     }
                 ]
             });


### PR DESCRIPTION
Editorial.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/stefhak/webrtc-pc/scalereso.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/a004acc...stefhak:adee435.html)