### PR TITLE
Add ICE candidates only to the applicable descriptions.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2691,16 +2691,20 @@ interface RTCPeerConnection : EventTarget  {
                                 then abort these steps.</p>
                               </li>
                               <li>
-                                <p>Let <var>remoteDescription</var> be
-                                <var>connection</var>'s <code><a data-for=
+                                <p>If <code><var>connection</var>.<a data-for=
                                 "RTCPeerConnection">pendingRemoteDescription</a></code>
-                                if not null, otherwise <var>connection</var>'s
-                                <code><a data-for=
-                                "RTCPeerConnection">currentRemoteDescription</a></code>.</p>
+                                is non-null, and represents the ICE <a>generation</a>
+                                for which <var>candidate</var> was processed, add <var>candidate</var>
+                                to <code><var>connection</var>.<a data-for=
+                                "RTCPeerConnection">pendingRemoteDescription</a></code>.</p>
                               </li>
                               <li>
-                                <p>Add <var>candidate</var> to
-                                <var>remoteDescription</var>.</p>
+                                <p>If <code><var>connection</var>.<a data-for=
+                                "RTCPeerConnection">currentRemoteDescription</a></code>
+                                is non-null, and represents the ICE <a>generation</a>
+                                for which <var>candidate</var> was processed, add <var>candidate</var>
+                                to <code><var>connection</var>.<a data-for=
+                                "RTCPeerConnection">currentRemoteDescription</a></code>.</p>
                               </li>
                               <li>
                                 <p>Resolve <var>p</var> with
@@ -7099,8 +7103,18 @@ sender.setParameters(params)
           for which this candidate is being made available.</p>
         </li>
         <li>
-          <p>Add the candidate to <var>connection</var>'s <code><a
-          data-link-for="RTCPeerConnection">localDescription</a></code>.</p>
+          <p>If <code><var>connection</var>.<a data-for=
+          "RTCPeerConnection">pendingLocalDescription</a></code> is non-null,
+          and represents the ICE <a>generation</a> for which <var>candidate</var>
+          was gathered, add <var>candidate</var> to <code><var>connection</var>.<a
+          data-for= "RTCPeerConnection">pendingLocalDescription</a></code>.</p>
+        </li>
+        <li>
+          <p>If <code><var>connection</var>.<a data-for=
+          "RTCPeerConnection">currentLocalDescription</a></code> is non-null,
+          and represents the ICE <a>generation</a> for which <var>candidate</var>
+          was gathered, add <var>candidate</var> to <code><var>connection</var>.<a
+          data-for= "RTCPeerConnection">currentLocalDescription</a></code>.</p>
         </li>
         <li>
           <p>Create an <code><a>RTCIceCandidate</a></code> instance to represent


### PR DESCRIPTION
Fixes #1227.

ICE candidates should only be added to descriptions that represent the
ICE generation of the candidate. For example, if
`currentLocalDescription` has ufrag "foo" and `pendingLocalDescription`
has ufrag "bar", because an ICE restart was initiated, then candidates
gathered for the old ICE generation ("foo") should be added only to
`currentLocalDescription`, and candidates gathered for the new ICE
generation should be added only to `pendingLocalDescription`.

Same goes for remote candidates, where the generation is inferred by
ufrag (or assumed, if ufrag isn't present).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/taylor-b/webrtc-pc/issue_1227_adding_ice_candidates_to_sdp.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/a004acc...taylor-b:9845f81.html)