### PR TITLE
RTCIceTransport: Use internal slots

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2846,8 +2846,7 @@ interface RTCPeerConnection : EventTarget  {
                     permissions).</p>
                   </li>
                   <li>
-                    <p>Set the <code><a data-link-for=
-                    "RTCIceTransport">state</a></code> of each of
+                    <p>Set the <a>[[\IceTransportState]]</a> slot of each of
                     <var>connection</var>'s <code><a>RTCIceTransport</a></code>s
                     to <code><a data-link-for=
                     "RTCIceTransportState">"closed"</a></code>.</p>
@@ -6996,9 +6995,9 @@ sender.setParameters(params)
           for which candidate gathering began.</p>
         </li>
         <li>
-          <p>Set <var>transport</var>'s <code><a data-link-for=
-          "RTCIceTransport">gatheringState</a></code> to <code><a
-          data-link-for="RTCIceGathererState">gathering</a></code>.</p>
+          <p>Set <var>transport</var>'s <a>[[\IceTransportGatheringState]]</a>
+          slot to <code><a data-link-for=
+          "RTCIceGathererState">gathering</a></code>.</p>
         </li>
         <li>
           <p>Fire a simple event named <code><a>gatheringstatechange</a></code>
@@ -7051,9 +7050,9 @@ sender.setParameters(params)
           </div>
         </li>
         <li>
-          <p>Set <var>transport</var>'s <code><a data-link-for=
-          "RTCIceTransport">gatheringState</a></code> to <code><a
-          data-link-for="RTCIceGathererState">complete</a></code>.</p>
+          <p>Set <var>transport</var>'s <a>[[\IceTransportGatheringState]]</a>
+          slot to <code><a data-link-for=
+          "RTCIceGathererState">complete</a></code>.</p>
         </li>
         <li>
           <p>Fire a simple event named <code><a>gatheringstatechange</a></code>
@@ -7134,8 +7133,8 @@ sender.setParameters(params)
           <code><a>RTCIceTransportState</a></code>.
         </li>
         <li>
-          <p>Set <var>transport</var>'s <code><a data-link-for=
-          "RTCIceTransport">state</a></code> to <var>newState</var>.</p>
+          <p>Set <var>transport</var>'s <a>[[\IceTransportState]]</a> slot to
+          <var>newState</var>.</p>
         </li>
         <li>
           <p>Fire a simple event named <code><a>statechange</a></code> at
@@ -7173,8 +7172,8 @@ sender.setParameters(params)
           pair if one is selected, and <code>null</code> otherwise.</p>
         </li>
         <li>
-          <p>Set <var>transport</var>'s selected candidate pair to
-          <var>newCandidatePair</var>.</p>
+          <p>Set <var>transport</var>'s <a>[[\SelectedCandidatePair]]</a> slot
+          to <var>newCandidatePair</var>.</p>
         </li>
         <li>
           <p>Fire a simple event named
@@ -7182,6 +7181,15 @@ sender.setParameters(params)
           <var>transport</var>.</p>
         </li>
       </ol>
+      <p>An <a>RTCIceTransport</a> object has the following internal slots:</p>
+      <ul>
+        <li><dfn>[[\IceTransportState]]</dfn> initialized to <code>
+        <a data-link-for="RTCIceTransportState">new</a></code></li>
+        <li><dfn>[[\IceTransportGatheringState]]</dfn> initialized to <code>
+        <a data-link-for="RTCIceGatheringState">new</a></code></li>
+        <li><dfn>[[\SelectedCandidatePair]]</dfn> initialized to
+        <code>null</code></li>
+      </ul>
       <div>
         <pre class="idl">[Exposed=Window] interface RTCIceTransport : EventTarget {
     readonly        attribute RTCIceRole           role;
@@ -7221,14 +7229,15 @@ sender.setParameters(params)
             "idlAttrType"><a>RTCIceTransportState</a></span>, readonly</dt>
             <dd>
               <p>The <dfn id="dom-icetransport-state"><code>state</code></dfn>
-              attribute MUST return the state of the transport.</p>
+              attribute MUST, on getting, return the value of the
+              <a>[[\IceTransportState]]</a> slot.</p>
             </dd>
             <dt><dfn><code>gatheringState</code></dfn> of type <span class=
             "idlAttrType"><a>RTCIceGatheringState</a></span>, readonly</dt>
             <dd>
               <p>The <dfn id="dom-icetransport-gatheringstate"><code>gathering
-              state</code></dfn> attribute MUST return the gathering state of
-              the transport.</p>
+              state</code></dfn> attribute MUST, on getting, return the value
+              of the <a>[[\IceTransportGatheringState]]</a> slot.</p>
             </dd>
             <dt><dfn><code>onstatechange</code></dfn> of type <span class=
             "idlAttrType"><a>EventHandler</a></span></dt>
@@ -7275,8 +7284,9 @@ sender.setParameters(params)
             </dd>
             <dt><dfn><code>getSelectedCandidatePair</code></dfn></dt>
             <dd>
-              <p>Returns the selected candidate pair on which packets are sent,
-              or <code>null</code> if there is no such pair.</p>
+              <p>Returns the selected candidate pair on which packets are sent.
+              This method MUST return the value of the
+              <a>[[\SelectedCandidatePair]]</a> slot.</p>
             </dd>
             <dt><dfn><code>getLocalParameters</code></dfn></dt>
             <dd>

--- a/webrtc.html
+++ b/webrtc.html
@@ -6995,7 +6995,7 @@ sender.setParameters(params)
           for which candidate gathering began.</p>
         </li>
         <li>
-          <p>Set <var>transport</var>'s <a>[[\IceTransportGatheringState]]</a>
+          <p>Set <var>transport</var>'s <a>[[\IceGathererState]]</a>
           slot to <code><a data-link-for=
           "RTCIceGathererState">gathering</a></code>.</p>
         </li>
@@ -7050,7 +7050,7 @@ sender.setParameters(params)
           </div>
         </li>
         <li>
-          <p>Set <var>transport</var>'s <a>[[\IceTransportGatheringState]]</a>
+          <p>Set <var>transport</var>'s <a>[[\IceGathererState]]</a>
           slot to <code><a data-link-for=
           "RTCIceGathererState">complete</a></code>.</p>
         </li>
@@ -7185,7 +7185,7 @@ sender.setParameters(params)
       <ul>
         <li><dfn>[[\IceTransportState]]</dfn> initialized to <code>
         <a data-link-for="RTCIceTransportState">new</a></code></li>
-        <li><dfn>[[\IceTransportGatheringState]]</dfn> initialized to <code>
+        <li><dfn>[[\IceGathererState]]</dfn> initialized to <code>
         <a data-link-for="RTCIceGatheringState">new</a></code></li>
         <li><dfn>[[\SelectedCandidatePair]]</dfn> initialized to
         <code>null</code></li>
@@ -7237,7 +7237,7 @@ sender.setParameters(params)
             <dd>
               <p>The <dfn id="dom-icetransport-gatheringstate"><code>gathering
               state</code></dfn> attribute MUST, on getting, return the value
-              of the <a>[[\IceTransportGatheringState]]</a> slot.</p>
+              of the <a>[[\IceGathererState]]</a> slot.</p>
             </dd>
             <dt><dfn><code>onstatechange</code></dfn> of type <span class=
             "idlAttrType"><a>EventHandler</a></span></dt>


### PR DESCRIPTION
Patch 2 of 2 for #1574


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/ice-transport-slots.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/4f0ef95...fbc3ee7.html)