### PR TITLE
Use internal slot for RTCRtpSender's track

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4692,7 +4692,8 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   following steps to use that sender:</p>
                   <ol>
                     <li>
-                      <p>Set <var>sender.track</var> to <var>track</var>.</p>
+                      <p>Set <var>sender</var>'s <a>[[\SenderTrack]]</a> to
+                      <var>track</var>.</p>
                     </li>
                     <li>
                       <p>Set <var>sender</var>'s <a>[[\AssociatedMediaStreams]]</a>
@@ -4819,11 +4820,11 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   type "rollback"), then abort these steps.</p>
                 </li>
                 <li>
-                  <p>If <code><var>sender</var>.track</code> is null, then
+                  <p>If <var>sender</var>'s <a>[[\SenderTrack]]</a> is null,
                   abort these steps.
                 </li>
                 <li>
-                  <p>Set <code><var>sender</var>.track</code> to null.
+                  <p>Set <var>sender</var>'s <a>[[\SenderTrack]]</a> to null.
                 </li>
                 <li>
                   <p>Let <var>transceiver</var> be the
@@ -5179,7 +5180,8 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           object.</p>
         </li>
         <li>
-          <p>Set <var>sender.track</var> to <var>track</var>.</p>
+          <p>Let <var>sender</var> have a <dfn>[[\SenderTrack]]</dfn> internal
+          slot initialized to <var>track</var>.</p>
         </li>
         <li>
           <p>Let <var>sender</var> have an <dfn>[[\AssociatedMediaStreams]]</dfn>
@@ -5245,8 +5247,10 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <code>track</code> is ended, or if
               <code>track</code>.<var>muted</var> is set to <code>true</code>,
               the <code>RTCRtpSender</code> sends silence (audio) or a black
-              frame (video). If <code>track</code> is set to null then
-              the <code>RTCRtpSender</code> does not send.</p>
+              frame (video). If <code>track</code> is null then
+              the <code>RTCRtpSender</code> does not send. On getting, the
+              attribute MUST return the value of the <a>[[\SenderTrack]]</a>
+              slot.</p>
             </dd>
             <dt><dfn><code>transport</code></dfn> of type <span class=
             "idlAttrType"><a>RTCDtlsTransport</a></span>, readonly,
@@ -8676,9 +8680,9 @@ interface RTCDataChannelEvent : Event {
             "idlAttrType"><a>RTCDTMFSender</a></span>, readonly, nullable</dt>
             <dd>
               <p>The <dfn>dtmf</dfn> attribute returns an RTCDTMFSender which
-              can be used to send DTMF. The attribute is set when
-              <code><a>RTCRtpSender</a>.track.kind</code> is <code>"audio"</code>
-              and is <code>null</code> otherwise.</p>
+              can be used to send DTMF, or null if unset. The attribute is set
+              when the kind of an <code><a>RTCRtpSender</a></code>'s
+              <a>[[\SenderTrack]]</a> is <code>"audio"</code>.</p>
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
Fixes #1583


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/sender-slots.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/4f0ef95...5195f2f.html)