### PR TITLE
Add some text about how the [[AssociatedMediaStreams]] slot is used

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5186,7 +5186,9 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           internal slot, representing a list of
           <code><a>MediaStream</a></code> objects that the
           <code><a>MediaStreamTrack</a></code> object of this sender is
-          associated with.</p>
+          associated with. The <a>[[\AssociatedMediaStreams]]</a> slot is used
+          when <var>sender</var> is represented in SDP as described in <span
+          data-jsep="initial-offers">[[!JSEP]]</span>.</p>
         </li>
         <li>
           <p>Set <var>sender</var>'s <a>[[\AssociatedMediaStreams]]</a> slot to


### PR DESCRIPTION
Proposed fix for #1237


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/use-associated-ms-slot.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/4f0ef95...9100c94.html)