### PR TITLE
connectionstate: add missing "one"

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -840,7 +840,7 @@
                 <td>All <code><a>RTCIceTransport</a></code>s and
                 <code><a>RTCDtlsTransport</a></code>s are in the
                 <code>"connected"</code>, <code>"completed"</code> or
-                <code>"closed"</code> state and at least of them is in the
+                <code>"closed"</code> state and at least one of them is in the
                 <code>"connected"</code> or <code>"completed"</code> state.</td>
               </tr>
               <tr>


### PR DESCRIPTION
adds a "and at least *one* of them" in the connectionstate algorithm

spotted by @nils-ohlmeier


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/fippo/webrtc-pc/connectionstate-typo.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/20e3445...fippo:787b7f8.html)