### PR TITLE
Add note that null candidate is for legacy compatibility

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1215,6 +1215,10 @@
             <p>If <var>newState</var> is <code>"completed"</code>, <a>fire an ice candidate event</a>
             named <code><a>icecandidate</a></code> with <code>null</code> at
             <var>connection</var>.</p>
+            <div class="note">The null candidate event is fired to ensure
+            legacy compatibility. New code should monitor the gathering state
+            of <code><a>RTCIceTransport</a></code> and/or <code>
+            <a>RTCPeerConnection</a></code>.</div>
           </li>
         </ol>
         </section>


### PR DESCRIPTION
Fixes #1191


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/null-candidate-note.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/4f0ef95...3610317.html)