### PR TITLE
Add Promise terms to Terminology section

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -85,6 +85,10 @@
     <dfn data-dfn-for="exception" data-cite=
     "!WEBIDL-1#dfn-create-exception">create</dfn> are
     defined in [[!WEBIDL-1]].</p>
+    <p>The terms <dfn data-lt="fulfill|fulfillment">fulfilled</dfn>, <dfn
+    data-lt="reject|rejection|rejecting">rejected</dfn>, <dfn>pending</dfn> and
+    <dfn>settled</dfn> used in the context of Promises are defined in
+    [[!ECMASCRIPT-6.0]].</p>
   </section>
   <section>
     <h2>Peer-to-peer connections</h2>
@@ -1070,9 +1074,9 @@
         <dfn>operations queue</dfn>, <a>[[\Operations]]</a>, which ensures that
         only one asynchronous operation in the queue is executed concurrently.
         If subsequent calls are made while the returned promise of a previous
-        call is still not settled, they are added to the queue and executed
+        call is still not <a>settled</a>, they are added to the queue and executed
         when all the previous calls have finished executing and their promises
-        have settled.</p>
+        have <a>settled</a>.</p>
         </section>
 
         <section>
@@ -1087,7 +1091,7 @@
           </li>
           <li>
             <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
-            <code>true</code>, return a promise rejected with a newly
+            <code>true</code>, return a promise <a>rejected</a> with a newly
             <a data-link-for="exception" data-lt="create">created</a>
             <code>InvalidStateError</code>.</p>
           </li>
@@ -1105,7 +1109,7 @@
             <var>operation</var>.</p>
           </li>
           <li>
-            <p>Upon fulfillment or rejection of the promise returned by the
+            <p>Upon <a>fulfillment</a> or <a>rejection</a> of the promise returned by the
             <var>operation</var>, run the following steps:</p>
             <ol>
               <li>
@@ -1114,15 +1118,15 @@
               </li>
               <li>
                 <p>If the promise returned by <var>operation</var> was
-                fulfilled with a value, fulfill <var>p</var> with that
+                <a>fulfilled</a> with a value, <a>fulfill</a> <var>p</var> with that
                 value.</p>
               </li>
               <li>
-                <p>If the promise returned by <var>operation</var> was rejected
-                with a value, reject <var>p</var> with that value.</p>
+                <p>If the promise returned by <var>operation</var> was <a>rejected</a>
+                with a value, <a>reject</a> <var>p</var> with that value.</p>
               </li>
               <li>
-                <p>Upon fulfillment or rejection of <var>p</var>, execute the
+                <p>Upon <a>fulfillment</a> or <a>rejection</a> of <var>p</var>, execute the
                 following steps:</p>
                 <ol>
                   <li>
@@ -1283,7 +1287,7 @@
                     current <a>signaling state</a> of <var>connection</var>
                     as described in <span data-jsep=
                     "processing-a-local-desc processing-a-remote-desc">[[!JSEP]]</span>,
-                    then reject <var>p</var> with a newly
+                    then <a>reject</a> <var>p</var> with a newly
                     <a data-link-for="exception" data-lt="create">created</a>
                     <code>InvalidStateError</code> and abort these steps.</p>
                   </li>
@@ -1292,7 +1296,7 @@
                     if <code><var>description</var>.type</code> is
                     <code>offer</code> and <code><var>description</var>.sdp</code>
                     is not equal to <var>connection</var>'s <a>[[\LastOffer]]</a> slot,
-                    then reject <var>p</var> with a newly <a data-link-for="exception"
+                    then <a>reject</a> <var>p</var> with a newly <a data-link-for="exception"
                     data-lt="create">created</a>
                     <code>InvalidModificationError</code> and abort these steps.
                   </li>
@@ -1300,7 +1304,7 @@
                     <p>If <var>description</var> is set as a local description,
                     if <code><var>description</var>.type</code> is <code>"rollback"</code>
                     and <a>signaling state</a> is <code>"stable"</code>
-                    then reject <var>p</var> with a newly <a data-link-for="exception"
+                    then <a>reject</a> <var>p</var> with a newly <a data-link-for="exception"
                     data-lt="create">created</a>
                     <code>InvalidStateError</code> and abort these steps.</p>
                   </li>
@@ -1310,13 +1314,13 @@
                     <code>"answer"</code> or <code>"pranswer"</code> and
                     <code><var>description</var>.sdp</code> is not equal
                     to <var>connection</var>'s <a>[[\LastAnswer]]</a> slot,
-                    then reject <var>p</var> with a newly <a data-link-for="exception"
+                    then <a>reject</a> <var>p</var> with a newly <a data-link-for="exception"
                     data-lt="create">created</a>
                     <code>InvalidModificationError</code> and abort these steps.
                   </li>
                   <li>
                     <p>If the content of <var>description</var> is not
-                    valid SDP syntax, then reject <var>p</var> with an
+                    valid SDP syntax, then <a>reject</a> <var>p</var> with an
                     <code><a>RTCError</a></code> (with <code>errorDetail</code>
                     set to "sdp-syntax-error" and the sdpLineNumber
                     attribute set to the line number in the SDP where
@@ -1324,12 +1328,12 @@
                   </li>
                   <li>
                     <p>If the content of <var>description</var> is invalid,
-                    then reject <var>p</var> with a newly
+                    then <a>reject</a> <var>p</var> with a newly
                     <a data-link-for="exception" data-lt="create">created</a>
                     <code>InvalidAccessError</code> and abort these steps.</p>
                   </li>
                   <li>
-                    <p>For all other errors, reject <var>p</var> with a newly
+                    <p>For all other errors, <a>reject</a> <var>p</var> with a newly
                     <a data-link-for="exception" data-lt="create">created</a>
                     <code>OperationError</code>.</p>
                   </li>
@@ -1400,7 +1404,7 @@
                         <p>If <var>description</var> is set as a remote description,
                         if <code><var>description</var>.type</code> is <code>"rollback"</code>
                         and <a>signaling state</a> is <code>"stable"</code>
-                        then reject <var>p</var> with a newly <a data-link-for="exception"
+                        then <a>reject</a> <var>p</var> with a newly <a data-link-for="exception"
                         data-lt="create">created</a>
                         <code>InvalidStateError</code> and abort these steps.</p>
                       </li>
@@ -2121,7 +2125,7 @@ interface RTCPeerConnection : EventTarget  {
                 <code>setLocalDescription</code> will succeed when it attempts
                 to acquire those resources. The session descriptions MUST
                 remain usable by <code>setLocalDescription</code> without
-                causing an error until at least the end of the fulfillment
+                causing an error until at least the end of the <a>fulfillment</a>
                 callback of the returned promise.</p>
                 <p>Creating the SDP MUST follow the appropriate process for
                 generating an offer described in [[!JSEP]].
@@ -2172,7 +2176,7 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
-                    <code>true</code>, return a promise rejected with a newly
+                    <code>true</code>, return a promise <a>rejected</a> with a newly
                     <a data-link-for="exception" data-lt="create">created</a>
                     <code>InvalidStateError</code>.</p>
                   </li>
@@ -2221,7 +2225,7 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>If <var>provider</var> was unable to produce an
-                    identity assertion, reject <var>p</var> with a newly
+                    identity assertion, <a>reject</a> <var>p</var> with a newly
                     <a data-link-for="exception" data-lt="create">created</a>
                     <code>NotReadableError</code> and abort these steps.</p>
                   </li>
@@ -2232,7 +2236,7 @@ interface RTCPeerConnection : EventTarget  {
                     "createoffer">[[!JSEP]]</span>.</p>
                   </li>
                   <li>
-                    <p>If this inspection failed for any reason, reject
+                    <p>If this inspection failed for any reason, <a>reject</a>
                     <var>p</var> with a newly
                     <a data-link-for="exception" data-lt="create">created</a>
                     <code>OperationError</code> and abort these steps.</p>
@@ -2306,7 +2310,7 @@ interface RTCPeerConnection : EventTarget  {
                 returned description SHOULD reflect the current state of the
                 system. The session descriptions MUST remain usable by
                 <code>setLocalDescription</code> without causing an error until
-                at least the end of the fulfillment callback of the returned
+                at least the end of the <a>fulfillment</a> callback of the returned
                 promise.</p>
                 <p>As an answer, the generated SDP will contain a specific
                 codec/RTP/RTCP configuration that, along with the corresponding offer,
@@ -2345,7 +2349,7 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
-                    <code>true</code>, return a promise rejected with a newly
+                    <code>true</code>, return a promise <a>rejected</a> with a newly
                     <a data-link-for="exception" data-lt="create">created</a>
                     <code>InvalidStateError</code>.</p>
                   </li>
@@ -2365,7 +2369,7 @@ interface RTCPeerConnection : EventTarget  {
                         <p>If <var>connection</var>'s <a>signaling state</a>
                         is neither <code>"have-remote-offer"</code> nor
                         <code>"have-local-pranswer"</code>, return a promise
-                        rejected with a newly <a data-link-for="exception"
+                        <a>rejected</a> with a newly <a data-link-for="exception"
                         data-lt="create">created</a>
                         <code>InvalidStateError</code>.</p>
                       </li>
@@ -2402,7 +2406,7 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>If <var>provider</var> was unable to produce an
-                    identity assertion, reject <var>p</var> with a newly
+                    identity assertion, <a>reject</a> <var>p</var> with a newly
                     <a data-link-for="exception" data-lt="create">created</a>
                     <code>NotReadableError</code> and abort these steps.</p>
                   </li>
@@ -2413,7 +2417,7 @@ interface RTCPeerConnection : EventTarget  {
                     "createanswer">[[!JSEP]]</span>.</p>
                   </li>
                   <li>
-                    <p>If this inspection failed for any reason, reject
+                    <p>If this inspection failed for any reason, <a>reject</a>
                     <var>p</var> with a newly
                     <a data-link-for="exception" data-lt="create">created</a>
                     <code>OperationError</code> and abort these steps.</p>
@@ -2550,7 +2554,7 @@ interface RTCPeerConnection : EventTarget  {
                 establishes a <a>target peer identity</a>.</p>
                 <p>The <a>target peer identity</a> cannot be changed once set.
                 Once set, if a different value is provided, the user agent MUST
-                reject the returned promise with a newly
+                <a>reject</a> the returned promise with a newly
                 <a data-link-for="exception" data-lt="create">created</a>
                 <code>InvalidModificationError</code> and abort this operation.
                 The <code><a>RTCPeerConnection</a></code> MUST be closed if the
@@ -2586,7 +2590,7 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>If both <var>sdpMid</var> and <var>sdpMLineIndex</var> are
-                    <code>null</code>, return a promise rejected with a newly
+                    <code>null</code>, return a promise <a>rejected</a> with a newly
                     <a data-link-for="exception" data-lt="create">created</a>
                     <code>TypeError</code>.</p>
                   </li>
@@ -2598,7 +2602,7 @@ interface RTCPeerConnection : EventTarget  {
                       <li>
                         <p>If <code><a data-for=
                         "RTCPeerConnection">remoteDescription</a></code> is
-                        <code>null</code> return a promise rejected with a newly
+                        <code>null</code> return a promise <a>rejected</a> with a newly
                         <a data-link-for="exception" data-lt="create">created
                         </a> <code>InvalidStateError</code>.</p>
                       </li>
@@ -2614,7 +2618,7 @@ interface RTCPeerConnection : EventTarget  {
                             the mid of any media description in
                             <code><a data-for=
                             "RTCPeerConnection">remoteDescription</a></code>,
-                            reject <var>p</var> with a newly
+                            <a>reject</a> <var>p</var> with a newly
                             <a data-link-for="exception" data-lt="create">
                             created</a> <code>OperationError</code> and abort
                             these steps.</p>
@@ -2630,7 +2634,7 @@ interface RTCPeerConnection : EventTarget  {
                             to or larger than the number of media descriptions
                             in <code><a data-for=
                             "RTCPeerConnection">remoteDescription</a></code>,
-                            reject <var>p</var> with a newly
+                            <a>reject</a> <var>p</var> with a newly
                             <a data-link-for="exception" data-lt="create">
                             created</a> <code>OperationError</code> and abort
                             these steps.</p>
@@ -2642,7 +2646,7 @@ interface RTCPeerConnection : EventTarget  {
                         <code>undefined</code> nor <code>null</code>, and is not
                         equal to any username fragment present in the corresponding
                         <a>media description</a> of an applied remote
-                        description, reject <var>p</var> with a newly
+                        description, <a>reject</a> <var>p</var> with a newly
                         <a data-link-for="exception" data-lt="create">created
                         </a> <code>OperationError</code> and abort these steps.
                         </p>
@@ -2672,7 +2676,7 @@ interface RTCPeerConnection : EventTarget  {
                                 then abort these steps.</p>
                               </li>
                               <li>
-                                <p>Reject <var>p</var> with a
+                                <p><a>Reject</a> <var>p</var> with a
                                 <code>DOMException</code> object whose
                                 <code>name</code> attribute has the value
                                 <code>OperationError</code> and abort these
@@ -2910,12 +2914,12 @@ interface RTCPeerConnection : EventTarget  {
                     <var>p</var> be the resulting promise.</p>
                   </li>
                   <li>
-                    <p>Upon fulfillment of <var>p</var> with value
+                    <p>Upon <a>fulfillment</a> of <var>p</var> with value
                     <var>offer</var>, invoke <var>successCallback</var> with
                     <var>offer</var> as the argument.</p>
                   </li>
                   <li>
-                    <p>Upon rejection of <var>p</var> with reason <var>r</var>,
+                    <p>Upon <a>rejection</a> of <var>p</var> with reason <var>r</var>,
                     invoke <var>failureCallback</var> with <var>r</var> as the
                     argument.</p>
                   </li>
@@ -2952,12 +2956,12 @@ interface RTCPeerConnection : EventTarget  {
                     <var>p</var> be the resulting promise.</p>
                   </li>
                   <li>
-                    <p>Upon fulfillment of <var>p</var>, invoke
+                    <p>Upon <a>fulfillment</a> of <var>p</var>, invoke
                     <var>successCallback</var> with <code>undefined</code> as
                     the argument.</p>
                   </li>
                   <li>
-                    <p>Upon rejection of <var>p</var> with reason <var>r</var>,
+                    <p>Upon <a>rejection</a> of <var>p</var> with reason <var>r</var>,
                     invoke <var>failureCallback</var> with <var>r</var> as the
                     argument.</p>
                   </li>
@@ -2994,12 +2998,12 @@ interface RTCPeerConnection : EventTarget  {
                     promise.</p>
                   </li>
                   <li>
-                    <p>Upon fulfillment of <var>p</var> with value
+                    <p>Upon <a>fulfillment</a> of <var>p</var> with value
                     <var>answer</var>, invoke <var>successCallback</var> with
                     <var>answer</var> as the argument.</p>
                   </li>
                   <li>
-                    <p>Upon rejection of <var>p</var> with reason <var>r</var>,
+                    <p>Upon <a>rejection</a> of <var>p</var> with reason <var>r</var>,
                     invoke <var>failureCallback</var> with <var>r</var> as the
                     argument.</p>
                   </li>
@@ -3036,12 +3040,12 @@ interface RTCPeerConnection : EventTarget  {
                     <var>p</var> be the resulting promise.</p>
                   </li>
                   <li>
-                    <p>Upon fulfillment of <var>p</var>, invoke
+                    <p>Upon <a>fulfillment</a> of <var>p</var>, invoke
                     <var>successCallback</var> with <code>undefined</code> as
                     the argument.</p>
                   </li>
                   <li>
-                    <p>Upon rejection of <var>p</var> with reason <var>r</var>,
+                    <p>Upon <a>rejection</a> of <var>p</var> with reason <var>r</var>,
                     invoke <var>failureCallback</var> with <var>r</var> as the
                     argument.</p>
                   </li>
@@ -3076,12 +3080,12 @@ interface RTCPeerConnection : EventTarget  {
                     <var>p</var> be the resulting promise.</p>
                   </li>
                   <li>
-                    <p>Upon fulfillment of <var>p</var>, invoke
+                    <p>Upon <a>fulfillment</a> of <var>p</var>, invoke
                     <var>successCallback</var> with <code>undefined</code> as
                     the argument.</p>
                   </li>
                   <li>
-                    <p>Upon rejection of <var>p</var> with reason <var>r</var>,
+                    <p>Upon <a>rejection</a> of <var>p</var> with reason <var>r</var>,
                     invoke <var>failureCallback</var> with <var>r</var> as the
                     argument.</p>
                   </li>
@@ -4335,7 +4339,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             with an <code><a>object</a></code> argument, the <a>user agent</a>
             attempts to convert the object into an
             <code><a>RTCCertificateExpiration</a></code>. If this is
-            unsuccessful, immediately return a promise that is rejected with a
+            unsuccessful, immediately return a promise that is <a>rejected</a> with a
             newly <a data-link-for="exception" data-lt="create">created</a>
             <code>TypeError</code> and abort processing.</p>
             <p>A <a>user agent</a> generates a certificate that has an
@@ -5321,12 +5325,12 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 parallel.</li>
                 <li>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot is
                 <code>true</code>, abort these steps and return a promise
-                rejected with a newly
+                <a>rejected</a> with a newly
                 <a data-link-for="exception" data-lt="create">created</a>
                 <code>InvalidStateError</code>.</li>
                 <li>If <var>sender</var>'s <a>[[\LastReturnedParameters]]</a>
                 internal slot is empty, meaning <code><a>getParameters</a></code>
-                has never been called, return a promise rejected with a newly
+                has never been called, return a promise <a>rejected</a> with a newly
                 <a data-link-for="exception" data-lt="create">created</a>
                 <code>InvalidStateError</code>.</li>
                 <li>If <code><var>parameters</var>.encodings.length</code>
@@ -5335,13 +5339,13 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 marked as a <dfn>Read-only parameter</dfn>, has a value that is
                 different from the corresponding parameter value in <var>sender</var>'s
                 <a>[[\LastReturnedParameters]]</a> internal slot,
-                abort these steps and return a promise rejected with a newly
+                abort these steps and return a promise <a>rejected</a> with a newly
                 <a data-link-for="exception" data-lt="create">created</a>
                 <code>InvalidModificationError</code>. Note that this also
                 applies to <var>transactionId</var>.</li>
                 <li>If the <code>scaleResolutionDownBy</code> parameter in the
                 <var>parameters</var> argument has a value less than 1.0, abort
-                these steps and return a promise rejected with a newly
+                these steps and return a promise <a>rejected</a> with a newly
                 <a data-link-for="exception" data-lt="create">created</a>
                 <code>RangeError</code>.</li>
                 <li>Set <var>sender</var>'s internal <a>[[\SendEncodings]]</a>
@@ -5468,13 +5472,13 @@ sender.setParameters(params)
                 </li>
                 <li>
                   <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
-                  <code>true</code>, return a promise rejected with a newly
+                  <code>true</code>, return a promise <a>rejected</a> with a newly
                   <a data-link-for="exception" data-lt="create">created</a>
                   <code>InvalidStateError</code> and abort these steps.</p>
                 </li>
                 <li>
                   <p>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot is
-                  <code>true</code>, return a promise rejected
+                  <code>true</code>, return a promise <a>rejected</a>
                   with a newly <a data-link-for="exception" data-lt="create">
                   created</a> <code>InvalidStateError</code>.</p>
                 </li>
@@ -5486,7 +5490,7 @@ sender.setParameters(params)
                   <p>If <code><var>withTrack</var></code> is non-null and
                   <code><var>withTrack</var>.kind</code> differs from the
                   <a>transceiver kind</a> of <var>transceiver</var>, return a
-                  promise rejected with a newly
+                  promise <a>rejected</a> with a newly
                   <a data-link-for="exception" data-lt="create">created</a>
                   <code>TypeError</code>.</p>
                 </li>
@@ -5513,7 +5517,7 @@ sender.setParameters(params)
                       muted). Ignore which <code>MediaStream</code> the track
                       resides in and the <code>id</code> attribute of the track
                       in this determination. If negotiation is needed, then
-                      reject <var>p</var> with a newly
+                      <a>reject</a> <var>p</var> with a newly
                       <a data-link-for="exception" data-lt="create">created</a>
                       <code>InvalidModificationError</code> and abort these
                       steps.</p>
@@ -8965,7 +8969,7 @@ interface RTCDTMFToneChangeEvent : Event {
                   <code>track</code> member matches <var>selectorArg</var>.
                   If no such sender or receiver exists, or if more than one
                   sender or receiver fit this criteria, return a promise
-                  rejected with a newly
+                  <a>rejected</a> with a newly
                   <a data-link-for="exception" data-lt="create">created</a>
                   <code>InvalidAccessError</code>.</p>
                 </li>
@@ -9393,7 +9397,7 @@ interface RTCIdentityProviderRegistrar {
                 generation of an identity assertion.</p>
                 <p>The IdP provides a promise that resolves to an
                 <code><a>RTCIdentityAssertionResult</a></code> to successfully
-                generate an identity assertion. Any other value, or a rejected
+                generate an identity assertion. Any other value, or a <a>rejected</a>
                 promise, is treated as an error.</p>
               </dd>
               <dt><dfn><code>validateAssertion</code></dfn> of type
@@ -9405,7 +9409,7 @@ interface RTCIdentityProviderRegistrar {
                 <p>The IdP returns a Promise that resolves to an
                 <code><a>RTCIdentityValidationResult</a></code> to successfully
                 validate an identity assertion and to provide the actual
-                identity. Any other value, or a rejected promise, is treated as
+                identity. Any other value, or a <a>rejected</a> promise, is treated as
                 an error.</p>
               </dd>
             </dl>
@@ -9634,7 +9638,7 @@ interface RTCIdentityProviderRegistrar {
         </li>
       </ol>
       <p>If assertion generation fails, then the promise for the corresponding
-      function call is rejected with a newly <a data-link-for="exception"
+      function call is <a>rejected</a> with a newly <a data-link-for="exception"
       data-lt="create">created</a> <code>OperationError</code>.</p>
       <section>
         <h4 id="sec.idp-loginneeded">User Login Procedure</h4>
@@ -9644,7 +9648,7 @@ interface RTCIdentityProviderRegistrar {
         to it (such as cookies).</p>
         <p>Rejecting the promise returned by <code><a data-for=
         "RTCIdentityProvider">generateAssertion</a></code> will cause the error
-        to propagate to the application. Login errors are indicated by rejecting
+        to propagate to the application. Login errors are indicated by <a>rejecting</a>
         the promise with an <code><a>RTCError</a></code> with <code>errorDetail</code>
         set to "idp-need-login".</p>
         <p>The URL to login at will be passed to the application in the
@@ -9764,12 +9768,12 @@ interface RTCIdentityProviderRegistrar {
         </li>
       </ol>
       <p>If identity validation fails, the <code><a data-for=
-      "RTCPeerConnection">peerIdentity</a></code> promise is rejected with a
+      "RTCPeerConnection">peerIdentity</a></code> promise is <a>rejected</a> with a
       newly <a data-link-for="exception" data-lt="create">created</a>
       <code>OperationError</code>.</p>
       <p>If identity validation fails and there is a <a>target peer
       identity</a> for the <code>RTCPeerConnection</code>, the promise returned
-      by <code>setRemoteDescription</code> MUST be rejected with the same
+      by <code>setRemoteDescription</code> MUST be <a>rejected</a> with the same
       <code>DOMException</code>.</p>
       <p>If identity validation fails and there is no a <a>target peer
       identity</a>, the value of the <code><a data-for=
@@ -9782,18 +9786,18 @@ interface RTCIdentityProviderRegistrar {
       <h2 id="sec.idp-error-handling">IdP Error Handling</h2>
       <p>Errors in IdP processing will - in most cases - result in the failure
       of the procedure that invoked the IdP proxy. This will result in the
-      rejection of the promise returned by <code><a data-for=
+      <a>rejection</a> of the promise returned by <code><a data-for=
       "RTCPeerConnection">getIdentityAssertion</a></code>, <code><a data-for=
       "RTCPeerConnection">createOffer</a></code>, or <code><a data-for=
       "RTCPeerConnection">createAnswer</a></code>. An IdP proxy error causes a
       <code><a data-for="RTCPeerConnection">setRemoteDescription</a></code>
-      promise to be rejected if there is a <a>target peer identity</a>; IdP
+      promise to be <a>rejected</a> if there is a <a>target peer identity</a>; IdP
       errors in calls to <code><a data-for=
       "RTCPeerConnection">setRemoteDescription</a></code> where there is no
       <a>target peer identity</a> cause the <code><a data-for=
-      "RTCPeerConnection">peerIdentity</a></code> promise to be rejected
+      "RTCPeerConnection">peerIdentity</a></code> promise to be <a>rejected</a>
       instead.</p>
-      <p>If an error occurs these promises are rejected with an
+      <p>If an error occurs these promises are <a>rejected</a> with an
       <code><a>RTCError</a></code> if an error occurs in interacting with the IdP
       proxy. The following scenarios result in errors:</p>
       <ul>
@@ -9825,7 +9829,7 @@ interface RTCIdentityProviderRegistrar {
         "idp-token-invalid".
         <!-- 3 remove this comment later. THREE -->
         If an identity provider throws an exception or returns a promise
-        that is ultimately rejected, then the procedure that depends on the IdP
+        that is ultimately <a>rejected</a>, then the procedure that depends on the IdP
         MUST also fail. These types of errors will cause an IdP failure with an
         <code><a>RTCError</a></code> with <code>errorDetail</code> set to
         "idp-execution-failure".</p></li>
@@ -9876,9 +9880,9 @@ interface RTCIdentityProviderRegistrar {
             <dd>
               <p>A promise that resolves with the identity of the peer if the
               identity is successfully validated.</p>
-              <p>This promise is rejected if an identity assertion is present
+              <p>This promise is <a>rejected</a> if an identity assertion is present
               in a remote session description and validation of that assertion
-              fails for any reason. If the promise is rejected, a new
+              fails for any reason. If the promise is <a>rejected</a>, a new
               unresolved value is created, unless a <a>target peer identity</a>
               has been established. If this promise successfully resolves, the
               value will not change.</p>
@@ -11180,7 +11184,7 @@ if (sender.dtmf) {
               <tr>
                 <td><dfn><code>idp-execution-failure</code></dfn></td>
                 <td>The identity provider has thrown an exception or
-                returned a rejected promise.</td>
+                returned a <a>rejected</a> promise.</td>
               </tr>
               <tr>
                 <td><dfn><code>idp-load-failure</code></dfn></td>


### PR DESCRIPTION
... and link the them.

Fixes #1189


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/promise-terminology.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/4f0ef95...dac3d35.html)