### PR TITLE
Revert "Adding `remoteTrackId` attribute to represent SDP-signaled track ID."

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6520,7 +6520,6 @@ sender.setParameters(params)
     readonly        attribute boolean                     stopped;
     readonly        attribute RTCRtpTransceiverDirection  direction;
     readonly        attribute RTCRtpTransceiverDirection? currentDirection;
-    readonly        attribute DOMString?                  remoteTrackId;
     void setDirection (RTCRtpTransceiverDirection direction);
     void stop ();
     void setCodecPreferences (sequence&lt;RTCRtpCodecCapability&gt; codecs);
@@ -6592,23 +6591,6 @@ sender.setParameters(params)
               represented in an offer/answer exchange, or if the transceiver is
               <code><a>stopped</a></code>, the value is null. On getting, this
               attribute MUST return the value of the <a>[[\CurrentDirection]]</a> slot.</p>
-            </dd>
-            <dt><dfn><code>remoteTrackId</code></dfn> of type <span class=
-            "idlAttrType"><a>DOMString</a></span>, readonly, nullable</dt>
-            <dd>
-              <p>Returns the track ID of this transceiver's <a>associated</a>
-              <a>media description</a> in
-              <code><a data-link-for="RTCPeerConnection">remoteDescription</a></code>;
-              returns <code>null</code> is no such ID is present, or if this
-              transceiver is not <a>associated</a> with a <a>media description</a>.
-              </p>
-              <div class="note">If a transceiver is created by a method other
-              than <code><a>setRemoteDescription</a></code>,
-              <code>receiver.track.id</code> will be set to a randomly
-              generated value instead of one that comes from SDP. Thus this
-              attribute exists to reliably provide the value from SDP, for the
-              benefit of applications that rely on track IDs being
-              signaled.</div>
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
As agreed at the September interim, reverts w3c/webrtc-pc#1567


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/revert-1567-issue_1128_remoteTrackId.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/20e3445...3d5e807.html)