### PR TITLE
RTCIceTransport.gatheringState: Fix type inconsistency

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7224,7 +7224,7 @@ sender.setParameters(params)
               attribute MUST return the state of the transport.</p>
             </dd>
             <dt><dfn><code>gatheringState</code></dfn> of type <span class=
-            "idlAttrType"><a>RTCIceGatheringState</a></span>, readonly</dt>
+            "idlAttrType"><a>RTCIceGathererState</a></span>, readonly</dt>
             <dd>
               <p>The <dfn id="dom-icetransport-gatheringstate"><code>gathering
               state</code></dfn> attribute MUST return the gathering state of


### PR DESCRIPTION
IDL and description has different types for the gatheringState attribute.

Fixes #1594


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/ice-gatherer-typo.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/4f0ef95...aaa02f5.html)