### PR TITLE
Add 'resolved' (and variants) to Promise terminology

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -86,7 +86,8 @@
     "!WEBIDL-1#dfn-create-exception">create</dfn> are
     defined in [[!WEBIDL-1]].</p>
     <p>The terms <dfn data-lt="fulfill|fulfillment">fulfilled</dfn>, <dfn
-    data-lt="reject|rejection|rejecting">rejected</dfn>, <dfn>pending</dfn> and
+    data-lt="reject|rejection|rejecting">rejected</dfn>, <dfn data-lt=
+    "resolve|resolves">resolved</dfn>, <dfn>pending</dfn> and
     <dfn>settled</dfn> used in the context of Promises are defined in
     [[!ECMASCRIPT-6.0]].</p>
   </section>
@@ -1703,7 +1704,7 @@
                     </ol>
                   </li>
                   <li>
-                    <p>Resolve <var>p</var> with <var>undefined</var>.</p>
+                    <p><a>Resolve</a> <var>p</var> with <var>undefined</var>.</p>
                   </li>
                 </ol>
               </li>
@@ -2310,7 +2311,7 @@ interface RTCPeerConnection : EventTarget  {
                     <var>sdpString</var>.</p>
                   </li>
                   <li>
-                    <p>Resolve <var>p</var> with <var>offer</var>.</p>
+                    <p><a>Resolve</a> <var>p</var> with <var>offer</var>.</p>
                   </li>
                 </ol>
               </dd>
@@ -2491,7 +2492,7 @@ interface RTCPeerConnection : EventTarget  {
                     <var>sdpString</var>.</p>
                   </li>
                   <li>
-                    <p>Resolve <var>p</var> with <var>answer</var>.</p>
+                    <p><a>Resolve</a> <var>p</var> with <var>answer</var>.</p>
                   </li>
                 </ol>
               </dd>
@@ -2731,7 +2732,7 @@ interface RTCPeerConnection : EventTarget  {
                                 "RTCPeerConnection">currentRemoteDescription</a></code>.</p>
                               </li>
                               <li>
-                                <p>Resolve <var>p</var> with
+                                <p><a>Resolve</a> <var>p</var> with
                                 <code>undefined</code>.</p>
                               </li>
                             </ol>
@@ -2948,7 +2949,7 @@ interface RTCPeerConnection : EventTarget  {
                     argument.</p>
                   </li>
                   <li>
-                    <p>Return a promise resolved with
+                    <p>Return a promise <a>resolved</a> with
                     <code>undefined</code>.</p>
                   </li>
                 </ol>
@@ -2990,7 +2991,7 @@ interface RTCPeerConnection : EventTarget  {
                     argument.</p>
                   </li>
                   <li>
-                    <p>Return a promise resolved with
+                    <p>Return a promise <a>resolved</a> with
                     <code>undefined</code>.</p>
                   </li>
                 </ol>
@@ -3032,7 +3033,7 @@ interface RTCPeerConnection : EventTarget  {
                     argument.</p>
                   </li>
                   <li>
-                    <p>Return a promise resolved with
+                    <p>Return a promise <a>resolved</a> with
                     <code>undefined</code>.</p>
                   </li>
                 </ol>
@@ -3074,7 +3075,7 @@ interface RTCPeerConnection : EventTarget  {
                     argument.</p>
                   </li>
                   <li>
-                    <p>Return a promise resolved with
+                    <p>Return a promise <a>resolved</a> with
                     <code>undefined</code>.</p>
                   </li>
                 </ol>
@@ -3114,7 +3115,7 @@ interface RTCPeerConnection : EventTarget  {
                     argument.</p>
                   </li>
                   <li>
-                    <p>Return a promise resolved with
+                    <p>Return a promise <a>resolved</a> with
                     <code>undefined</code>.</p>
                   </li>
                 </ol>
@@ -5406,7 +5407,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <code>RangeError</code>.</li>
                 <li>Set <var>sender</var>'s internal <a>[[\SendEncodings]]</a>
                 slot to <code><var>parameters</var>.encodings</code>.</li>
-                <li>Resolve <var>p</var> with <code>undefined</code>.</li>
+                <li><a>Resolve</a> <var>p</var> with <code>undefined</code>.</li>
               </ol>
               <p>If the application selects a codec via <code><a
               data-link-for="RTCRtpEncodingParameters">codecPayloadType</a></code>,
@@ -5549,7 +5550,7 @@ sender.setParameters(params)
                   <a>media description</a>, then set
                   <var>sender</var>'s <code><a data-for=
                   "RTCRtpSender">track</a></code> attribute to
-                  <var>withTrack</var>, and return a promise resolved with
+                  <var>withTrack</var>, and return a promise <a>resolved</a> with
                   <code>undefined</code>.</p>
                 </li>
                 <li>
@@ -5592,7 +5593,7 @@ sender.setParameters(params)
                           <var>withTrack</var>.</p>
                         </li>
                         <li>
-                          <p>Resolve <var>p</var> with
+                          <p><a>Resolve</a> <var>p</var> with
                           <code>undefined</code>.</p>
                         </li>
                       </ol>
@@ -5646,7 +5647,7 @@ sender.setParameters(params)
                       according to the <a>stats selection algorithm</a>.</p>
                     </li>
                     <li>
-                      <p>Resolve <var>p</var> with the resulting
+                      <p><a>Resolve</a> <var>p</var> with the resulting
                       <code><a>RTCStatsReport</a></code> object, containing
                       the gathered stats.</p>
                     </li>
@@ -6389,7 +6390,7 @@ sender.setParameters(params)
                       according to the <a>stats selection algorithm</a>.</p>
                     </li>
                     <li>
-                      <p>Resolve <var>p</var> with the resulting
+                      <p><a>Resolve</a> <var>p</var> with the resulting
                       <code><a>RTCStatsReport</a></code> object, containing
                       the gathered stats.</p>
                     </li>
@@ -9038,7 +9039,7 @@ interface RTCDTMFToneChangeEvent : Event {
                       according to the <a>stats selection algorithm</a>.</p>
                     </li>
                     <li>
-                      <p>Resolve <var>p</var> with the resulting
+                      <p><a>Resolve</a> <var>p</var> with the resulting
                       <code><a>RTCStatsReport</a></code> object, containing
                       the gathered stats.</p>
                     </li>
@@ -9449,7 +9450,7 @@ interface RTCIdentityProviderRegistrar {
               <dd>
                 <p>A user agent invokes this method on the IdP to request the
                 generation of an identity assertion.</p>
-                <p>The IdP provides a promise that resolves to an
+                <p>The IdP provides a promise that <a>resolves</a> to an
                 <code><a>RTCIdentityAssertionResult</a></code> to successfully
                 generate an identity assertion. Any other value, or a <a>rejected</a>
                 promise, is treated as an error.</p>
@@ -9460,7 +9461,7 @@ interface RTCIdentityProviderRegistrar {
               <dd>
                 <p>A user agent invokes this method on the IdP to request the
                 validation of an identity assertion.</p>
-                <p>The IdP returns a Promise that resolves to an
+                <p>The IdP returns a Promise that <a>resolves</a> to an
                 <code><a>RTCIdentityValidationResult</a></code> to successfully
                 validate an identity assertion and to provide the actual
                 identity. Any other value, or a <a>rejected</a> promise, is treated as
@@ -9663,7 +9664,7 @@ interface RTCIdentityProviderRegistrar {
           <code>RTCPeerConnection</code>. The IdP proxy is expected to generate
           the identity assertion asynchronously.</p>
           <p>If the user has been authenticated by the IdP, and the IdP is able
-          to generate an identity assertion, the IdP resolves the promise with
+          to generate an identity assertion, the IdP <a>resolves</a> the promise with
           an identity assertion in the form of an
           <code><a>RTCIdentityAssertionResult</a></code>.</p>
           <p>This step depends entirely on the IdP. The methods by which an IdP
@@ -9673,7 +9674,7 @@ interface RTCIdentityProviderRegistrar {
         </li>
         <li>
           <p>If the IdP proxy produces an error or returns a promise that does
-          not resolve to a valid
+          not <a>resolve</a> to a valid
           <code><a>RTCIdentityAssertionResult</a></code> (see <a href=
           "#sec.idp-error-handling"></a>), then assertion generation fails.</p>
         </li>
@@ -9775,13 +9776,13 @@ interface RTCIdentityProviderRegistrar {
         </li>
         <li>
           <p>If the IdP proxy produces an error or returns a promise that does
-          not resolve to a valid
+          not <a>resolve</a> to a valid
           <code><a>RTCIdentityValidationResult</a></code> (see <a href=
           "#sec.idp-error-handling"></a>), then identity validation fails.</p>
         </li>
         <li>
           <p>Once the assertion is successfully verified, the IdP proxy
-          resolves the promise with an
+          <a>resolves</a> the promise with an
           <code><a>RTCIdentityValidationResult</a></code> containing the
           validated identity and the original contents that are the payload of
           the assertion.</p>
@@ -9932,13 +9933,13 @@ interface RTCIdentityProviderRegistrar {
             "idlAttrType">Promise&lt;<a>RTCIdentityAssertion</a>&gt;</span>,
             readonly</dt>
             <dd>
-              <p>A promise that resolves with the identity of the peer if the
+              <p>A promise that <a>resolves</a> with the identity of the peer if the
               identity is successfully validated.</p>
               <p>This promise is <a>rejected</a> if an identity assertion is present
               in a remote session description and validation of that assertion
               fails for any reason. If the promise is <a>rejected</a>, a new
               unresolved value is created, unless a <a>target peer identity</a>
-              has been established. If this promise successfully resolves, the
+              has been established. If this promise successfully <a>resolves</a>, the
               value will not change.</p>
             </dd>
             <dt><dfn><code>idpLoginUrl</code></dfn> of type <span class=
@@ -10014,7 +10015,7 @@ interface RTCIdentityProviderRegistrar {
                   identity assertion</a> from the IdP.</p>
                 </li>
                 <li>
-                  <p>Resolve the promise with the base64 and JSON encoded
+                  <p><a>Resolve</a> the promise with the base64 and JSON encoded
                   assertion.</p>
                 </li>
               </ol>


### PR DESCRIPTION
Fixes #1603


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/promise-terminology-2.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/67270e5...f2502d5.html)