### PR TITLE
Validate protocol string in IdP operations

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9943,8 +9943,9 @@ interface RTCIdentityProviderRegistrar {
               "idlMemberType"><a>DOMString</a></span>, defaulting to
               <code>"default"</code></dt>
               <dd>
-                <p>The protocol parameter used for the IdP. This attribute MUST
-                contain only characters legal for inclusion in URIs [[!RFC3986]].</p>
+                <p>The protocol parameter used for the IdP. The string
+                MUST NOT include the character <code>'/'</code> or
+                <code>'\'</code>.</p>
               </dd>
             </dl>
           </section>
@@ -10106,6 +10107,11 @@ interface RTCIdentityProviderRegistrar {
           resulting dictionary contains a <var>domain</var> and an optional
           <var>protocol</var> value that identifies the IdP, as described in
           [[!RTCWEB-SECURITY-ARCH]].</p>
+        </li>
+        <li>
+          <p>If the identity assertion is malformed, or if <var>protocol</var>
+          includes the character <code>'/'</code> or <code>'\'</code>,
+          this process fails.</p>
         </li>
         <li>
           <p>The <code>RTCPeerConnection</code> instantiates the identified IdP
@@ -10332,6 +10338,11 @@ interface RTCIdentityProviderRegistrar {
                   <p>If the <code><a>RTCPeerConnection</a></code> object's
                   <a>[[\IsClosed]]</a> slot is <code>true</code>, <a>throw</a> an
                   <code>InvalidStateError</code>.</p>
+                </li>
+                <li>
+                  <p>If <var>options.protocol</var> includes the the character
+                  <code>'/'</code> or <code>'\'</code>, throw a
+                  <code>SyntaxError</code>.</p>
                 </li>
                 <li>
                   <p>Set the current identity provider values to the tuple


### PR DESCRIPTION
Fixes #1500.

This is based the protocol field defined in [ietf-rtcweb-security-arch](https://tools.ietf.org/html/draft-ietf-rtcweb-security-arch-12#section-5.6.5):

> protocol:  The specific IdP protocol which the IdP is using.  This is a completely opaque IdP-specific string, but allows an IdP to implement two protocols in parallel.  This value may be the empty string.  If no value for protocol is provided, a value of "default" is used.

> Note that the separator characters '/' (%2F) and '\\' (%5C) MUST NOT be permitted in the protocol field, lest an attacker be able to direct requests outside of the controlled "/.well-known/" prefix.  Query and fragment values MAY be used by including '?' or '#' characters.

The spec is not clear of how "opaque" the protocol can be in respect to the well-formness of the URI format. They way I interpret this is that the provider string may contain the path, query, and fragment components of a URI, and each component will be normalized accordingly when forming the well-known URI for the IdP proxy, e.g. invalid characters will be percent-encoded.

Since anything can be percent encoded, that means protocol may contain arbitrary characters other than "/" and "\\" which are explicitly forbidden. Here the percent encoded strings "%2F" and "%5C" are not banned, because my understanding is that percent encoding will be done by the browser instead of the application.

This PR differs with the approach in #1538. #1538 does not cover percent encoding and the query/fragment component. We might want to discuss more on whether it is the browser or application responsibility to encode the protocol field as well-formed URI.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/soareschen/webrtc-pc/protocol-validation.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/67270e5...soareschen:8ea135e.html)