### PR TITLE
setParameters: Use more specific hardware encoder errors

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5432,7 +5432,13 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                         being available, <a>reject</a> <var>p</var> with a newly
                         created <code><a>RTCError</a></code> whose
                         <code>errorDetail</code> is set to
-                        "hardware-encoder-error" and abort these steps.</li>
+                        "hardware-encoder-not-available" and abort these steps.</li>
+                        <li>If an error occurred due to a hardware encoder not
+                        supporting <var>parameters</var>, <a>reject</a>
+                        <var>p</var> with a newly created <code>
+                        <a>RTCError</a></code> whose <code>errorDetail</code>
+                        is set to "hardware-encoder-error" and abort these
+                        steps.</li>
                         <li>For all other errors, <a>reject</a> <var>p</var>
                         with a newly <a data-link-for="exception" data-lt=
                         "create">created</a> <code>OperationError</code>.</li>
@@ -11261,6 +11267,7 @@ if (sender.dtmf.canInsertDTMF) {
               "idp-token-invalid",
               "sctp-failure",
               "sdp-syntax-error",
+              "hardware-encoder-not-available",
               "hardware-encoder-error"
           };</pre>
           <table data-link-for="RTCErrorDetailType" data-dfn-for=
@@ -11347,9 +11354,14 @@ if (sender.dtmf.canInsertDTMF) {
                 error was detected.</td>
               </tr>
               <tr>
-                <td><dfn><code>hardware-encoder-error</code></dfn></td>
+                <td><dfn><code>hardware-encoder-not-available</code></dfn></td>
                 <td>The hardware encoder resources required for the requested
                 operation are not available.</td>
+              </tr>
+              <tr>
+                <td><dfn><code>hardware-encoder-error</code></dfn></td>
+                <td>The hardware encoder does not support the provided
+                parameters.</td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
For example, errors due to incompatible parameters and the hardware resource not being available.

Fixes #1602


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/setparams-async-errors.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/19827c9...69819c2.html)