### PR TITLE
Duration, InterToneGap, ToneBuffer and CanInsertDTMF internal slots of RTCDTMFSender

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8811,6 +8811,30 @@ interface RTCDataChannelEvent : Event {
     </section>
     <section>
       <h4><dfn>RTCDTMFSender</dfn></h4>
+        <p>To create an <code>RTCDTMFSender</code>, the user agent MUST
+        run the following steps:</p>
+        <ol>
+          <li>
+            <p>Let <var>dtmf</var> be a newly created
+            <code><a>RTCDTMFSender</a></code> object.</p>
+          </li>
+          <li>
+            <p>Let <var>dtmf</var> have a <dfn>[[\CanInsertDtmf]]</dfn>
+            internal slot, initialized to <code>false</code>.</p>
+          </li>
+          <li>
+            <p>Let <var>dtmf</var> have a <dfn>[[\Duration]]</dfn>
+            internal slot.</p>
+          </li>
+          <li>
+            <p>Let <var>dtmf</var> have a <dfn>[[\InterToneGap]]</dfn>
+            internal slot.</p>
+          </li>
+          <li>
+            <p>Let <var>dtmf</var> have a <dfn>[[\ToneBuffer]]</dfn>
+            internal slot.</p>
+          </li>
+       </ol>
       <div>
         <pre class="idl">
 [Exposed=Window] interface RTCDTMFSender : EventTarget {
@@ -8891,40 +8915,51 @@ interface RTCDataChannelEvent : Event {
                 <li>If <var>transceiver</var>'s <a>[[\CurrentDirection]]</a> slot
                 is <code>recvonly</code> or <code>inactive</code>,
                 <a>throw</a> an <code>InvalidStateError</code>.</li>
+                <li>Let <var>dtmf</var> be the <code><a>RTCDTMFSender</a></code>
+                associated with <var>sender</var>.</li>
+                <li>If <var>dtmf</var>'s <a>[[\CanInsertDTMF]]</a> internal slot
+                is <code>false</code>, <a>throw</a> an <code>InvalidStateError</code>.</li>
                 <li>Let <var>tones</var> be the method's first argument.</li>
                 <li>If <var>tones</var> contains any <a>unrecognized</a>
                 characters, <a>throw</a> an <code>InvalidCharacterError</code>.
-                </li>
-                <li>Set the object's <code><a data-for=
-                "RTCDTMFSender">toneBuffer</a></code> attribute to
+                </li>                
+                <li>Set the object's <a>[[\ToneBuffer]]</a> slot to
                 <var>tones</var>.</li>
+                <li>Set <var>dtmf</var>'s <a>[[\Duration]]</a> slot to the
+                value of the <code><a data-for=
+                "RTCDTMFSender">duration</a></code> parameter.</li>
+                <li>Set <var>dtmf</var>'s <a>[[\InterToneGap]]</a> slot to the
+                value of the <code><a data-for=
+                "RTCDTMFSender">interToneGap</a></code> parameter.</li>
                 <li>If the value of the <code><a data-for=
-                "RTCDTMFSender">duration</a></code> parameter is less than 40,
-                set it to 40. If, on the other hand, the value is greater than
-                6000, set it to 6000.</li>
+                "RTCDTMFSender">duration</a></code> parameter is less than 40 ms,
+                set <var>dtmf</var>'s <a>[[\Duration]]</a> slot to 40 ms.</li>
                 <li>If the value of the <code><a data-for=
-                "RTCDTMFSender">interToneGap</a></code> parameter is less than
-                30, set it to 30. If, on the other hand, the value is greater
-                than 6000, set it to 6000.</li>
-                <li>If <code><a data-for="RTCDTMFSender">toneBuffer</a></code>
-                is an empty string, abort these steps.</li>
+                "RTCDTMFSender">duration</a></code> parameter is greater than 6000 ms,
+                set <var>dtmf</var>'s <a>[[\Duration]]</a> slot to 6000 ms.</li>
+                <li>If the value of the <code><a data-for=
+                "RTCDTMFSender">interToneGap</a></code> parameter is less than 30 ms,
+                set <var>dtmf</var>'s <a>[[\InterToneGap]]</a> slot to 30 ms.</li>
+                <li>If the value of the <code><a data-for=
+                "RTCDTMFSender">interToneGap</a></code> parameter is greater than 6000 ms,
+                set <var>dtmf</var>'s <a>[[\InterToneGap]]</a> slot to 6000 ms.</li>
+                <li>If <a>[[\ToneBuffer]]</a> slot is an empty string,
+                abort these steps.</li>
                 <li>If a <em>Playout task</em> is scheduled to be run, abort
                 these steps; otherwise queue a task that runs the following
                 steps (<em>Playout task</em>):
                   <ol>
-                    <li>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot is
-                    <code>true</code>, abort these steps.</li>
-                    <li>If <var>transceiver</var>'s <a>[[\CurrentDirection]]</a> slot
-                    is <code>recvonly</code> or <code>inactive</code>,
+                    <li>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot
+                    is <code>true</code>, abort these steps.</li>
+                    <li>If <var>transceiver</var>'s <a>[[\CurrentDirection]]</a>
+                    slot is <code>recvonly</code> or <code>inactive</code>,
                     abort these steps.</li>
-                    <li>If <code><a data-for=
-                    "RTCDTMFSender">toneBuffer</a></code> is an empty string,
-                    <a>fire a tonechange event</a> named <code><a>tonechange</a></code> with an
-                    empty string at the <code><a>RTCDTMFSender</a></code>
+                    <li>If the <a>[[\ToneBuffer]]</a> slot contains the empty
+                    string, fire an event named <code><a>tonechange</a></code>
+                    with an empty string at the <code><a>RTCDTMFSender</a></code>
                     object and abort these steps.</li>
-                    <li>Remove the first character from <code><a data-for=
-                    "RTCDTMFSender">toneBuffer</a></code> and let that
-                    character be <var>tone</var>.</li>
+                    <li>Remove the first character from the <a>[[\ToneBuffer]]</a>
+                    slot and let that character be <var>tone</var>.</li>
                     <li>If <var>tone</var> is "," delay sending tones for
                     <code><a data-for="RTCDTMFSender">2000</a></code> ms on
                     the associated RTP media stream, and queue a task to
@@ -8932,14 +8967,12 @@ interface RTCDataChannelEvent : Event {
                     "RTCDTMFSender">2000</a></code> ms from now that
                     runs the steps labelled <em>Playout task</em>.</li>
                     <li>If <var>tone</var> is not "," start playout of
-                    <var>tone</var> for <code><a data-for=
-                    "RTCDTMFSender">duration</a></code> ms on the associated
+                    <var>tone</var> for <a>[[\Duration]]</a> ms on the associated
                     RTP media stream, using the appropriate codec, then
-                    queue a task to be executed in <code><a data-for=
-                    "RTCDTMFSender">duration</a></code> + <code><a data-for=
-                    "RTCDTMFSender">interToneGap</a></code> ms from now that
+                    queue a task to be executed in <a>[[\Duration]]</a>
+                    + <a>[[\InterToneGap]]</a> ms from now that
                     runs the steps labelled <em>Playout task</em>.</li>
-                    <li><a>Fire a tonechange event</a> named <code><a>tonechange</a></code> with
+                    <li>Fire an event named <code><a>tonechange</a></code> with
                     a string consisting of <var>tone</var> at the
                     <code><a>RTCDTMFSender</a></code> object.</li>
                   </ol>
@@ -8948,8 +8981,8 @@ interface RTCDataChannelEvent : Event {
               <p>Since <code>insertDTMF</code> replaces the tone
               buffer, in order to add to the DTMF tones being played,
               it is necessary to call <code>insertDTMF</code> with a
-              string containing both the remaining tones (stored in
-              <code>toneBuffer</code>) and the new tones appended
+              string containing both the remaining tones (stored in the
+              <a>[[\ToneBuffer]]</a> slot) and the new tones appended
               together. Calling <code><a data-for=
               "RTCDTMFSender">insertDTMF</a></code> with an empty tones
               parameter can be used to cancel all tones queued to play after
@@ -8994,11 +9027,11 @@ interface RTCDTMFToneChangeEvent : Event {
             <dt><code>tone</code> of type <span class=
             "idlAttrType"><a>DOMString</a></span>, readonly</dt>
             <dd>
-              <p>The <dfn><code>tone</code></dfn> attribute contains the
+              <p>The <code>tone</code> attribute contains the
               character for the tone (including ",") that has just
-              begun playout (see <code><a>insertDTMF</a></code> ). If the
-              value is the empty string, it indicates that the <code><a data-for=
-              "RTCDTMFSender">toneBuffer</a></code> is an empty string and that
+              begun playout (see <code><a>insertDTMF</a></code> ). If
+              the value is the empty string, it indicates that the
+              <a>[[\ToneBuffer]]</a> slot is an empty string and that
               the previous tones have completed playback.</p>
             </dd>
           </dl>
@@ -9018,9 +9051,9 @@ interface RTCDTMFToneChangeEvent : Event {
             <dd>
               <p>The <code>tone</code> attribute contains the
               character for the tone (including ",") that has just
-              begun playout (see <code><a>insertDTMF</a></code> ). If the
-              value is the empty string, it indicates that the <code><a data-for=
-              "RTCDTMFSender">toneBuffer</a></code> is an empty string and that
+              begun playout (see <code><a>insertDTMF</a></code> ). If
+              the value is the empty string, it indicates that the
+              <a>[[\ToneBuffer]]</a> slot is an empty string and that
               the previous tones have completed playback.</p>
             </dd>
           </dl>

--- a/webrtc.html
+++ b/webrtc.html
@@ -8972,8 +8972,9 @@ interface RTCDataChannelEvent : Event {
                     queue a task to be executed in <a>[[\Duration]]</a>
                     + <a>[[\InterToneGap]]</a> ms from now that
                     runs the steps labelled <em>Playout task</em>.</li>
-                    <li>Fire an event named <code><a>tonechange</a></code> with
-                    a string consisting of <var>tone</var> at the
+                    <li><a>Fire a tonechange event</a> named
+                    <code><a>tonechange</a></code> with a string
+                    consisting of <var>tone</var> at the
                     <code><a>RTCDTMFSender</a></code> object.</li>
                   </ol>
                 </li>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/1516

Rebase of PR https://github.com/w3c/webrtc-pc/pull/1542


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/issue-1516-patchv2.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/19827c9...97eaca3.html)