### PR TITLE
pc.close() should close Data Channels and SctpTransports

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7922,6 +7922,10 @@ interface RTCTrackEvent : Event {
                   <code>null</code>.</p>
                 </li>
                 <li>
+                  <p>Let <var>channel</var> have a <dfn>[[\ReadyState]</dfn> internal slot
+                  initialized to <code>"connecting"</code>.</p>
+                </li>
+                <li>
                   <p>Let <var>channel</var> have a <dfn>[[\MaxRetransmits]]</dfn> internal slot
                   initialized to <var>option</var>'s <code>maxRetransmits</code>
                   member, if present, otherwise <code>null</code>.</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1501,7 +1501,7 @@
                           </li>
                           <li>
                             <p>Set <var>channel</var>'s <code><a data-for=
-                            "RTCDataChannel">readyState</a></code> attribute to
+                            <a>[[\ReadyState]]</a> slot to
                             <code>"closed"</code>.</p>
                           </li>
                           <li>
@@ -8128,8 +8128,7 @@ interface RTCTrackEvent : Event {
           object to be announced.</p>
         </li>
         <li>
-          <p>Set <var>channel</var>'s <code><a data-for=
-          "RTCDataChannel">readyState</a></code> attribute to
+          <p>Set <var>channel</var>'s <a>[[\ReadyState]]</a> slot to
           <code>open</code>.</p>
         </li>
         <li>
@@ -8197,8 +8196,7 @@ interface RTCTrackEvent : Event {
           </table>
         </li>
         <li>
-          <p>Set <var>channel</var>'s <code><a data-for=
-          "RTCDataChannel">readyState</a></code> attribute to
+          <p>Set <var>channel</var>'s <a>[[\ReadyState]]</a> slot to
           <code>connecting</code>.</p>
         </li>
         <li>
@@ -8212,8 +8210,7 @@ interface RTCTrackEvent : Event {
       <dfn id="data-transport-closing-procedure">closing procedure</dfn>. When
       that happens the user agent MUST, unless the procedure was initiated by
       the <code><a data-for="RTCDataChannel">close</a></code> method, queue a
-      task that sets the object's <code><a data-for=
-      "RTCDataChannel">readyState</a></code> attribute to <code>closing</code>.
+      task that sets the object's <a>[[\ReadyState]]</a> slot to <code>closing</code>.
       This will eventually render the <a>data transport</a> <a>closed</a>.</p>
       <p>When an <code><a>RTCDataChannel</a></code> object's <a>underlying data
       transport</a> has been <dfn id="data-transport-closed">closed</dfn>, the
@@ -8225,8 +8222,7 @@ interface RTCTrackEvent : Event {
           closed.</p>
         </li>
         <li>
-          <p>Set <var>channel</var>'s <code><a data-for=
-          "RTCDataChannel">readyState</a></code> attribute to
+          <p>Set <var>channel</var>'s <a>[[\ReadyState]]</a> slot to
           <code>closed</code>.</p>
         </li>
         <li>
@@ -8256,8 +8252,7 @@ interface RTCTrackEvent : Event {
           data transport</a>.</p>
         </li>
         <li>
-          <p>Set <var>channel</var>'s <code><a data-for=
-          "RTCDataChannel">readyState</a></code> attribute to
+          <p>Set <var>channel</var>'s <a>[[\ReadyState]]</a> slot to
           <code>closed</code>.</p>
         </li>
         <li>
@@ -8389,8 +8384,8 @@ interface RTCTrackEvent : Event {
               <p>The <dfn id=
               "dom-datachannel-readystate"><code>readyState</code></dfn>
               attribute represents the state of the <code>RTCDataChannel</code>
-              object. It MUST return the value to which the user agent last set
-              it (as defined by the processing model algorithms).</p>
+              object. On getting, the attribute MUST return the value
+              of the <a>[[\ReadyState]]</a> slot.</p>
             </dd>
             <dt><code>bufferedAmount</code> of type <span class=
             "idlAttrType"><a>unsigned long</a></span>, readonly</dt>
@@ -8490,14 +8485,12 @@ interface RTCTrackEvent : Event {
                   be closed.</p>
                 </li>
                 <li>
-                  <p>If <var>channel</var>'s <code><a data-for=
-                  "RTCDataChannel">readyState</a></code> is
+                  <p>If <var>channel</var>'s <a>[[\ReadyState]]</a> slot is
                   <code>closing</code> or <code>closed</code>, then abort these
                   steps.</p>
                 </li>
                 <li>
-                  <p>Set <var>channel</var>'s <code><a data-for=
-                  "RTCDataChannel">readyState</a></code> attribute to
+                  <p>Set <var>channel</var>'s <a>[[\ReadyState]]</a> slot to
                   <code>closing</code>.</p>
                 </li>
                 <li>
@@ -8614,8 +8607,7 @@ interface RTCTrackEvent : Event {
           object on which data is to be sent.</p>
         </li>
         <li>
-          <p>If <var>channel</var>'s <a data-for=
-          "RTCDataChannel"><code>readyState</code></a> attribute is not
+          <p>If <var>channel</var>'s <a>[[\ReadyState]]</a> slot is not
           <code>open</code>, <a>throw</a> an
           <code>InvalidStateError</code>.</p>
         </li>
@@ -8793,19 +8785,19 @@ interface RTCDataChannelEvent : Event {
       collected if its</p>
       <ul>
         <li>
-          <p><code><a data-for="RTCDataChannel">readyState</a></code> is
+          <p><a>[[\ReadyState]]</a> slot is
           <code>connecting</code> and at least one event listener is registered
           for <code>open</code> events, <code>message</code> events,
           <code>error</code> events, or <code>close</code> events.</p>
         </li>
         <li>
-          <p><code><a data-for="RTCDataChannel">readyState</a></code> is
+          <p><a>[[\ReadyState]]</a> slot is
           <code>open</code> and at least one event listener is registered for
           <code>message</code> events, <code>error</code> events, or
           <code>close</code> events.</p>
         </li>
         <li>
-          <p><code><a data-for="RTCDataChannel">readyState</a></code> is
+          <p><<a>[[\ReadyState]]</a> slot is
           <code>closing</code> and at least one event listener is registered
           for <code>error</code> events, or <code>close</code> events.</p>
         </li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -2862,6 +2862,18 @@ interface RTCPeerConnection : EventTarget  {
                     </ol>
                   </li>
                   <li>
+                    <p>Set the <a>[[\ReadyState]]</a> slot of each of
+                    <var>connection</var>'s <code><a>RTCDataChannel</a></code>s
+                    to <code><a data-link-for=
+                    "RTCDataChannelState">"closed"</a></code>.</p>
+                  </li>
+                  <li>
+                    <p>Set the <a>[[\SctpTransportState]]</a> slot of each of
+                    <var>connection</var>'s <code><a>RTCSctpTransport</a></code>s
+                    to <code><a data-link-for=
+                    "RTCSctpTransportState">"closed"</a></code>.</p>
+                  </li>
+                  <li>
                     <p>Set the <a>[[\DtlsTransportState]]</a> slot of each of
                     <var>connection</var>'s <code><a>RTCDtlsTransport</a></code>s
                     to <code><a data-link-for=

--- a/webrtc.html
+++ b/webrtc.html
@@ -1008,6 +1008,7 @@
             "RTCConfiguration">rtcpMuxPolicy</a></code> is
             <code>"negotiate"</code>, and the user agent does not implement
             non-muxed RTCP, <a>throw</a> a <code>NotSupportedError</code>.</p>
+          </li>
           <li>
             <p>Initialize <var>connection</var>'s <a>ICE Agent</a>.</p>
           </li>
@@ -1500,9 +1501,8 @@
                             an ID could not be generated.</p>
                           </li>
                           <li>
-                            <p>Set <var>channel</var>'s <code><a data-for=
-                            <a>[[\ReadyState]]</a> slot to
-                            <code>"closed"</code>.</p>
+                            <p>Set <var>channel</var>'s <a>[[\ReadyState]]</a> slot
+                            to <code>"closed"</code>.</p>
                           </li>
                           <li>
                             <p>Fire an event named <code><a data-for=
@@ -3457,6 +3457,7 @@ interface RTCSessionDescription {
             <dfn>clear the negotiation-needed flag</dfn> by setting
             <var>connection</var>'s <a>[[\NegotiationNeeded]]</a> slot to
             <code>false</code>, and abort these steps.</p>
+          </li>
           <li>
             <p>If <var>connection</var>'s <a>[[\NegotiationNeeded]]</a> slot is
             already <code>true</code>, abort these steps.</p>


### PR DESCRIPTION
Fix for Issues https://github.com/w3c/webrtc-pc/issues/1288 and https://github.com/w3c/webrtc-pc/issues/1381


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/yet-another-patchv42.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/293176b...b5b8c81.html)