### PR TITLE
Describe how transport objects are assigned to senders/receivers.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -78,6 +78,7 @@
     <dfn>MediaStreamConstraints</dfn> are defined in [[!GETUSERMEDIA]].</p>
     <p>The term <dfn>Blob</dfn> is defined in [[!FILEAPI]].</p>
     <p>The term <dfn>media description</dfn> is defined in [[!RFC4566]].</p>
+    <p>The term <dfn>media transport</dfn> is defined in [[!RFC7656]].</p>
     <p>The term <dfn>generation</dfn> is defined in [[!TRICKLE-ICE]] Section 2.</p>
     <p>The term <dfn data-cite="!WEBRTC-STATS#dom-rtcstatstype">RTCStatsType</dfn> is defined in [[!WEBRTC-STATS]].
     <p>When referring to exceptions, the terms <dfn
@@ -1523,19 +1524,19 @@
                   </li>
                   <li>
                     <p>If <var>description</var> is set as a local description,
-                    then run the following steps for each media description
+                    then run the following steps for each <a>media description</a>
                     in <var>description</var> that is not yet <a>associated</a> with
                     an <code><a>RTCRtpTransceiver</a></code> object:</p>
                     <ol>
                       <li>
                         <p>Let <var>transceiver</var> be the <code>
                         <a>RTCRtpTransceiver</a></code> used to create the
-                        media description.</p>
+                        <a>media description</a>.</p>
                       </li>
                       <li>
                         <p>Set <var>transceiver</var>'s <code><a data-for=
                         "RTCRtpTransceiver">mid</a></code> value to the mid of
-                        the corresponding media description.</p>
+                        the corresponding <a>media description</a>.</p>
                       </li>
                       <li>
                         <p>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot
@@ -1547,7 +1548,58 @@
                         set <var>transceiver</var>'s <a>[[\CurrentDirection]]</a> slot
                         to an <code><a>RTCRtpTransceiverDirection</a></code>
                         value representing the direction of the corresponding
-                        media description.</p>
+                        <a>media description</a>.</p>
+                      </li>
+                      <li>
+                        <p>
+                          If the <a>media description</a> is indicated as using
+                          an existing <a>media transport</a> according to
+                          [[!BUNDLE]], let <var>transport</var> and
+                          <var>rtcpTransport</var> be the
+                          <code><a>RTCDtlsTransport</a></code> objects
+                          representing the RTP and RTCP components of that
+                          transport, respectively.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Otherwise, let <var>transport</var> and
+                          <var>rtcpTransport</var> be newly created
+                          <code><a>RTCDtlsTransport</a></code> objects, each
+                          with a new underlying
+                          <code><a>RTCIceTransport</a></code>. Though if RTCP
+                          multiplexing is negotiated according to [[!RFC5761]],
+                          or if <var>connection</var>'s
+                          <code><a>RTCRtcpMuxPolicy</a></code> is <code><a
+                          data-link-for="RTCRtcpMuxPolicy">require</a></code>,
+                          do not create any RTCP-specific transport objects,
+                          and instead let <var>rtcpTransport</var> equal
+                          <var>transport</var>.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set <var>transceiver</var>.<a>[[\Sender]]</a>.<a>[[\SenderTransport]]</a>
+                          to <var>transport</var>.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set <var>transceiver</var>.<a>[[\Sender]]</a>.<a>[[\SenderRtcpTransport]]</a>
+                          to <var>rtcpTransport</var>.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\ReceiverTransport]]</a>
+                          to <var>transport</var>.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\ReceiverRtcpTransport]]</a>
+                          to <var>rtcpTransport</var>.
+                        </p>
                       </li>
                     </ol>
                   </li>
@@ -1559,14 +1611,14 @@
                         <p>Let <var>trackEvents</var> be an empty list.</p>
                       </li>
                       <li>
-                        <p>Run the following steps for each media description
+                        <p>Run the following steps for each <a>media description</a>
                         in <var>description</var>:</p>
                         <ol>
                           <li>
                             <p>Let <var>direction</var> be an <code>
                             <a>RTCRtpTransceiverDirection</a></code> value
-                            representing the direction from the media
-                            description, but with the send and receive
+                            representing the direction from the <a>media
+                            description</a>, but with the send and receive
                             directions reversed to represent this peer's point
                             of view.</p>
                           </li>
@@ -1574,8 +1626,8 @@
                             <p>As described by <span data-jsep=
                             "applying-a-remote-desc">[[!JSEP]]</span>, attempt to
                             find an existing <code><a>RTCRtpTransceiver</a></code>
-                            object, <var>transceiver</var>, to represent the media
-                            description.</p>
+                            object, <var>transceiver</var>, to represent the <a>media
+                            description</a>.</p>
                           </li>
                           <li>
                             <p> If no suitable transceiver is found
@@ -1584,11 +1636,11 @@
                             <ol>
                               <li>
                                 <p><a>Create an RTCRtpSender</a>, <var>sender</var>,
-                                from the media description.</p>
+                                from the <a>media description</a>.</p>
                               </li>
                               <li>
                                 <p><a>Create an RTCRtpReceiver</a>,
-                                <var>receiver</var>, from the media description.</p>
+                                <var>receiver</var>, from the <a>media description</a>.</p>
                               </li>
                               <li>
                                 <p><a>Create an RTCRtpTransceiver</a> with
@@ -1601,8 +1653,8 @@
                           <li>
                             <p>Set <var>transceiver</var>'s <code><a data-for=
                             "RTCRtpTransceiver">mid</a></code> value to the mid of
-                            the corresponding media description. If the media
-                            description has no MID, and <var>transceiver</var>'s
+                            the corresponding <a>media description</a>. If the <a>media
+                            description</a> has no MID, and <var>transceiver</var>'s
                             <code><a data-for="RTCRtpTransceiver">mid</a></code>
                             is unset, generate a random value as
                             described in <span data-jsep=
@@ -1615,7 +1667,7 @@
                             <a>[[\CurrentDirection]]</a> slot
                             is neither <code>"sendrecv"</code> nor <code>"recvonly"</code>,
                             <a>process the addition of a remote track</a> for
-                            the media description, given <var>transceiver</var>
+                            the <a>media description</a>, given <var>transceiver</var>
                             and <var>trackEvents</var>.</p>
                           </li>
                           <li>
@@ -1625,16 +1677,55 @@
                             <a>[[\CurrentDirection]]</a> slot
                             is neither <code>"sendonly"</code> nor <code>"inactive"</code>,
                             <a>process the removal of a remote track</a> for
-                            the media description, given <var>transceiver</var>.</p>
+                            the <a>media description</a>, given <var>transceiver</var>.</p>
                           </li>
                           <li>
                             <p>If <var>description</var> is of type
-                            <code>"answer"</code> or <code>"pranswer"</code>, set
-                            <var>transceiver</var>'s <a>[[\CurrentDirection]]</a> slot
-                            to <var>direction</var>.</p>
+                            <code>"answer"</code> or <code>"pranswer"</code>, then run
+                            the following steps:</p>
+                            <ol>
+                              <li>
+                                <p>Set <var>transceiver</var>'s
+                                <a>[[\CurrentDirection]]</a> slot to
+                                <var>direction</var>.</p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let <var>transport</var> and <var>rtcpTransport</var> be the
+                                  <code><a>RTCDtlsTransport</a></code> objects representing the RTP
+                                  and RTCP components of the <a>media transport</a> used by
+                                  <var>transceiver</var>'s <a>associated</a> <a>media description</a>,
+                                  according to [[!BUNDLE]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set <var>transceiver</var>.<a>[[\Sender]]</a>.<a>[[\SenderTransport]]</a>
+                                  to <var>transport</var>.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set <var>transceiver</var>.<a>[[\Sender]]</a>.<a>[[\SenderRtcpTransport]]</a>
+                                  to <var>rtcpTransport</var>.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\ReceiverTransport]]</a>
+                                  to <var>transport</var>.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\ReceiverRtcpTransport]]</a>
+                                  to <var>rtcpTransport</var>.
+                                </p>
+                              </li>
+                            </ol>
                           </li>
                           <li>
-                            <p>If the media description is rejected, and
+                            <p>If the <a>media description</a> is rejected, and
                             <var>transceiver</var> is not already stopped, <a>stop
                             the RTCRtpTransceiver</a> <var>transceiver</var>.</p>
                           </li>
@@ -5259,6 +5350,14 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           slot initialized to <var>track</var>.</p>
         </li>
         <li>
+          <p>Let <var>sender</var> have a <dfn>[[\SenderTransport]]</dfn> internal
+          slot initialized to <code>null</code>.</p>
+        </li>
+        <li>
+          <p>Let <var>sender</var> have a <dfn>[[\SenderRtcpTransport]]</dfn> internal
+          slot initialized to <code>null</code>.</p>
+        </li>
+        <li>
           <p>Let <var>sender</var> have an <dfn>[[\AssociatedMediaStreams]]</dfn>
           internal slot, representing a list of
           <code><a>MediaStream</a></code> objects that the
@@ -5341,6 +5440,8 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               used, multiple <code><a>RTCRtpSender</a></code> objects will
               share one <code>transport</code> and will all send RTP and RTCP
               over the same transport.</p>
+              <p>On getting, the attribute MUST return the value of the
+              <a>[[\SenderTransport]]</a> slot.</p>
             </dd>
             <dt><dfn><code>rtcpTransport</code></dfn> of type <span class=
             "idlAttrType"><a>RTCDtlsTransport</a></span>, readonly,
@@ -5354,6 +5455,8 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <code>rtcpTransport</code> will be null, and both RTP and RTCP
               traffic will flow over the transport described by
               <code>transport</code>.</p>
+              <p>On getting, the attribute MUST return the value of the
+              <a>[[\SenderRtcpTransport]]</a> slot.</p>
             </dd>
           </dl>
         </section>
@@ -6274,6 +6377,14 @@ sender.setParameters(params)
           internal slot initialized to <var>track</var>.</p>
         </li>
         <li>
+          <p>Let <var>receiver</var> have a <dfn>[[\ReceiverTransport]]</dfn> internal
+          slot initialized to <code>null</code>.</p>
+        </li>
+        <li>
+          <p>Let <var>receiver</var> have a <dfn>[[\ReceiverRtcpTransport]]</dfn> internal
+          slot initialized to <code>null</code>.</p>
+        </li>
+        <li>
           <p>Let <var>receiver</var> have an
           <a>[[\AssociatedRemoteMediaStreams]]</a> internal slot, representing a
           list of <code><a>MediaStream</a></code> objects that the
@@ -6329,6 +6440,8 @@ sender.setParameters(params)
               used, multiple <code><a>RTCRtpReceiver</a></code> objects will
               share one <code>transport</code> and will all receive RTP and
               RTCP over the same transport.</p>
+              <p>On getting, the attribute MUST return the value of the
+              <a>[[\ReceiverTransport]]</a> slot.</p>
             </dd>
             <dt><code>rtcpTransport</code> of type <span class=
             "idlAttrType"><a>RTCDtlsTransport</a></span>, readonly,
@@ -6341,6 +6454,8 @@ sender.setParameters(params)
               mux is used (or bundling, which mandates RTCP mux),
               <code>rtcpTransport</code> will be null, and both RTP and RTCP
               traffic will flow over <code>transport</code>.</p>
+              <p>On getting, the attribute MUST return the value of the
+              <a>[[\ReceiverRtcpTransport]]</a> slot.</p>
             </dd>
           </dl>
         </section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -6741,6 +6741,11 @@ sender.setParameters(params)
           <p>Return <var>transceiver</var>.</p>
         </li>
       </ol>
+      <div class="note">Creating a transceiver does not create the underlying
+      <code><a>RTCDtlsTransport</a></code> and
+      <code><a>RTCIceTransport</a></code> objects. This will only occur as part
+      of the process of <a data-lt="set the RTCSessionDescription">setting an
+      <code>RTCSessionDescription</code></a>.</div>
       <div>
         <pre class="idl">[Exposed=Window] interface RTCRtpTransceiver {
     readonly        attribute DOMString?                  mid;


### PR DESCRIPTION
Fixes #1178.

As decided in the June virtual interim, DTLS/ICE transport objects will
only be created as a result of setting a local description. Also,
applying an answer may change the mapping between media descriptions and
transports (according to the rules in BUNDLE), which may result in
`sender.transport` (for example) pointing to a different object than
before.

This PR puts the actual responsibility for figuring out the media/
transport mapping on BUNDLE, using the "media transport" term, which in
this case is something that encapsulates the pair of ICE and DTLS
transports. Note that BUNDLE itself does not use that term (yet), but it
will, optimistically, if
https://github.com/cdh4u/draft-sdp-bundle/pull/19 is merged.

Note that this PR does not yet handle rollbacks, or RTCP mux
negotiation.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/taylor-b/webrtc-pc/issue_1178_transport_creation.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/c5eb099...taylor-b:a212628.html)