### PR TITLE
Explain the scope of DTLS/ICE transport objects in more detail.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6953,7 +6953,19 @@ sender.setParameters(params)
       about the underlying transport and the security added.
       <code><a>RTCDtlsTransport</a></code> objects are constructed as a result
       of calls to <code>setLocalDescription()</code> and
-      <code>setRemoteDescription()</code>.</p>
+      <code>setRemoteDescription()</code>. Each
+      <code><a>RTCDtlsTransport</a></code> object represents the DTLS transport
+      layer for the RTP or RTCP <code><a data-link-for="RTCIceTransport">component</a></code>
+      of a specific <code><a>RTCRtpTransceiver</a></code>, or a group of
+      <code><a>RTCRtpTransceiver</a></code>s if such a group has been
+      negotiated via [[!BUNDLE]].</p>
+
+      <div class="note">A new DTLS association for an existing
+      <code><a>RTCRtpTransceiver</a></code> will be represented by an existing
+      <code><a>RTCDtlsTransport</a></code> object, whose <code><a
+      data-link-for="RTCDtlsTransport">state</a></code> will be updated accordingly,
+      as opposed to being represented by a new object.</div>
+
       <p>An <code><a>RTCDtlsTransport</a></code> has a
       <dfn>[[\DtlsTransportState]]</dfn> internal slot initialized to <code>
       <a data-link-for="RTCDtlsTransportState">new</a></code>.</p>
@@ -7118,7 +7130,18 @@ sender.setParameters(params)
       <code>setRemoteDescription()</code>. The underlying ICE state is managed
       by the <a>ICE agent</a>; as such, the state of an
       <code><a>RTCIceTransport</a></code> changes when the <a>ICE Agent</a>
-      provides indications to the user agent as described below.</p>
+      provides indications to the user agent as described below. Each
+      <code><a>RTCIceTransport</a></code> object represents the ICE transport
+      layer for the RTP or RTCP <code><a data-link-for="RTCIceTransport">component</a></code>
+      of a specific <code><a>RTCRtpTransceiver</a></code>, or a group of
+      <code><a>RTCRtpTransceiver</a></code>s if such a group has been
+      negotiated via [[!BUNDLE]].</p>
+
+      <div class="note">An ICE restart for an existing
+      <code><a>RTCRtpTransceiver</a></code> will be represented by an existing
+      <code><a>RTCIceTransport</a></code> object, whose <code><a
+      data-link-for="RTCIceTransport">state</a></code> will be updated
+      accordingly, as opposed to being represented by a new object.</div>
 
       <p>When the <a>ICE Agent</a> indicates that it began gathering a
       <a>generation</a> of candidates for an <code><a>RTCIceTransport</a></code>, the


### PR DESCRIPTION
Fixes #1406.

In the September virtual interim, we decided that new DTLS associations
and ICE restarts should *not* result in new objects, since this
introduces more complexity to the API for arguably little benefit.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/taylor-b/webrtc-pc/issue_1406_transport_objects_scope.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/c5eb099...taylor-b:6c33f6c.html)