### PR TITLE
Adding relativeBitrate parameter to RTCRtpEncodingParameters.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5794,6 +5794,7 @@ sender.setParameters(params)
              boolean             active = true;
              RTCPriorityType     priority = "low";
              unsigned long       ptime;
+             double              relativeBitrate = 1.0;
              unsigned long       maxBitrate;
              double              maxFramerate;
              DOMString           rid;
@@ -5863,6 +5864,21 @@ sender.setParameters(params)
               data-jsep= "applying-a-remote-desc">[[!JSEP]]</span>. Note that
               the user agent MUST still respect the limit imposed by any
               "maxptime" attribute, as defined in [[!RFC4566]], Section 6.</p>
+            </dd>
+            <dt><dfn><code>relativeBitrate</code></dfn> of type <span class=
+            "idlMemberType"><a>double</a></span></dt>
+            <dd>
+              <p>Indicates the relative amount of bitrate that this encoding
+              SHOULD be allocated when congestion occurs, relative to other
+              encodings being sent under the same congestion control regime.
+              For example, if two encodings use values of 1.0 and 1.5,
+              respectively, and the congestion controller determines that 5Mbps
+              are available to allocate, the encodings SHOULD be allocated
+              2Mbps and 3Mbps, respectively. The encoding may also be further
+              constrained by other limits (such as
+              <code><a>maxBitrate</a></code> or per-transport or per-session
+              bandwidth limits), resulting in it using less than its available
+              share.</p>
             </dd>
             <dt><dfn><code>maxBitrate</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long</a></span></dt>
@@ -5942,6 +5958,12 @@ sender.setParameters(params)
               <tr id="def-ptime*">
                 <td><dfn>ptime</dfn></td>
                 <td><code>unsigned long</code></td>
+                <td>Sender</td>
+                <td>Read/Write</td>
+              </tr>
+              <tr id="def-relativebitrate*">
+                <td><dfn>relativeBitrate</dfn></td>
+                <td><code>double</code></td>
                 <td>Sender</td>
                 <td>Read/Write</td>
               </tr>


### PR DESCRIPTION
Fixes #1625.

This provides more fine-grained control over the relative amount of bits
different encodings should be allocated. This allows the webrtc
implementation to respond quickly to changes in available capacity; the
alternative would be for an application to inspect the stats
periodically, and continually adjust `maxBitrate`, which would result in
wasted bandwidth and slower responsiveness to changing bandwidth
estimates (since polling stats and calling getParameters/setParameters
is not instantaneous).

This assumes that rtcweb-transports will update its definition of
"priority," such that it only controls the priority of streams in
network queues (via DSCP and SCTP priority values), and not the
relative amount of bitrate they're granted.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/taylor-b/webrtc-pc/issue_1625_relativeBitrate.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/c5eb099...taylor-b:634fcc5.html)