### PR TITLE
Add onstatechange event to SctpTransport Event table

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -11945,6 +11945,26 @@ interface RTCErrorEvent : Event {
         </tr>
       </tbody>
     </table>
+    <p>The following events fire on <code><a>RTCSctpTransport</a></code>
+    objects:</p>
+    <table>
+      <tbody>
+        <tr>
+          <th>Event name</th>
+          <th>Interface</th>
+          <th>Fired when...</th>
+        </tr>
+      </tbody>
+      <tbody>
+        <tr>
+          <td><dfn id="event-sctptransport-statechange" data-lt=
+          "RTCSctpTransport state change" data-lt-nodefault=
+          ""><code>statechange</code></dfn></td>
+          <td><code><a>Event</a></code></td>
+          <td>The <code><a>RTCSctpTransport</a></code> state changes.</td>
+        </tr>
+      </tbody>
+    </table>
   </section>
   <section class="informative">
     <h2>Privacy and Security Considerations</h2>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/1612


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/onstatechange-patch-v42.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/5577890...ee51c91.html)