### PR TITLE
Simple text for scaling issue - no letterbox allowed.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4500,18 +4500,12 @@ interface RTCPeerConnectionIceErrorEvent : Event {
     be created on the remote side.</p>
     <p>When sending media, the sender may need to rescale or
     resample the media to meet various requirements including the
-    envelope negotiated by SDP. When resizing video, the source
-    video is first centered relative to the desired video then
-    scaled down the minimum amount such that the video fully covers
-    the desired size, then finally cropped to the destination
-    size. The video remains centered while scaling and cropping. For
-    example, if the source video was 1280 by 720, and the max size
-    that could be sent was 640 by 480, the video would be scaled
-    down by 1.5 and 160 columns of pixels on both the right and left
-    sides of the source video would be cropped off. This algorithm
-    is designed to minimize occurrence of images with with letter
-    box or or pillow boxing. The media MUST NOT be upscaled to
-    create fake data that did not occur in the input source.</p>
+    envelope negotiated by SDP.</p>
+    <p>Following the rules in <span data-jsep="imageattr">[[!JSEP]]</span>, the
+    video MAY be downscaled in order to fit the SDP constraints. The media MUST
+    NOT be upscaled to create fake data that did not occur in the input source,
+    the media MUST NOT be cropped except as needed to satisfy constraints on
+    pixel counts, and the aspect ratio MUST NOT be changed.</p>
     <p>When video is rescaled, for example for certain combinations
     of width or height and
     <code><a data-link-for="RTCRtpEncodingParameters">


### PR DESCRIPTION
Fixes #1283.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/hta-no-letterbox.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/5577890...62c942c.html)