### PR TITLE
Let setLocalDescription use [[LastAnswer/Offer]] internal slots

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2615,19 +2615,16 @@ interface RTCPeerConnection : EventTarget  {
                 <ol>
                   <li>Let <var>description</var> be the first argument to
                   <code>setLocalDescription</code>.</li>
-                  <li>Let <var>lastOffer</var> be the result returned by the
-                  last call to <code>createOffer</code>.</li>
-                  <li>Let <var>lastAnswer</var> be the result returned by the
-                  last call to <code>createAnswer</code>.</li>
                   <li>If <code><var>description</var>.sdp</code> is the
                   empty string and <code><var>description</var>.type</code>
                   is <code>"answer"</code> or <code>"pranswer"</code>,
-                  set <code><var>description</var>.sdp</code> to
-                  <var>lastAnswer</var>.</li>
+                  set <code><var>description</var>.sdp</code> to the value of
+                  <var>connection</var>'s <a>[[\LastAnswer]]</a> slot.</li>
                   <li>If <code><var>description</var>.sdp</code> is the
                   empty string and <code><var>description</var>.type</code>
                   is <code>"offer"</code>, set <code><var>description</var>.sdp</code>
-                  to <var>lastOffer</var>.</li>
+                  to the value of <var>connection</var>'s
+                  <a>[[\LastOffer]]</a> slot.</li>
                   <li>Return the result of <a href="#set-description">setting
                   the RTCSessionDescription</a> indicated by
                   <code><var>description</var></code>.</li>


### PR DESCRIPTION
Fixes #1164.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/soareschen/webrtc-pc/sld-last-offer-answer.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webrtc-pc/da266a1...soareschen:951dd1b.html)