### PR TITLE
Specify how RTCSctpTransport.maxMessageSize gets its value

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8240,7 +8240,10 @@ interface RTCTrackEvent : Event {
               <dd>
                 <p>The maximum size of data that can be passed to
                 <code><a>RTCDataChannel</a></code>'s <code><a data-for=
-                "RTCDataChannel">send()</a></code> method.</p>
+                "RTCDataChannel">send()</a></code> method. The value represents
+                what the other peer can receive and MUST, on getting, return
+                the value specified by the 'max-message-size' SDP attribute or
+                the corresponding default value [[!SCTP-SDP]].</p>
               </dd>
               <dt><dfn><code>onstatechange</code></dfn> of type <span class=
               "idlAttrType"><a>EventHandler</a></span></dt>


### PR DESCRIPTION
Fixes: #1205