### PR TITLE
Set muted before SRD resolves, using new set muted algorithm.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1618,7 +1618,8 @@
                     then run the following steps:</p>
                     <ol>
                       <li>
-                        <p>Let <var>trackEvents</var> be an empty list.</p>
+                        <p>Let <var>trackEvents</var> and <var>muteTracks</var>
+                        be empty lists.</p>
                       </li>
                       <li>
                         <p>Run the following steps for each <a>media description</a>
@@ -1687,7 +1688,8 @@
                             <a>[[\CurrentDirection]]</a> slot
                             is neither <code>"sendonly"</code> nor <code>"inactive"</code>,
                             <a>process the removal of a remote track</a> for
-                            the <a>media description</a>, given <var>transceiver</var>.</p>
+                            the <a>media description</a>, given <var>transceiver</var>
+                            and <var>muteTracks</var>.</p>
                           </li>
                           <li>
                             <p>If <var>description</var> is of type
@@ -1740,6 +1742,11 @@
                             the RTCRtpTransceiver</a> <var>transceiver</var>.</p>
                           </li>
                         </ol>
+                      </li>
+                      <li>
+                        <p>For each track in <var>muteTracks</var>,
+                        <a>set the muted state</a> to the value
+                        <code>true</code>.</p>
                       </li>
                       <li>
                         <p>For each <code><a>RTCTrackEvent</a></code>
@@ -5274,8 +5281,8 @@ interface RTCPeerConnectionIceErrorEvent : Event {
         process the removal of a remote track</dfn> for
         an incoming media description <span data-jsep=
         "applying-a-remote-desc">[[!JSEP]]</span> given
-        <code>RTCRtpTransceiver</code> <var>transceiver</var>, the user agent
-        MUST run the following steps:</p>
+        <code>RTCRtpTransceiver</code> <var>transceiver</var> and
+        <var>muteTracks</var>, the user agent MUST run the following steps:</p>
         <ol>
           <li>
             <p>Let <var>receiver</var> be <var>transceiver</var>'s
@@ -5294,8 +5301,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           </li>
           <li>
             <p>If <var>track.muted</var> is <code>false</code>,
-            <a>set the muted state</a> of <var>track</var> to the value
-            <code>true</code>.</p>
+            add <var>track</var> to <var>muteTracks</var>.</p>
           </li>
         </ol>
         <p>To <dfn id="set-associated-remote-streams">set the associated remote streams</dfn> given

--- a/webrtc.html
+++ b/webrtc.html
@@ -10625,8 +10625,8 @@ async function consumeIdentityAssertion() {
       <code><a>MediaStreamTrack</a></code> to <code>false</code>.
       </p>
       <p>When one of the SSRCs for RTP source media streams received
-      by an <code><a>RTCPeerConnection</a></code> is removed (either
-      due to reception of a BYE or via timeout), it MUST queue a task to
+      by an <code><a>RTCPeerConnection</a></code> is removed either
+      due to reception of a BYE or via timeout, it MUST queue a task to
       <a>set the muted state</a> of the corresponding
       <code><a>MediaStreamTrack</a></code> to
       <code>true</code>. If and when packets are received again, it must queue a

--- a/webrtc.html
+++ b/webrtc.html
@@ -10630,10 +10630,10 @@ async function consumeIdentityAssertion() {
       <a>set the muted state</a> of the corresponding
       <code><a>MediaStreamTrack</a></code> to
       <code>true</code>. If and when packets are received again, it must queue a
-      task to <a data-lt="update the muted state">set the muted state</a> back
+      task to <a data-lt="set the muted state">set the muted state</a> back
       to <code>false</code>.</p>
       <p>The procedure <dfn data-lt="set the muted state" id=
-      "update-track-muted">set a track's muted state</dfn> is specified in
+      "set-track-muted">set a track's muted state</dfn> is specified in
       [[!GETUSERMEDIA]].</p>
       <p>When a <code><a>MediaStreamTrack</a></code> track produced by
         an <code><a>RTCRtpReceiver</a></code> <var>receiver</var> has

--- a/webrtc.html
+++ b/webrtc.html
@@ -5294,7 +5294,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           </li>
           <li>
             <p>If <var>track.muted</var> is <code>false</code>,
-            <a>update the muted state</a> of <var>track</var> with the value
+            <a>set the muted state</a> of <var>track</var> to the value
             <code>true</code>.</p>
           </li>
         </ol>
@@ -10618,21 +10618,22 @@ async function consumeIdentityAssertion() {
       <p>A <code>MediaStreamTrack</code> object's reference to its
       <code>MediaStream</code> in the non-local media source case (an RTP
       source, as is the case for <code>MediaStreamTrack</code>s received over
-      an <code><a>RTCPeerConnection</a></code> ) is always strong.</p>
+      an <code><a>RTCPeerConnection</a></code>) is always strong.</p>
       <p>When an <code><a>RTCPeerConnection</a></code> receives data on an RTP
-      source for the first time, it MUST <a>update the muted state</a> of the
-      corresponding <code><a>MediaStreamTrack</a></code> with the value
-      <code>false</code>.</p>
+      source for the first time, it MUST queue a task to
+      <a>set the muted state</a> of the corresponding
+      <code><a>MediaStreamTrack</a></code> to <code>false</code>.
+      </p>
       <p>When one of the SSRCs for RTP source media streams received
       by an <code><a>RTCPeerConnection</a></code> is removed (either
-      due to reception of a BYE or via timeout), it MUST <a>update
-      the muted state</a> of the corresponding
-      <code><a>MediaStreamTrack</a></code> with the value
-      <code>true</code>. If and when packets are received again,
-      the <a data-lt="update the muted state">muted state MUST be
-      updated</a> with the value <code>false</code>.</p>
-      <p>The procedure <dfn data-lt="update the muted state" id=
-      "update-track-muted">update a track's muted state</dfn> is specified in
+      due to reception of a BYE or via timeout), it MUST queue a task to
+      <a>set the muted state</a> of the corresponding
+      <code><a>MediaStreamTrack</a></code> to
+      <code>true</code>. If and when packets are received again, it must queue a
+      task to <a data-lt="update the muted state">set the muted state</a> back
+      to <code>false</code>.</p>
+      <p>The procedure <dfn data-lt="set the muted state" id=
+      "update-track-muted">set a track's muted state</dfn> is specified in
       [[!GETUSERMEDIA]].</p>
       <p>When a <code><a>MediaStreamTrack</a></code> track produced by
         an <code><a>RTCRtpReceiver</a></code> <var>receiver</var> has


### PR DESCRIPTION
Fix for https://github.com/w3c/webrtc-pc/issues/1568 (along with https://github.com/w3c/mediacapture-main/pull/498).