### PR TITLE
remove idl comment about rtcpTransport being at risk

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5441,7 +5441,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
         <pre class="idl">[Exposed=Window] interface RTCRtpSender {
     readonly        attribute MediaStreamTrack? track;
     readonly        attribute RTCDtlsTransport?  transport;
-    readonly        attribute RTCDtlsTransport? rtcpTransport;  // Feature at risk
+    readonly        attribute RTCDtlsTransport? rtcpTransport;
     static RTCRtpCapabilities getCapabilities (DOMString kind);
     Promise&lt;void&gt;             setParameters (optional RTCRtpParameters parameters);
     RTCRtpParameters          getParameters ();
@@ -6448,7 +6448,7 @@ async function updateParameters() {
         <pre class="idl">[Exposed=Window] interface RTCRtpReceiver {
     readonly        attribute MediaStreamTrack  track;
     readonly        attribute RTCDtlsTransport? transport;
-    readonly        attribute RTCDtlsTransport? rtcpTransport; // Feature at risk
+    readonly        attribute RTCDtlsTransport? rtcpTransport;
     static RTCRtpCapabilities          getCapabilities (DOMString kind);
     RTCRtpParameters                   getParameters ();
     sequence&lt;RTCRtpContributingSource&gt;    getContributingSources ();


### PR DESCRIPTION
the linebreak is confusing and without checking the source its not
clear that rtcpTransport is at risk and not getCapabilities

![atrisk](https://user-images.githubusercontent.com/289731/33543936-35b77c46-d8d9-11e7-8a42-be21bea46423.jpg)
