### PR TITLE
offerToReceive: s/transceiver type/transceiver kind/ (and do it for kinds, not mediaTypes)

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3287,7 +3287,7 @@ interface RTCPeerConnection : EventTarget  {
                 <p>Offer to receive audio even though no audio will be sent.
                 When this dictionary member is present as an option to <a href=
                 "#dom-rtcpeerconnection-createoffer">createOffer</a>, run the
-                <a>offer to receive</a> steps with a <var>mediaType</var> of
+                <a>offer to receive</a> steps with a <var>kind</var> of
                 "audio" instead of the regular <a href=
                 "#dom-rtcpeerconnection-createoffer">createOffer</a> steps.</p>
               </dd>
@@ -3296,12 +3296,12 @@ interface RTCPeerConnection : EventTarget  {
                 <p>Offer to receive video even though no video will be sent.
                 When this dictionary member is present as an option to <a href=
                 "#dom-rtcpeerconnection-createoffer">createOffer</a>, run the
-                <a>offer to receive</a> steps with a <var>mediaType</var> of
+                <a>offer to receive</a> steps with a <var>kind</var> of
                 "video" instead of the regular <a href=
                 "#dom-rtcpeerconnection-createoffer">createOffer</a> steps.</p>
               </dd>
             </dl>
-            <p>To <dfn>offer to receive</dfn> with <var>mediaType</var>, run
+            <p>To <dfn>offer to receive</dfn> with <var>kind</var>, run
             the following steps:</p>
             <ol>
               <li>
@@ -3314,12 +3314,12 @@ interface RTCPeerConnection : EventTarget  {
               </li>
               <li>
                 <p>If <var>connection</var> has any stopped "sendrecv" or
-                "recvonly" transceivers of type <var>mediaType</var>, jump to
+                "recvonly" transceivers of <a>transceiver kind</a> <var>kind</var>, jump to
                 the step labeled <em>create offer</em>.</p>
               </li>
               <li>
                 <p>Let <var>transceiver</var> be the result of invoking the
-                equivalent of <code>connection.addTransceiver(mediaType)</code>,
+                equivalent of <code>connection.addTransceiver(kind)</code>,
                 except that this operation MUST NOT <a>update the
                 negotiation-needed flag</a>.</p>
               </li>


### PR DESCRIPTION
clarifies https://github.com/w3c/webrtc-pc/pull/1672#discussion_r155347548
Also changes mediaType to kind for consistency.
