### PR TITLE
Fire removetrack/addtrack events before track events.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5383,7 +5383,8 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           <li>
             <p>For each <var>stream</var> in <var>receiver</var>'s
             <a>[[\AssociatedRemoteMediaStreams]]</a> that is not present in
-            <var>streams</var>, remove <var>track</var> from <var>stream</var>.
+            <var>streams</var>, <a>remove the track</a> <var>track</var> from
+            <var>stream</var>.
             </p>
             <p class="note">This will result in a removetrack event being fired
             at each MediaStream as described in [[!GETUSERMEDIA]].</p>
@@ -5391,8 +5392,8 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           <li>
             <p>For each <var>stream</var> in
             <var>streams</var> that is not present in <var>receiver</var>'s
-            <a>[[\AssociatedRemoteMediaStreams]]</a>, add <var>track</var> to
-            <var>stream</var>.</p>
+            <a>[[\AssociatedRemoteMediaStreams]]</a>,
+            <a>add the track</a> <var>track</var> to <var>stream</var>.</p>
             <p class="note">This will result in an addtrack event being fired
             at each MediaStream as described in [[!GETUSERMEDIA]].</p>
           </li>
@@ -10708,9 +10709,11 @@ async function consumeIdentityAssertion() {
       <code>true</code>. If and when packets are received again, it must queue a
       task to <a data-lt="set the muted state">set the muted state</a> back
       to <code>false</code>.</p>
-      <p>The procedure <dfn data-lt="set the muted state" id=
-      "set-track-muted">set a track's muted state</dfn> is specified in
-      [[!GETUSERMEDIA]].</p>
+      <p>The procedures
+      <dfn data-lt="add the track" id="add-track">add a track</dfn>,
+      <dfn data-lt="remove the track" id="remove-track">remove a track</dfn> and
+      <dfn data-lt="set the muted state" id="set-track-muted">set a track's
+      muted state</dfn> are specified in [[!GETUSERMEDIA]].</p>
       <p>When a <code><a>MediaStreamTrack</a></code> track produced by
         an <code><a>RTCRtpReceiver</a></code> <var>receiver</var> has
         <code>ended</code> [[!GETUSERMEDIA]] (such as via a call to


### PR DESCRIPTION
Fix for https://github.com/w3c/webrtc-pc/issues/1599 (along with https://github.com/w3c/mediacapture-main/pull/500).