### PR TITLE
Specify legacy behavior when offerToReceive* option is set to false

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3313,8 +3313,22 @@ interface RTCPeerConnection : EventTarget  {
             kind, <var>kind</var>, run the following steps:</p>
             <ol>
               <li>
-                <p>If the value of the dictionary member is false, continue
-                with the next option, if any.</p>
+                <p>If the value of the dictionary member is false,
+                <ol>
+                  <li>
+                    <p>For each non-stopped "sendrecv" transceiver of
+                    <a>transceiver kind</a> <var>kind</var>, set
+                    <var>transceiver</var>'s <a>[[\Direction]]</a> slot to
+                    "sendonly".</p>
+                  </li>
+                  <li>
+                    <p>For each non-stopped "recvonly" transceiver of
+                    <a>transceiver kind</a> <var>kind</var>, set
+                    <var>transceiver</var>'s <a>[[\Direction]]</a> slot to
+                    "inactive".</p>
+                  </li>
+                </ol>
+                Continue with the next option, if any.</p>
               </li>
               <li>
                 <p>If <var>connection</var> has any non-stopped "sendrecv"

--- a/webrtc.html
+++ b/webrtc.html
@@ -3313,7 +3313,7 @@ interface RTCPeerConnection : EventTarget  {
             kind, <var>kind</var>, run the following steps:</p>
             <ol>
               <li>
-                <p>If the value of the dictionary member is false,
+                <p>If the value of the dictionary member is false,</p>
                 <ol>
                   <li>
                     <p>For each non-stopped "sendrecv" transceiver of
@@ -3328,7 +3328,7 @@ interface RTCPeerConnection : EventTarget  {
                     "inactive".</p>
                   </li>
                 </ol>
-                Continue with the next option, if any.</p>
+                <p>Continue with the next option, if any.</p>
               </li>
               <li>
                 <p>If <var>connection</var> has any non-stopped "sendrecv"


### PR DESCRIPTION
specifies that offerToReceive* stops all non-stopped transceivers from sending.

rebase of #1683 (which accidentially got closed while squashing :-/)