### PR TITLE
RTPRtcSender: provided properties to get related MediaStreamTrackId and media type

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6881,6 +6881,7 @@ async function updateParameters() {
       <div>
         <pre class="idl">[Exposed=Window] interface RTCRtpTransceiver {
     readonly        attribute DOMString?                  mid;
+    readonly        attribute DOMString                   kind;
     [SameObject]
     readonly        attribute RTCRtpSender                sender;
     [SameObject]
@@ -6905,6 +6906,11 @@ async function updateParameters() {
               negotiation is complete, the <code>mid</code> value may be null.
               After rollbacks, the value may change from a non-null value
               to null.</p>
+            </dd>
+            <dt><dfn><code>kind</code></dfn> of type <span class=
+            "idlAttrType"><a>DOMString</a></span>, readonly</dt>
+            <dd>
+              <p>Media type of the related SDP mline.</p>
             </dd>
             <dt><dfn><code>sender</code></dfn> of type <span class=
             "idlAttrType"><a>RTCRtpSender</a></span>, readonly</dt>

--- a/webrtc.html
+++ b/webrtc.html
@@ -5509,6 +5509,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
     readonly        attribute MediaStreamTrack? track;
     readonly        attribute RTCDtlsTransport?  transport;
     readonly        attribute RTCDtlsTransport? rtcpTransport;
+    readonly        attribute DOMString mediaStreamTrackId;
     static RTCRtpCapabilities getCapabilities (DOMString kind);
     Promise&lt;void&gt;             setParameters (optional RTCRtpParameters parameters);
     RTCRtpParameters          getParameters ();
@@ -5564,6 +5565,13 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <code>transport</code>.</p>
               <p>On getting, the attribute MUST return the value of the
               <a>[[\SenderRtcpTransport]]</a> slot.</p>
+            </dd>
+            <dt><dfn><code>mediaStreamTrackId</code></dfn> of type <span class=
+            "idlAttrType"><a>DOMString</a></span>, readonly, nullable</dt>
+            <dd>
+              <p>msid-appdata token from draft-ietf-mmusic-msid attribute as carried
+              in related SDP mline or null if there is not draft-ietf-mmusic-msid attribute.
+              Useful for senders created without a track (or detached from a track).</p>
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
This properties are quite useful (even needed) to several use cases where application metadata is attached to an specific msid (as commented in several discussions), but "addTransceiverByKind" is used, so no track is attached to the RtpSender yet.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mparis/webrtc-pc/pull/1698.html" title="Last updated on Feb 6, 2018, 9:47 AM GMT (1bf977a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1698/f0d453c...mparis:1bf977a.html" title="Last updated on Feb 6, 2018, 9:47 AM GMT (1bf977a)">Diff</a>