### PR TITLE
Move operations queue definition paragraph to right section (editorial)

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1092,6 +1092,10 @@
             <p>Return <var>connection</var>.</p>
           </li>
         </ol>
+        </section>
+
+        <section>
+        <h4>Enqueue an operation</h4>
         <p>An <code><a>RTCPeerConnection</a></code> object has an
         <dfn>operations queue</dfn>, <a>[[\Operations]]</a>, which ensures that
         only one asynchronous operation in the queue is executed concurrently.
@@ -1099,10 +1103,6 @@
         call is still not <a>settled</a>, they are added to the queue and executed
         when all the previous calls have finished executing and their promises
         have <a>settled</a>.</p>
-        </section>
-
-        <section>
-        <h4>Enqueue an operation</h4>
         <p>To <dfn>enqueue an operation</dfn> to an
         <a><code>RTCPeerConnection</code></a> object's operation queue, run
         the following steps:</p>


### PR DESCRIPTION
Fix for editorial nit in https://github.com/w3c/webrtc-pc/issues/1711#issue-285615065. Thanks @fippo!