### PR TITLE
Define pc.getTransceivers() et al to be in insertion order.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4785,19 +4785,14 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <ol>
                 <li>Let <var>transceivers</var> be the result of executing the
                 <code><a>CollectTransceivers</a></code> algorithm.</li>
-                <li>Let <var>senderset</var> be a new empty set.</li>
+                <li>Let <var>senders</var> be a new empty sequence.</li>
                 <li>For each <var>transceiver</var> in <var>transceivers</var>,
                   <ol>
                     <li>Let <var>sender</var> be
                     <var>transceiver</var>'s <a>[[\Sender]]</a>.</li>
-                    <li>Add <var>sender</var> to <var>senderset</var>.</li>
+                    <li>Add <var>sender</var> to <var>senders</var>.</li>
                   </ol>
                 </li>
-                <li>Let <var>senders</var> be a new sequence consisting of all
-                the <code><a>RTCRtpSender</a></code> objects in
-                <var>senderset</var>. The conversion from the senders set to
-                the sequence is user agent defined and the order does not have
-                to be stable between calls.</li>
                 <li>Return <var>senders</var>.</li>
               </ol>
             </dd>
@@ -4817,19 +4812,14 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <ol>
                 <li>Let <var>transceivers</var> be the result of executing the
                 <code><a>CollectTransceivers</a></code> algorithm.</li>
-                <li>Let <var>receiverset</var> be a new empty set.</li>
+                <li>Let <var>receivers</var> be a new empty sequence.</li>
                 <li>For each <var>transceiver</var> in <var>transceivers</var>,
                   <ol>
                     <li>Let <var>receiver</var> be <var>transceiver</var>'s
                     <a>[[\Receiver]]</a>.</li>
-                    <li>Add <var>receiver</var> to <var>receiverset</var>.</li>
+                    <li>Add <var>receiver</var> to <var>receivers</var>.</li>
                   </ol>
                 </li>
-                <li>Let <var>receivers</var> be a new sequence consisting of
-                all the <code><a>RTCRtpReceiver</a></code> objects in
-                <var>receiverset</var>. The conversion from the receivers set
-                to the sequence is user agent defined and the order does not
-                have to be stable between calls.</li>
                 <li>Return <var>receivers</var>.</li>
               </ol>
             </dd>
@@ -4847,13 +4837,10 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <p>We define the <dfn>CollectTransceivers</dfn> algorithm as
               follows:</p>
               <ol>
-                <li>Let <var>transceivers</var> be a new sequence that
-                represents a snapshot of all the
-                <code><a>RTCRtpTransceiver</a></code> objects in this <code><a>
-                  RTCPeerConnection</a></code> object's <a>set of
-                  transceivers</a>. The conversion from the transceiver set to
-                  the sequence is user agent defined and the order does not
-                  have to be stable between calls.
+                <li>Let <var>transceivers</var> be a new sequence consisting of
+                all <code><a>RTCRtpTransceiver</a></code> objects in this
+                <code><a>RTCPeerConnection</a></code> object's
+                <a>set of transceivers</a>, in insertion order.
                 </li>
                 <li>Return <var>transceivers</var>.</li>
               </ol>


### PR DESCRIPTION
Fix for https://github.com/w3c/webrtc-pc/issues/1669.