### PR TITLE
Make audioLevel and voiceActivityFlag optional and non-nullable.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6703,7 +6703,7 @@ async function updateParameters() {
         <pre class="idl">dictionary RTCRtpContributingSource {
     required DOMHighResTimeStamp timestamp;
     required unsigned long       source;
-    required byte?     audioLevel;
+    byte     audioLevel;
 };</pre>
         <section>
           <h2>Dictionary RTCRtpContributingSource Members</h2>
@@ -6724,15 +6724,15 @@ async function updateParameters() {
               synchronization source.</p>
             </dd>
             <dt><dfn><code>audioLevel</code></dfn> of type <span class=
-            "idlMemberType"><a>byte</a></span>, required, nullable</dt>
+            "idlMemberType"><a>byte</a></span></dt>
             <dd>
               <p>The audio level contained in the last RTP packet played from
               this source. For CSRCs, <code>audioLevel</code> must be the level
               value defined in [[!RFC6465]] if the RFC 6465 header extension is
-              present, otherwise <code>null</code>. For SSRCs, it must be the
-              level value defined in [[!RFC6464]] if the RFC 6464 header
+              present, otherwise this member must be absent. For SSRCs, it must
+              be the level value defined in [[!RFC6464]] if the RFC 6464 header
               extension is present, otherwise a browser computed value as if it
-              had come from RFC 6464 (never <code>null</code>).</p>
+              had come from RFC 6464 (never absent).</p>
               <p>Both RFCs define the level as an integral value from 0 to 127
               representing the audio level in negative decibels relative to the
               loudest signal that the system could possibly encode. Thus,
@@ -6744,21 +6744,21 @@ async function updateParameters() {
       </div>
       <div>
         <pre class="idl">dictionary RTCRtpSynchronizationSource : RTCRtpContributingSource {
-    required boolean?  voiceActivityFlag;
+    boolean voiceActivityFlag;
 };</pre>
         <section>
           <h2>Dictionary RTCRtpSynchronizationSource Members</h2>
           <dl data-link-for="RTCRtpSynchronizationSource" data-dfn-for=
           "RTCRtpSynchronizationSource" class="dictionary-members">
             <dt><dfn><code>voiceActivityFlag</code></dfn> of type <span class=
-            "idlMemberType"><a>boolean</a></span>, required, nullable</dt>
+            "idlMemberType"><a>boolean</a></span></dt>
             <dd>
               <p>Whether the last RTP packet played from this source contains
               voice activity (true) or not (false). If the RFC 6464 extension
               header was not present, or if the peer has signaled that it is
               not using the V bit by setting the "vad" extension attribute to
               "off", as described in [[!RFC6464]], Section 4,
-              <code>voiceActivityFlag</code> will be <code>null</code>.</p>
+              <code>voiceActivityFlag</code> will be absent.</p>
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
Fix for https://github.com/w3c/webrtc-pc/issues/1689.