### PR TITLE
Passing receiver when constructing track event in 'Processing Remote …

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5337,8 +5337,9 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           </li>
           <li>
             <p>Add a new <code><a>RTCTrackEvent</a></code> with
-            <var>transceiver</var>, <var>track</var>, and
-            <var>streams</var> to <var>trackEvents</var>.</p>
+            <var>receiver</var>, <var>track</var>,
+            <var>streams</var> and <var>transceiver</var> to
+            <var>trackEvents</var>.</p>
           </li>
         </ol>
         <p>To <dfn id="process-remote-track-removal">


### PR DESCRIPTION
…MediaStreamTracks'.

Close #1499