### PR TITLE
Gating 'unmute' events on track with transceiver direction.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -10869,7 +10869,7 @@ async function consumeIdentityAssertion() {
       one and only one <code>MediaStreamTrack</code> to the recipient. A peer
       is defined as a user agent that supports this specification. In addition,
       the sending side application can indicate what <code>MediaStream</code>
-      object(s) the <code>MediaStreamTrack</code> is member of. The
+      object(s) the <code>MediaStreamTrack</code> is a member of. The
       corresponding <code>MediaStream</code> object(s) on the receiver side
       will be created (if not already present) and populated accordingly.</p>
       <p>As also described earlier in this document, the objects
@@ -10943,7 +10943,7 @@ async function consumeIdentityAssertion() {
       source whose corresponding <code><a>MediaStreamTrack</a></code> is muted,
       and the <a>[[\Receptive]]</a> slot of the 
       <a><code>RTCRtpTransceiver</code></a> object the
-      <a><code>RTCRtpReceiver</code></a> is member of is <code>true</code>,
+      <a><code>RTCRtpReceiver</code></a> is a member of is <code>true</code>,
       it MUST queue a task to <a>set the muted state</a> of the corresponding
       <code><a>MediaStreamTrack</a></code> to <code>false</code>.
       </p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -6614,11 +6614,10 @@ async function updateParameters() {
               by <var>receiver</var> is removed (either due to reception of
               a BYE or via timeout), <a>set the muted state</a> of the
               <code>track</code> to the value <code>true</code>.
-
-              <a data-lt="set the RTCSessionDescription">
-              Setting an <code>RTCSessionDescription</code></a> can also 
-              lead to <a data-lt="set the muted state"> setting the muted
-              state</a> of the <code>track</code> to the
+              Note that <a data-lt="set the RTCSessionDescription">
+              setting an <code>RTCSessionDescription</code></a>
+              can also lead to <a data-lt="set the muted state"> setting
+              the muted state</a> of the <code>track</code> to the
               value <code>true</code>.
               If packets are received again, and the <code>track</code> is
               muted, and either the [[\PendingDirection]] or

--- a/webrtc.html
+++ b/webrtc.html
@@ -1635,7 +1635,7 @@
                       <li>
                         <p>If <var>description</var> is of type
                         <code>"offer"</code> 
-                        set <var>transceiver</var>'s <a>[[\PendingDirection]]</a> slot
+                        set <var>transceiver</var>'s <a>[[\OfferedDirection]]</a> slot
                         to an <code><a>RTCRtpTransceiverDirection</a></code>
                         value representing the direction of the <a>media description</a>.</p>
                       </li>
@@ -1645,7 +1645,7 @@
                         set <var>transceiver</var>'s <a>[[\CurrentDirection]]</a> slot
                         to an <code><a>RTCRtpTransceiverDirection</a></code>
                         value representing the direction of the <a>media description</a>
-                        and set <var>transceiver</var>'s <a>[[\PendingDirection]]</a>
+                        and set <var>transceiver</var>'s <a>[[\OfferedDirection]]</a>
                         slot to the value <code>null</code>.</p>
                       </li>
                     </ol>
@@ -1739,7 +1739,7 @@
                                 <p>Set <var>transceiver</var>'s
                                 <a>[[\CurrentDirection]]</a> slot to
                                 <var>direction</var> and set <var>transceiver</var>'s
-                                <a>[[\PendingDirection]]</a> slot to <code>null</code>.</p>
+                                <a>[[\OfferedDirection]]</a> slot to <code>null</code>.</p>
                               </li>
                               <li>
                                 <p>
@@ -6619,7 +6619,7 @@ async function updateParameters() {
               the muted state</a> of the <code>track</code> to the
               value <code>true</code>.
               If packets are received again, and the <code>track</code> is
-              muted, and either the [[\PendingDirection]] or
+              muted, and either the [[\OfferedDirection]] or
               [[\CurrentDirection]] slot of the 
               <a><code>RTCRtpTransceiver</code></a> the
               <a><code>RTCRtpReceiver</code></a> is member of is either 
@@ -6926,7 +6926,7 @@ async function updateParameters() {
           <var>direction</var>.</p>
         </li>
         <li>
-          <p>Let <var>transceiver</var> have a <dfn>[[\PendingDirection]]</dfn> internal slot,
+          <p>Let <var>transceiver</var> have a <dfn>[[\OfferedDirection]]</dfn> internal slot,
           initialized to null.</p>
         </li>
         <li>
@@ -7143,7 +7143,7 @@ async function updateParameters() {
                   slot to <code>true</code>.</p>
                 </li>
                 <li>
-                  <p>Set <var>transceiver</var>'s <a>[[\PendingDirection]]</a>
+                  <p>Set <var>transceiver</var>'s <a>[[\OfferedDirection]]</a>
                   slot to <code>null</code>.</p>
                 </li>
                 <li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -10939,13 +10939,12 @@ async function consumeIdentityAssertion() {
       source, as is the case for each <code>MediaStreamTrack</code>
       associated with
       an <code><a>RTCRtpReceiver</a></code>) is always strong.</p>
-      <p>When an <code><a>RTCRtpReceiver</a></code> receives data on an RTP
-      source for the first time, and the [[\Receptive]]
-      slot of the 
+      <p>Whenever an <code><a>RTCRtpReceiver</a></code> receives data on an RTP
+      source whose corresponding <code><a>MediaStreamTrack</a></code> is muted,
+      and the <a>[[\Receptive]]</a> slot of the 
       <a><code>RTCRtpTransceiver</code></a> object the
-      <a><code>RTCRtpReceiver</code></a> is member of is either 
-      <code>true</code>, it MUST queue a task to
-      <a>set the muted state</a> of the corresponding
+      <a><code>RTCRtpReceiver</code></a> is member of is <code>true</code>,
+      it MUST queue a task to <a>set the muted state</a> of the corresponding
       <code><a>MediaStreamTrack</a></code> to <code>false</code>.
       </p>
       <p>When one of the SSRCs for RTP source media streams received
@@ -10957,15 +10956,7 @@ async function consumeIdentityAssertion() {
       "RTCPeerConnection">setRemoteDescription</a></code>
       can also lead to <a data-lt="set the muted state"> the setting
       of the muted state</a> of the <code>track</code> to the
-      value <code>true</code>. 
-      When a <code><a>MediaStreamTrack</a></code>
-      is muted, whenever its associated <code><a>RTCRtpReceiver</a></code> receives data on an RTP
-      source and the [[\Receptive]] slot of the 
-      <a><code>RTCRtpTransceiver</code></a> object the
-      associated <a><code>RTCRtpReceiver</code></a> is member of is 
-      <code>true</code>, the associated <a><code>RTCRtpReceiver</code></a> 
-      MUST queue a task to <a>set the muted state</a> of the
-      <code><a>MediaStreamTrack</a></code> to the value <code>false</code>.</p>
+      value <code>true</code>.</p>
       <p>The procedures
       <dfn data-lt="add the track" id="add-track">add a track</dfn>,
       <dfn data-lt="remove the track" id="remove-track">remove a track</dfn> and

--- a/webrtc.html
+++ b/webrtc.html
@@ -1567,14 +1567,6 @@
                         is <code>true</code>, abort these sub steps.</p>
                       </li>
                       <li>
-                        <p>If <var>description</var> is of type
-                        <code>"answer"</code> or <code>"pranswer"</code>, then
-                        set <var>transceiver</var>'s <a>[[\CurrentDirection]]</a> slot
-                        to an <code><a>RTCRtpTransceiverDirection</a></code>
-                        value representing the direction of the corresponding
-                        <a>media description</a>.</p>
-                      </li>
-                      <li>
                         <p>
                           If the <a>media description</a> is indicated as using
                           an existing <a>media transport</a> according to
@@ -1624,6 +1616,38 @@
                           Set <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\ReceiverRtcpTransport]]</a>
                           to <var>rtcpTransport</var>.
                         </p>
+                      </li>
+                    </ol>
+                  </li>
+                  <li>
+                    <p>If <var>description</var> is set as a local description,
+                    then run the following steps for each <a>media description</a>
+                    in <var>description</var>:</p>
+                    <ol>
+                      <li>
+                        <p>Let <var>transceiver</var> be the <code>
+                        <a>RTCRtpTransceiver</a></code> <a>associated</a> with the
+                        <a>media description</a>.</p>
+                      </li>
+                      <li>
+                        <p>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot
+                        is <code>true</code>, abort these sub steps.</p>
+                      </li>
+                      <li>
+                        <p>If <var>description</var> is of type
+                        <code>"offer"</code> 
+                        set <var>transceiver</var>'s <a>[[\PendingDirection]]</a> slot
+                        to an <code><a>RTCRtpTransceiverDirection</a></code>
+                        value representing the direction of the corresponding
+                        <a>media description</a>.</p>
+                      </li>
+                      <li>
+                        <p>If <var>description</var> is of type
+                        <code>"answer"</code> or <code>"pranswer"</code>, then
+                        set <var>transceiver</var>'s <a>[[\CurrentDirection]]</a> slot
+                        to an <code><a>RTCRtpTransceiverDirection</a></code>
+                        value representing the direction of the corresponding
+                        <a>media description</a>.</p>
                       </li>
                     </ol>
                   </li>
@@ -1715,7 +1739,8 @@
                               <li>
                                 <p>Set <var>transceiver</var>'s
                                 <a>[[\CurrentDirection]]</a> slot to
-                                <var>direction</var>.</p>
+                                <var>direction</var> and set <var>transceiver</var>'s
+                                <a>[[\PendingDirection]]</a> slot to <code>null</code>.</p>
                               </li>
                               <li>
                                 <p>
@@ -6588,8 +6613,17 @@ async function updateParameters() {
               When one of the SSRCs for RTP source media streams received
               by <var>receiver</var> is removed (either due to reception of
               a BYE or via timeout), the <code>mute</code> event is fired at
-              <code>track</code>.  If and when packets are received again,
-              the <code>unmute</code> event is fired at <code>track</code>.</p>
+              <code>track</code>. <a data-lt="set the RTCSessionDescription">
+              Setting an <code>RTCSessionDescription</code></a> can also
+              lead to the firing of the <code>mute</code> event at
+              <code>track</code>.
+              If and when packets are received again, and either the
+              [[\PendingDirection]] or [[\CurrentDirection]] slot of the
+              <a><code>RTCRtpTransceiver</code></a> the
+              <a><code>RTCRtpReceiver</code></a> is member of is either 
+              <code>"recvonly"</code> or <code>"sendrecv"</code>, the
+              the <code>unmute</code> event is fired at <code>track</code>.
+              </p>
               <p>Note that <code>track.stop()</code> is final, although
               clones are not affected. Since
               <code><var>receiver</var>.track.stop()</code>
@@ -6889,6 +6923,10 @@ async function updateParameters() {
           <var>direction</var>.</p>
         </li>
         <li>
+          <p>Let <var>transceiver</var> have a <dfn>[[\PendingDirection]]</dfn> internal slot,
+          initialized to null.</p>
+        </li>
+        <li>
           <p>Let <var>transceiver</var> have a <dfn>[[\CurrentDirection]]</dfn> internal slot,
           initialized to null.</p>
         </li>
@@ -7100,6 +7138,10 @@ async function updateParameters() {
                 <li>
                   <p>Set <var>transceiver</var>'s <a>[[\Stopped]]</a>
                   slot to <code>true</code>.</p>
+                </li>
+                <li>
+                  <p>Set <var>transceiver</var>'s <a>[[\PendingDirection]]</a>
+                  slot to <code>null</code>.</p>
                 </li>
                 <li>
                   <p>Set <var>transceiver</var>'s <a>[[\CurrentDirection]]</a>

--- a/webrtc.html
+++ b/webrtc.html
@@ -84,7 +84,11 @@
     handlers</dfn> and <dfn data-cite="!HTML51/webappapis.html#event-handler-event-type">event
     handler event types</dfn> are defined in [[!HTML51]].</p>
     <p>The terms <dfn>MediaStream</dfn>, <dfn>MediaStreamTrack</dfn>, and
-    <dfn>MediaStreamConstraints</dfn> are defined in [[!GETUSERMEDIA]].</p>
+    <dfn>MediaStreamConstraints</dfn> are defined in [[!GETUSERMEDIA]].
+    Note that <code><a>MediaStream</a></code> is extended in <code><a href="#mediastream-network-use">
+    the MediaStream section</a></code> in this document while <code><a>MediaStreamTrack</a></code>
+    is extended in <code><a href="#mediastreamtrack-network-use">
+    the MediaStreamTrack section</a></code> in this document.</p>
     <p>The term <dfn>Blob</dfn> is defined in [[!FILEAPI]].</p>
     <p>The term <dfn>media description</dfn> is defined in [[!RFC4566]].</p>
     <p>The term <dfn>media transport</dfn> is defined in [[!RFC7656]].</p>
@@ -1552,9 +1556,9 @@
                     in <var>description</var>:</p>
                     <ol>
                       <li>
-                        If the <a>media description</a> is not yet <a>associated</a>
+                        <p>If the <a>media description</a> is not yet <a>associated</a>
                         with an <code><a>RTCRtpTransceiver</a></code> object then run
-                        the following steps:
+                        the following steps:</p>
                         <ol>
                           <li>
                             <p>Let <var>transceiver</var> be the <code>
@@ -1562,7 +1566,7 @@
                             <a>media description</a>.</p>
                           </li>
                           <li>
-                            <p>Set <var>transceiver</var>'s <code><a data-for=
+                            <p>Set <var>transceiver</var>'s <code><a data-link-for=
                             "RTCRtpTransceiver">mid</a></code> value to the mid of
                             the <a>media description</a>.</p>
                           </li>
@@ -1633,20 +1637,22 @@
                         is <code>true</code>, abort these sub steps.</p>
                       </li>
                       <li>
-                        <p>If <var>description</var> is of type
-                        <code>"offer"</code> 
-                        set <var>transceiver</var>'s <a>[[\OfferedDirection]]</a> slot
-                        to an <code><a>RTCRtpTransceiverDirection</a></code>
-                        value representing the direction of the <a>media description</a>.</p>
+                        <p>Let <var>direction</var> be an <code>
+                        <a>RTCRtpTransceiverDirection</a></code> value
+                        representing the direction from the <a>media
+                        description</a>.</p>
+                      </li>
+                      <li>
+                        <p>If <var>direction</var> is <code>"sendrecv"</code> or
+                        <code>"recvonly"</code>,
+                        set <var>transceiver</var>'s <a>[[\Receptive]]</a> slot
+                        to <code>true</code>, otherwise set it to <code>false</code>.</p>
                       </li>
                       <li>
                         <p>If <var>description</var> is of type
-                        <code>"answer"</code> or <code>"pranswer"</code>, then
-                        set <var>transceiver</var>'s <a>[[\CurrentDirection]]</a> slot
-                        to an <code><a>RTCRtpTransceiverDirection</a></code>
-                        value representing the direction of the <a>media description</a>
-                        and set <var>transceiver</var>'s <a>[[\OfferedDirection]]</a>
-                        slot to the value <code>null</code>.</p>
+                        <code>"answer"</code> or <code>"pranswer"</code>, then set
+                        <var>transceiver</var>'s <a>[[\CurrentDirection]]</a> slot
+                        to <var>direction</var>.</p>
                       </li>
                     </ol>
                   </li>
@@ -1712,6 +1718,12 @@
                           </li>
                           <li>
                             <p>If <var>direction</var> is <code>"sendrecv"</code> or
+                            <code>"recvonly"</code>,
+                            set <var>transceiver</var>'s <a>[[\Receptive]]</a> slot
+                            to <code>true</code>, otherwise set it to <code>false</code>.</p>
+                          </li>
+                              <li>
+                            <p>If <var>direction</var> is <code>"sendrecv"</code> or
                             <code>"recvonly"</code>, and
                             <var>transceiver</var>'s
                             <a>[[\CurrentDirection]]</a> slot
@@ -1738,8 +1750,7 @@
                               <li>
                                 <p>Set <var>transceiver</var>'s
                                 <a>[[\CurrentDirection]]</a> slot to
-                                <var>direction</var> and set <var>transceiver</var>'s
-                                <a>[[\OfferedDirection]]</a> slot to <code>null</code>.</p>
+                                <var>direction</var>.</p>
                               </li>
                               <li>
                                 <p>
@@ -6609,23 +6620,6 @@ async function updateParameters() {
               <p>The <code id="dom-rtpreceiver-track">track</code>
               attribute is the track that is associated with this
               <code><a>RTCRtpReceiver</a></code> object <var>receiver</var>.
-              When one of the SSRCs for RTP source media streams received
-              by <var>receiver</var> is removed (either due to reception of
-              a BYE or via timeout), <a>set the muted state</a> of the
-              <code>track</code> to the value <code>true</code>.
-              Note that <a data-lt="set the RTCSessionDescription">
-              setting an <code>RTCSessionDescription</code></a>
-              can also lead to <a data-lt="set the muted state"> setting
-              the muted state</a> of the <code>track</code> to the
-              value <code>true</code>.
-              If packets are received again, and the <code>track</code> is
-              muted, and either the [[\OfferedDirection]] or
-              [[\CurrentDirection]] slot of the 
-              <a><code>RTCRtpTransceiver</code></a> the
-              <a><code>RTCRtpReceiver</code></a> is member of is either 
-              <code>"recvonly"</code> or <code>"sendrecv"</code>,
-              <a>set the muted state</a> of the
-              <code>track</code> to the value <code>false</code>.
               </p>
               <p>Note that <code>track.stop()</code> is final, although
               clones are not affected. Since
@@ -6926,8 +6920,8 @@ async function updateParameters() {
           <var>direction</var>.</p>
         </li>
         <li>
-          <p>Let <var>transceiver</var> have a <dfn>[[\OfferedDirection]]</dfn> internal slot,
-          initialized to null.</p>
+          <p>Let <var>transceiver</var> have a <dfn>[[\Receptive]]</dfn> internal slot,
+          initialized to <code>false</code>.</p>
         </li>
         <li>
           <p>Let <var>transceiver</var> have a <dfn>[[\CurrentDirection]]</dfn> internal slot,
@@ -7143,8 +7137,8 @@ async function updateParameters() {
                   slot to <code>true</code>.</p>
                 </li>
                 <li>
-                  <p>Set <var>transceiver</var>'s <a>[[\OfferedDirection]]</a>
-                  slot to <code>null</code>.</p>
+                  <p>Set <var>transceiver</var>'s <a>[[\Receptive]]</a>
+                  slot to <code>false</code>.</p>
                 </li>
                 <li>
                   <p>Set <var>transceiver</var>'s <a>[[\CurrentDirection]]</a>
@@ -10915,7 +10909,7 @@ async function consumeIdentityAssertion() {
       <code>MediaStreamTrack</code>.</p>
     </section>
     <section>
-      <h3>MediaStream</h3>
+      <h3 id="mediastream-network-use">MediaStream</h3>
       <section>
         <h4>id</h4>
         <p>The <code><a data-cite=
@@ -10939,24 +10933,39 @@ async function consumeIdentityAssertion() {
       </section>
     </section>
     <section>
-      <h3>MediaStreamTrack</h3>
+      <h3 id="mediastreamtrack-network-use">MediaStreamTrack</h3>
       <p>A <code>MediaStreamTrack</code> object's reference to its
       <code>MediaStream</code> in the non-local media source case (an RTP
-      source, as is the case for <code>MediaStreamTrack</code>s received over
-      an <code><a>RTCPeerConnection</a></code>) is always strong.</p>
-      <p>When an <code><a>RTCPeerConnection</a></code> receives data on an RTP
-      source for the first time, it MUST queue a task to
+      source, as is the case for each <code>MediaStreamTrack</code>
+      associated with
+      an <code><a>RTCRtpReceiver</a></code>) is always strong.</p>
+      <p>When an <code><a>RTCRtpReceiver</a></code> receives data on an RTP
+      source for the first time, and the [[\Receptive]]
+      slot of the 
+      <a><code>RTCRtpTransceiver</code></a> object the
+      <a><code>RTCRtpReceiver</code></a> is member of is either 
+      <code>true</code>, it MUST queue a task to
       <a>set the muted state</a> of the corresponding
       <code><a>MediaStreamTrack</a></code> to <code>false</code>.
       </p>
       <p>When one of the SSRCs for RTP source media streams received
-      by an <code><a>RTCPeerConnection</a></code> is removed either
+      by an <code><a>RTCRtpReceiver</a></code> is removed either
       due to reception of a BYE or via timeout, it MUST queue a task to
       <a>set the muted state</a> of the corresponding
       <code><a>MediaStreamTrack</a></code> to
-      <code>true</code>. If and when packets are received again, it must queue a
-      task to <a data-lt="set the muted state">set the muted state</a> back
-      to <code>false</code>.</p>
+      <code>true</code>. Note that <code><a data-link-for=
+      "RTCPeerConnection">setRemoteDescription</a></code>
+      can also lead to <a data-lt="set the muted state"> the setting
+      of the muted state</a> of the <code>track</code> to the
+      value <code>true</code>. 
+      When a <code><a>MediaStreamTrack</a></code>
+      is muted, whenever its associated <code><a>RTCRtpReceiver</a></code> receives data on an RTP
+      source and the [[\Receptive]] slot of the 
+      <a><code>RTCRtpTransceiver</code></a> object the
+      associated <a><code>RTCRtpReceiver</code></a> is member of is 
+      <code>true</code>, the associated <a><code>RTCRtpReceiver</code></a> 
+      MUST queue a task to <a>set the muted state</a> of the
+      <code><a>MediaStreamTrack</a></code> to the value <code>false</code>.</p>
       <p>The procedures
       <dfn data-lt="add the track" id="add-track">add a track</dfn>,
       <dfn data-lt="remove the track" id="remove-track">remove a track</dfn> and

--- a/webrtc.html
+++ b/webrtc.html
@@ -1552,9 +1552,9 @@
                     in <var>description</var>:</p>
                     <ol>
                       <li>
-                        If <a>media description</a> in <var>description</var> is not yet
-                        <a>associated</a> with an <code><a>RTCRtpTransceiver</a></code>
-                        object then run the following steps:
+                        If the <a>media description</a> is not yet <a>associated</a>
+                        with an <code><a>RTCRtpTransceiver</a></code> object then run
+                        the following steps:
                         <ol>
                           <li>
                             <p>Let <var>transceiver</var> be the <code>
@@ -1564,7 +1564,7 @@
                           <li>
                             <p>Set <var>transceiver</var>'s <code><a data-for=
                             "RTCRtpTransceiver">mid</a></code> value to the mid of
-                            the corresponding <a>media description</a>.</p>
+                            the <a>media description</a>.</p>
                           </li>
                           <li>
                             <p>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot
@@ -1637,16 +1637,16 @@
                         <code>"offer"</code> 
                         set <var>transceiver</var>'s <a>[[\PendingDirection]]</a> slot
                         to an <code><a>RTCRtpTransceiverDirection</a></code>
-                        value representing the direction of the corresponding
-                        <a>media description</a>.</p>
+                        value representing the direction of the <a>media description</a>.</p>
                       </li>
                       <li>
                         <p>If <var>description</var> is of type
                         <code>"answer"</code> or <code>"pranswer"</code>, then
                         set <var>transceiver</var>'s <a>[[\CurrentDirection]]</a> slot
                         to an <code><a>RTCRtpTransceiverDirection</a></code>
-                        value representing the direction of the corresponding
-                        <a>media description</a>.</p>
+                        value representing the direction of the <a>media description</a>
+                        and set <var>transceiver</var>'s <a>[[\PendingDirection]]</a>
+                        slot to the value <code>null</code>.</p>
                       </li>
                     </ol>
                   </li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1718,12 +1718,6 @@
                           </li>
                           <li>
                             <p>If <var>direction</var> is <code>"sendrecv"</code> or
-                            <code>"recvonly"</code>,
-                            set <var>transceiver</var>'s <a>[[\Receptive]]</a> slot
-                            to <code>true</code>, otherwise set it to <code>false</code>.</p>
-                          </li>
-                              <li>
-                            <p>If <var>direction</var> is <code>"sendrecv"</code> or
                             <code>"recvonly"</code>, and
                             <var>transceiver</var>'s
                             <a>[[\CurrentDirection]]</a> slot
@@ -1731,6 +1725,12 @@
                             <a>process the addition of a remote track</a> for
                             the <a>media description</a>, given <var>transceiver</var>,
                             <var>addList</var>, and <var>trackEvents</var>.</p>
+                          </li>
+                          <li>
+                            <p>If <var>direction</var> is <code>"sendonly"</code> or
+                            <code>"inactive"</code>,
+                            set <var>transceiver</var>'s <a>[[\Receptive]]</a> slot
+                            to <code>false</code>.</p>
                           </li>
                           <li>
                             <p>If <var>direction</var> is

--- a/webrtc.html
+++ b/webrtc.html
@@ -1549,81 +1549,80 @@
                   <li>
                     <p>If <var>description</var> is set as a local description,
                     then run the following steps for each <a>media description</a>
-                    in <var>description</var> that is not yet <a>associated</a> with
-                    an <code><a>RTCRtpTransceiver</a></code> object:</p>
-                    <ol>
-                      <li>
-                        <p>Let <var>transceiver</var> be the <code>
-                        <a>RTCRtpTransceiver</a></code> used to create the
-                        <a>media description</a>.</p>
-                      </li>
-                      <li>
-                        <p>Set <var>transceiver</var>'s <code><a data-link-for=
-                        "RTCRtpTransceiver">mid</a></code> value to the mid of
-                        the corresponding <a>media description</a>.</p>
-                      </li>
-                      <li>
-                        <p>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot
-                        is <code>true</code>, abort these sub steps.</p>
-                      </li>
-                      <li>
-                        <p>
-                          If the <a>media description</a> is indicated as using
-                          an existing <a>media transport</a> according to
-                          [[!BUNDLE]], let <var>transport</var> and
-                          <var>rtcpTransport</var> be the
-                          <code><a>RTCDtlsTransport</a></code> objects
-                          representing the RTP and RTCP components of that
-                          transport, respectively.
-                        </p>
-                      </li>
-                      <li>
-                        <p>
-                          Otherwise, let <var>transport</var> and
-                          <var>rtcpTransport</var> be newly created
-                          <code><a>RTCDtlsTransport</a></code> objects, each
-                          with a new underlying
-                          <code><a>RTCIceTransport</a></code>. Though if RTCP
-                          multiplexing is negotiated according to [[!RFC5761]],
-                          or if <var>connection</var>'s
-                          <code><a>RTCRtcpMuxPolicy</a></code> is <code><a
-                          data-link-for="RTCRtcpMuxPolicy">require</a></code>,
-                          do not create any RTCP-specific transport objects,
-                          and instead let <var>rtcpTransport</var> equal
-                          <var>transport</var>.
-                        </p>
-                      </li>
-                      <li>
-                        <p>
-                          Set <var>transceiver</var>.<a>[[\Sender]]</a>.<a>[[\SenderTransport]]</a>
-                          to <var>transport</var>.
-                        </p>
-                      </li>
-                      <li>
-                        <p>
-                          Set <var>transceiver</var>.<a>[[\Sender]]</a>.<a>[[\SenderRtcpTransport]]</a>
-                          to <var>rtcpTransport</var>.
-                        </p>
-                      </li>
-                      <li>
-                        <p>
-                          Set <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\ReceiverTransport]]</a>
-                          to <var>transport</var>.
-                        </p>
-                      </li>
-                      <li>
-                        <p>
-                          Set <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\ReceiverRtcpTransport]]</a>
-                          to <var>rtcpTransport</var>.
-                        </p>
-                      </li>
-                    </ol>
-                  </li>
-                  <li>
-                    <p>If <var>description</var> is set as a local description,
-                    then run the following steps for each <a>media description</a>
                     in <var>description</var>:</p>
                     <ol>
+                      <li>
+                        If <a>media description</a> in <var>description</var> is not yet
+                        <a>associated</a> with an <code><a>RTCRtpTransceiver</a></code>
+                        object then run the following steps:
+                        <ol>
+                          <li>
+                            <p>Let <var>transceiver</var> be the <code>
+                            <a>RTCRtpTransceiver</a></code> used to create the
+                            <a>media description</a>.</p>
+                          </li>
+                          <li>
+                            <p>Set <var>transceiver</var>'s <code><a data-for=
+                            "RTCRtpTransceiver">mid</a></code> value to the mid of
+                            the corresponding <a>media description</a>.</p>
+                          </li>
+                          <li>
+                            <p>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot
+                            is <code>true</code>, abort these sub steps.</p>
+                          </li>
+                          <li>
+                            <p>
+                              If the <a>media description</a> is indicated as using
+                              an existing <a>media transport</a> according to
+                              [[!BUNDLE]], let <var>transport</var> and
+                              <var>rtcpTransport</var> be the
+                              <code><a>RTCDtlsTransport</a></code> objects
+                              representing the RTP and RTCP components of that
+                              transport, respectively.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Otherwise, let <var>transport</var> and
+                              <var>rtcpTransport</var> be newly created
+                              <code><a>RTCDtlsTransport</a></code> objects, each
+                              with a new underlying
+                              <code><a>RTCIceTransport</a></code>. Though if RTCP
+                              multiplexing is negotiated according to [[!RFC5761]],
+                              or if <var>connection</var>'s
+                              <code><a>RTCRtcpMuxPolicy</a></code> is <code><a
+                              data-link-for="RTCRtcpMuxPolicy">require</a></code>,
+                              do not create any RTCP-specific transport objects,
+                              and instead let <var>rtcpTransport</var> equal
+                              <var>transport</var>.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Set <var>transceiver</var>.<a>[[\Sender]]</a>.<a>[[\SenderTransport]]</a>
+                              to <var>transport</var>.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Set <var>transceiver</var>.<a>[[\Sender]]</a>.<a>[[\SenderRtcpTransport]]</a>
+                              to <var>rtcpTransport</var>.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Set <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\ReceiverTransport]]</a>
+                              to <var>transport</var>.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Set <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\ReceiverRtcpTransport]]</a>
+                              to <var>rtcpTransport</var>.
+                            </p>
+                          </li>
+                        </ol>
+                      </li>
                       <li>
                         <p>Let <var>transceiver</var> be the <code>
                         <a>RTCRtpTransceiver</a></code> <a>associated</a> with the

--- a/webrtc.html
+++ b/webrtc.html
@@ -6612,17 +6612,22 @@ async function updateParameters() {
               <code><a>RTCRtpReceiver</a></code> object <var>receiver</var>.
               When one of the SSRCs for RTP source media streams received
               by <var>receiver</var> is removed (either due to reception of
-              a BYE or via timeout), the <code>mute</code> event is fired at
-              <code>track</code>. <a data-lt="set the RTCSessionDescription">
-              Setting an <code>RTCSessionDescription</code></a> can also
-              lead to the firing of the <code>mute</code> event at
-              <code>track</code>.
-              If and when packets are received again, and either the
-              [[\PendingDirection]] or [[\CurrentDirection]] slot of the
+              a BYE or via timeout), <a>set the muted state</a> of the
+              <code>track</code> to the value <code>true</code>.
+
+              <a data-lt="set the RTCSessionDescription">
+              Setting an <code>RTCSessionDescription</code></a> can also 
+              lead to <a data-lt="set the muted state"> setting the muted
+              state</a> of the <code>track</code> to the
+              value <code>true</code>.
+              If packets are received again, and the <code>track</code> is
+              muted, and either the [[\PendingDirection]] or
+              [[\CurrentDirection]] slot of the 
               <a><code>RTCRtpTransceiver</code></a> the
               <a><code>RTCRtpReceiver</code></a> is member of is either 
-              <code>"recvonly"</code> or <code>"sendrecv"</code>, the
-              the <code>unmute</code> event is fired at <code>track</code>.
+              <code>"recvonly"</code> or <code>"sendrecv"</code>,
+              <a>set the muted state</a> of the
+              <code>track</code> to the value <code>false</code>.
               </p>
               <p>Note that <code>track.stop()</code> is final, although
               clones are not affected. Since


### PR DESCRIPTION
Fix for #1737 and #1707


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/stefhak/webrtc-pc/pull/1748.html" title="Last updated on Mar 8, 2018, 1:13 PM GMT (bc78c39)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1748/312b635...stefhak:bc78c39.html" title="Last updated on Mar 8, 2018, 1:13 PM GMT (bc78c39)">Diff</a>