### PR TITLE
Add "statsended" event and surrounding machinery

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9557,7 +9557,16 @@ interface RTCDTMFToneChangeEvent : Event {
       queries can be linked by the <code><a>RTCStats</a></code> <a data-link-for=
       "RTCStats">id</a> dictionary member. Thus, a Web application can make
       measurements over a given time period by requesting measurements at the
-      beginning and end of that period.</p>
+        beginning and end of that period.</p>
+      <p>
+        Stats objects may have a limited lifetime. Until the end of
+        their lifetime, they are always present in the result from
+        getStats(). When their lifetime ends, a record of the
+        statistics for that object is emitted through a
+        "statslifetimeended" event, containing an RTCStats
+        dictionary. The object descriptions in [[WEBRTC-STATS]]
+        describe the lifetime of each stats object type.
+      </p>
     </section>
     <section>
       <h3>RTCPeerConnection Interface Extensions</h3>
@@ -9566,7 +9575,15 @@ interface RTCDTMFToneChangeEvent : Event {
       <div>
         <pre class="idl">partial interface RTCPeerConnection {
     Promise&lt;RTCStatsReport&gt; getStats (optional MediaStreamTrack? selector = null);
-};</pre>
+    attribute EventHandler onstatslifetimeended;
+          };</pre>
+        <section>
+          <h2>Attributes</h2>
+          <dl data-link-for="RTCPeerConnection"
+              data-dfn-for="RTCPeerConnection" class="attributes">
+            <dt><dfn><code>onstatslifetimeended</code></dfn> of type
+              <span class="idlAttrType"><a>EventHandler</a></span></dt>
+            <dd>The event type of this event handler is <code><a>statslifetimeended</a></code>.</dd>
         <section>
           <h2>Methods</h2>
           <dl data-link-for="RTCPeerConnection" data-dfn-for=
@@ -9732,6 +9749,58 @@ interface RTCDTMFToneChangeEvent : Event {
       <p>The set of valid values for <code><a>RTCStatsType</a></code>, and the dictionaries derived
       from RTCStats that they indicate, are documented in
       [[!WEBRTC-STATS]].</p>
+    </section>
+    <section>
+      <h3><dfn>RTCStatsLifetimeEvent</dfn></h3>
+      <p>The <code><a>statslifetimeended</a></code> event uses
+        the <code><a>RTCStatsLifetimeEvent</a></code>.</p>
+      <div>
+        <pre class="idl">
+          [ Constructor (DOMString type, RTCDataChannelEventInit
+          eventInitDict), Exposed=Window]
+          interface RTCStatsLifetimeEvent : Event {
+            readonly attribute any stat; // Must be RTCStats subtype
+          };</pre>
+        <section>
+          <h2>Constructors</h2>
+          <dl data-link-for="RTCStatsLifetimeEvent"
+              data-dfn-for="RTCStatsLifetimeEvent" class="constructors">
+            <dt><code>RTCStatsLifetimeEvent</code></dt>
+            <dd>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h2>Attributes</h2>
+          <dl data-link-for="RTCStatsLifetimeEvent"
+              data-dfn-for="RTCStatsLifetimeEvent" class="attributes">
+            <dt><code>stat</code> of
+              type <span class="idlAttrType">any</span>
+            </dt>
+            <dd>
+              <p>The <dfn id=dom-statslifetimeevent-stat><code>stat</code></dfn>
+              attribute represents the object of the appropriate
+              subclass of <code><a>RTCStats</a></code>
+              object giving the value of the statistics for the object
+                whose lifetime has ended, at the time that it ended.</p>
+            </dd>
+          </dl>
+        <section>
+          <h2>Dictionary <dfn>RTCStatsLifetimeEventInit</dfn>
+            members</h2> 
+          <dl  data-link-for="RTCStatsLifetimeEventInit"
+            data-dfn-for="RTCStatsLifetimeEventInit"
+               class="dictionary-members">
+            <dt><dfn><code>stat</code></dfn> of
+            type <span class="idlMemberType"><a>RTCStats</a></span>,
+              required</dt>
+            <dd>
+              <p>The <code><a>RTCStats</a></code> object giving the
+                stats for the object whose lifetime has ended.</p>
+            </dd>
+          </dl>
+          </section>
+       </div>
     </section>
     <section>
       <h3>The stats selection algorithm</h3>
@@ -12165,6 +12234,11 @@ interface RTCErrorEvent : Event {
           the <var>isolated</var> attribute on a <code>MediaStreamTrack</code>
           changes.</td>
         </tr>
+        <tr>
+          <td><dfn id="event-statslifetimeended"><code>statslifetimeended</code></dfn></td>
+          <td><code><a>RTCStatsLifetimeEvent</a></code></td>
+          <td>A new <code><a>RTCStatsLifetimeEvent</a></code> is dispatched to
+          the script in response to the end of a stats object's lifetime.</td>
       </tbody>
     </table>
     <p>The following events fire on <code><a>RTCDTMFSender</a></code>

--- a/webrtc.html
+++ b/webrtc.html
@@ -9583,8 +9583,29 @@ interface RTCDTMFToneChangeEvent : Event {
               data-dfn-for="RTCPeerConnection" class="attributes">
             <dt><dfn><code>onstatslifetimeended</code></dfn> of type
               <span class="idlAttrType"><a>EventHandler</a></span></dt>
-            <dd>The event type of this event handler
-              is <code><a>statslifetimeended</a></code>.</dd>
+            <dd>
+              <p>The event type of this event handler
+                is <code><a>statslifetimeended</a></code>.
+              </p>
+              <p>When the lifetime of one or more monitored objects ends, the UA MUST
+                queue a task to run the following steps:
+                <ul>
+                  <li>Create a new RTCStatsReport object called <var>r</var></li>
+                  <li>For each monitored object, create a new RTCStats
+                    object with the statatistics for that object, and
+                    add it to <var>r</var>
+                  </li>
+                  <li>
+                    Create a new <a>RTCStatsLifetimeEndedEvent</a>
+                    called <var>e</var>, with its name set to
+                    "statsended" and its "report" being set to <var>r</var>
+                  </li>
+                  <li>
+                    Fire <var>e</var>
+                  </li>
+                </ul>
+                
+            </dd>
           </dl>
         </section>
         <section>
@@ -9754,53 +9775,52 @@ interface RTCDTMFToneChangeEvent : Event {
       [[!WEBRTC-STATS]].</p>
     </section>
     <section>
-      <h3><dfn>RTCStatsLifetimeEvent</dfn></h3>
+      <h3><dfn>RTCStatsLifetimeEndedEvent</dfn></h3>
       <p>The <code><a>statslifetimeended</a></code> event uses
-        the <code><a>RTCStatsLifetimeEvent</a></code>.</p>
+        the <code><a>RTCStatsLifetimeEndedEvent</a></code>.</p>
       <div>
-        <pre class="idl">
-          [ Constructor (DOMString type, RTCStatsLifetimeEventInit
+        <pre class="idl">[ Constructor (DOMString type, RTCStatsLifetimeEndedEventInit
           eventInitDict), Exposed=Window]
-          interface RTCStatsLifetimeEvent : Event {
-            readonly attribute any stat; // Must be RTCStats subtype
+          interface RTCStatsLifetimeEndedEvent : Event {
+            readonly attribute RTCStatsReport report;
           };</pre>
         <section>
           <h2>Constructors</h2>
-          <dl data-link-for="RTCStatsLifetimeEvent"
-              data-dfn-for="RTCStatsLifetimeEvent" class="constructors">
-            <dt><code>RTCStatsLifetimeEvent</code></dt>
+          <dl data-link-for="RTCStatsLifetimeEndedEvent"
+              data-dfn-for="RTCStatsLifetimeEndedEvent" class="constructors">
+            <dt><code>RTCStatsLifetimeEndedEvent</code></dt>
             <dd>
             </dd>
           </dl>
         </section>
         <section>
           <h2>Attributes</h2>
-          <dl data-link-for="RTCStatsLifetimeEvent"
-              data-dfn-for="RTCStatsLifetimeEvent" class="attributes">
-            <dt><code>stat</code> of
-              type <span class="idlAttrType">any</span>
+          <dl data-link-for="RTCStatsLifetimeEndedEvent"
+              data-dfn-for="RTCStatsLifetimeEndedEvent" class="attributes">
+            <dt><code>report</code> of
+              type <span class="idlAttrType">RTCStatsReport</span>
             </dt>
             <dd>
-              <p>The <dfn id=dom-statslifetimeevent-stat><code>stat</code></dfn>
-              attribute represents the object of the appropriate
+              <p>The <dfn id=dom-statslifetimeevent-report><code>report</code></dfn>
+              attribute contains the objects of the appropriate
               subclass of <code><a>RTCStats</a></code>
-              object giving the value of the statistics for the object
-                whose lifetime has ended, at the time that it ended.</p>
+              object giving the value of the statistics for the objects
+                whose lifetime have ended, at the time that it ended.</p>
             </dd>
           </dl>
         </section>
         <section>
-          <h2>Dictionary <dfn>RTCStatsLifetimeEventInit</dfn>
+          <h2>Dictionary <dfn>RTCStatsLifetimeEndedEventInit</dfn>
             members</h2> 
-          <dl  data-link-for="RTCStatsLifetimeEventInit"
-            data-dfn-for="RTCStatsLifetimeEventInit"
+          <dl  data-link-for="RTCStatsLifetimeEndedEventInit"
+            data-dfn-for="RTCStatsLifetimeEndedEventInit"
                class="dictionary-members">
-            <dt><dfn><code>stat</code></dfn> of
-            type <span class="idlMemberType"><a>RTCStats</a></span>,
+            <dt><code>report</code> of
+            type <span class="idlMemberType"><a>RTCStatsReport</a></span>,
               required</dt>
             <dd>
-              <p>The <code><a>RTCStats</a></code> object giving the
-                stats for the object whose lifetime has ended.</p>
+              <p>Contains the <code><a>RTCStats</a></code> objects giving the
+                stats for the objects whose lifetime have ended.</p>
             </dd>
           </dl>
           </section>
@@ -12240,8 +12260,8 @@ interface RTCErrorEvent : Event {
         </tr>
         <tr>
           <td><dfn id="event-statslifetimeended"><code>statslifetimeended</code></dfn></td>
-          <td><code><a>RTCStatsLifetimeEvent</a></code></td>
-          <td>A new <code><a>RTCStatsLifetimeEvent</a></code> is dispatched to
+          <td><code><a>RTCStatsLifetimeEndedEvent</a></code></td>
+          <td>A new <code><a>RTCStatsLifetimeEndedEvent</a></code> is dispatched to
           the script in response to the end of a stats object's lifetime.</td>
       </tbody>
     </table>

--- a/webrtc.html
+++ b/webrtc.html
@@ -9583,7 +9583,10 @@ interface RTCDTMFToneChangeEvent : Event {
               data-dfn-for="RTCPeerConnection" class="attributes">
             <dt><dfn><code>onstatslifetimeended</code></dfn> of type
               <span class="idlAttrType"><a>EventHandler</a></span></dt>
-            <dd>The event type of this event handler is <code><a>statslifetimeended</a></code>.</dd>
+            <dd>The event type of this event handler
+              is <code><a>statslifetimeended</a></code>.</dd>
+          </dl>
+        </section>
         <section>
           <h2>Methods</h2>
           <dl data-link-for="RTCPeerConnection" data-dfn-for=
@@ -9756,7 +9759,7 @@ interface RTCDTMFToneChangeEvent : Event {
         the <code><a>RTCStatsLifetimeEvent</a></code>.</p>
       <div>
         <pre class="idl">
-          [ Constructor (DOMString type, RTCDataChannelEventInit
+          [ Constructor (DOMString type, RTCStatsLifetimeEventInit
           eventInitDict), Exposed=Window]
           interface RTCStatsLifetimeEvent : Event {
             readonly attribute any stat; // Must be RTCStats subtype
@@ -9785,6 +9788,7 @@ interface RTCDTMFToneChangeEvent : Event {
                 whose lifetime has ended, at the time that it ended.</p>
             </dd>
           </dl>
+        </section>
         <section>
           <h2>Dictionary <dfn>RTCStatsLifetimeEventInit</dfn>
             members</h2> 

--- a/webrtc.html
+++ b/webrtc.html
@@ -9590,18 +9590,18 @@ interface RTCDTMFToneChangeEvent : Event {
               <p>The event type of this event handler
                 is <code><a>statsended</a></code>.
               </p>
-              <p>When the lifetime of one or more <a>monitored object</a>s ends, the UA MUST
-                queue a task to run the following steps:
+              <p>To <dfn>delete stats</dfn> for a set of <a>monitored object</a>s,
+                the UA MUST queue a task to run the following steps:
                 <ul>
-                  <li>Create a new RTCStatsReport object called <var>r</var></li>
+                  <li>Create a new RTCStatsReport object called <var>report</var></li>
                   <li>For each monitored object, create a new RTCStats
                     object with the <a>stats object</a> for that monitored object, and
-                    add it to <var>r</var>
+                    add it to <var>report</var>
                   </li>
                   <li>
                     Create a new <a>RTCStatsEvent</a>
                     called <var>e</var>, with its name set to
-                    "statsended" and its "report" being set to <var>r</var>
+                    "statsended" and its "report" being set to <var>report</var>
                   </li>
                   <li>
                     Fire <var>e</var>
@@ -9710,7 +9710,7 @@ interface RTCDTMFToneChangeEvent : Event {
     <section>
       <h3><dfn>RTCStats</dfn> Dictionary</h3>
       <p>An <code>RTCStats</code> dictionary represents the <a>stats object</a>
-      constructed by inspecting a specific <a>monitored object</a> relevant to a <a>selector</a>.
+      constructed by inspecting a specific <a>monitored object</a>.
       The <code>RTCStats</code> dictionary is a base type that specifies
       as set of default attributes, such as <a data-link-for=
       "RTCStats">timestamp</a> and <a data-link-for="RTCStats">type</a>. Specific
@@ -9804,7 +9804,7 @@ interface RTCDTMFToneChangeEvent : Event {
               type <span class="idlAttrType">RTCStatsReport</span>
             </dt>
             <dd>
-              <p>The <dfn id=dom-statslifetimeevent-report><code>report</code></dfn>
+              <p>The <dfn id=dom-statsevent-report><code>report</code></dfn>
               attribute contains the <a>stats object</a>s of the appropriate
               subclass of <code><a>RTCStats</a></code>
               object giving the value of the statistics for the <a>monitored object</a>s

--- a/webrtc.html
+++ b/webrtc.html
@@ -89,7 +89,7 @@
     <p>The term <dfn>media description</dfn> is defined in [[!RFC4566]].</p>
     <p>The term <dfn>media transport</dfn> is defined in [[!RFC7656]].</p>
     <p>The term <dfn>generation</dfn> is defined in [[!TRICKLE-ICE]] Section 2.</p>
-    <p>The term <dfn data-cite="!WEBRTC-STATS#dom-rtcstatstype">RTCStatsType</dfn> is defined in [[!WEBRTC-STATS]].
+    <p>The terms <dfn data-cite="!WEBRTC-STATS#dom-rtcstatstype">RTCStatsType</dfn>, <dfn data-cite="!WEBRTC-STATS#dfn-stats-object">stats object</dfn> and <dfn data-cite="!WEBRTC-STATS#dfn-monitored-object">monitored object</dfn> are defined in [[!WEBRTC-STATS]].
     <p>When referring to exceptions, the terms <dfn
     data-cite="!WEBIDL-1#dfn-throw">throw</dfn> and
     <dfn data-dfn-for="exception" data-cite=
@@ -9543,7 +9543,10 @@ interface RTCDTMFToneChangeEvent : Event {
     <section>
       <h3>Introduction</h3>
       <p>The basic statistics model is that the browser maintains a set of
-      statistics referenced by a <dfn id="stats-selector">selector</dfn>. The
+        statistics for <a>monitored object</a>s, in the form of <a>stats object</a>s.
+      </p>
+      <p>A group of related objects may be
+        referenced by a <dfn id="stats-selector">selector</dfn>. The
       selector may, for example, be a <code>MediaStreamTrack</code>. For a
       track to be a valid selector, it MUST be a <code>MediaStreamTrack</code>
       that is sent or received by the <code><a>RTCPeerConnection</a></code>
@@ -9559,11 +9562,11 @@ interface RTCDTMFToneChangeEvent : Event {
       measurements over a given time period by requesting measurements at the
         beginning and end of that period.</p>
       <p>
-        Stats objects may have a limited lifetime. Until the end of
+        <a>Stats object</a>s may have a limited lifetime. Until the end of
         their lifetime, they are always present in the result from
         getStats(). When their lifetime ends, a record of the
         statistics for that object is emitted through a
-        "statslifetimeended" event, containing an RTCStats
+        "statsended" event, containing an RTCStats
         dictionary. The object descriptions in [[WEBRTC-STATS]]
         describe the lifetime of each stats object type.
       </p>
@@ -9575,28 +9578,28 @@ interface RTCDTMFToneChangeEvent : Event {
       <div>
         <pre class="idl">partial interface RTCPeerConnection {
     Promise&lt;RTCStatsReport&gt; getStats (optional MediaStreamTrack? selector = null);
-    attribute EventHandler onstatslifetimeended;
+    attribute EventHandler onstatsended;
           };</pre>
         <section>
           <h2>Attributes</h2>
           <dl data-link-for="RTCPeerConnection"
               data-dfn-for="RTCPeerConnection" class="attributes">
-            <dt><dfn><code>onstatslifetimeended</code></dfn> of type
+            <dt><dfn><code>onstatsended</code></dfn> of type
               <span class="idlAttrType"><a>EventHandler</a></span></dt>
             <dd>
               <p>The event type of this event handler
-                is <code><a>statslifetimeended</a></code>.
+                is <code><a>statsended</a></code>.
               </p>
-              <p>When the lifetime of one or more monitored objects ends, the UA MUST
+              <p>When the lifetime of one or more <a>monitored object</a>s ends, the UA MUST
                 queue a task to run the following steps:
                 <ul>
                   <li>Create a new RTCStatsReport object called <var>r</var></li>
                   <li>For each monitored object, create a new RTCStats
-                    object with the statatistics for that object, and
+                    object with the <a>stats object</a> for that monitored object, and
                     add it to <var>r</var>
                   </li>
                   <li>
-                    Create a new <a>RTCStatsLifetimeEndedEvent</a>
+                    Create a new <a>RTCStatsEvent</a>
                     called <var>e</var>, with its name set to
                     "statsended" and its "report" being set to <var>r</var>
                   </li>
@@ -9706,8 +9709,8 @@ interface RTCDTMFToneChangeEvent : Event {
     </section>
     <section>
       <h3><dfn>RTCStats</dfn> Dictionary</h3>
-      <p>An <code>RTCStats</code> dictionary represents the stats
-      gathered by inspecting a specific object relevant to a <a>selector</a>.
+      <p>An <code>RTCStats</code> dictionary represents the <a>stats object</a>
+      constructed by inspecting a specific <a>monitored object</a> relevant to a <a>selector</a>.
       The <code>RTCStats</code> dictionary is a base type that specifies
       as set of default attributes, such as <a data-link-for=
       "RTCStats">timestamp</a> and <a data-link-for="RTCStats">type</a>. Specific
@@ -9775,45 +9778,45 @@ interface RTCDTMFToneChangeEvent : Event {
       [[!WEBRTC-STATS]].</p>
     </section>
     <section>
-      <h3><dfn>RTCStatsLifetimeEndedEvent</dfn></h3>
-      <p>The <code><a>statslifetimeended</a></code> event uses
-        the <code><a>RTCStatsLifetimeEndedEvent</a></code>.</p>
+      <h3><dfn>RTCStatsEvent</dfn></h3>
+      <p>The <code><a>statsended</a></code> event uses
+        the <code><a>RTCStatsEvent</a></code>.</p>
       <div>
-        <pre class="idl">[ Constructor (DOMString type, RTCStatsLifetimeEndedEventInit
+        <pre class="idl">[ Constructor (DOMString type, RTCStatsEventInit
           eventInitDict), Exposed=Window]
-          interface RTCStatsLifetimeEndedEvent : Event {
+          interface RTCStatsEvent : Event {
             readonly attribute RTCStatsReport report;
           };</pre>
         <section>
           <h2>Constructors</h2>
-          <dl data-link-for="RTCStatsLifetimeEndedEvent"
-              data-dfn-for="RTCStatsLifetimeEndedEvent" class="constructors">
-            <dt><code>RTCStatsLifetimeEndedEvent</code></dt>
+          <dl data-link-for="RTCStatsEvent"
+              data-dfn-for="RTCStatsEvent" class="constructors">
+            <dt><code>RTCStatsEvent</code></dt>
             <dd>
             </dd>
           </dl>
         </section>
         <section>
           <h2>Attributes</h2>
-          <dl data-link-for="RTCStatsLifetimeEndedEvent"
-              data-dfn-for="RTCStatsLifetimeEndedEvent" class="attributes">
+          <dl data-link-for="RTCStatsEvent"
+              data-dfn-for="RTCStatsEvent" class="attributes">
             <dt><code>report</code> of
               type <span class="idlAttrType">RTCStatsReport</span>
             </dt>
             <dd>
               <p>The <dfn id=dom-statslifetimeevent-report><code>report</code></dfn>
-              attribute contains the objects of the appropriate
+              attribute contains the <a>stats object</a>s of the appropriate
               subclass of <code><a>RTCStats</a></code>
-              object giving the value of the statistics for the objects
-                whose lifetime have ended, at the time that it ended.</p>
+              object giving the value of the statistics for the <a>monitored object</a>s
+              whose lifetime have ended, at the time that it ended.</p>
             </dd>
           </dl>
         </section>
         <section>
-          <h2>Dictionary <dfn>RTCStatsLifetimeEndedEventInit</dfn>
+          <h2>Dictionary <dfn>RTCStatsEventInit</dfn>
             members</h2> 
-          <dl  data-link-for="RTCStatsLifetimeEndedEventInit"
-            data-dfn-for="RTCStatsLifetimeEndedEventInit"
+          <dl  data-link-for="RTCStatsEventInit"
+            data-dfn-for="RTCStatsEventInit"
                class="dictionary-members">
             <dt><code>report</code> of
             type <span class="idlMemberType"><a>RTCStatsReport</a></span>,
@@ -12259,9 +12262,9 @@ interface RTCErrorEvent : Event {
           changes.</td>
         </tr>
         <tr>
-          <td><dfn id="event-statslifetimeended"><code>statslifetimeended</code></dfn></td>
-          <td><code><a>RTCStatsLifetimeEndedEvent</a></code></td>
-          <td>A new <code><a>RTCStatsLifetimeEndedEvent</a></code> is dispatched to
+          <td><dfn id="event-statsended"><code>statsended</code></dfn></td>
+          <td><code><a>RTCStatsEvent</a></code></td>
+          <td>A new <code><a>RTCStatsEvent</a></code> is dispatched to
           the script in response to the end of a stats object's lifetime.</td>
       </tbody>
     </table>


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-stats/issues/235

This adds an event that is emitted every time a stats object lifetime ends.
A companion PR to the stats spec will remove the "objectDeleted" flag.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/1753.html" title="Last updated on Feb 23, 2018, 8:48 AM GMT (0df866d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1753/35248b7...0df866d.html" title="Last updated on Feb 23, 2018, 8:48 AM GMT (0df866d)">Diff</a>