### PR TITLE
Change [[AssociatedMediaStreams]] to [[AssociatedMediaStreamIds]]

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4940,8 +4940,16 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                       <var>track</var>.</p>
                     </li>
                     <li>
-                      <p>Set <var>sender</var>'s <a>[[\AssociatedMediaStreams]]</a>
-                      to <var>streams</var>.</p>
+                      <p>Set <var>sender</var>'s
+                      <a>[[\AssociatedMediaStreamIds]]</a> to an empty set.
+                      </p>
+                    </li>
+                    <li>
+                      <p>For each <var>stream</var> in <var>streams</var>, add
+                      <var>stream.id</var> to
+                      <a>[[\AssociatedMediaStreamIds]]</a> if it's not already
+                      there.
+                      </p>
                     </li>
                     <li>
                       <p>Let <var>transceiver</var> be the
@@ -5463,17 +5471,23 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           slot initialized to <code>null</code>.</p>
         </li>
         <li>
-          <p>Let <var>sender</var> have an <dfn>[[\AssociatedMediaStreams]]</dfn>
-          internal slot, representing a list of
-          <code><a>MediaStream</a></code> objects that the
-          <code><a>MediaStreamTrack</a></code> object of this sender is
-          associated with. The <a>[[\AssociatedMediaStreams]]</a> slot is used
-          when <var>sender</var> is represented in SDP as described in <span
-          data-jsep="initial-offers">[[!JSEP]]</span>.</p>
+          <p>Let <var>sender</var> have an
+          <dfn>[[\AssociatedMediaStreamIds]]</dfn> internal slot, representing a
+          list of Ids of <code><a>MediaStream</a></code> objects that this
+          sender is to be associated with. The
+          <a>[[\AssociatedMediaStreamIds]]</a> slot is used when
+          <var>sender</var> is represented in SDP as described in
+          <span data-jsep="initial-offers">[[!JSEP]]</span>.</p>
         </li>
         <li>
-          <p>Set <var>sender</var>'s <a>[[\AssociatedMediaStreams]]</a> slot to
-          <var>streams</var>.</p>
+          <p>Set <var>sender</var>'s <a>[[\AssociatedMediaStreamIds]]</a> to an
+          empty set.</p>
+        </li>
+        <li>
+          <p>For each <var>stream</var> in <var>streams</var>, add
+          <var>stream.id</var> to <a>[[\AssociatedMediaStreamIds]]</a> if it's
+          not already there.
+          </p>
         </li>
         <li>
           <p>Let <var>sender</var> have a <dfn>[[\SendEncodings]]</dfn>


### PR DESCRIPTION
Avoid keeping local streams alive unnecessarily. Fix for https://github.com/w3c/webrtc-pc/issues/1756.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/1759.html" title="Last updated on Feb 1, 2018, 9:36 PM GMT (e01c833)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1759/d682ab2...jan-ivar:e01c833.html" title="Last updated on Feb 1, 2018, 9:36 PM GMT (e01c833)">Diff</a>