### PR TITLE
Removing 'readonly' from Tranceiver's 'direction'.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6928,8 +6928,7 @@ async function updateParameters() {
               <a>[[\Stopped]]</a> slot.</p>
             </dd>
             <dt><dfn><code>direction</code></dfn> of type <span class=
-            "idlAttrType"><a>RTCRtpTransceiverDirection</a></span>,
-            readonly</dt>
+            "idlAttrType"><a>RTCRtpTransceiverDirection</a></span></dt>
             <dd>
               <p>As defined in <span data-jsep=
               "transceiver-direction">[[!JSEP]]</span>, the


### PR DESCRIPTION
Close #1747


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/stefhak/webrtc-pc/pull/1762.html" title="Last updated on Feb 2, 2018, 11:57 AM GMT (5cf3ddb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1762/d682ab2...stefhak:5cf3ddb.html" title="Last updated on Feb 2, 2018, 11:57 AM GMT (5cf3ddb)">Diff</a>