### PR TITLE
RTCRtpTransceiver.direction is writable.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6928,8 +6928,7 @@ async function updateParameters() {
               <a>[[\Stopped]]</a> slot.</p>
             </dd>
             <dt><dfn><code>direction</code></dfn> of type <span class=
-            "idlAttrType"><a>RTCRtpTransceiverDirection</a></span>,
-            readonly</dt>
+            "idlAttrType"><a>RTCRtpTransceiverDirection</a></span></dt>
             <dd>
               <p>As defined in <span data-jsep=
               "transceiver-direction">[[!JSEP]]</span>, the


### PR DESCRIPTION
Fix an inconsistency between WebIDL and attribute description of `direction`.