### PR TITLE
Fix remaining compat issue with respec 19

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9984,9 +9984,9 @@ interface RTCIdentityProviderRegistrar {
     required ValidateAssertionCallback validateAssertion;
 };</pre>
           <section>
-            <h2>Dictionary <dfn>RTCIdentityProvider</dfn>
+            <h2>Dictionary <dfn data-dfn-for="">RTCIdentityProvider</dfn>
             Members</h2>
-            <dl>
+            <dl data-link-for="RTCIdentityProvider" data-dfn-for="RTCIdentityProvider">
               <dt><dfn><code>generateAssertion</code></dfn> of type
               <span class="idlMemberType"><a>GenerateAssertionCallback</a></span>,
               required</dt>


### PR DESCRIPTION
Had to use data-dfn-for='' for RTCIdentityProvider as there is a WebIDL attribute using that same name, which prevented respec from singling out the dictionary


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/1767.html" title="Last updated on Feb 7, 2018, 4:36 PM GMT (9403a1b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1767/f0d453c...9403a1b.html" title="Last updated on Feb 7, 2018, 4:36 PM GMT (9403a1b)">Diff</a>