### PR TITLE
Make initial state of dataChannel.readyState always be "connecting".

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9122,18 +9122,18 @@ interface RTCTrackEvent : Event {
               <td>
                 <p>The user agent is attempting to establish the <a>underlying
                 data transport</a>. This is the initial state of an
-                <code><a>RTCDataChannel</a></code> object created with
+                <code><a>RTCDataChannel</a></code> object, whether created with
                 <code><a data-link-for=
-                "RTCPeerConnection">createDataChannel</a></code>.</p>
+                  "RTCPeerConnection">createDataChannel</a></code>, or
+                dispatched as a part of an
+                <code><a>RTCDataChannelEvent</a></code>.</p>
               </td>
             </tr>
             <tr>
               <td><dfn><code>open</code></dfn></td>
               <td>
                 <p>The <a>underlying data transport</a> is established and
-                communication is possible. This is the initial state of an
-                <code><a>RTCDataChannel</a></code> object dispatched as a part
-                of an <code><a>RTCDataChannelEvent</a></code>.</p>
+                communication is possible.</p>
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
Fix for https://github.com/w3c/webrtc-pc/issues/1761.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/1768.html" title="Last updated on Feb 9, 2018, 8:34 PM GMT (f1c9b66)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1768/347380a...jan-ivar:f1c9b66.html" title="Last updated on Feb 9, 2018, 8:34 PM GMT (f1c9b66)">Diff</a>