### PR TITLE
Create a Dtmf internal slot and initialize it in RtpSender

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9285,8 +9285,10 @@ interface RTCDataChannelEvent : Event {
             <dt><code>dtmf</code> of type <span class=
             "idlAttrType"><a>RTCDTMFSender</a></span>, readonly, nullable</dt>
             <dd>
-              <p>The <dfn>dtmf</dfn> attribute returns an RTCDTMFSender which
-              can be used to send DTMF, or null if unset. The attribute is set
+              <p>On getting, the <dfn>dtmf</dfn> attribute returns the value
+              of the <a>[[\Dtmf]]</a>internal slot, which represents a <code>
+              <a>RTCDTMFSender</a></code> which can be used to send DTMF, or
+              null if unset. The <a>[[\Dtmf]]</a>internal slot is set
               when the kind of an <code><a>RTCRtpSender</a></code>'s
               <a>[[\SenderTrack]]</a> is <code>"audio"</code>.</p>
             </dd>

--- a/webrtc.html
+++ b/webrtc.html
@@ -5467,6 +5467,15 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           slot initialized to <code>null</code>.</p>
         </li>
         <li>
+          <p>Let <var>sender</var> have a <dfn>[[\Dtmf]]</dfn> internal
+          slot initialized to <code>null</code>.</p>
+        </li>
+        <li>
+          <p>If <var>sender</var> is of kind "audio" then
+          <a>create an <code>RTCDTMFSender</code></a> <var>dtmf</var> and set
+          the <a>[[\Dtmf]]</a> internal slot to <var>dtmf</var>.
+        </li>
+        <li>
           <p>Let <var>sender</var> have a <dfn>[[\SenderRtcpTransport]]</dfn> internal
           slot initialized to <code>null</code>.</p>
         </li>
@@ -9287,7 +9296,7 @@ interface RTCDataChannelEvent : Event {
     </section>
     <section>
       <h4><dfn>RTCDTMFSender</dfn></h4>
-        <p>To create an <code>RTCDTMFSender</code>, the user agent MUST
+      <p>To <dfn>create an <code>RTCDTMFSender</code></dfn>, the user agent MUST
         run the following steps:</p>
         <ol>
           <li>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/1776


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/1779.html" title="Last updated on Feb 23, 2018, 6:16 PM GMT (abe811b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1779/35248b7...abe811b.html" title="Last updated on Feb 23, 2018, 6:16 PM GMT (abe811b)">Diff</a>