### PR TITLE
Annotate definitions with IDL marker for compat with ReSpec 19.6

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7159,10 +7159,10 @@ async function updateParameters() {
       </div>
       <section>
         <h3>"Hold" functionality</h3>
-        <p>Together, the <code><a href=
-        "#dom-rtcrtptransceiver-direction">direction</a></code> attribute and
-        the <code><a href=
-        "#dom-rtcrtpsender-replacetrack">replaceTrack</a></code> method enable
+        <p>Together, the <code><a data-link-for=
+        "RTCRtpTransceiver">direction</a></code> attribute and
+        the <code><a data-link-for=
+        "RTCRtpSender">replaceTrack</a></code> method enable
         developers to implement "hold" scenarios.</p>
         <p>To send music to a peer and cease rendering received audio (music-on-hold):</p>
         <pre class="example highlight">

--- a/webrtc.html
+++ b/webrtc.html
@@ -140,34 +140,34 @@
             <h2>Dictionary <a class="idlType">RTCConfiguration</a> Members</h2>
             <dl data-link-for="RTCConfiguration" data-dfn-for=
             "RTCConfiguration" class="dictionary-members">
-              <dt><dfn><code>iceServers</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>iceServers</code></dfn> of type <span class=
               "idlMemberType">sequence&lt;<a>RTCIceServer</a>&gt;</span></dt>
               <dd>
                 <p>An array of objects describing servers available to be used
                 by ICE, such as STUN and TURN servers.</p>
               </dd>
-              <dt><dfn><code>iceTransportPolicy</code></dfn> of type
+              <dt><dfn data-idl><code>iceTransportPolicy</code></dfn> of type
               <span class="idlMemberType"><a>RTCIceTransportPolicy</a></span>,
               defaulting to <code>"all"</code></dt>
               <dd>
                 <p>Indicates which candidates the <a>ICE Agent</a> is allowed
                 to use.</p>
               </dd>
-              <dt><dfn><code>bundlePolicy</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>bundlePolicy</code></dfn> of type <span class=
               "idlMemberType"><a>RTCBundlePolicy</a></span>, defaulting to
               <code>"balanced"</code></dt>
               <dd>
                 <p>Indicates which <a>media-bundling policy</a> to use when
                 gathering ICE candidates.</p>
               </dd>
-              <dt><dfn><code>rtcpMuxPolicy</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>rtcpMuxPolicy</code></dfn> of type <span class=
               "idlMemberType"><a>RTCRtcpMuxPolicy</a></span>, defaulting to
               <code>"require"</code></dt>
               <dd>
                 <p>Indicates which <a>rtcp-mux policy</a> to use when gathering
                 ICE candidates.</p>
               </dd>
-              <dt><dfn><code>peerIdentity</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>peerIdentity</code></dfn> of type <span class=
               "idlMemberType"><a>DOMString</a></span></dt>
               <dd>
                 <p>Sets the <a>target peer identity</a> for the
@@ -175,7 +175,7 @@
                 establish a connection to a remote peer unless it can be
                 successfully authenticated with the provided name.</p>
               </dd>
-              <dt><dfn><code>certificates</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>certificates</code></dfn> of type <span class=
               "idlMemberType">sequence&lt;<a>RTCCertificate</a>&gt;</span></dt>
               <dd>
                 <p>A set of certificates that the
@@ -203,7 +203,7 @@
                 <p>The value for this configuration option cannot change after
                 its value is initially selected.</p>
               </dd>
-              <dt><dfn><code>iceCandidatePoolSize</code></dfn> of type
+              <dt><dfn data-idl><code>iceCandidatePoolSize</code></dfn> of type
               <span class="idlMemberType"><a>octet</a></span>, defaulting to
               <code>0</code></dt>
               <dd>
@@ -229,13 +229,13 @@
                 <th colspan="2">Enumeration description</th>
               </tr>
               <tr>
-                <td><dfn><code>password</code></dfn></td>
+                <td><dfn data-idl><code>password</code></dfn></td>
                 <td>The credential is a long-term authentication username and
                 password, as described in [[!RFC5389]], Section 10.2.
                 </td>
               </tr>
               <tr>
-                <td><dfn><code>oauth</code></dfn></td>
+                <td><dfn data-idl><code>oauth</code></dfn></td>
                 <td><p>An OAuth 2.0 based authentication method, as described in
                 [[!RFC7635]]. It uses the OAuth 2.0 Implicit Grant type, with
                 PoP (Proof-of-Possession) Token type, as described in
@@ -357,7 +357,7 @@
             </h2>
             <dl data-link-for="RTCOAuthCredential"
             data-dfn-for="RTCOAuthCredential" class="dictionary-members">
-              <dt><dfn><code>macKey</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>macKey</code></dfn> of type <span class=
               "idlMemberType"><a>DOMString</a></span>, required</dt>
               <dd>
                 <p>The "mac_key", as described in [[!RFC7635]], Section 6.2, in
@@ -370,7 +370,7 @@
                 parameter value from the JWK, which contains the needed
                 base64-encoded "mac_key".</p>
               </dd>
-              <dt><dfn><code>accessToken</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>accessToken</code></dfn> of type <span class=
               "idlMemberType"><a>DOMString</a></span>, required</dt>
               <dd>
                 <p>The "access_token", as described in [[!RFC7635]], Section
@@ -414,14 +414,14 @@
             <h2>Dictionary <a class="idlType">RTCIceServer</a> Members</h2>
             <dl data-link-for="RTCIceServer" data-dfn-for="RTCIceServer" class=
             "dictionary-members">
-              <dt><dfn><code>urls</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>urls</code></dfn> of type <span class=
               "idlMemberType"><a>(DOMString or
               sequence&lt;DOMString&gt;)</a></span>, required</dt>
               <dd>
                 <p>STUN or TURN URI(s) as defined in [[!RFC7064]] and
                 [[!RFC7065]] or other URI types.</p>
               </dd>
-              <dt><dfn><code>username</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>username</code></dfn> of type <span class=
               "idlMemberType"><a>DOMString</a></span></dt>
               <dd>
                 <p>If this <code><a>RTCIceServer</a></code> object represents a
@@ -442,7 +442,7 @@
                 parameter, as defined in [[!RFC7515]] Section 4.1.4.
               </p>
               </dd>
-              <dt><dfn><code>credential</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>credential</code></dfn> of type <span class=
               "idlMemberType">(<a>DOMString</a> or <a>RTCOAuthCredential</a>)
               </span></dt>
               <dd>
@@ -457,7 +457,7 @@
                 <code>credential</code> is an <a>RTCOAuthCredential</a>, which
                 contains the OAuth access token and MAC key.</p>
               </dd>
-              <dt><dfn><code>credentialType</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>credentialType</code></dfn> of type <span class=
               "idlMemberType"><a>RTCIceCredentialType</a></span>, defaulting to
               <code>"password"</code></dt>
               <dd>
@@ -508,7 +508,7 @@
                 <th colspan="2">Enumeration description (non-normative)</th>
               </tr>
               <tr>
-                <td><dfn><code>relay</code></dfn></td>
+                <td><dfn data-idl><code>relay</code></dfn></td>
                 <td>
                   <p>
                     The <a>ICE Agent</a> uses only media relay candidates
@@ -525,7 +525,7 @@
                 </td>
               </tr>
               <tr>
-                <td><dfn><code>all</code></dfn></td>
+                <td><dfn data-idl><code>all</code></dfn></td>
                 <td>
                   <p>
                     The <a>ICE Agent</a> can use any type of candidate when
@@ -563,20 +563,20 @@
                 <th colspan="2">Enumeration description (non-normative)</th>
               </tr>
               <tr>
-                <td><dfn><code>balanced</code></dfn></td>
+                <td><dfn data-idl><code>balanced</code></dfn></td>
                 <td>Gather ICE candidates for each media type in use (audio,
                 video, and data). If the remote endpoint is not bundle-aware,
                 negotiate only one audio and video track on separate
                 transports.</td>
               </tr>
               <tr>
-                <td><dfn><code>max-compat</code></dfn></td>
+                <td><dfn data-idl><code>max-compat</code></dfn></td>
                 <td>Gather ICE candidates for each track. If the remote
                 endpoint is not bundle-aware, negotiate all media tracks on
                 separate transports.</td>
               </tr>
               <tr>
-                <td><dfn><code>max-bundle</code></dfn></td>
+                <td><dfn data-idl><code>max-bundle</code></dfn></td>
                 <td>Gather ICE candidates for only one track. If the remote
                 endpoint is not bundle-aware, negotiate only one media
                 track.</td>
@@ -603,7 +603,7 @@
                 <th colspan="2">Enumeration description (non-normative)</th>
               </tr>
               <tr>
-                <td><dfn><code>negotiate</code></dfn></td>
+                <td><dfn data-idl><code>negotiate</code></dfn></td>
                 <td>Gather ICE candidates for both RTP and RTCP candidates. If
                 the remote-endpoint is capable of multiplexing RTCP, multiplex
                 RTCP on the RTP candidates. If it is not, use both the RTP and
@@ -614,7 +614,7 @@
                 <code>negotiate</code> policy.</td>
               </tr>
               <tr>
-                <td><dfn><code>require</code></dfn></td>
+                <td><dfn data-idl><code>require</code></dfn></td>
                 <td>Gather ICE candidates only for RTP and multiplex RTCP on
                 the RTP candidates. If the remote endpoint is not capable of
                 rtcp-mux, session negotiation will fail.</td>
@@ -647,7 +647,7 @@
             Members</h2>
             <dl data-link-for="RTCOfferAnswerOptions" data-dfn-for=
             "RTCOfferAnswerOptions" class="dictionary-members">
-              <dt><dfn><code>voiceActivityDetection</code></dfn> of type
+              <dt><dfn data-idl><code>voiceActivityDetection</code></dfn> of type
               <span class="idlMemberType"><a>boolean</a></span>, defaulting to
               <code>true</code></dt>
               <dd>
@@ -671,7 +671,7 @@
             <h2>Dictionary <dfn>RTCOfferOptions</dfn> Members</h2>
             <dl data-link-for="RTCOfferOptions" data-dfn-for="RTCOfferOptions"
             class="dictionary-members">
-              <dt><dfn><code>iceRestart</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>iceRestart</code></dfn> of type <span class=
               "idlMemberType"><a>boolean</a></span>, defaulting to
               <code>false</code></dt>
               <dd>
@@ -721,35 +721,35 @@
                 <th colspan="2">Enumeration description</th>
               </tr>
               <tr>
-                <td><dfn><code>stable</code></dfn></td>
+                <td><dfn data-idl><code>stable</code></dfn></td>
                 <td>There is no offer&shy;answer exchange in progress. This is
                 also the initial state in which case the local and remote
                 descriptions are empty.</td>
               </tr>
               <tr>
-                <td><dfn><code>have-local-offer</code></dfn></td>
+                <td><dfn data-idl><code>have-local-offer</code></dfn></td>
                 <td>A local description, of type <code>"offer"</code>, has been successfully
                 applied.</td>
               </tr>
               <tr>
-                <td><dfn><code>have-remote-offer</code></dfn></td>
+                <td><dfn data-idl><code>have-remote-offer</code></dfn></td>
                 <td>A remote description, of type <code>"offer"</code>, has been
                 successfully applied.</td>
               </tr>
               <tr>
-                <td><dfn><code>have-local-pranswer</code></dfn></td>
+                <td><dfn data-idl><code>have-local-pranswer</code></dfn></td>
                 <td>A remote description of type <code>"offer"</code> has been successfully
                 applied and a local description of type <code>"pranswer"</code> has been
                 successfully applied.</td>
               </tr>
               <tr>
-                <td><dfn><code>have-remote-pranswer</code></dfn></td>
+                <td><dfn data-idl><code>have-remote-pranswer</code></dfn></td>
                 <td>A local description of type <code>"offer"</code> has been successfully
                 applied and a remote description of type <code>"pranswer"</code> has been
                 successfully applied.</td>
               </tr>
               <tr>
-                <td><dfn><code>closed</code></dfn></td>
+                <td><dfn data-idl><code>closed</code></dfn></td>
                 <td>The <code><a>RTCPeerConnection</a></code> has been closed;
                 its <a>[[\IsClosed]]</a> slot is <code>true</code>.</td>
               </tr>
@@ -800,19 +800,19 @@
                 <th colspan="2">Enumeration description</th>
               </tr>
               <tr>
-                <td><dfn><code>new</code></dfn></td>
+                <td><dfn data-idl><code>new</code></dfn></td>
                 <td>Any of the <code><a>RTCIceTransport</a></code>s are in the
                 <code>"new"</code> gathering state and none of the transports are
                 in the <code>"gathering"</code> state, or there are no
                 transports.</td>
               </tr>
               <tr>
-                <td><dfn><code>gathering</code></dfn></td>
+                <td><dfn data-idl><code>gathering</code></dfn></td>
                 <td>Any of the <code><a>RTCIceTransport</a></code>s are in the
                 <code>"gathering"</code> state.</td>
               </tr>
               <tr>
-                <td><dfn><code>complete</code></dfn></td>
+                <td><dfn data-idl><code>complete</code></dfn></td>
                 <td>At least one <code><a>RTCIceTransport</a></code> exists,
                 and all <code><a>RTCIceTransport</a></code>s are in the
                 <code>"completed"</code> gathering state.</td>
@@ -839,7 +839,7 @@
                 <th colspan="2">Enumeration description</th>
               </tr>
               <tr>
-                <td><dfn><code>new</code></dfn></td>
+                <td><dfn data-idl><code>new</code></dfn></td>
                 <td>Any of the <code><a>RTCIceTransport</a></code>s or
                 <code><a>RTCDtlsTransport</a></code>s are in the
                 <code>"new"</code> state and none of the transports are in the
@@ -849,14 +849,14 @@
                 no transports.</td>
               </tr>
               <tr>
-                <td><dfn><code>connecting</code></dfn></td>
+                <td><dfn data-idl><code>connecting</code></dfn></td>
                 <td>Any of the <code><a>RTCIceTransport</a></code>s or
                 <code><a>RTCDtlsTransport</a></code>s are in the
                 <code>"connecting"</code> or <code>"checking"</code> state and none
                 of them is in the <code>"failed"</code> state.</td>
               </tr>
               <tr>
-                <td><dfn><code>connected</code></dfn></td>
+                <td><dfn data-idl><code>connected</code></dfn></td>
                 <td>All <code><a>RTCIceTransport</a></code>s and
                 <code><a>RTCDtlsTransport</a></code>s are in the
                 <code>"connected"</code>, <code>"completed"</code> or
@@ -864,7 +864,7 @@
                 <code>"connected"</code> or <code>"completed"</code> state.</td>
               </tr>
               <tr>
-                <td><dfn><code>disconnected</code></dfn></td>
+                <td><dfn data-idl><code>disconnected</code></dfn></td>
                 <td>Any of the <code><a>RTCIceTransport</a></code>s or
                 <code><a>RTCDtlsTransport</a></code>s are in the
                 <code>"disconnected"</code> state and none of them are in the
@@ -872,13 +872,13 @@
                 <code>"checking"</code> state.</td>
               </tr>
               <tr>
-                <td><dfn><code>failed</code></dfn></td>
+                <td><dfn data-idl><code>failed</code></dfn></td>
                 <td>Any of the <code><a>RTCIceTransport</a></code>s or
                 <code><a>RTCDtlsTransport</a></code>s are in a
                 <code>"failed"</code> state.</td>
               </tr>
               <tr>
-                <td><dfn><code>closed</code></dfn></td>
+                <td><dfn data-idl><code>closed</code></dfn></td>
                 <td>
                   The <code><a>RTCPeerConnection</a></code> object's
                   <a>[[\IsClosed]]</a> slot is <code>true</code>.
@@ -907,7 +907,7 @@
                 <th colspan="2">Enumeration description</th>
               </tr>
               <tr>
-                <td><dfn><code>new</code></dfn></td>
+                <td><dfn data-idl><code>new</code></dfn></td>
                 <td>Any of the <code><a>RTCIceTransport</a></code>s are in the
                 <code>"new"</code> state and none of them are in the
                 <code>"checking"</code>, <code>"disconnected"</code> or
@@ -916,37 +916,37 @@
                 <code>"closed"</code> state, or there are no transports.</td>
               </tr>
               <tr>
-                <td><dfn><code>checking</code></dfn></td>
+                <td><dfn data-idl><code>checking</code></dfn></td>
                 <td>Any of the <code><a>RTCIceTransport</a></code>s are in the
                 <code>"checking"</code> state and none of them are in the
                 <code>"disconnected"</code> or <code>"failed"</code> state.</td>
               </tr>
               <tr>
-                <td><dfn><code>connected</code></dfn></td>
+                <td><dfn data-idl><code>connected</code></dfn></td>
                 <td>All <code><a>RTCIceTransport</a></code>s are in the
                 <code>"connected"</code>, <code>"completed"</code> or
                 <code>"closed"</code> state and at least one of them is in the
                 <code>"connected"</code> state.</td>
               </tr>
               <tr>
-                <td><dfn><code>completed</code></dfn></td>
+                <td><dfn data-idl><code>completed</code></dfn></td>
                 <td>All <code><a>RTCIceTransport</a></code>s are in the
                 <code>"completed"</code> or <code>"closed"</code> state and at
                 least one of them is in the <code>"completed"</code> state.</td>
               </tr>
               <tr>
-                <td><dfn><code>disconnected</code></dfn></td>
+                <td><dfn data-idl><code>disconnected</code></dfn></td>
                 <td>Any of the <code><a>RTCIceTransport</a></code>s are in the
                 <code>"disconnected"</code> state and none of them are in the
                 <code>"failed"</code> state.</td>
               </tr>
               <tr>
-                <td><dfn><code>failed</code></dfn></td>
+                <td><dfn data-idl><code>failed</code></dfn></td>
                 <td>Any of the <code><a>RTCIceTransport</a></code>s are in the
                 <code>"failed"</code> state.</td>
               </tr>
               <tr>
-                <td><dfn><code>closed</code></dfn></td>
+                <td><dfn data-idl><code>closed</code></dfn></td>
                 <td>
                   The <code><a>RTCPeerConnection</a></code> object's
                   <a>[[\IsClosed]]</a> slot is <code>true</code>.
@@ -2048,7 +2048,7 @@ interface RTCPeerConnection : EventTarget  {
             <h2>Constructors</h2>
             <dl data-link-for="RTCPeerConnection" data-dfn-for=
             "RTCPeerConnection" class="constructors">
-              <dt><dfn><code>RTCPeerConnection</code></dfn></dt>
+              <dt><dfn data-idl><code>RTCPeerConnection</code></dfn></dt>
               <dd>
                 See the <a data-lt="RTCPeerConnection()">RTCPeerConnection
                 constructor algorithm</a>.
@@ -2221,7 +2221,7 @@ interface RTCPeerConnection : EventTarget  {
               <dt><code>canTrickleIceCandidates</code> of type <span class=
               "idlAttrType"><a>boolean</a></span>, readonly, nullable</dt>
               <dd>
-                <p>The <dfn><code>canTrickleIceCandidates</code></dfn>
+                <p>The <dfn data-idl><code>canTrickleIceCandidates</code></dfn>
                 attribute indicates whether the remote peer is able to accept
                 trickled ICE candidates [[TRICKLE-ICE]]. The value is
                 determined based on whether a remote description indicates
@@ -2231,31 +2231,31 @@ interface RTCPeerConnection : EventTarget  {
                 "RTCPeerConnection"><code>setRemoteDescription</code></a>, this
                 value is <code>null</code>.</p>
               </dd>
-              <dt><dfn><code>onnegotiationneeded</code></dfn> of type
+              <dt><dfn data-idl><code>onnegotiationneeded</code></dfn> of type
               <span class="idlAttrType"><a>EventHandler</a></span></dt>
               <dd>The event type of this event handler is
               <code><a>negotiationneeded</a></code>.</dd>
-              <dt><dfn><code>onicecandidate</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>onicecandidate</code></dfn> of type <span class=
               "idlAttrType"><a>EventHandler</a></span></dt>
               <dd>The event type of this event handler is
               <code><a>icecandidate</a></code>.</dd>
-              <dt><dfn><code>onicecandidateerror</code></dfn> of type
+              <dt><dfn data-idl><code>onicecandidateerror</code></dfn> of type
               <span class="idlAttrType"><a>EventHandler</a></span></dt>
               <dd>The event type of this event handler is
               <code><a>icecandidateerror</a></code>.</dd>
-              <dt><dfn><code>onsignalingstatechange</code></dfn> of type
+              <dt><dfn data-idl><code>onsignalingstatechange</code></dfn> of type
               <span class="idlAttrType"><a>EventHandler</a></span></dt>
               <dd>The event type of this event handler is
               <code><a>signalingstatechange</a></code>.</dd>
-              <dt><dfn><code>oniceconnectionstatechange</code></dfn> of type
+              <dt><dfn data-idl><code>oniceconnectionstatechange</code></dfn> of type
               <span class="idlAttrType"><a>EventHandler</a></span></dt>
               <dd>The event type of this event handler is
               <code><a>iceconnectionstatechange</a></code></dd>
-              <dt><dfn><code>onicegatheringstatechange</code></dfn> of type
+              <dt><dfn data-idl><code>onicegatheringstatechange</code></dfn> of type
               <span class="idlAttrType"><a>EventHandler</a></span></dt>
               <dd>The event type of this event handler is
               <code><a>icegatheringstatechange</a></code>.</dd>
-              <dt><dfn><code>onconnectionstatechange</code></dfn> of type
+              <dt><dfn data-idl><code>onconnectionstatechange</code></dfn> of type
               <span class="idlAttrType"><a>EventHandler</a></span></dt>
               <dd>The event type of this event handler is
               <code><a>connectionstatechange</a></code>.</dd>
@@ -2265,7 +2265,7 @@ interface RTCPeerConnection : EventTarget  {
             <h2>Methods</h2>
             <dl data-link-for="RTCPeerConnection" data-dfn-for=
             "RTCPeerConnection" class="methods">
-              <dt><dfn><code>createOffer</code></dfn></dt>
+              <dt><dfn data-idl><code>createOffer</code></dfn></dt>
               <dd>
                 <p>The <code>createOffer</code> method generates a blob of SDP that contains
                 an RFC 3264 offer with the supported configurations for the
@@ -2451,7 +2451,7 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                 </ol>
               </dd>
-              <dt><dfn><code>createAnswer</code></dfn></dt>
+              <dt><dfn data-idl><code>createAnswer</code></dfn></dt>
               <dd>
                 <p>The <code>createAnswer</code> method generates an [[!SDP]]
                 answer with the supported configuration for the session that is
@@ -2879,7 +2879,7 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                 </ol>
               </dd>
-              <dt><dfn><code>getDefaultIceServers</code></dfn></dt>
+              <dt><dfn data-idl><code>getDefaultIceServers</code></dfn></dt>
               <dd>
                 <p>Returns a list of ICE servers that are configured into the
                 browser. A browser might be configured to use local or private
@@ -2896,7 +2896,7 @@ interface RTCPeerConnection : EventTarget  {
                 agent with these defaults does not per se increase a user's
                 ability to limit the exposure of their IP addresses.</p>
               </dd>
-              <dt><dfn><code>getConfiguration</code></dfn></dt>
+              <dt><dfn data-idl><code>getConfiguration</code></dfn></dt>
               <dd>
                 <p>Returns an <code><a>RTCConfiguration</a></code> object
                 representing the current configuration of this
@@ -2914,7 +2914,7 @@ interface RTCPeerConnection : EventTarget  {
                 "ice-gather-overview">[[!JSEP]]</span>, when the ICE
                 configuration changes in a way that requires a new gathering
                 phase, an ICE restart is required.</p>
-                <p>When the <dfn><code>setConfiguration</code></dfn> method is
+                <p>When the <dfn data-idl><code>setConfiguration</code></dfn> method is
                 invoked, the user agent MUST run the following steps:</p>
                 <ol>
                   <li>
@@ -2935,7 +2935,7 @@ interface RTCPeerConnection : EventTarget  {
               </dd>
               <dt><code>close</code></dt>
               <dd>
-                <p>When the <dfn><code>close</code></dfn> method is invoked,
+                <p>When the <dfn data-idl><code>close</code></dfn> method is invoked,
                 the user agent MUST run the following steps:</p>
                 <ol>
                   <li>
@@ -3449,14 +3449,14 @@ interface RTCPeerConnection : EventTarget  {
                 <th colspan="2">Enumeration description</th>
               </tr>
               <tr>
-                <td><dfn><code>offer</code></dfn></td>
+                <td><dfn data-idl><code>offer</code></dfn></td>
                 <td>
                   <p>An <code>RTCSdpType</code> of <code>offer</code> indicates
                   that a description MUST be treated as an [[!SDP]] offer.</p>
                 </td>
               </tr>
               <tr>
-                <td><dfn><code>pranswer</code></dfn></td>
+                <td><dfn data-idl><code>pranswer</code></dfn></td>
                 <td>
                   <p>An <code>RTCSdpType</code> of <code>pranswer</code>
                   indicates that a description MUST be treated as an [[!SDP]]
@@ -3466,7 +3466,7 @@ interface RTCPeerConnection : EventTarget  {
                 </td>
               </tr>
               <tr>
-                <td><dfn><code>answer</code></dfn></td>
+                <td><dfn data-idl><code>answer</code></dfn></td>
                 <td>
                   <p>An <code>RTCSdpType</code> of <code>answer</code>
                   indicates that a description MUST be treated as an [[!SDP]]
@@ -3477,7 +3477,7 @@ interface RTCPeerConnection : EventTarget  {
                 </td>
               </tr>
               <tr>
-                <td><dfn><code>rollback</code></dfn></td>
+                <td><dfn data-idl><code>rollback</code></dfn></td>
                 <td>
                   <p>An <code>RTCSdpType</code> of <code>rollback</code>
                   indicates that a description MUST be treated as canceling the
@@ -3525,10 +3525,10 @@ interface RTCSessionDescription {
             <h2>Attributes</h2>
             <dl data-link-for="RTCSessionDescription" data-dfn-for=
             "RTCSessionDescription" class="attributes">
-              <dt><dfn><code>type</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>type</code></dfn> of type <span class=
               "idlAttrType"><a>RTCSdpType</a></span>, readonly</dt>
               <dd>The type of this RTCSessionDescription.</dd>
-              <dt><dfn><code>sdp</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>sdp</code></dfn> of type <span class=
               "idlAttrType"><a>DOMString</a></span>, readonly</dt>
               <dd>The string representation of the SDP [[!SDP]].</dd>
             </dl>
@@ -3537,7 +3537,7 @@ interface RTCSessionDescription {
             <h2>Methods</h2>
             <dl data-link-for="RTCSessionDescription" data-dfn-for=
             "RTCSessionDescription" class="methods">
-              <dt><dfn><code>toJSON()</code></dfn></dt>
+              <dt><dfn data-idl><code>toJSON()</code></dfn></dt>
               <dd>When called, run [[!WEBIDL-1]]'s <a data-cite=
               "WEBIDL#default-tojson-operation">default toJSON
               operation</a>.</dd>
@@ -3554,10 +3554,10 @@ interface RTCSessionDescription {
             Members</h2>
             <dl data-link-for="RTCSessionDescriptionInit" data-dfn-for=
             "RTCSessionDescriptionInit" class="dictionary-members">
-              <dt><dfn><code>type</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>type</code></dfn> of type <span class=
               "idlMemberType"><a>RTCSdpType</a></span>, required</dt>
               <dd>DOMString sdp</dd>
-              <dt><dfn><code>sdp</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>sdp</code></dfn> of type <span class=
               "idlMemberType"><a>DOMString</a></span></dt>
               <dd>The string representation of the SDP [[!SDP]]; if
               <code>type</code> is <code>"rollback"</code>, this member is unused.
@@ -3850,18 +3850,18 @@ interface RTCIceCandidate {
             <p>Most attributes below are defined in section 15.1 of [[!ICE]].</p>
             <dl data-link-for="RTCIceCandidate" data-dfn-for="RTCIceCandidate"
             class="attributes">
-              <dt><dfn><code>candidate</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>candidate</code></dfn> of type <span class=
               "idlAttrType"><a>DOMString</a></span>, readonly</dt>
               <dd>This carries the <a><code>candidate-attribute</code></a> as defined
               in section 15.1 of [[!ICE]]. If this <code>RTCIceCandidate</code>
               represents an end-of-candidates indication,
               <code>candidate</code> is an empty string.</dd>
-              <dt><dfn><code>sdpMid</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>sdpMid</code></dfn> of type <span class=
               "idlAttrType"><a>DOMString</a></span>, readonly, nullable</dt>
               <dd>If not <code>null</code>, this contains the media stream
               "identification-tag" defined in [[!RFC5888]] for the
               media component this candidate is associated with.</dd>
-              <dt><dfn><code>sdpMLineIndex</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>sdpMLineIndex</code></dfn> of type <span class=
               "idlAttrType"><a>unsigned short</a></span>, readonly,
               nullable</dt>
               <dd>
@@ -3869,22 +3869,22 @@ interface RTCIceCandidate {
                 zero) of the <a>media description</a> in the SDP this candidate
                 is associated with.
               </dd>
-              <dt><dfn><code>foundation</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>foundation</code></dfn> of type <span class=
               "idlAttrType"><a>DOMString</a></span>, readonly, nullable</dt>
               <dd>A unique identifier that allows ICE to correlate candidates
               that appear on multiple
               <code><a>RTCIceTransport</a></code>s.</dd>
-              <dt><dfn><code>component</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>component</code></dfn> of type <span class=
               "idlAttrType"><a>RTCIceComponent</a></span>, readonly, nullable</dt>
               <dd>The assigned network component of the candidate
               (<code>rtp</code> or <code>rtcp</code>). This corresponds to the
               <code>component-id</code> field in <a><code>candidate-attribute</code></a>,
               decoded to the string representation as defined in
               <a><code>RTCIceComponent</code></a>.</dd>
-              <dt><dfn><code>priority</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>priority</code></dfn> of type <span class=
               "idlAttrType"><a>unsigned long</a></span>, readonly, nullable</dt>
               <dd>The assigned priority of the candidate.</dd>
-              <dt><dfn><code>ip</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>ip</code></dfn> of type <span class=
               "idlAttrType"><a>DOMString</a></span>, readonly, nullable</dt>
               <dd>
                 <p>The IP address of the candidate. This corresponds to the
@@ -3916,19 +3916,19 @@ interface RTCIceCandidate {
                   [[RTCWEB-IP-HANDLING]].</p>
                 </div>
               </dd>
-              <dt><dfn><code>protocol</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>protocol</code></dfn> of type <span class=
               "idlAttrType"><a>RTCIceProtocol</a></span>, readonly, nullable</dt>
               <dd>The protocol of the candidate
               (<code>udp</code>/<code>tcp</code>). This corresponds to the
               <code>transport</code> field in <a><code>candidate-attribute</code></a>.</dd>
-              <dt><dfn><code>port</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>port</code></dfn> of type <span class=
               "idlAttrType"><a>unsigned short</a></span>, readonly, nullable</dt>
               <dd>The port of the candidate.</dd>
-              <dt><dfn><code>type</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>type</code></dfn> of type <span class=
               "idlAttrType"><a>RTCIceCandidateType</a></span>, readonly, nullable</dt>
               <dd>The type of the candidate. This corresponds to the
               <code>candidate-types</code> field in <a><code>candidate-attribute</code></a>.</dd>
-              <dt><dfn><code>tcpType</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>tcpType</code></dfn> of type <span class=
               "idlAttrType"><a>RTCIceTcpCandidateType</a></span>, readonly,
                nullable</dt>
               <dd>If <code>protocol</code> is <code>tcp</code>,
@@ -3961,7 +3961,7 @@ interface RTCIceCandidate {
             <h2>Methods</h2>
             <dl data-link-for="RTCIceCandidate" data-dfn-for="RTCIceCandidate"
             class="methods">
-              <dt><dfn><code>toJSON()</code></dfn></dt>
+              <dt><dfn data-idl><code>toJSON()</code></dfn></dt>
               <dd>To invoke the <code>toJSON()</code> operation of the <code>RTCIceCandidate</code> interface, run the following steps:
                 <ol>
                   <li>Let <var>json</var> be a new <code>RTCIceCandidateInit</code> dictionary.</li>
@@ -3989,26 +3989,26 @@ interface RTCIceCandidate {
             Members</h2>
             <dl data-link-for="RTCIceCandidateInit" data-dfn-for=
             "RTCIceCandidateInit" class="dictionary-members">
-              <dt><dfn><code>candidate</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>candidate</code></dfn> of type <span class=
               "idlMemberType"><a>DOMString</a></span>, defaulting to
               <code>""</code></dt>
               <dd>This carries the <code>candidate-attribute</code> as defined
               in section 15.1 of [[!ICE]]. If this represents an
               end-of-candidates indication, <code>candidate</code>
               is an empty string.</dd>
-              <dt><dfn><code>sdpMid</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>sdpMid</code></dfn> of type <span class=
               "idlMemberType"><a>DOMString</a></span>, nullable, defaulting to
               <code>null</code></dt>
               <dd>If not <code>null</code>, this contains the media stream
               "identification-tag" defined in [[!RFC5888]] for the
               media component this candidate is associated with.</dd>
-              <dt><dfn><code>sdpMLineIndex</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>sdpMLineIndex</code></dfn> of type <span class=
               "idlMemberType"><a>unsigned short</a></span>, nullable,
               defaulting to <code>null</code></dt>
               <dd>If not <code>null</code>, this indicates the index (starting at
               zero) of the <a>media description</a> in the SDP this candidate
               is associated with.</dd>
-              <dt><dfn><code>usernameFragment</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>usernameFragment</code></dfn> of type <span class=
               "idlMemberType"><a>DOMString</a></span></dt>
               <dd>This carries the <code>ufrag</code> as defined in section
               15.4 of [[!ICE]].</dd>
@@ -4016,7 +4016,7 @@ interface RTCIceCandidate {
           </section>
         </div>
         <section>
-          <h4><dfn><code>candidate-attribute</code></dfn> Grammar</h4>
+          <h4><dfn data-idl><code>candidate-attribute</code></dfn> Grammar</h4>
           <p>The <code>candidate-attribute</code> grammar is used to parse
           the <a href="#idl-def-rtcicecandidateinit-candidate">
           <code>candidate</code></a> member of <var>candidateInitDict</var>
@@ -4044,11 +4044,11 @@ interface RTCIceCandidate {
                   <th colspan="2">Enumeration description</th>
                 </tr>
                 <tr>
-                  <td><dfn><code>udp</code></dfn></td>
+                  <td><dfn data-idl><code>udp</code></dfn></td>
                   <td>A UDP candidate, as described in [[!ICE]].</td>
                 </tr>
                 <tr>
-                  <td><dfn><code>tcp</code></dfn></td>
+                  <td><dfn data-idl><code>tcp</code></dfn></td>
                   <td>A TCP candidate, as described in [[!RFC6544]].</td>
                 </tr>
               </tbody>
@@ -4072,19 +4072,19 @@ interface RTCIceCandidate {
                   <th colspan="2">Enumeration description</th>
                 </tr>
                 <tr>
-                  <td><dfn><code>active</code></dfn></td>
+                  <td><dfn data-idl><code>active</code></dfn></td>
                   <td>An <code>active</code> TCP candidate is one for which the
                   transport will attempt to open an outbound connection but
                   will not receive incoming connection requests.</td>
                 </tr>
                 <tr>
-                  <td><dfn><code>passive</code></dfn></td>
+                  <td><dfn data-idl><code>passive</code></dfn></td>
                   <td>A <code>passive</code> TCP candidate is one for which the
                   transport will receive incoming connection attempts but not
                   attempt a connection.</td>
                 </tr>
                 <tr>
-                  <td><dfn><code>so</code></dfn></td>
+                  <td><dfn data-idl><code>so</code></dfn></td>
                   <td>An <code>so</code> candidate is one for which the
                   transport will attempt to open a connection simultaneously
                   with its peer.</td>
@@ -4113,22 +4113,22 @@ interface RTCIceCandidate {
                   <th colspan="2">Enumeration description</th>
                 </tr>
                 <tr>
-                  <td><dfn><code>host</code></dfn></td>
+                  <td><dfn data-idl><code>host</code></dfn></td>
                   <td>A host candidate, as defined in Section 4.1.1.1 of
                   [[!ICE]].</td>
                 </tr>
                 <tr>
-                  <td><dfn><code>srflx</code></dfn></td>
+                  <td><dfn data-idl><code>srflx</code></dfn></td>
                   <td>A server reflexive candidate, as defined in Section
                   4.1.1.2 of [[!ICE]].</td>
                 </tr>
                 <tr>
-                  <td><dfn><code>prflx</code></dfn></td>
+                  <td><dfn data-idl><code>prflx</code></dfn></td>
                   <td>A peer reflexive candidate, as defined in Section 4.1.1.2
                   of [[!ICE]].</td>
                 </tr>
                 <tr>
-                  <td><dfn><code>relay</code></dfn></td>
+                  <td><dfn data-idl><code>relay</code></dfn></td>
                   <td>A relay candidate, as defined in Section 7.1.3.2.1 of
                   [[!ICE]].</td>
                 </tr>
@@ -4220,7 +4220,7 @@ interface RTCPeerConnectionIceEvent : Event {
             <h2>Attributes</h2>
             <dl data-link-for="RTCPeerConnectionIceEvent" data-dfn-for=
             "RTCPeerConnectionIceEvent" class="attributes">
-              <dt><dfn><code>candidate</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>candidate</code></dfn> of type <span class=
               "idlAttrType"><a>RTCIceCandidate</a></span>, readonly,
               nullable</dt>
               <dd>
@@ -4233,7 +4233,7 @@ interface RTCPeerConnectionIceEvent : Event {
                 only one event containing a <code>null</code> candidate is
                 fired.</p>
               </dd>
-              <dt><dfn><code>url</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>url</code></dfn> of type <span class=
               "idlAttrType"><a>DOMString</a></span>, readonly, nullable</dt>
               <dd>
                 <p>The <code>url</code> attribute is the STUN or TURN URL that
@@ -4256,14 +4256,14 @@ interface RTCPeerConnectionIceEvent : Event {
             Members</h2>
             <dl data-link-for="RTCPeerConnectionIceEventInit" data-dfn-for=
             "RTCPeerConnectionIceEventInit" class="dictionary-members">
-              <dt><dfn><code>candidate</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>candidate</code></dfn> of type <span class=
               "idlMemberType"><a>RTCIceCandidate</a></span>, nullable</dt>
               <dd>
                 <p>See <a data-link-for="RTCPeerConnection">the
                 <code>candidate</code> attribute of the
                 <code>RTCPeerConnectionIceEvent</code> interface</a>.</p>
               </dd>
-              <dt><dfn><code>url</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>url</code></dfn> of type <span class=
               "idlMemberType"><a>DOMString</a></span>, nullable</dt>
               <dd>The <code>url</code> attribute is the STUN or TURN URL that
               identifies the STUN or TURN server used to gather this
@@ -4299,7 +4299,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             <h2>Attributes</h2>
             <dl data-link-for="RTCPeerConnectionIceErrorEvent" data-dfn-for=
             "RTCPeerConnectionIceErrorEvent" class="attributes">
-              <dt><dfn><code>hostCandidate</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>hostCandidate</code></dfn> of type <span class=
               "idlAttrType"><a>DOMString</a></span>, readonly</dt>
               <dd>
                 <p>The <code>hostCandidate</code> attribute is the local IP
@@ -4312,14 +4312,14 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 privacy reasons, this attribute will be set to 0.0.0.0:0 or
                 [::]:0, as appropriate.</p>
               </dd>
-              <dt><dfn><code>url</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>url</code></dfn> of type <span class=
               "idlAttrType"><a>DOMString</a></span>, readonly</dt>
               <dd>
                 <p>The <code>url</code> attribute is the STUN or TURN URL that
                 identifies the STUN or TURN server for which the failure
                 occurred.</p>
               </dd>
-              <dt><dfn><code>errorCode</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>errorCode</code></dfn> of type <span class=
               "idlAttrType"><a>unsigned short</a></span>, readonly</dt>
               <dd>
                 <p>The <code>errorCode</code> attribute is the numeric STUN
@@ -4331,7 +4331,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 once per server URL while in the
                 <code>RTCIceGatheringState</code> of "gathering".</p>
               </dd>
-              <dt><dfn><code>errorText</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>errorText</code></dfn> of type <span class=
               "idlAttrType"><a>USVString</a></span>, readonly</dt>
               <dd>
                 <p>The <code>errorText</code> attribute is the STUN reason text
@@ -4357,25 +4357,25 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             <dl data-link-for="RTCPeerConnectionIceErrorEventInit"
             data-dfn-for="RTCPeerConnectionIceErrorEventInit" class=
             "dictionary-members">
-              <dt><dfn><code>hostCandidate</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>hostCandidate</code></dfn> of type <span class=
               "idlMemberType"><a>DOMString</a></span></dt>
               <dd>
                 <p>The local IP address and port used to communicate
                  with the STUN or TURN server.</p>
               </dd>
-              <dt><dfn><code>url</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>url</code></dfn> of type <span class=
               "idlMemberType"><a>DOMString</a></span></dt>
               <dd>
                 <p>The STUN or TURN URL that identifies the STUN
                 or TURN server for which the failure occurred.</p>
               </dd>
-              <dt><dfn><code>errorCode</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>errorCode</code></dfn> of type <span class=
               "idlMemberType"><a>unsigned short</a></span>, required</dt>
               <dd>
                 <p>The numeric STUN error code returned by the STUN
                 or TURN server.</p>
               </dd>
-              <dt><dfn><code>statusText</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>statusText</code></dfn> of type <span class=
               "idlMemberType"><a>USVString</a></span></dt>
               <dd>
                 <p>The STUN reason text returned by the STUN
@@ -4416,22 +4416,22 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <th colspan="2">Enumeration description</th>
               </tr>
               <tr>
-                <td><dfn><code>very-low</code></dfn></td>
+                <td><dfn data-idl><code>very-low</code></dfn></td>
                 <td>See [[!RTCWEB-TRANSPORT]], Section 4. Corresponds to "below
                 normal" as defined in [[!RTCWEB-DATA]].</td>
               </tr>
               <tr>
-                <td><dfn><code>low</code></dfn></td>
+                <td><dfn data-idl><code>low</code></dfn></td>
                 <td>See [[!RTCWEB-TRANSPORT]], Section 4. Corresponds to
                 "normal" as defined in [[!RTCWEB-DATA]].</td>
               </tr>
               <tr>
-                <td><dfn><code>medium</code></dfn></td>
+                <td><dfn data-idl><code>medium</code></dfn></td>
                 <td>See [[!RTCWEB-TRANSPORT]], Section 4. Corresponds to "high"
                 as defined in [[!RTCWEB-DATA]].</td>
               </tr>
               <tr>
-                <td><dfn><code>high</code></dfn></td>
+                <td><dfn data-idl><code>high</code></dfn></td>
                 <td>See [[!RTCWEB-TRANSPORT]], Section 4. Corresponds to "extra
                 high" as defined in [[!RTCWEB-DATA]].</td>
               </tr>
@@ -4468,7 +4468,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           <h2>Methods</h2>
           <dl data-link-for="RTCPeerConnection" data-dfn-for=
           "RTCPeerConnection" class="methods">
-            <dt><dfn><code>generateCertificate</code></dfn>, static</dt>
+            <dt><dfn data-idl><code>generateCertificate</code></dfn>, static</dt>
             <dd>
               <p>The <code>generateCertificate</code> function causes the
               <a>user agent</a> to create and store an X.509 certificate
@@ -4593,7 +4593,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             <h2>Attributes</h2>
             <dl data-link-for="RTCCertificate" data-dfn-for="RTCCertificate"
             class="attributes">
-              <dt><dfn><code>expires</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>expires</code></dfn> of type <span class=
               "idlAttrType"><a>DOMTimeStamp</a></span>, readonly</dt>
               <dd>
                 <p>The <var>expires</var> attribute indicates the date and time
@@ -4610,7 +4610,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             <h2>Methods</h2>
             <dl data-link-for="RTCCertificate" data-dfn-for="RTCCertificate"
             class="methods">
-              <dt><dfn><code>getSupportedAlgorithms</code></dfn></dt>
+              <dt><dfn data-idl><code>getSupportedAlgorithms</code></dfn></dt>
               <dd>
                 <p>Returns a sequence providing a representative set of supported
                 certificate algorithms. At least one algorithm MUST be returned.</p>
@@ -4627,7 +4627,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   (such as 1024 and 65537, respectively).</p>
                 </div>
               </dd>
-              <dt><dfn><code>getFingerprints</code></dfn></dt>
+              <dt><dfn data-idl><code>getFingerprints</code></dfn></dt>
               <dd>
                 <p>Returns the list of certificate fingerprints, one of which is
                 computed with the digest algorithm used in the certificate
@@ -4772,7 +4772,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           <h2>Attributes</h2>
           <dl data-link-for="RTCPeerConnection" data-dfn-for=
           "RTCPeerConnection" class="attributes">
-            <dt><dfn><code>ontrack</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>ontrack</code></dfn> of type <span class=
             "idlAttrType"><a>EventHandler</a></span></dt>
             <dd>
               <p>The event type of this event handler is
@@ -4864,7 +4864,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <p>Adds a new track to the <code><a>RTCPeerConnection</a></code>,
               and indicates that it is contained in the specified
               <code>MediaStream</code>s.</p>
-              <p>When the <dfn><code>addTrack</code></dfn> method is invoked,
+              <p>When the <dfn data-idl><code>addTrack</code></dfn> method is invoked,
               the user agent MUST run the following steps:</p>
               <ol>
                 <li>
@@ -5039,7 +5039,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               if the <code><a>MediaStreamTrack</a></code> is not already muted,
               a <code title="event-MediaStreamTrack-muted">muted</code> event is
               fired at the track.</p>
-              <p>When the <dfn><code>removeTrack</code></dfn> method is
+              <p>When the <dfn data-idl><code>removeTrack</code></dfn> method is
               invoked, the user agent MUST run the following steps:</p>
               <ol>
                 <li>
@@ -5099,7 +5099,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 </li>
               </ol>
             </dd>
-            <dt><dfn><code>addTransceiver</code></dfn></dt>
+            <dt><dfn data-idl><code>addTransceiver</code></dfn></dt>
             <dd>
               <p>Create a new <code><a>RTCRtpTransceiver</a></code> and add it
               to the <a>set of transceivers</a>.</p>
@@ -5235,18 +5235,18 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           Members</h2>
           <dl data-link-for="RTCRtpTransceiverInit" data-dfn-for=
           "RTCRtpTransceiverInit" class="dictionary-members">
-            <dt><dfn><code>direction</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>direction</code></dfn> of type <span class=
             "idlMemberType"><a>RTCRtpTransceiverDirection</a></span>,
             defaulting to <code>"sendrecv"</code></dt>
             <dd>The direction of the <code>RTCRtpTransceiver</code>.</dd>
-            <dt><dfn><code>streams</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>streams</code></dfn> of type <span class=
             "idlMemberType">sequence&lt;<a>MediaStream</a>&gt;</span></dt>
             <dd>
               <p>When the remote PeerConnection's ontrack event fires
               corresponding to the <code><a>RTCRtpReceiver</a></code> being
               added, these are the streams that will be put in the event.</p>
             </dd>
-            <dt><dfn><code>sendEncodings</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>sendEncodings</code></dfn> of type <span class=
             "idlMemberType">sequence&lt;<a>RTCRtpEncodingParameters</a>&gt;</span></dt>
             <dd>
               <p>A sequence containing parameters for sending RTP encodings of
@@ -5269,7 +5269,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <th colspan="2"><dfn>RTCRtpTransceiverDirection</dfn> Enumeration description</th>
             </tr>
             <tr>
-              <td><dfn><code>sendrecv</code></dfn></td>
+              <td><dfn data-idl><code>sendrecv</code></dfn></td>
               <td>The <code><a>RTCRtpTransceiver</a></code>'s
               <code><a>RTCRtpSender</a></code> <var>sender</var> will offer to
               send RTP, and will send RTP if the remote peer accepts and
@@ -5280,7 +5280,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               will receive RTP if the remote peer accepts.</td>
             </tr>
             <tr>
-              <td><dfn><code>sendonly</code></dfn></td>
+              <td><dfn data-idl><code>sendonly</code></dfn></td>
               <td>The <code><a>RTCRtpTransceiver</a></code>'s
               <code><a>RTCRtpSender</a></code> <var>sender</var> will offer to
               send RTP, and will send RTP if the remote peer accepts and
@@ -5291,7 +5291,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               and will not receive RTP.</td>
             </tr>
             <tr>
-              <td><dfn><code>recvonly</code></dfn></td>
+              <td><dfn data-idl><code>recvonly</code></dfn></td>
               <td>The <code><a>RTCRtpTransceiver</a></code>'s
               <code><a>RTCRtpSender</a></code> will not offer to send RTP, and
               will not send RTP. The <code><a>RTCRtpTransceiver</a></code>'s
@@ -5299,7 +5299,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               will receive RTP if the remote peer accepts.</td>
             </tr>
             <tr>
-              <td><dfn><code>inactive</code></dfn></td>
+              <td><dfn data-idl><code>inactive</code></dfn></td>
               <td>The <code><a>RTCRtpTransceiver</a></code>'s
               <code><a>RTCRtpSender</a></code> will not offer to send RTP, and
               will not send RTP. The <code><a>RTCRtpTransceiver</a></code>'s
@@ -5520,7 +5520,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
         <li>
           <p>Let <var>sender</var> have a <dfn>[[\LastReturnedParameters]]</dfn>
           internal slot, which will be used to match
-          <code><a data-link-for="RTCRtpSender">getParameters</a></code> and
+          <code><a data-link-for="RTCRtpSender">getParameters()</a></code> and
           <code><a data-link-for="RTCRtpSender">setParameters</a></code> transactions.</p>
         </li>
         <li>
@@ -5542,7 +5542,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           <h2>Attributes</h2>
           <dl data-link-for="RTCRtpSender" data-dfn-for="RTCRtpSender" class=
           "attributes">
-            <dt><dfn><code>track</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>track</code></dfn> of type <span class=
             "idlAttrType"><a>MediaStreamTrack</a></span>, readonly,
             nullable</dt>
             <dd>
@@ -5558,7 +5558,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               attribute MUST return the value of the <a>[[\SenderTrack]]</a>
               slot.</p>
             </dd>
-            <dt><dfn><code>transport</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>transport</code></dfn> of type <span class=
             "idlAttrType"><a>RTCDtlsTransport</a></span>, readonly,
             nullable</dt>
             <dd>
@@ -5573,7 +5573,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <p>On getting, the attribute MUST return the value of the
               <a>[[\SenderTransport]]</a> slot.</p>
             </dd>
-            <dt><dfn><code>rtcpTransport</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>rtcpTransport</code></dfn> of type <span class=
             "idlAttrType"><a>RTCDtlsTransport</a></span>, readonly,
             nullable</dt>
             <dd>
@@ -5596,7 +5596,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           "methods">
             <dt><code>getCapabilities</code>, static</dt>
             <dd>
-              <p>The <dfn>getCapabilities()</dfn>
+              <p>The <dfn data-idl>getCapabilities()</dfn>
               method returns the most optimistic view of the capabilities of the
               system for sending media of the given kind. It does not reserve
               any resources, ports, or other state but is meant to provide a
@@ -5612,7 +5612,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               privacy-sensitive contexts, browsers can consider mitigations
               such as reporting only a common subset of the capabilities.</p>
             </dd>
-            <dt><dfn><code>setParameters</code></dfn></dt>
+            <dt><dfn data-idl><code>setParameters</code></dfn></dt>
             <dd>
               <p>The <code>setParameters</code> method updates how
               <code>track</code> is encoded and transmitted to a remote
@@ -5738,7 +5738,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             </dd>
             <dt><code>getParameters</code></dt>
             <dd>
-              <p>The <dfn>getParameters()</dfn> method
+              <p>The <dfn data-idl>getParameters()</dfn> method
               returns the <code><a>RTCRtpSender</a></code> object's current
               parameters for how <code>track</code> is encoded and transmitted
               to a remote <code><a>RTCRtpReceiver</a></code>.</p>
@@ -5817,7 +5817,7 @@ async function updateParameters() {
               end when a track is replaced, the sender MUST retain the original
               track identifier and stream associations and use these in
               subsequent negotiations.</p>
-              <p>When the <dfn><code>replaceTrack</code></dfn> method is
+              <p>When the <dfn data-idl><code>replaceTrack</code></dfn> method is
               invoked, the user agent MUST run the following steps:</p>
               <ol>
                 <li>Let <var>sender</var> be the
@@ -5934,7 +5934,7 @@ async function updateParameters() {
             <dd>
               <p>Gathers stats for this sender only and reports the result
               asynchronously.</p>
-              <p>When the <dfn id=
+              <p>When the <dfn data-idl id=
               "widl-RTCRtpSender-getStats-Promise-RTCStatsReport">
               <code>getStats()</code></dfn> method is invoked, the user
               agent MUST run the following steps:</p>
@@ -5982,31 +5982,31 @@ async function updateParameters() {
           <h2>Dictionary <code><a>RTCRtpParameters</a></code> Members</h2>
           <dl data-link-for="RTCRtpParameters" data-dfn-for="RTCRtpParameters"
           class="dictionary-members">
-            <dt><dfn><code>transactionId</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>transactionId</code></dfn> of type <span class=
             "idlMemberType"><a>DOMString</a></span></dt>
             <dd>
               <p>An unique identifier for the last set of parameters applied.
               Ensures that setParameters can only be called based on a previous
               getParameters, and that there are no intervening changes.
               <a>Read-only parameter</a>.</p></dd>
-            <dt><dfn><code>encodings</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>encodings</code></dfn> of type <span class=
             "idlMemberType">sequence&lt;<a>RTCRtpEncodingParameters</a>&gt;</span></dt>
             <dd>
               <p>A sequence containing parameters for RTP encodings of
               media.</p>
             </dd>
-            <dt><dfn><code>headerExtensions</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>headerExtensions</code></dfn> of type <span class=
             "idlMemberType">sequence&lt;<a>RTCRtpHeaderExtensionParameters</a>&gt;</span></dt>
             <dd>
               <p>A sequence containing parameters for RTP header
               extensions. <a>Read-only parameter</a>.</p>
             </dd>
-            <dt><dfn><code>rtcp</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>rtcp</code></dfn> of type <span class=
             "idlMemberType"><a>RTCRtcpParameters</a></span></dt>
             <dd>
               <p>Parameters used for RTCP. <a>Read-only parameter</a>.</p>
             </dd>
-            <dt><dfn><code>codecs</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>codecs</code></dfn> of type <span class=
             "idlMemberType">sequence&lt;<a>RTCRtpCodecParameters</a>&gt;</span></dt>
             <dd>
               <p>A sequence containing the media codecs that an
@@ -6018,7 +6018,7 @@ async function updateParameters() {
               "video/rtx", and an <code>sdpFmtpLine</code> attribute (providing
               the "apt" and "rtx-time" parameters). <a>Read-only parameter</a>.</p>
             </dd>
-            <dt><dfn><code>degradationPreference</code></dfn> of type
+            <dt><dfn data-idl><code>degradationPreference</code></dfn> of type
             <span class="idlMemberType"><a>RTCDegradationPreference</a></span></dt>
             <dd>
               <p>When bandwidth is constrained and the
@@ -6054,7 +6054,7 @@ async function updateParameters() {
           Members</h2>
           <dl data-link-for="RTCRtpEncodingParameters" data-dfn-for=
           "RTCRtpEncodingParameters" class="dictionary-members">
-            <dt><dfn><code>codecPayloadType</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>codecPayloadType</code></dfn> of type <span class=
             "idlMemberType"><a>octet</a></span></dt>
             <dd>
               <p>For an <code><a>RTCRtpSender</a></code>, used to select a
@@ -6065,7 +6065,7 @@ async function updateParameters() {
               This field is not used for <code><a>RTCRtpReceiver</a></code>s.
               </p>
             </dd>
-            <dt><dfn><code>dtx</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>dtx</code></dfn> of type <span class=
             "idlMemberType"><a>RTCDtxStatus</a></span></dt>
             <dd>
               <p>For an <code><a>RTCRtpSender</a></code>, indicates whether
@@ -6081,7 +6081,7 @@ async function updateParameters() {
               is detected. This attribute is ignored by a receiver or video
               sender.</p>
             </dd>
-            <dt><dfn><code>active</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>active</code></dfn> of type <span class=
             "idlMemberType"><a>boolean</a></span>, defaulting to
             <code>true</code></dt>
             <dd>
@@ -6093,14 +6093,14 @@ async function updateParameters() {
               A value of <code>false</code> indicates this encoding is no longer being
               decoded.</p>
             </dd>
-            <dt><dfn><code>priority</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>priority</code></dfn> of type <span class=
             "idlMemberType"><a>RTCPriorityType</a></span>, defaulting to
             <code>"low"</code></dt>
             <dd>
               <p>Indicates the priority of this encoding. It is specified in
               [[!RTCWEB-TRANSPORT]], Section 4.</p>
             </dd>
-            <dt><dfn><code>ptime</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>ptime</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long</a></span></dt>
             <dd>
               <p>For an <code><a>RTCRtpSender</a></code>, indicates the
@@ -6114,7 +6114,7 @@ async function updateParameters() {
               the user agent MUST still respect the limit imposed by any
               "maxptime" attribute, as defined in [[!RFC4566]], Section 6.</p>
             </dd>
-            <dt><dfn><code>maxBitrate</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>maxBitrate</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long</a></span></dt>
             <dd>
               <p>Indicates the maximum bitrate that can be used to send this
@@ -6126,13 +6126,13 @@ async function updateParameters() {
               maximum bandwidth needed without counting IP or other transport
               layers like TCP or UDP.</p>
             </dd>
-            <dt><dfn><code>maxFramerate</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>maxFramerate</code></dfn> of type <span class=
             "idlMemberType"><a>double</a></span></dt>
             <dd>
               <p>Indicates the maximum framerate that can be used to send this
               encoding, in frames per second.</p>
             </dd>
-            <dt><dfn><code>rid</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>rid</code></dfn> of type <span class=
             "idlMemberType"><a>DOMString</a></span></dt>
             <dd>
               <p>If set, this RTP encoding will be sent with the RID header
@@ -6141,7 +6141,7 @@ async function updateParameters() {
               <code>setParameters</code>. It can only be set or modified in
               <code>addTransceiver</code>.</p>
             </dd>
-            <dt><dfn><code>scaleResolutionDownBy</code></dfn> of type
+            <dt><dfn data-idl><code>scaleResolutionDownBy</code></dfn> of type
             <span class="idlMemberType"><a>double</a></span></dt>
             <dd>
               <p>If the sender's <code>kind</code> is "video", the video's
@@ -6238,13 +6238,13 @@ async function updateParameters() {
               <th colspan="2"><code><a>RTCDtxStatus</a></code> Enumeration description</th>
             </tr>
             <tr>
-              <td><dfn><code>disabled</code></dfn></td>
+              <td><dfn data-idl><code>disabled</code></dfn></td>
               <td>
                 <p>Discontinuous transmission is disabled.</p>
               </td>
             </tr>
             <tr>
-              <td><dfn><code>enabled</code></dfn></td>
+              <td><dfn data-idl><code>enabled</code></dfn></td>
               <td>
                 <p>Discontinuous transmission is enabled if negotiated.</p>
               </td>
@@ -6268,19 +6268,19 @@ async function updateParameters() {
               <th colspan="2"><code><a>RTCDegradationPreference</a></code> Enumeration description</th>
             </tr>
             <tr>
-              <td><dfn><code>maintain-framerate</code></dfn></td>
+              <td><dfn data-idl><code>maintain-framerate</code></dfn></td>
               <td>
                 <p>Degrade resolution in order to maintain framerate.</p>
               </td>
             </tr>
             <tr>
-              <td><dfn><code>maintain-resolution</code></dfn></td>
+              <td><dfn data-idl><code>maintain-resolution</code></dfn></td>
               <td>
                 <p>Degrade framerate in order to maintain resolution.</p>
               </td>
             </tr>
             <tr>
-              <td><dfn><code>balanced</code></dfn></td>
+              <td><dfn data-idl><code>balanced</code></dfn></td>
               <td>
                 <p>Degrade a balance of framerate and resolution.</p>
               </td>
@@ -6300,13 +6300,13 @@ async function updateParameters() {
           <h2>Dictionary <code><a>RTCRtcpParameters</a></code> Members</h2>
           <dl data-link-for="RTCRtcpParameters" data-dfn-for=
           "RTCRtcpParameters" class="dictionary-members">
-            <dt><dfn><code>cname</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>cname</code></dfn> of type <span class=
             "idlMemberType"><a>DOMString</a></span></dt>
             <dd>
               <p>The Canonical Name (CNAME) used by RTCP (e.g. in SDES
               messages). <a>Read-only parameter</a>.</p>
             </dd>
-            <dt><dfn><code>reducedSize</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>reducedSize</code></dfn> of type <span class=
             "idlMemberType"><a>boolean</a></span></dt>
             <dd>
               <p>Whether reduced size RTCP [[RFC5506]] is configured (if true)
@@ -6330,19 +6330,19 @@ async function updateParameters() {
           Members</h2>
           <dl data-link-for="RTCRtpHeaderExtensionParameters" data-dfn-for=
           "RTCRtpHeaderExtensionParameters" class="dictionary-members">
-            <dt><dfn><code>uri</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>uri</code></dfn> of type <span class=
             "idlMemberType"><a>DOMString</a></span></dt>
             <dd>
               <p>The URI of the RTP header extension, as defined in
               [[RFC5285]]. <a>Read-only parameter</a>.</p>
             </dd>
-            <dt><dfn><code>id</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>id</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned short</a></span></dt>
             <dd>
               <p>The value put in the RTP packet to identify the header
               extension. <a>Read-only parameter</a>.</p>
             </dd>
-            <dt><dfn><code>encrypted</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>encrypted</code></dfn> of type <span class=
             "idlMemberType"><a>boolean</a></span></dt>
             <dd>
               <p>Whether the header extension is encryted or not. <a>Read-only
@@ -6366,32 +6366,32 @@ async function updateParameters() {
           <h2>Dictionary <code><a>RTCRtpCodecParameters</a></code> Members</h2>
           <dl data-link-for="RTCRtpCodecParameters" data-dfn-for=
           "RTCRtpCodecParameters" class="dictionary-members">
-            <dt><dfn><code>payloadType</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>payloadType</code></dfn> of type <span class=
             "idlMemberType"><a>octet</a></span></dt>
             <dd>
               <p>The RTP payload type used to identify this codec. <a>Read-only
               parameter</a>.</p>
             </dd>
-            <dt><dfn><code>mimeType</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>mimeType</code></dfn> of type <span class=
             "idlMemberType"><a>DOMString</a></span></dt>
             <dd>
               <p>The codec MIME media type/subtype. Valid media types and
               subtypes are listed in [[IANA-RTP-2]]. <a>Read-only
               parameter</a>.</p>
             </dd>
-            <dt><dfn><code>clockRate</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>clockRate</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long</a></span></dt>
             <dd>
               <p>The codec clock rate expressed in Hertz. <a>Read-only
               parameter</a>.</p>
             </dd>
-            <dt><dfn><code>channels</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>channels</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned short</a></span></dt>
             <dd>
               <p>The number of channels (mono=1, stereo=2). <a>Read-only
               parameter</a>.</p>
             </dd>
-            <dt><dfn><code>sdpFmtpLine</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>sdpFmtpLine</code></dfn> of type <span class=
             "idlMemberType"><a>DOMString</a></span></dt>
             <dd>
               <p>The "format specific parameters" field from the "a=fmtp" line
@@ -6417,7 +6417,7 @@ async function updateParameters() {
           <h2>Dictionary <code><a>RTCRtpCapabilities</a></code> Members</h2>
           <dl data-link-for="RTCRtpCapabilities" data-dfn-for=
           "RTCRtpCapabilities" class="dictionary-members">
-            <dt><dfn><code>codecs</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>codecs</code></dfn> of type <span class=
             "idlMemberType">sequence&lt;<a>RTCRtpCodecCapability</a>&gt;</span></dt>
             <dd>
               <p>Supported media codecs as well as entries for RTX, RED and FEC
@@ -6425,7 +6425,7 @@ async function updateParameters() {
               <code>codecs[]</code> for retransmission via RTX, with
               <code>sdpFmtpLine</code> not present.</p>
             </dd>
-            <dt><dfn><code>headerExtensions</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>headerExtensions</code></dfn> of type <span class=
             "idlMemberType">sequence&lt;<a>RTCRtpHeaderExtensionCapability</a>&gt;</span></dt>
             <dd>
               <p>Supported RTP header extensions.</p>
@@ -6456,23 +6456,23 @@ async function updateParameters() {
           </ol>
           <dl data-link-for="RTCRtpCodecCapability" data-dfn-for=
           "RTCRtpCodecCapability" class="dictionary-members">
-            <dt><dfn><code>mimeType</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>mimeType</code></dfn> of type <span class=
             "idlMemberType"><a>DOMString</a></span></dt>
             <dd>
               <p>The codec MIME media type/subtype. Valid media types and
               subtypes are listed in [[IANA-RTP-2]].</p>
             </dd>
-            <dt><dfn><code>clockRate</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>clockRate</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long</a></span></dt>
             <dd>
               <p>The codec clock rate expressed in Hertz.</p>
             </dd>
-            <dt><dfn><code>channels</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>channels</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned short</a></span></dt>
             <dd>
               <p>The maximum number of channels (mono=1, stereo=2).</p>
             </dd>
-            <dt><dfn><code>sdpFmtpLine</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>sdpFmtpLine</code></dfn> of type <span class=
             "idlMemberType"><a>DOMString</a></span></dt>
             <dd>
               <p>The "format specific parameters" field from the "a=fmtp" line
@@ -6492,7 +6492,7 @@ async function updateParameters() {
           <h2>Dictionary <code><a>RTCRtpHeaderExtensionCapability</a></code> Members</h2>
           <dl data-link-for="RTCRtpHeaderExtensionCapability" data-dfn-for=
           "RTCRtpHeaderExtensionCapability" class="dictionary-members">
-            <dt><dfn><code>uri</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>uri</code></dfn> of type <span class=
             "idlMemberType"><a>DOMString</a></span></dt>
             <dd>
               <p>The URI of the RTP header extension, as defined in
@@ -6579,7 +6579,7 @@ async function updateParameters() {
           <h2>Attributes</h2>
           <dl data-link-for="RTCRtpReceiver" data-dfn-for="RTCRtpReceiver"
           class="attributes">
-            <dt><dfn><code>track</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>track</code></dfn> of type <span class=
             "idlAttrType"><a>MediaStreamTrack</a></span>, readonly</dt>
             <dd>
               <p>The <code id="dom-rtpreceiver-track">track</code>
@@ -6601,7 +6601,7 @@ async function updateParameters() {
             "idlAttrType"><a>RTCDtlsTransport</a></span>, readonly,
             nullable</dt>
             <dd>
-              <p>The <dfn><code>transport</code></dfn> attribute is the
+              <p>The <dfn data-idl><code>transport</code></dfn> attribute is the
               transport over which media for the receiver's <code>track</code>
               is received in the form of RTP packets. Prior to construction of
               the <code><a>RTCDtlsTransport</a></code> object, the
@@ -6616,7 +6616,7 @@ async function updateParameters() {
             "idlAttrType"><a>RTCDtlsTransport</a></span>, readonly,
             nullable</dt>
             <dd>
-              <p>The <dfn><code>rtcpTransport</code></dfn> attribute is the
+              <p>The <dfn data-idl><code>rtcpTransport</code></dfn> attribute is the
               transport over which RTCP is sent and received. Prior to
               construction of the <code><a>RTCDtlsTransport</a></code> object,
               the <code>rtcpTransport</code> attribute will be null. When RTCP
@@ -6634,7 +6634,7 @@ async function updateParameters() {
           class="methods">
             <dt><code>getCapabilities</code>, static</dt>
             <dd>
-              <p>The <dfn>getCapabilities()</dfn>
+              <p>The <dfn data-idl>getCapabilities()</dfn>
               method returns the most optimistic view of the capabilities of
               the system for receiving media of the given kind. It does not
               reserve any resources, ports, or other state but is meant to
@@ -6652,7 +6652,7 @@ async function updateParameters() {
             </dd>
             <dt><code>getParameters</code></dt>
             <dd>
-              <p>The <dfn>getParameters()</dfn> method returns the
+              <p>The <dfn data-idl>getParameters()</dfn> method returns the
               <code>RTCRtpReceiver</code> object's current parameters for how
               <code>track</code> is decoded.</p>
 
@@ -6700,13 +6700,13 @@ async function updateParameters() {
                 </li>
               </ul>
             </dd>
-            <dt><dfn><code>getContributingSources</code></dfn></dt>
+            <dt><dfn data-idl><code>getContributingSources</code></dfn></dt>
             <dd>
               <p>Returns an <code><a>RTCRtpContributingSource</a></code> for
               each unique CSRC identifier received by this RTCRtpReceiver in
               the last 10 seconds.</p>
             </dd>
-            <dt><dfn><code>getSynchronizationSources</code></dfn></dt>
+            <dt><dfn data-idl><code>getSynchronizationSources</code></dfn></dt>
             <dd>
               <p>Returns an <code><a>RTCRtpSynchronizationSource</a></code> for
               each unique SSRC identifier received by this RTCRtpReceiver in
@@ -6716,7 +6716,7 @@ async function updateParameters() {
             <dd>
               <p>Gathers stats for this receiver only and reports the result
               asynchronously.</p>
-              <p>When the <dfn id=
+              <p>When the <dfn data-idl id=
               "widl-RTCRtpReceiver-getStats-Promise-RTCStatsReport">
               <code>getStats()</code></dfn> method is invoked, the user
               agent MUST run the following steps:</p>
@@ -6785,7 +6785,7 @@ async function updateParameters() {
           <h2>Dictionary RTCRtpContributingSource Members</h2>
           <dl data-link-for="RTCRtpContributingSource" data-dfn-for=
           "RTCRtpContributingSource" class="dictionary-members">
-            <dt><dfn><code>timestamp</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>timestamp</code></dfn> of type <span class=
             "idlMemberType"><a>DOMHighResTimeStamp</a></span>, required</dt>
             <dd>
               <p>The timestamp of type DOMHighResTimeStamp [[!HIGHRES-TIME]],
@@ -6793,13 +6793,13 @@ async function updateParameters() {
               containing the source. The timestamp is defined in
               [[!HIGHRES-TIME]] and corresponds to a local clock.</p>
             </dd>
-            <dt><dfn><code>source</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>source</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long</a></span>, required</dt>
             <dd>
               <p>The CSRC or SSRC identifier of the contributing or
               synchronization source.</p>
             </dd>
-            <dt><dfn><code>audioLevel</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>audioLevel</code></dfn> of type <span class=
             "idlMemberType"><a>double</a></span></dt>
             <dd>
               <p>This is a value between 0..1 (linear), where 1.0 represents 0
@@ -6833,7 +6833,7 @@ async function updateParameters() {
           <h2>Dictionary RTCRtpSynchronizationSource Members</h2>
           <dl data-link-for="RTCRtpSynchronizationSource" data-dfn-for=
           "RTCRtpSynchronizationSource" class="dictionary-members">
-            <dt><dfn><code>voiceActivityFlag</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>voiceActivityFlag</code></dfn> of type <span class=
             "idlMemberType"><a>boolean</a></span></dt>
             <dd>
               <p>Whether the last RTP packet played from this source contains
@@ -6929,7 +6929,7 @@ async function updateParameters() {
               After rollbacks, the value may change from a non-null value
               to null.</p>
             </dd>
-            <dt><dfn><code>sender</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>sender</code></dfn> of type <span class=
             "idlAttrType"><a>RTCRtpSender</a></span>, readonly</dt>
             <dd>
               <p>The <code>sender</code> attribute exposes the
@@ -6938,7 +6938,7 @@ async function updateParameters() {
               the attribute MUST return the value of the <a>[[\Sender]]</a>
               slot.</p>
             </dd>
-            <dt><dfn><code>receiver</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>receiver</code></dfn> of type <span class=
             "idlAttrType"><a>RTCRtpReceiver</a></span>, readonly</dt>
             <dd>
               <p>The <code>receiver</code> attribute is the
@@ -6947,7 +6947,7 @@ async function updateParameters() {
               getting the attribute MUST return the value of the
               <a>[[\Receiver]]</a> slot.</p>
             </dd>
-            <dt><dfn><code>stopped</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>stopped</code></dfn> of type <span class=
             "idlAttrType"><a>boolean</a></span>, readonly</dt>
             <dd>
               <p>The <code>stopped</code> attribute indicates that the sender
@@ -6958,7 +6958,7 @@ async function updateParameters() {
               getting, this attribute MUST return the value of the
               <a>[[\Stopped]]</a> slot.</p>
             </dd>
-            <dt><dfn><code>direction</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>direction</code></dfn> of type <span class=
             "idlAttrType"><a>RTCRtpTransceiverDirection</a></span></dt>
             <dd>
               <p>As defined in <span data-jsep=
@@ -7018,7 +7018,7 @@ async function updateParameters() {
                 </li>
               </ol>
             </dd>
-            <dt><dfn><code>currentDirection</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>currentDirection</code></dfn> of type <span class=
             "idlAttrType"><a>RTCRtpTransceiverDirection</a></span>,
             readonly, nullable</dt>
             <dd>
@@ -7042,7 +7042,7 @@ async function updateParameters() {
           "RTCRtpTransceiver" class="methods">
             <dt><code>stop</code></dt>
             <dd>
-              <p>The <dfn><code>stop</code></dfn> method irreversibly
+              <p>The <dfn data-idl><code>stop</code></dfn> method irreversibly
               stops the <a><code>RTCRtpTransceiver</code></a>. The
               sender of this transceiver will no longer send, the
               receiver will no longer receive. Calling
@@ -7121,7 +7121,7 @@ async function updateParameters() {
               "!GETUSERMEDIA#track-ended">track ended</a></code>
               MUST be followed.</p>
             </dd>
-            <dt><dfn><code>setCodecPreferences</code></dfn></dt>
+            <dt><dfn data-idl><code>setCodecPreferences</code></dfn></dt>
             <dd>
               <p>The <code>setCodecPreferences</code> method overrides the
               default codec preferences used by the <a>user agent</a>. When
@@ -7290,7 +7290,7 @@ async function onOffHold() {
           <h2>Attributes</h2>
           <dl data-link-for="RTCDtlsTransport" data-dfn-for="RTCDtlsTransport"
           class="attributes">
-            <dt><dfn><code>transport</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>transport</code></dfn> of type <span class=
             "idlAttrType"><a>RTCIceTransport</a></span>, readonly</dt>
             <dd>
               <p>The <code>transport</code> attribute is the underlying
@@ -7298,19 +7298,19 @@ async function onOffHold() {
               underlying transport may not be shared between multiple active
               <code><a>RTCDtlsTransport</a></code> objects.</p>
             </dd>
-            <dt><dfn><code>state</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>state</code></dfn> of type <span class=
             "idlAttrType"><a>RTCDtlsTransportState</a></span>, readonly</dt>
             <dd>
               <p>The <code>state</code> attribute MUST, on getting, return the
               value of the <a>[[\DtlsTransportState]]</a> slot.</p>
             </dd>
-            <dt><dfn><code>onstatechange</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>onstatechange</code></dfn> of type <span class=
             "idlAttrType"><a>EventHandler</a></span></dt>
             <dd>
               The event type of this event handler is <code>
               <a>statechange</a></code>.
             </dd>
-            <dt><dfn><code>onerror</code></dfn> of type
+            <dt><dfn data-idl><code>onerror</code></dfn> of type
               <span class="idlAttrType"><a>EventHandler</a></span></dt>
               <dd>The event type of this event handler is
               <code><a>error</a></code>.</dd>
@@ -7320,7 +7320,7 @@ async function onOffHold() {
           <h2>Methods</h2>
           <dl data-link-for="RTCDtlsTransport" data-dfn-for="RTCDtlsTransport"
           class="methods">
-            <dt><dfn><code>getRemoteCertificates</code></dfn></dt>
+            <dt><dfn data-idl><code>getRemoteCertificates</code></dfn></dt>
             <dd>
               <p>Returns the certificate chain in use by the remote side, with
               each certificate encoded in binary Distinguished Encoding Rules
@@ -7349,26 +7349,26 @@ async function onOffHold() {
               <th colspan="2">Enumeration description</th>
             </tr>
             <tr>
-              <td><dfn><code>new</code></dfn></td>
+              <td><dfn data-idl><code>new</code></dfn></td>
               <td>DTLS has not started negotiating yet.</td>
             </tr>
             <tr>
-              <td><dfn><code>connecting</code></dfn></td>
+              <td><dfn data-idl><code>connecting</code></dfn></td>
               <td>DTLS is in the process of negotiating a secure connection
               and verifying the remote fingerprint.</td>
             </tr>
             <tr>
-              <td><dfn><code>connected</code></dfn></td>
+              <td><dfn data-idl><code>connected</code></dfn></td>
               <td>DTLS has completed negotiation of a secure connection and
               verified the remote fingerprint.</td>
             </tr>
             <tr>
-              <td><dfn><code>closed</code></dfn></td>
+              <td><dfn data-idl><code>closed</code></dfn></td>
               <td>The transport has been closed intentionally as the result of
               receipt of a close_notify alert, or calling <code>close()</code>.</td>
             </tr>
             <tr>
-              <td><dfn><code>failed</code></dfn></td>
+              <td><dfn data-idl><code>failed</code></dfn></td>
               <td>The transport has failed as the result of an error (such as
               receipt of an error alert or failure to validate the remote fingerprint).</td>
             </tr>
@@ -7390,13 +7390,13 @@ async function onOffHold() {
             Members</h2>
             <dl data-link-for="RTCDtlsFingerprint" data-dfn-for=
             "RTCDtlsFingerprint" class="dictionary-members">
-              <dt><dfn><code>algorithm</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>algorithm</code></dfn> of type <span class=
               "idlMemberType"><a>DOMString</a></span></dt>
               <dd>
                 <p>One of the the hash function algorithms defined in the 'Hash
                 function Textual Names' registry [[IANA-HASH-FUNCTION]].</p>
               </dd>
-              <dt><dfn><code>value</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>value</code></dfn> of type <span class=
               "idlMemberType"><a>DOMString</a></span></dt>
               <dd>
                 <p>The value of the certificate fingerprint in lowercase hex
@@ -7687,14 +7687,14 @@ async function onOffHold() {
               attribute MUST, on getting, return the value of the
               <a>[[\IceTransportState]]</a> slot.</p>
             </dd>
-            <dt><dfn><code>gatheringState</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>gatheringState</code></dfn> of type <span class=
             "idlAttrType"><a>RTCIceGathererState</a></span>, readonly</dt>
             <dd>
               <p>The <dfn id="dom-icetransport-gatheringstate"><code>gathering
               state</code></dfn> attribute MUST, on getting, return the value
               of the <a>[[\IceGathererState]]</a> slot.</p>
             </dd>
-            <dt><dfn><code>onstatechange</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>onstatechange</code></dfn> of type <span class=
             "idlAttrType"><a>EventHandler</a></span></dt>
             <dd>
               This event handler, of event handler event type
@@ -7702,7 +7702,7 @@ async function onOffHold() {
               <a data-link-for="RTCIceTransport"><code>RTCIceTransport</code>
               state</a> changes.
             </dd>
-            <dt><dfn><code>ongatheringstatechange</code></dfn> of type
+            <dt><dfn data-idl><code>ongatheringstatechange</code></dfn> of type
             <span class="idlAttrType"><a>EventHandler</a></span></dt>
             <dd>
               This event handler, of event handler event type
@@ -7711,7 +7711,7 @@ async function onOffHold() {
               "RTCIceTransport"><code>RTCIceTransport</code>gathering state</a>
               changes.
             </dd>
-            <dt><dfn><code>onselectedcandidatepairchange</code></dfn> of type
+            <dt><dfn data-idl><code>onselectedcandidatepairchange</code></dfn> of type
             <span class="idlAttrType"><a>EventHandler</a></span></dt>
             <dd>This event handler, of event handler event type
             <code><a>selectedcandidatepairchange</a></code>, MUST be fired any
@@ -7723,27 +7723,27 @@ async function onOffHold() {
           <h2>Methods</h2>
           <dl data-link-for="RTCIceTransport" data-dfn-for="RTCIceTransport"
           class="methods">
-            <dt><dfn><code>getLocalCandidates</code></dfn></dt>
+            <dt><dfn data-idl><code>getLocalCandidates</code></dfn></dt>
             <dd>
               <p>Returns a sequence describing the local ICE candidates
               gathered for this <code><a>RTCIceTransport</a></code> and sent in
               <code><a data-link-for=
               "RTCPeerConnection">onicecandidate</a></code></p>
             </dd>
-            <dt><dfn><code>getRemoteCandidates</code></dfn></dt>
+            <dt><dfn data-idl><code>getRemoteCandidates</code></dfn></dt>
             <dd>
               <p>Returns a sequence describing the remote ICE candidates
               received by this <code><a>RTCIceTransport</a></code> via
               <code><a data-link-for=
               "RTCPeerConnection">addIceCandidate()</a></code></p>
             </dd>
-            <dt><dfn><code>getSelectedCandidatePair</code></dfn></dt>
+            <dt><dfn data-idl><code>getSelectedCandidatePair</code></dfn></dt>
             <dd>
               <p>Returns the selected candidate pair on which packets are sent.
               This method MUST return the value of the
               <a>[[\SelectedCandidatePair]]</a> slot.</p>
             </dd>
-            <dt><dfn><code>getLocalParameters</code></dfn></dt>
+            <dt><dfn data-idl><code>getLocalParameters</code></dfn></dt>
             <dd>
               <p>Returns the local ICE parameters received by this
               <code><a>RTCIceTransport</a></code> via <code><a data-link-for=
@@ -7751,7 +7751,7 @@ async function onOffHold() {
               <code>null</code> if the parameters have not yet been
               received.</p>
             </dd>
-            <dt><dfn><code>getRemoteParameters</code></dfn></dt>
+            <dt><dfn data-idl><code>getRemoteParameters</code></dfn></dt>
             <dd>
               <p>Returns the remote ICE parameters received by this
               <code><a>RTCIceTransport</a></code> via <code><a data-link-for=
@@ -7773,13 +7773,13 @@ async function onOffHold() {
           <h2>Dictionary <code><a>RTCIceParameters</a></code> Members</h2>
           <dl data-link-for="RTCIceParameters" data-dfn-for="RTCIceParameters"
           class="dictionary-members">
-            <dt><dfn><code>usernameFragment</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>usernameFragment</code></dfn> of type <span class=
             "idlMemberType"><a>DOMString</a></span></dt>
             <dd>
               <p>The ICE username fragment as defined in [[!ICE]], Section
               7.1.2.3.</p>
             </dd>
-            <dt><dfn><code>password</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>password</code></dfn> of type <span class=
             "idlMemberType"><a>DOMString</a></span></dt>
             <dd>
               <p>The ICE password as defined in [[!ICE]], Section 7.1.2.3.</p>
@@ -7800,12 +7800,12 @@ async function onOffHold() {
           Members</h2>
           <dl data-link-for="RTCIceCandidatePair" data-dfn-for=
           "RTCIceCandidatePair" class="dictionary-members">
-            <dt><dfn><code>local</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>local</code></dfn> of type <span class=
             "idlMemberType"><a>RTCIceCandidate</a></span></dt>
             <dd>
               <p>The local ICE candidate.</p>
             </dd>
-            <dt><dfn><code>remote</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>remote</code></dfn> of type <span class=
             "idlMemberType"><a>RTCIceCandidate</a></span></dt>
             <dd>
               <p>The remote ICE candidate.</p>
@@ -7829,17 +7829,17 @@ async function onOffHold() {
               <th colspan="2"><code><a>RTCIceGathererState</a></code> Enumeration description</th>
             </tr>
             <tr>
-              <td><dfn><code>new</code></dfn></td>
+              <td><dfn data-idl><code>new</code></dfn></td>
               <td>The <code><a>RTCIceTransport</a></code> was just created, and
               has not started gathering candidates yet.</td>
             </tr>
             <tr>
-              <td><dfn><code>gathering</code></dfn></td>
+              <td><dfn data-idl><code>gathering</code></dfn></td>
               <td>The <code><a>RTCIceTransport</a></code> is in the process of
               gathering candidates.</td>
             </tr>
             <tr>
-              <td><dfn><code>complete</code></dfn></td>
+              <td><dfn data-idl><code>complete</code></dfn></td>
               <td>The <code><a>RTCIceTransport</a></code> has completed
               gathering and the end-of-candidates indication for this transport
               has been sent. It will not gather candidates again until an ICE
@@ -7868,13 +7868,13 @@ async function onOffHold() {
               <th colspan="2"><code><a>RTCIceTransportState</a></code> Enumeration description</th>
             </tr>
             <tr>
-              <td><dfn><code>new</code></dfn></td>
+              <td><dfn data-idl><code>new</code></dfn></td>
               <td>The <code><a>RTCIceTransport</a></code> is gathering
               candidates and/or waiting for remote candidates to be supplied,
               and has not yet started checking.</td>
             </tr>
             <tr>
-              <td><dfn><code>checking</code></dfn></td>
+              <td><dfn data-idl><code>checking</code></dfn></td>
               <td>The <code><a>RTCIceTransport</a></code> has received at least
               one remote candidate and is checking candidate pairs and has
               either not yet found a connection or consent checks [[!RFC7675]]
@@ -7882,7 +7882,7 @@ async function onOffHold() {
               addition to checking, it may also still be gathering.</td>
             </tr>
             <tr>
-              <td><dfn><code>connected</code></dfn></td>
+              <td><dfn data-idl><code>connected</code></dfn></td>
               <td>The <code><a>RTCIceTransport</a></code> has found a usable
               connection, but is still checking other candidate pairs to see if
               there is a better connection. It may also still be gathering
@@ -7895,7 +7895,7 @@ async function onOffHold() {
               additional remote candidates).</td>
             </tr>
             <tr>
-              <td><dfn><code>completed</code></dfn></td>
+              <td><dfn data-idl><code>completed</code></dfn></td>
               <td>The <code><a>RTCIceTransport</a></code> has finished
               gathering, received an indication that there are no more remote
               candidates, finished checking all candidate pairs and found a
@@ -7904,7 +7904,7 @@ async function onOffHold() {
               "failed".</td>
             </tr>
             <tr>
-              <td><dfn><code>disconnected</code></dfn></td>
+              <td><dfn data-idl><code>disconnected</code></dfn></td>
               <td>
                 The <a>ICE Agent</a> has determined that connectivity is
                 currently lost for this <code><a>RTCIceTransport</a></code>.
@@ -7925,7 +7925,7 @@ async function onOffHold() {
               </td>
             </tr>
             <tr>
-              <td><dfn><code>failed</code></dfn></td>
+              <td><dfn data-idl><code>failed</code></dfn></td>
               <td>The <code><a>RTCIceTransport</a></code> has finished
               gathering, received an indication that there are no more remote
               candidates, finished checking all candidate pairs, and all pairs
@@ -7933,7 +7933,7 @@ async function onOffHold() {
               This is a terminal state.</td>
             </tr>
             <tr>
-              <td><dfn><code>closed</code></dfn></td>
+              <td><dfn data-idl><code>closed</code></dfn></td>
               <td>The <code><a>RTCIceTransport</a></code> has shut down and is
               no longer responding to STUN requests.</td>
             </tr>
@@ -7991,11 +7991,11 @@ async function onOffHold() {
               <th colspan="2"><code><a>RTCIceRole</a></code> Enumeration description</th>
             </tr>
             <tr>
-              <td><dfn><code>controlling</code></dfn></td>
+              <td><dfn data-idl><code>controlling</code></dfn></td>
               <td>A controlling agent as defined by [[!ICE]], Section 3.</td>
             </tr>
             <tr>
-              <td><dfn><code>controlled</code></dfn></td>
+              <td><dfn data-idl><code>controlled</code></dfn></td>
               <td>A controlled agent as defined by [[!ICE]], Section 3.</td>
             </tr>
           </tbody>
@@ -8016,7 +8016,7 @@ async function onOffHold() {
               <th colspan="2"><code><a>RTCIceComponent</a></code> Enumeration description</th>
             </tr>
             <tr>
-              <td><dfn><code>rtp</code></dfn></td>
+              <td><dfn data-idl><code>rtp</code></dfn></td>
               <td>The ICE Transport is used for RTP (or RTCP multiplexing),
               as defined in [[!ICE]], Section 4.1.1.1. Protocols multiplexed
               with RTP (e.g. data channel) share its component ID. This represents
@@ -8024,7 +8024,7 @@ async function onOffHold() {
               in <a><code>candidate-attribute</code></a>.</td>
             </tr>
             <tr>
-              <td><dfn><code>rtcp</code></dfn></td>
+              <td><dfn data-idl><code>rtcp</code></dfn></td>
               <td>The ICE Transport is used for RTCP as defined by [[!ICE]],
               Section 4.1.1.1. This represents the <code>component-id</code>
               value <code>2</code> when encoded in
@@ -8083,7 +8083,7 @@ interface RTCTrackEvent : Event {
               represents the <code><a>RTCRtpReceiver</a></code> object
               associated with the event.</p>
             </dd>
-            <dt><dfn><code>track</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>track</code></dfn> of type <span class=
             "idlAttrType"><a>MediaStreamTrack</a></span>, readonly</dt>
             <dd>
               <p>The <code>track</code> attribute represents the
@@ -8095,7 +8095,7 @@ interface RTCTrackEvent : Event {
             "idlAttrType">FrozenArray&lt;<a>MediaStream</a>&gt;</span>,
             readonly</dt>
             <dd>
-              <p>The <dfn><code>streams</code></dfn> attribute returns an array
+              <p>The <dfn data-idl><code>streams</code></dfn> attribute returns an array
               of <code><a>MediaStream</a></code> objects representing the
               <code><a>MediaStream</a></code>s that this event's
               <code>track</code> is a part of.</p>
@@ -8122,14 +8122,14 @@ interface RTCTrackEvent : Event {
           <h2>Dictionary <dfn>RTCTrackEventInit</dfn> Members</h2>
           <dl data-link-for="RTCTrackEventInit" data-dfn-for=
           "RTCTrackEventInit" class="dictionary-members">
-            <dt><dfn><code>receiver</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>receiver</code></dfn> of type <span class=
             "idlMemberType"><a>RTCRtpReceiver</a></span>, required</dt>
             <dd>
               <p>The <code>receiver</code> attribute represents the
               <code><a>RTCRtpReceiver</a></code> object associated with the
               event.</p>
             </dd>
-            <dt><dfn><code>track</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>track</code></dfn> of type <span class=
             "idlMemberType"><a>MediaStreamTrack</a></span>, required</dt>
             <dd>
               <p>The <code>track</code> attribute represents the
@@ -8137,7 +8137,7 @@ interface RTCTrackEvent : Event {
               with the <code><a>RTCRtpReceiver</a></code> identified by
               <code>receiver</code>.</p>
             </dd>
-            <dt><dfn><code>streams</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>streams</code></dfn> of type <span class=
             "idlMemberType">sequence&lt;<a>MediaStream</a>&gt;</span>,
             defaulting to <code>[]</code></dt>
             <dd>
@@ -8146,7 +8146,7 @@ interface RTCTrackEvent : Event {
               <code><a>MediaStream</a></code>s that this event's
               <code>track</code> is a part of.</p>
             </dd>
-            <dt><dfn><code>transceiver</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>transceiver</code></dfn> of type <span class=
             "idlMemberType"><a>RTCRtpTransceiver</a></span>, required</dt>
             <dd>
               <p>The <code>transceiver</code> attribute represents the
@@ -8177,7 +8177,7 @@ interface RTCTrackEvent : Event {
           <h2>Attributes</h2>
           <dl data-link-for="RTCPeerConnection" data-dfn-for=
           "RTCPeerConnection" class="attributes">
-            <dt><dfn><code>sctp</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>sctp</code></dfn> of type <span class=
             "idlAttrType"><a>RTCSctpTransport</a></span>, readonly,
             nullable</dt>
             <dd>
@@ -8187,7 +8187,7 @@ interface RTCTrackEvent : Event {
               object stored in the <a>[[\SctpTransport]]</a>
               internal slot.</p>
             </dd>
-            <dt><dfn><code>ondatachannel</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>ondatachannel</code></dfn> of type <span class=
             "idlAttrType"><a>EventHandler</a></span></dt>
             <dd>The event type of this event handler is
             <code><a>datachannel</a></code>.</dd>
@@ -8419,20 +8419,20 @@ interface RTCTrackEvent : Event {
             <h2>Attributes</h2>
             <dl data-link-for="RTCSctpTransport" data-dfn-for=
             "RTCSctpTransport" class="attributes">
-              <dt><dfn><code>transport</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>transport</code></dfn> of type <span class=
               "idlAttrType"><a>RTCDtlsTransport</a></span>, readonly</dt>
               <dd>
                 <p>The transport over which all SCTP packets for data channels
                 will be sent and received.</p>
               </dd>
-              <dt><dfn><code>state</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>state</code></dfn> of type <span class=
               "idlAttrType"><a>RTCSctpTransportState</a></span>, readonly</dt>
               <dd>
                 <p>The current state of the SCTP transport. On getting, this
                 attribute MUST return the value of the
                 <a>[[\SctpTransportState]]</a> slot.</p>
               </dd>
-              <dt><dfn><code>maxMessageSize</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>maxMessageSize</code></dfn> of type <span class=
               "idlAttrType"><a>unrestricted double</a></span>, readonly</dt>
               <dd>
                 <p>The maximum size of data that can be passed to
@@ -8441,7 +8441,7 @@ interface RTCTrackEvent : Event {
                 on getting, return the value of the <a>[[\MaxMessageSize]]</a>
                 slot.</p>
               </dd>
-              <dt><dfn><code>onstatechange</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>onstatechange</code></dfn> of type <span class=
               "idlAttrType"><a>EventHandler</a></span></dt>
               <dd>
                 <p>The event type of this event handler is
@@ -8469,7 +8469,7 @@ interface RTCTrackEvent : Event {
                 <th colspan="2">Enumeration description</th>
               </tr>
               <tr>
-                <td><dfn><code id=
+                <td><dfn data-idl><code id=
                 "idl-def-RTCSctpTransportState.new">new</code></dfn></td>
                 <td>
                   <p>The <code><a>RTCSctpTransport</a></code>
@@ -8477,7 +8477,7 @@ interface RTCTrackEvent : Event {
                 </td>
               </tr>
               <tr>
-                <td><dfn><code id=
+                <td><dfn data-idl><code id=
                 "idl-def-RTCSctpTransportState.connecting">connecting</code></dfn></td>
                 <td>
                   <p>The <code><a>RTCSctpTransport</a></code> is in the process of
@@ -8487,7 +8487,7 @@ interface RTCTrackEvent : Event {
                 </td>
               </tr>
               <tr>
-                <td><dfn><code id=
+                <td><dfn data-idl><code id=
                 "idl-def-RTCSctpTransportState.connected">connected</code></dfn></td>
                 <td>
                   <p>The <code><a>RTCSctpTransport</a></code> has completed
@@ -8495,7 +8495,7 @@ interface RTCTrackEvent : Event {
                 </td>
               </tr>
               <tr>
-                <td><dfn><code id=
+                <td><dfn data-idl><code id=
                 "idl-def-RTCSctpTransportState.closed">closed</code></dfn></td>
                 <td>
                   <p>The SCTP association has been closed intentionally
@@ -8668,7 +8668,7 @@ interface RTCTrackEvent : Event {
       task that sets the object's <a>[[\ReadyState]]</a> slot to <code>closing</code>.
       This will eventually render the <a>data transport</a> <a>closed</a>.</p>
       <p>When an <code><a>RTCDataChannel</a></code> object's <a>underlying data
-      transport</a> has been <dfn id="data-transport-closed">closed</dfn>, the
+      transport</a> has been <dfn id="data-transport-closed" data-dfn-for="">closed</dfn>, the
       user agent MUST queue a task to run the following steps:</p>
       <ol>
         <li>
@@ -8810,7 +8810,7 @@ interface RTCTrackEvent : Event {
               was negotiated by the application, or false otherwise. On getting,
               the attribute MUST return the value of the <a>[[\Negotiated]]</a> slot.</p>
             </dd>
-            <dt><dfn><code>id</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>id</code></dfn> of type <span class=
             "idlAttrType"><a>unsigned short</a></span>, readonly, nullable</dt>
             <dd>
               <p>The <code>id</code> attribute returns the ID for this
@@ -8824,7 +8824,7 @@ interface RTCTrackEvent : Event {
               value, it will not change. On getting, the attribute MUST return
               the value of the <a>[[\DataChannelId]]</a> slot.</p>
             </dd>
-            <dt><dfn><code>priority</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>priority</code></dfn> of type <span class=
             "idlAttrType"><a>RTCPriorityType</a></span>, readonly</dt>
             <dd>
               <p>The <code>priority</code> attribute returns the priority for
@@ -8865,7 +8865,7 @@ interface RTCTrackEvent : Event {
             <dt><code>bufferedAmountLowThreshold</code> of type <span class=
             "idlAttrType"><a>unsigned long</a></span></dt>
             <dd>
-              <p>The <dfn><code>bufferedAmountLowThreshold</code></dfn>
+              <p>The <dfn data-idl><code>bufferedAmountLowThreshold</code></dfn>
               attribute sets the threshold at which the <code><a data-link-for=
               "RTCDataChannel">bufferedAmount</a></code> is considered to be
               low. When the <code><a data-link-for=
@@ -8877,29 +8877,29 @@ interface RTCTrackEvent : Event {
               initially zero on each new <code><a>RTCDataChannel</a></code>,
               but the application may change its value at any time.</p>
             </dd>
-            <dt><dfn><code>onopen</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>onopen</code></dfn> of type <span class=
             "idlAttrType"><a>EventHandler</a></span></dt>
             <dd>The event type of this event handler is
             <code><a>open</a></code>.</dd>
-            <dt><dfn><code>onbufferedamountlow</code></dfn> of type
+            <dt><dfn data-idl><code>onbufferedamountlow</code></dfn> of type
             <span class="idlAttrType"><a>EventHandler</a></span></dt>
             <dd>The event type of this event handler is
             <code><a>bufferedamountlow</a></code>.</dd>
-            <dt><dfn><code>onerror</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>onerror</code></dfn> of type <span class=
             "idlAttrType"><a>EventHandler</a></span></dt>
             <dd>
               <p>The event type of this event handler is <code><a
-              data-link-for="RTCDataChannel">RTCErrorEvent</a></code>.
+              >RTCErrorEvent</a></code>.
               <code>errorDetail</code> contains "sctp-failure",
               <code>sctpCauseCode</code> contains the SCTP
               Cause Code value, and <code>message</code>
               contains the SCTP Cause-Specific-Information,
               possibly with additional text.</p></dd>
-            <dt><dfn><code>onclose</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>onclose</code></dfn> of type <span class=
             "idlAttrType"><a>EventHandler</a></span></dt>
             <dd><p>The event type of this event handler is
             <code><a>close</a></code>.</p></dd>
-            <dt><dfn><code>onmessage</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>onmessage</code></dfn> of type <span class=
             "idlAttrType"><a>EventHandler</a></span></dt>
             <dd><p>The event type of this event handler is
             <code><a>message</a></code>.</p></dd>
@@ -8955,7 +8955,7 @@ interface RTCTrackEvent : Event {
                 </li>
               </ol>
             </dd>
-            <dt><dfn><code>send</code></dfn></dt>
+            <dt><dfn data-idl><code>send</code></dfn></dt>
             <dd>
               <p>Run the steps described by the <code><a data-link-for=
               "RTCDataChannel">send()</a></code> algorithm with argument type
@@ -9000,7 +9000,7 @@ interface RTCTrackEvent : Event {
           <h2>Dictionary <dfn>RTCDataChannelInit</dfn> Members</h2>
           <dl data-link-for="RTCDataChannelInit" data-dfn-for=
           "RTCDataChannelInit" class="dictionary-members">
-            <dt><dfn><code>ordered</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>ordered</code></dfn> of type <span class=
             "idlMemberType"><a>boolean</a></span>, defaulting to
             <code>true</code></dt>
             <dd>
@@ -9008,27 +9008,27 @@ interface RTCTrackEvent : Event {
               The default value of true, guarantees that data will be delivered
               in order.</p>
             </dd>
-            <dt><dfn><code>maxPacketLifeTime</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>maxPacketLifeTime</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned short</a></span></dt>
             <dd>
               <p>Limits the time (in milliseconds) during which the channel will
               transmit or retransmit data if not acknowledged. This value may be
               clamped if it exceeds the maximum value supported by the user agent.</p>
             </dd>
-            <dt><dfn><code>maxRetransmits</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>maxRetransmits</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned short</a></span></dt>
             <dd>
               <p>Limits the number of times a channel will retransmit data if
               not successfully delivered. This value may be clamped if it
               exceeds the maximum value supported by the user agent.</p>
             </dd>
-            <dt><dfn><code>protocol</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>protocol</code></dfn> of type <span class=
             "idlMemberType"><a>USVString</a></span>, defaulting to
             <code>""</code></dt>
             <dd>
               <p>Subprotocol name used for this channel.</p>
             </dd>
-            <dt><dfn><code>negotiated</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>negotiated</code></dfn> of type <span class=
             "idlMemberType"><a>boolean</a></span>, defaulting to
             <code>false</code></dt>
             <dd>
@@ -9040,12 +9040,12 @@ interface RTCTrackEvent : Event {
               <code><a data-link-for="RTCDataChannel">id</a></code> at the other
               peer.</p>
             </dd>
-            <dt><dfn><code>id</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>id</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned short</a></span></dt>
             <dd>
               <p>Overrides the default selection of ID for this channel.</p>
             </dd>
-            <dt><dfn><code>priority</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>priority</code></dfn> of type <span class=
             "idlMemberType"><a>RTCPriorityType</a></span>, defaulting to
             <code>low</code></dt>
             <dd>
@@ -9054,7 +9054,7 @@ interface RTCTrackEvent : Event {
           </dl>
         </section>
       </div>
-      <p>The <dfn><code>send()</code></dfn> method is overloaded to handle
+      <p>The <dfn data-idl><code>send()</code></dfn> method is overloaded to handle
       different data argument types. When any version of the method is called,
       the user agent MUST run the following steps:</p>
       <ol>
@@ -9135,7 +9135,7 @@ interface RTCTrackEvent : Event {
               <th colspan="2"><dfn>RTCDataChannelState</dfn> Enumeration description</th>
             </tr>
             <tr>
-              <td><dfn><code>connecting</code></dfn></td>
+              <td><dfn data-idl><code>connecting</code></dfn></td>
               <td>
                 <p>The user agent is attempting to establish the <a>underlying
                 data transport</a>. This is the initial state of an
@@ -9147,14 +9147,14 @@ interface RTCTrackEvent : Event {
               </td>
             </tr>
             <tr>
-              <td><dfn><code>open</code></dfn></td>
+              <td><dfn data-idl><code>open</code></dfn></td>
               <td>
                 <p>The <a>underlying data transport</a> is established and
                 communication is possible.</p>
               </td>
             </tr>
             <tr>
-              <td><dfn><code>closing</code></dfn></td>
+              <td><dfn data-idl><code>closing</code></dfn></td>
               <td>
                 <p>The <code><a data-lt=
                 "closing procedure">procedure</a></code> to close down the
@@ -9162,7 +9162,7 @@ interface RTCTrackEvent : Event {
               </td>
             </tr>
             <tr>
-              <td><dfn><code>closed</code></dfn></td>
+              <td><dfn data-idl><code>closed</code></dfn></td>
               <td>
                 <p>The <a>underlying data transport</a> has been
                 <code><a>closed</a></code> or could not be established.</p>
@@ -9225,7 +9225,7 @@ interface RTCDataChannelEvent : Event {
           Members</h2>
           <dl data-link-for="RTCDataChannelEventInit" data-dfn-for=
           "RTCDataChannelEventInit" class="dictionary-members">
-            <dt><dfn><code>channel</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>channel</code></dfn> of type <span class=
             "idlMemberType"><a>RTCDataChannel</a></span>, required</dt>
             <dd>
               <p>The <code><a>RTCDataChannel</a></code> object to be announced
@@ -9334,13 +9334,13 @@ interface RTCDataChannelEvent : Event {
           <h2>Attributes</h2>
           <dl data-link-for="RTCDTMFSender" data-dfn-for="RTCDTMFSender" class=
           "attributes">
-            <dt><dfn><code>ontonechange</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>ontonechange</code></dfn> of type <span class=
             "idlAttrType"><a>EventHandler</a></span></dt>
             <dd>
               <p>The event type of this event handler is
               <code><a>tonechange</a></code>.</p>
             </dd>
-            <dt><dfn><code>canInsertDTMF</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>canInsertDTMF</code></dfn> of type <span class=
             "idlAttrType"><a>boolean</a></span>, readonly</dt>
             <dd>
               <p>Whether the <a>RTCDTMFSender</a> is capable of sending DTMF.</p>
@@ -9515,7 +9515,7 @@ interface RTCDTMFToneChangeEvent : Event {
             <dt><code>tone</code> of type <span class=
             "idlAttrType"><a>DOMString</a></span>, readonly</dt>
             <dd>
-              <p>The <dfn><code>tone</code></dfn> attribute contains the
+              <p>The <dfn data-idl><code>tone</code></dfn> attribute contains the
               character for the tone (including ",") that has just
               begun playout (see <code><a>insertDTMF</a></code> ). If
               the value is the empty string, it indicates that the
@@ -9534,7 +9534,7 @@ interface RTCDTMFToneChangeEvent : Event {
           Members</h2>
           <dl data-link-for="RTCDTMFToneChangeEventInit" data-dfn-for=
           "RTCDTMFToneChangeEventInit" class="dictionary-members">
-            <dt><dfn><code>tone</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>tone</code></dfn> of type <span class=
             "idlMemberType"><a>DOMString</a></span></dt>
             <dd>
               <p>The <code>tone</code> attribute contains the
@@ -9595,7 +9595,7 @@ interface RTCDTMFToneChangeEvent : Event {
           <h2>Attributes</h2>
           <dl data-link-for="RTCPeerConnection"
               data-dfn-for="RTCPeerConnection" class="attributes">
-            <dt><dfn><code>onstatsended</code></dfn> of type
+            <dt><dfn data-idl><code>onstatsended</code></dfn> of type
               <span class="idlAttrType"><a>EventHandler</a></span></dt>
             <dd>
               <p>The event type of this event handler
@@ -9751,7 +9751,7 @@ interface RTCDTMFToneChangeEvent : Event {
             <dt><code>timestamp</code> of type <span class=
             "idlMemberType"><a>DOMHighResTimeStamp</a></span></dt>
             <dd>
-              <p>The <dfn><code>timestamp</code></dfn>, of type
+              <p>The <dfn data-idl><code>timestamp</code></dfn>, of type
               <code>DOMHighResTimeStamp</code> [[!HIGHRES-TIME]], associated
               with this object. The time is relative to the UNIX epoch (Jan 1,
               1970, UTC). For statistics that came from a remote source (e.g.,
@@ -9765,14 +9765,14 @@ interface RTCDTMFToneChangeEvent : Event {
             "idlMemberType"><a>RTCStatsType</a></span></dt>
             <dd>
               <p>The type of this object.</p>
-              <p>The <dfn><code>type</code></dfn> attribute MUST be initialized
+              <p>The <dfn data-idl><code>type</code></dfn> attribute MUST be initialized
               to the name of the most specific type this
               <code><a>RTCStats</a></code> dictionary represents.</p>
             </dd>
             <dt><code>id</code> of type <span class=
             "idlMemberType"><a>DOMString</a></span></dt>
             <dd>
-              <p>A unique <dfn><code>id</code></dfn> that is associated with
+              <p>A unique <dfn data-idl><code>id</code></dfn> that is associated with
               the object that was inspected to produce this
               <code><a>RTCStats</a></code> object. Two
               <code><a>RTCStats</a></code> objects, extracted from two
@@ -10040,7 +10040,7 @@ interface RTCIdentityProviderGlobalScope : WorkerGlobalScope {
             <h2>Attributes</h2>
             <dl data-link-for="RTCIdentityProviderGlobalScope" data-dfn-for=
             "RTCIdentityProviderGlobalScope" class="attributes">
-              <dt><dfn><code>rtcIdentityProvider</code></dfn> of type
+              <dt><dfn data-idl><code>rtcIdentityProvider</code></dfn> of type
               <span class=
               "idlAttrType"><a>RTCIdentityProviderRegistrar</a></span>,
               readonly</dt>
@@ -10091,7 +10091,7 @@ interface RTCIdentityProviderRegistrar {
           <h2>Methods</h2>
           <dl data-link-for="RTCIdentityProviderRegistrar" data-dfn-for=
           "RTCIdentityProviderRegistrar" class="methods">
-            <dt><dfn><code>register</code></dfn></dt>
+            <dt><dfn data-idl><code>register</code></dfn></dt>
             <dd>
               <p>This method is invoked by the IdP when its script is first
               executed. This registers <code><a>RTCIdentityProvider</a></code>
@@ -10115,7 +10115,7 @@ interface RTCIdentityProviderRegistrar {
             <h2>Dictionary <dfn data-dfn-for="">RTCIdentityProvider</dfn>
             Members</h2>
             <dl data-link-for="RTCIdentityProvider" data-dfn-for="RTCIdentityProvider">
-              <dt><dfn><code>generateAssertion</code></dfn> of type
+              <dt><dfn data-idl><code>generateAssertion</code></dfn> of type
               <span class="idlMemberType"><a>GenerateAssertionCallback</a></span>,
               required</dt>
               <dd>
@@ -10126,7 +10126,7 @@ interface RTCIdentityProviderRegistrar {
                 generate an identity assertion. Any other value, or a <a>rejected</a>
                 promise, is treated as an error.</p>
               </dd>
-              <dt><dfn><code>validateAssertion</code></dfn> of type
+              <dt><dfn data-idl><code>validateAssertion</code></dfn> of type
               <span class="idlMemberType"><a>ValidateAssertionCallback</a></span>,
               required</dt>
               <dd>
@@ -10220,7 +10220,7 @@ interface RTCIdentityProviderRegistrar {
             Members</h2>
             <dl data-link-for="RTCIdentityAssertionResult" data-dfn-for=
             "RTCIdentityAssertionResult" class="dictionary-members">
-              <dt><dfn><code>idp</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>idp</code></dfn> of type <span class=
               "idlMemberType"><a>RTCIdentityProviderDetails</a></span>,
               required</dt>
               <dd>
@@ -10229,7 +10229,7 @@ interface RTCIdentityProviderRegistrar {
                 information that is provided to
                 <code><a>setIdentityProvider</a></code>.</p>
               </dd>
-              <dt><dfn><code>assertion</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>assertion</code></dfn> of type <span class=
               "idlMemberType"><a>DOMString</a></span>, required</dt>
               <dd>
                 <p>An identity assertion. This is an opaque string that MUST
@@ -10249,13 +10249,13 @@ interface RTCIdentityProviderRegistrar {
             Members</h2>
             <dl data-link-for="RTCIdentityProviderDetails" data-dfn-for=
             "RTCIdentityProviderDetails" class="dictionary-members">
-              <dt><dfn><code>domain</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>domain</code></dfn> of type <span class=
               "idlMemberType"><a>DOMString</a></span>, required</dt>
               <dd>
                 <p>The domain name of the IdP that validated the associated
                 identity assertion.</p>
               </dd>
-              <dt><dfn><code>protocol</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>protocol</code></dfn> of type <span class=
               "idlMemberType"><a>DOMString</a></span>, defaulting to
               <code>"default"</code></dt>
               <dd>
@@ -10276,12 +10276,12 @@ interface RTCIdentityProviderRegistrar {
             Members</h2>
             <dl data-link-for="RTCIdentityValidationResult" data-dfn-for=
             "RTCIdentityValidationResult" class="dictionary-members">
-              <dt><dfn><code>identity</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>identity</code></dfn> of type <span class=
               "idlMemberType"><a>DOMString</a></span>, required</dt>
               <dd>
                 <p>The validated identity of the peer.</p>
               </dd>
-              <dt><dfn><code>contents</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>contents</code></dfn> of type <span class=
               "idlMemberType"><a>DOMString</a></span>, required</dt>
               <dd>
                 <p>The payload of the identity assertion. An IdP that validates
@@ -10607,7 +10607,7 @@ interface RTCIdentityProviderRegistrar {
           <h2>Attributes</h2>
           <dl data-link-for="RTCPeerConnection" data-dfn-for=
           "RTCPeerConnection" class="attributes">
-            <dt><dfn><code>peerIdentity</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>peerIdentity</code></dfn> of type <span class=
             "idlAttrType">Promise&lt;<a>RTCIdentityAssertion</a>&gt;</span>,
             readonly</dt>
             <dd>
@@ -10620,14 +10620,14 @@ interface RTCIdentityProviderRegistrar {
               has been established. If this promise successfully <a>resolves</a>, the
               value will not change.</p>
             </dd>
-            <dt><dfn><code>idpLoginUrl</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>idpLoginUrl</code></dfn> of type <span class=
             "idlAttrType"><a>DOMString</a></span>, readonly, nullable</dt>
             <dd>
               <p>The URL that an application can navigate to so that the user
               can login to the IdP, as described in <a href=
               "#sec.idp-loginneeded"></a>.</p>
             </dd>
-            <dt><dfn><code>idpErrorInfo</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>idpErrorInfo</code></dfn> of type <span class=
             "idlAttrType"><a>DOMString</a></span>, readonly, nullable</dt>
             <dd>
               <p>An attribute that the IdP can use to pass additional
@@ -10647,7 +10647,7 @@ interface RTCIdentityProviderRegistrar {
               <code>RTCPeerConnection</code> object. Applications need not make
               this call; if the browser is already configured for an IdP, then
               that configured IdP might be used to get an assertion.</p>
-              <p>When the <dfn><code>setIdentityProvider</code></dfn> method is
+              <p>When the <dfn data-idl><code>setIdentityProvider</code></dfn> method is
               invoked, the user agent MUST run the following steps:</p>
               <ol>
                 <li>
@@ -10675,7 +10675,7 @@ interface RTCIdentityProviderRegistrar {
               requested with a call to either <code>createOffer</code> or
               <code>createAnswer</code>.</p>
             </dd>
-            <dt><dfn><code>getIdentityAssertion</code></dfn></dt>
+            <dt><dfn data-idl><code>getIdentityAssertion</code></dfn></dt>
             <dd>
               <p>Initiates the process of obtaining an identity assertion.
               Applications need not make this call. It is merely intended to
@@ -10717,21 +10717,21 @@ interface RTCIdentityProviderRegistrar {
           <h2><dfn>RTCIdentityProviderOptions</dfn> Members</h2>
           <dl data-link-for="RTCIdentityProviderOptions" data-dfn-for=
           "RTCIdentityProviderOptions" class="attributes">
-            <dt><dfn><code>protocol</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>protocol</code></dfn> of type <span class=
             "idlAttrType"><a>DOMString</a></span></dt>
             <dd>
               <p>The name of the protocol that is used by the identity
               provider. This MUST NOT include '/' (U+002F) or '\' (U+005C)
               characters. This value defaults to "default" if not provided.</p>
             </dd>
-            <dt><dfn><code>usernameHint</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>usernameHint</code></dfn> of type <span class=
             "idlAttrType"><a>DOMString</a></span></dt>
             <dd>
               <p>A hint to the identity provider about the identity of the
               principal for which it should generate an identity assertion. If
               absent, the value <code>undefined</code> is used.</p>
             </dd>
-            <dt><dfn><code>peerIdentity</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>peerIdentity</code></dfn> of type <span class=
             "idlAttrType"><a>DOMString</a></span></dt>
             <dd>
               <p>The identity of the peer. For identity providers that bind
@@ -10756,13 +10756,13 @@ interface RTCIdentityAssertion {
           <h2><dfn>RTCIdentityAssertion</dfn> Attributes</h2>
           <dl data-link-for="RTCIdentityAssertion" data-dfn-for=
           "RTCIdentityAssertion" class="attributes">
-            <dt><dfn><code>idp</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>idp</code></dfn> of type <span class=
             "idlAttrType"><a>DOMString</a></span></dt>
             <dd>
               <p>The domain name of the identity provider that validated this
               identity.</p>
             </dd>
-            <dt><dfn><code>name</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>name</code></dfn> of type <span class=
             "idlAttrType"><a>DOMString</a></span></dt>
             <dd>
               <p>An RFC5322-conformant [[RFC5322]] representation of the
@@ -10966,7 +10966,7 @@ async function consumeIdentityAssertion() {
           Members</h2>
           <dl data-link-for="MediaStreamConstraints" data-dfn-for=
           "MediaStreamConstraints" class="dictionary-members">
-            <dt><dfn><code>peerIdentity</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>peerIdentity</code></dfn> of type <span class=
             "idlMemberType"><a>DOMString</a></span></dt>
             <dd>
               <p>If set, <code>peerIdentity</code> isolates media from the
@@ -11033,7 +11033,7 @@ async function consumeIdentityAssertion() {
             <h2>Attributes</h2>
             <dl data-link-for="MediaStreamTrack" data-dfn-for=
             "MediaStreamTrack" class="attributes">
-              <dt><dfn><code>isolated</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>isolated</code></dfn> of type <span class=
               "idlAttrType"><a>boolean</a></span>, readonly</dt>
               <dd>
                 <p>A <code>MediaStreamTrack</code> is isolated (and the
@@ -11043,7 +11043,7 @@ async function consumeIdentityAssertion() {
                 <var>peerIdentity</var> option. A track is also isolated if it
                 comes from a cross origin source.</p>
               </dd>
-              <dt><dfn><code>onisolationchange</code></dfn> of type
+              <dt><dfn data-idl><code>onisolationchange</code></dfn> of type
               <span class="idlAttrType"><a>EventHandler</a></span></dt>
               <dd>
                 <p>This event handler, of type <a>isolationchange</a>, is fired
@@ -11832,11 +11832,11 @@ if (sender.dtmf.canInsertDTMF) {
                 <th colspan="2">Enumeration description</th>
               </tr>
               <tr>
-                <td><dfn><code>data-channel-failure</code></dfn></td>
+                <td><dfn data-idl><code>data-channel-failure</code></dfn></td>
                 <td>The data channel has failed.</td>
               </tr>
               <tr>
-                <td><dfn><code>dtls-failure</code></dfn></td>
+                <td><dfn data-idl><code>dtls-failure</code></dfn></td>
                 <td>The DTLS negotiation has failed or the connection
                 has been terminated with a fatal error. The
                 <code>message</code> contains information relating to
@@ -11847,7 +11847,7 @@ if (sender.dtmf.canInsertDTMF) {
                 the value of the DTLS alert sent.</td>
               </tr>
               <tr>
-                <td><dfn><code>fingerprint-failure</code></dfn></td>
+                <td><dfn data-idl><code>fingerprint-failure</code></dfn></td>
                 <td>The <code><a>RTCDtlsTransport</a></code>'s
                 remote certificate did not match any of the fingerprints
                 provided in the SDP. If the remote peer cannot match
@@ -11857,64 +11857,64 @@ if (sender.dtmf.canInsertDTMF) {
                 resulting in a "dtls-failure".</td>
               </tr>
               <tr>
-                <td><dfn><code>idp-bad-script-failure</code></dfn></td>
+                <td><dfn data-idl><code>idp-bad-script-failure</code></dfn></td>
                 <td>The script loaded from the identity provider is not valid
                 JavaScript or did not implement the correct interfaces.</td>
               </tr>
               <tr>
-                <td><dfn><code>idp-execution-failure</code></dfn></td>
+                <td><dfn data-idl><code>idp-execution-failure</code></dfn></td>
                 <td>The identity provider has thrown an exception or
                 returned a <a>rejected</a> promise.</td>
               </tr>
               <tr>
-                <td><dfn><code>idp-load-failure</code></dfn></td>
+                <td><dfn data-idl><code>idp-load-failure</code></dfn></td>
                 <td>Loading of the IdP URI has failed. The
                 <code>httpRequestStatusCode</code> attribute is
                 set to the HTTP status code of the response.</td>
               </tr>
               <tr>
-                <td><dfn><code>idp-need-login</code></dfn></td>
+                <td><dfn data-idl><code>idp-need-login</code></dfn></td>
                 <td>The identity provider requires the user to login. The
                 <code>idpLoginUrl</code> attribute is set to the URL that
                 can be used to login.</td>
               </tr>
               <tr>
-                <td><dfn><code>idp-timeout</code></dfn></td>
+                <td><dfn data-idl><code>idp-timeout</code></dfn></td>
                 <td>The IdP timer has expired.</td>
               </tr>
               <tr>
-                <td><dfn><code>idp-tls-failure</code></dfn></td>
+                <td><dfn data-idl><code>idp-tls-failure</code></dfn></td>
                 <td>The TLS certificate used for the IdP HTTPS connection
                 is not trusted.</td>
               </tr>
               <tr>
-                <td><dfn><code>idp-token-expired</code></dfn></td>
+                <td><dfn data-idl><code>idp-token-expired</code></dfn></td>
                 <td>The IdP token has expired.</td>
               </tr>
               <tr>
-                <td><dfn><code>idp-token-invalid</code></dfn></td>
+                <td><dfn data-idl><code>idp-token-invalid</code></dfn></td>
                 <td>The IdP token is invalid.</td>
               </tr>
               <tr>
-                <td><dfn><code>sctp-failure</code></dfn></td>
+                <td><dfn data-idl><code>sctp-failure</code></dfn></td>
                 <td>The SCTP negotiation has failed or the connection
                 has been terminated with a fatal error. The
                 <code>sdpCauseCode</code> attribute is set to the
                 SCTP cause code.</td>
               </tr>
               <tr>
-                <td><dfn><code>sdp-syntax-error</code></dfn></td>
+                <td><dfn data-idl><code>sdp-syntax-error</code></dfn></td>
                 <td>The SDP syntax is not valid. The <code>sdpLineNumber</code>
                 attribute is set to the line number in the SDP where the syntax
                 error was detected.</td>
               </tr>
               <tr>
-                <td><dfn><code>hardware-encoder-not-available</code></dfn></td>
+                <td><dfn data-idl><code>hardware-encoder-not-available</code></dfn></td>
                 <td>The hardware encoder resources required for the requested
                 operation are not available.</td>
               </tr>
               <tr>
-                <td><dfn><code>hardware-encoder-error</code></dfn></td>
+                <td><dfn data-idl><code>hardware-encoder-error</code></dfn></td>
                 <td>The hardware encoder does not support the provided
                 parameters.</td>
               </tr>
@@ -12014,13 +12014,13 @@ if (sender.dtmf.canInsertDTMF) {
         <section>
           <h2>RTCError.prototype.receivedAlert</h2>
           <p>An unsigned integer representing the value of the DTLS alert received.
-          The initial value of the <dfn><code>receivedAlert</code></dfn> property of
+          The initial value of the <dfn data-idl><code>receivedAlert</code></dfn> property of
           the prototype for the <code>RTCError</code> constructor is null.</p>
         </section>
         <section>
           <h2>RTCError.prototype.sentAlert</h2>
           <p>An unsigned integer representing the value of the DTLS alert sent.
-          The initial value of the <dfn><code>sentAlert</code></dfn> property of
+          The initial value of the <dfn data-idl><code>sentAlert</code></dfn> property of
           the prototype for the <code>RTCError</code> constructor is null.</p>
         </section>
         <section>
@@ -12043,7 +12043,7 @@ if (sender.dtmf.canInsertDTMF) {
         ([[!ECMASCRIPT-6.0]], section 19.1.3.6) to identify instances of Error or its
         various subclasses.</p>
       </section>
-      <p>The following interface is defined for cases when an
+      <p>The <dfn data-idl><code>RTCErrorEvent</code></dfn> interface is defined for cases when an
       RTCError is raised as an event:</p>
       <div>
         <pre class="idl">[Exposed=Window,
@@ -12055,7 +12055,7 @@ interface RTCErrorEvent : Event {
           <h2>Constructors</h2>
           <dl data-link-for="RTCErrorEvent" data-dfn-for=
           "RTCErrorEvent" class="constructors">
-            <dt><dfn><code>RTCErrorEvent</code></dfn></dt>
+            <dt><dfn data-idl><code>RTCErrorEvent</code></dfn></dt>
             <dd>
               <p>Constructs a new
               <code><a>RTCErrorEvent</a></code>.</p>
@@ -12066,7 +12066,7 @@ interface RTCErrorEvent : Event {
           <h2>Attributes</h2>
           <dl data-link-for="RTCErrorEvent" data-dfn-for=
           "RTCErrorEvent" class="attributes">
-            <dt><dfn><code>error</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>error</code></dfn> of type <span class=
             "idlAttrType"><a>RTCError</a></span>, readonly,
             nullable</dt>
             <dd>
@@ -12085,7 +12085,7 @@ interface RTCErrorEvent : Event {
           Members</h2>
           <dl data-link-for="RTCErrorEventInit" data-dfn-for=
           "RTCErrorEventInit" class="dictionary-members">
-            <dt><dfn><code>error</code></dfn> of type <span class=
+            <dt><dfn data-idl><code>error</code></dfn> of type <span class=
             "idlMemberType"><a>RTCError</a></span>, nullable,
             defaulting to <code>null</code></dt>
             <dd>
@@ -12138,12 +12138,12 @@ interface RTCErrorEvent : Event {
           "RTCDataChannel">bufferedAmountLowThreshold</a></code>.</td>
         </tr>
         <tr>
-          <td><dfn id="event-datachannel-error"><code>error</code></dfn></td>
+          <td><dfn><code id="event-datachannel-error">error</code></dfn></td>
           <td><code><a>RTCErrorEvent</a></code></td>
           <td>An error occurred on the data channel.</td>
         </tr>
         <tr>
-          <td><dfn id="event-datachannel-close"><code>close</code></dfn></td>
+          <td><code id="event-datachannel-close">close</code></td>
           <td><code><a>Event</a></code></td>
           <td>
             The <code><a>RTCDataChannel</a></code> object's <a>underlying data


### PR DESCRIPTION
close #1781


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/1784.html" title="Last updated on Mar 2, 2018, 11:37 AM GMT (eb1d3c2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1784/ccf6f3e...eb1d3c2.html" title="Last updated on Mar 2, 2018, 11:37 AM GMT (eb1d3c2)">Diff</a>