### PR TITLE
fix RTCIceCandidate.toJson description

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3933,7 +3933,7 @@ interface RTCIceCandidate {
               <dd>To invoke the <code>toJSON()</code> operation of the <code>RTCIceCandidate</code> interface, run the following steps:
                 <ol>
                   <li>Let <var>json</var> be a new <code>RTCIceCandidateInit</code> dictionary.</li>
-                  <li>For each attribute identifier <var>attr</var> in «"candidate", "sdpMid", "sdpMLineIndex", "description"»:
+                  <li>For each attribute identifier <var>attr</var> in «"candidate", "sdpMid", "sdpMLineIndex", "usernameFragment"»:
                     <ol>
                       <li>Let <var>value</var> be the result of getting the underlying value of the attribute identified by <var>attr</var>, given this <code>RTCIceCandidate</code> object.</li>
                       <li>Set <code><var>json</var>[<var>attr</var>]</code> to <var>value</var>.</li>


### PR DESCRIPTION
which erroneously refers to a description property. Fixes #1786