### PR TITLE
RTCDataChannel: Specify that a string argument to send must be encoded

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9074,7 +9074,7 @@ interface RTCTrackEvent : Event {
             <li>
               <p><code>string</code> object:</p>
               <p>Let <var>data</var> be a byte buffer that represents the
-              result of encoding the methods argument as UTF-8 and increase the
+              result of encoding the method's argument as UTF-8 and increase the
               <code><a data-link-for="RTCDataChannel">bufferedAmount</a></code>
               attribute with the length of <var>data</var>.</p>
             </li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -9073,10 +9073,10 @@ interface RTCTrackEvent : Event {
           <ul>
             <li>
               <p><code>string</code> object:</p>
-              <p>Let <var>data</var> be the object and increase the
+              <p>Let <var>data</var> be a byte buffer that represents the
+              result of encoding the methods argument as UTF-8 and increase the
               <code><a data-link-for="RTCDataChannel">bufferedAmount</a></code>
-              attribute by the number of bytes needed to express
-              <var>data</var> as UTF-8.</p>
+              attribute with the length of <var>data</var>.</p>
             </li>
             <li>
               <p><code>Blob</code> object:</p>


### PR DESCRIPTION
Fix #1628


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/1790.html" title="Last updated on Mar 15, 2018, 1:55 PM GMT (ac985fc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1790/312b635...ac985fc.html" title="Last updated on Mar 15, 2018, 1:55 PM GMT (ac985fc)">Diff</a>