### PR TITLE
Fix warnings on definitions from ReSpec upgrade to 20.4

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1542,8 +1542,8 @@
                             <var>channel</var>.</p>
                           </li>
                           <li>
-                            <p>Fire a simple event named <code title=
-                            "event-RTCDataChannel-close"><a>close</a></code> at
+                            <p>Fire a simple event named
+                            <code><a>close</a></code> at
                             <var>channel</var>.</p>
                           </li>
                         </ol>
@@ -12094,7 +12094,7 @@ if (sender.dtmf.canInsertDTMF) {
         ([[!ECMASCRIPT-6.0]], section 19.1.3.6) to identify instances of Error or its
         various subclasses.</p>
       </section>
-      <p>The <dfn data-idl><code>RTCErrorEvent</code></dfn> interface is defined for cases when an
+      <p>The <dfn data-dfn-for='' data-idl><code>RTCErrorEvent</code></dfn> interface is defined for cases when an
       RTCError is raised as an event:</p>
       <div>
         <pre class="idl">[Exposed=Window,
@@ -12194,7 +12194,7 @@ interface RTCErrorEvent : Event {
           <td>An error occurred on the data channel.</td>
         </tr>
         <tr>
-          <td><code id="event-datachannel-close">close</code></td>
+          <td><dfn><code id="event-datachannel-close">close</code></dfn></td>
           <td><code><a>Event</a></code></td>
           <td>
             The <code><a>RTCDataChannel</a></code> object's <a>underlying data


### PR DESCRIPTION
close #1798


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/1800.html" title="Last updated on Mar 13, 2018, 5:33 PM GMT (96a84e8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1800/be474c4...96a84e8.html" title="Last updated on Mar 13, 2018, 5:33 PM GMT (96a84e8)">Diff</a>