### PR TITLE
RTCDataChannel: Specify common create steps for locally and remotely created channels

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8275,12 +8275,13 @@ interface RTCTrackEvent : Event {
                   <code>InvalidStateError</code>.</p>
                 </li>
                 <li>
-                  <p>Let <var>channel</var> be a newly created
-                  <code><a>RTCDataChannel</a></code> object.</p>
+                  <p><a>Create an <code>RTCDataChannel</code></a>,
+                  <var>channel</var>.</p>
                 </li>
                 <li>
-                  <p>Let <var>channel</var> have a <dfn>[[\DataChannelLabel]]</dfn> internal slot initialized to the
-                  value of the first argument.</p>
+                  <p>Initialize <var>channel</var>'s
+                  <a>[[\DataChannelLabel]]</a> slot to the value of the first
+                  argument.</p>
                 </li>
                 <li>If <a>[[\DataChannelLabel]]</a>
                 is longer than 65535 bytes, <a>throw</a> a
@@ -8290,42 +8291,35 @@ interface RTCTrackEvent : Event {
                   <p>Let <var>options</var> be the second argument.</p>
                 </li>
                 <li>
-                  <p>Let <var>channel</var> have a <dfn>[[\MaxPacketLifeTime]]</dfn> internal
-                  slot initialized to <var>option</var>'s
+                  <p>Initialize <var>channel</var>'s <a>[[\MaxPacketLifeTime]]</a>
+                  slot to <var>option</var>'s
                   <code>maxPacketLifeTime</code> member, if present, otherwise
                   <code>null</code>.</p>
                 </li>
                 <li>
-                  <p>Let <var>channel</var> have a <dfn>[[\ReadyState]]</dfn> internal slot
-                  initialized to <code>"connecting"</code>.</p>
-                </li>
-                <li>
-                  <p>Let <var>channel</var> have a <dfn>[[\BufferedAmount]]</dfn>
-                  internal slot initialized to <code>0</code>.</p>
-                </li>
-                <li>
-                  <p>Let <var>channel</var> have a <dfn>[[\MaxRetransmits]]</dfn> internal slot
-                  initialized to <var>option</var>'s <code>maxRetransmits</code>
+                  <p>Initialize <var>channel</var>'s <a>[[\MaxRetransmits]]</a>
+                  slot to <var>option</var>'s <code>maxRetransmits</code>
                   member, if present, otherwise <code>null</code>.</p>
                 </li>
                 <li>
-                  <p>Let <var>channel</var> have an <dfn>[[\Ordered]]</dfn> internal slot initialized to
-                  <var>option</var>'s <code>ordered</code> member.</p>
+                  <p>Initialize <var>channel</var>'s <a>[[\Ordered]]</a> slot
+                  to <var>option</var>'s <code>ordered</code> member.</p>
                 </li>
                 <li>
-                  <p>Let <var>channel</var> have a <dfn>[[\DataChannelProtocol]]</dfn> internal slot initialized to
-                  <var>option</var>'s <code>protocol</code> member.</p>
+                  <p>Initialize <var>channel</var>'s
+                  <a>[[\DataChannelProtocol]]</a> slot to <var>option</var>'s
+                  <code>protocol</code> member.</p>
                 </li>
                 <li>If <a>[[\DataChannelProtocol]]</a> is longer than
                 65535 bytes long, <a>throw</a> a <code>TypeError</code>.
                 </li>
                 <li>
-                  <p>Let <var>channel</var> have a <dfn>[[\Negotiated]]</dfn> internal slot initialized
-                  to <var>option</var>'s <code>negotiated</code> member.</p>
+                  <p>Initialize <var>channel</var>'s <a>[[\Negotiated]]</a>
+                  slot to <var>option</var>'s <code>negotiated</code> member.</p>
                 </li>
                 <li>
-                  <p>Let <var>channel</var> have an <dfn>[[\DataChannelId]]</dfn>
-                  internal slot initialized to <var>option</var>'s
+                  <p>Initialize <var>channel</var>'s <a>[[\DataChannelId]]</a>
+                  slot to the value of <var>option</var>'s
                   <code>id</code> member, if it is present and
                   <a>[[\Negotiated]]</a> is true, otherwise
                   <code>null</code>.</p>
@@ -8343,9 +8337,9 @@ interface RTCTrackEvent : Event {
                   a <code>TypeError</code>.</p>
                 </li>
                 <li>
-                  <p>Let <var>channel</var> have an
-                  <dfn>[[\DataChannelPriority]]</dfn> internal slot initialized
-                  to <var>option</var>'s <code>priority</code> member.</p>
+                  <p>Initialize <var>channel</var>'s
+                  <a>[[\DataChannelPriority]]</a> slot to <var>option</var>'s
+                  <code>priority</code> member.</p>
                 </li>
                 <li>
                   <p>If both <a>[[\MaxPacketLifeTime]]</a> and
@@ -8628,6 +8622,33 @@ interface RTCTrackEvent : Event {
       <code><a>RTCDataChannel</a></code> object's <a>underlying data
       transport</a> is ready, the user agent MUST <a>announce the
       <code>RTCDataChannel</code> as open</a>.</p>
+      <p>To <dfn>create an <code><a>RTCDataChannel</a></code></dfn>, run the
+      following steps:</p>
+      <ol>
+        <li>
+          <p>Let <var>channel</var> be a newly created <code>
+          <a>RTCDataChannel</a></code> object.</p>
+        </li>
+        <li>
+          <p>Let <var>channel</var> have a <dfn>[[\ReadyState]]</dfn> internal
+          slot initialized to <code>"connecting"</code>.</p>
+        </li>
+        <li>
+          <p>Let <var>channel</var> have a <dfn>[[\BufferedAmount]]</dfn>
+          internal slot initialized to <code>0</code>.</p>
+        </li>
+        <li>
+          <p>Let <var>channel</var> have internal slots named
+          <dfn>[[\DataChannelLabel]]</dfn>, <dfn>[[\Ordered]]</dfn>,
+          <dfn>[[\MaxPacketLifeTime]]</dfn>, <dfn>[[\MaxRetransmits]]</dfn>,
+          <dfn>[[\DataChannelProtocol]]</dfn>, <dfn>[[\Negotiated]]</dfn>,
+          <dfn>[[\DataChannelId]]</dfn>, and
+          <dfn>[[\DataChannelPriority]]</dfn>.</p>
+        </li>
+        <li>
+          <p>Return <var>channel</var>.</p>
+        </li>
+      </ol>
       <p>When the user agent is to <dfn data-lt=
       "announce the rtcdatachannel as open" id=
       "announce-datachannel-open">announce an <code>RTCDataChannel</code> as
@@ -8662,8 +8683,8 @@ interface RTCTrackEvent : Event {
           <a>[[\IsClosed]]</a> slot is <code>true</code>, abort these steps.</p>
         </li>
         <li>
-          <p>Let <var>channel</var> be a newly created
-          <code><a>RTCDataChannel</a></code> object.</p>
+          <p><a>Create an <code>RTCDataChannel</code></a>,
+          <var>channel</var>.</p>
         </li>
         <li>
           <p>Let <var>configuration</var> be an information bundle received
@@ -8709,10 +8730,6 @@ interface RTCTrackEvent : Event {
               <td><code><a data-link-for="RTCPriorityType">high</a></code></td>
             </tr>
           </table>
-        </li>
-        <li>
-          <p>Set <var>channel</var>'s <a>[[\ReadyState]]</a> slot to
-          <code>connecting</code>.</p>
         </li>
         <li>
           <p><a>Fire a datachannel event</a> named


### PR DESCRIPTION
Fixes #1795


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/1809.html" title="Last updated on Apr 5, 2018, 2:17 PM GMT (0061b80)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1809/18a45b0...0061b80.html" title="Last updated on Apr 5, 2018, 2:17 PM GMT (0061b80)">Diff</a>