### PR TITLE
Limit sendEncodings to video.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5159,7 +5159,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               non-null value, as defined in <span data-jsep=
               "processing-a-local-desc processing-a-remote-desc">[[!JSEP]]</span>.</p>
               <p>The <code>sendEncodings</code> argument can be used to
-              specify the number of offered simulcast encodings, and
+              specify the number of offered simulcast encodings for video, and
               optionally their RIDs and encoding parameters.</p>
               <p>When this method is invoked, the user agent MUST run the
               following steps:</p>
@@ -5200,8 +5200,14 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   <var>track.kind</var>.</p>
                 </li>
                 <li>
+                  <p>If the number of <code><a>RTCRtpEncodingParameters</a></code>
+                  stored in <var>sendEncodings</var> is greater than <code>0</code>,
+                  and <code>kind</code> is not <code>"video"</code>,
+                  <a>throw</a> a <code>TypeError</code>.</p>
+                </li>
+                <li>
                   <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">rid</a></code>
-                  value in <var>sendEncodings</var> is composed only of
+                  value in <var>sendEncodings</var> is either absent or composed only of
                   alphanumeric characters (a-z, A-Z, 0-9) up to
                   a maximum of 16 characters. If one of the RIDs does not meet
                   these requirements, <a>throw</a> a <code>TypeError</code>.</p>


### PR DESCRIPTION
Potential fix for  https://github.com/w3c/webrtc-pc/issues/1813.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/1814.html" title="Last updated on Mar 22, 2018, 3:53 AM GMT (56b14bb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1814/1cc5bfc...jan-ivar:56b14bb.html" title="Last updated on Mar 22, 2018, 3:53 AM GMT (56b14bb)">Diff</a>