### PR TITLE
Describe how ICE restarts affect the RTCIceTransportState.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7996,6 +7996,12 @@ async function onOffHold() {
           </tbody>
         </table>
       </div>
+      <p>An ICE restart causes candidate gathering and connectity checks to
+      begin anew, causing a transition to <code>connected</code> if begun in the
+      <code>completed</code> state. If begun in the transient
+      <code>disconnected</code> state, it causes a transition to
+      <code>checking</code>, effectively forgetting that connectivity was
+      previously lost.</p>
       <p>The <code>failed</code> and <code>completed</code> states require an
       indication that there are no additional remote candidates. This can be
       indicated by calling <code><a href=
@@ -8004,7 +8010,7 @@ async function onOffHold() {
       to an empty string or by <a data-link-for=
       "RTCPeerConnection">canTrickleIceCandidates</a> being set to
       <code>false</code>.</p>
-      <p>Some example transitions might be:</p>
+      <p>Some example state transitions are:</p>
       <ul>
         <li>(<code><a>RTCIceTransport</a></code> first created, as a result of
         <code>setLocalDescription</code> or <code>setRemoteDescription</code>):
@@ -8022,7 +8028,10 @@ async function onOffHold() {
         <code>completed</code></li>
         <li>(<code>completed</code>, lost connectivity):
         <code>disconnected</code></li>
-        <li>(any state, ICE restart occurs): <code>new</code></li>
+        <li>(<code>disconnected</code> or <code>failed</code>, ICE restart occurs):
+        <code>checking</code></li>
+        <li>(<code>completed</code>, ICE restart occurs):
+        <code>connected</code></li>
         <li><code>RTCPeerConnection.close()</code>: <code>closed</code></li>
       </ul>
       <figure>


### PR DESCRIPTION
Fixes #1630.

This attempts to clarify that an ICE restart will cause these state
transitions:

failed -> checking
disconnected -> checking
completed -> connected


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/taylor-b/webrtc-pc/pull/1815.html" title="Last updated on Mar 22, 2018, 5:40 AM GMT (adb7a66)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1815/1cc5bfc...taylor-b:adb7a66.html" title="Last updated on Mar 22, 2018, 5:40 AM GMT (adb7a66)">Diff</a>