### PR TITLE
Require RTCRtpHeaderExtensionParameters members.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6373,9 +6373,9 @@ async function updateParameters() {
       <h3><dfn>RTCRtpHeaderExtensionParameters</dfn> Dictionary</h3>
       <div>
         <pre class="idl">dictionary RTCRtpHeaderExtensionParameters {
-             DOMString      uri;
-             unsigned short id;
-             boolean        encrypted;
+             required DOMString      uri;
+             required unsigned short id;
+             required boolean        encrypted;
 };</pre>
         <section>
           <h2>Dictionary <code><a>RTCRtpHeaderExtensionParameters</a></code>
@@ -6383,19 +6383,19 @@ async function updateParameters() {
           <dl data-link-for="RTCRtpHeaderExtensionParameters" data-dfn-for=
           "RTCRtpHeaderExtensionParameters" class="dictionary-members">
             <dt><dfn data-idl><code>uri</code></dfn> of type <span class=
-            "idlMemberType"><a>DOMString</a></span></dt>
+            "idlMemberType"><a>DOMString</a></span>, required</dt>
             <dd>
               <p>The URI of the RTP header extension, as defined in
               [[RFC5285]]. <a>Read-only parameter</a>.</p>
             </dd>
             <dt><dfn data-idl><code>id</code></dfn> of type <span class=
-            "idlMemberType"><a>unsigned short</a></span></dt>
+            "idlMemberType"><a>unsigned short</a></span>, required</dt>
             <dd>
               <p>The value put in the RTP packet to identify the header
               extension. <a>Read-only parameter</a>.</p>
             </dd>
             <dt><dfn data-idl><code>encrypted</code></dfn> of type <span class=
-            "idlMemberType"><a>boolean</a></span></dt>
+            "idlMemberType"><a>boolean</a></span>, required</dt>
             <dd>
               <p>Whether the header extension is encryted or not. <a>Read-only
               parameter</a>.</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -6397,7 +6397,7 @@ async function updateParameters() {
             <dt><dfn data-idl><code>encrypted</code></dfn> of type <span class=
             "idlMemberType"><a>boolean</a></span></dt>
             <dd>
-              <p>Whether the header extension is encryted or not. <a>Read-only
+              <p>Whether the header extension is encrypted or not. <a>Read-only
               parameter</a>.</p>
             </dd>
           </dl>

--- a/webrtc.html
+++ b/webrtc.html
@@ -6375,7 +6375,7 @@ async function updateParameters() {
         <pre class="idl">dictionary RTCRtpHeaderExtensionParameters {
              required DOMString      uri;
              required unsigned short id;
-             required boolean        encrypted;
+             boolean                 encrypted = false;
 };</pre>
         <section>
           <h2>Dictionary <code><a>RTCRtpHeaderExtensionParameters</a></code>
@@ -6395,7 +6395,7 @@ async function updateParameters() {
               extension. <a>Read-only parameter</a>.</p>
             </dd>
             <dt><dfn data-idl><code>encrypted</code></dfn> of type <span class=
-            "idlMemberType"><a>boolean</a></span>, required</dt>
+            "idlMemberType"><a>boolean</a></span></dt>
             <dd>
               <p>Whether the header extension is encryted or not. <a>Read-only
               parameter</a>.</p>


### PR DESCRIPTION
Another fix for https://github.com/w3c/webrtc-pc/issues/1493.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/1816.html" title="Last updated on Mar 28, 2018, 12:54 AM GMT (6dbebf2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1816/1cc5bfc...jan-ivar:6dbebf2.html" title="Last updated on Mar 28, 2018, 12:54 AM GMT (6dbebf2)">Diff</a>