### PR TITLE
Data channel closing procedure

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8738,22 +8738,26 @@ interface RTCTrackEvent : Event {
           <code>closing</code>.</p>
         </li>
         <li>
-          <p>Finish sending all currently pending messages of the
-          <var>channel</var>.</p>
-        </li>
-        <li>
-          <p>Follow the closing procedure defined for the <var>channel</var>'s
-          underlying <a data-lt="data transport">transport</a>:</p>
+          <p>Run the following steps in parallel:</p>
           <ol>
             <li>
-              <p>In the case of an SCTP-based <a data-lt="data transport">
-              transport</a>, follow [[!RTCWEB-DATA]], section 6.7.</p>
+              <p>Finish sending all currently pending messages of the <var>channel</var>.</p>
+            </li>
+            <li>
+              <p>Follow the closing procedure defined for the <var>channel</var>'s
+              underlying <a data-lt="data transport">transport</a>:</p>
+              <ol>
+                <li>
+                  <p>In the case of an SCTP-based <a data-lt="data transport">
+                  transport</a>, follow [[!RTCWEB-DATA]], section 6.7.</p>
+                </li>
+              </ol>
+            </li>
+            <li>
+              <p>Render the <var>channel</var>'s <a>data transport</a> <a>closed</a> by following
+              the associated procedure.
             </li>
           </ol>
-        </li>
-        <li>
-          <p>Render the <var>channel</var>'s <a>data transport</a>
-          <a>closed</a> and follow the associated procedure.
         </li>
       </ol>
       <p>When an <code><a>RTCDataChannel</a></code> object's <a>underlying data

--- a/webrtc.html
+++ b/webrtc.html
@@ -8723,10 +8723,39 @@ interface RTCTrackEvent : Event {
       <p>An <code><a>RTCDataChannel</a></code> object's <a>underlying data
       transport</a> may be torn down in a non-abrupt manner by running the
       <dfn id="data-transport-closing-procedure">closing procedure</dfn>. When
-      that happens the user agent MUST, unless the procedure was initiated by
-      the <code><a data-link-for="RTCDataChannel">close</a></code> method, queue a
-      task that sets the object's <a>[[\ReadyState]]</a> slot to <code>closing</code>.
-      This will eventually render the <a>data transport</a> <a>closed</a>.</p>
+      that happens the user agent MUST queue a task to run the following
+      steps:</p>
+      <ol>
+        <li>
+          <p>Let <var>channel</var> be the <code><a>RTCDataChannel</a></code>
+          object whose <a data-lt="data transport">transport</a> was
+          closed.</p>
+        </li>
+        <li>
+          <p>Unless the procedure was initiated by the <var>channel</var>'s
+          <code><a data-link-for="RTCDataChannel">close</a></code> method, set
+          <var>channel</var>'s <a>[[\ReadyState]]</a> slot to
+          <code>closing</code>.</p>
+        </li>
+        <li>
+          <p>Finish sending all currently pending messages of the
+          <var>channel</var>.</p>
+        </li>
+        <li>
+          <p>Follow the closing procedure defined for the <var>channel</var>'s
+          underlying <a data-lt="data transport">transport</a>:</p>
+          <ol>
+            <li>
+              <p>In the case of an SCTP-based <a data-lt="data transport">
+              transport</a>, follow [[!RTCWEB-DATA]], section 6.7.</p>
+            </li>
+          </ol>
+        </li>
+        <li>
+          <p>Render the <var>channel</var>'s <a>data transport</a>
+          <a>closed</a> and follow the associated procedure.
+        </li>
+      </ol>
       <p>When an <code><a>RTCDataChannel</a></code> object's <a>underlying data
       transport</a> has been <dfn id="data-transport-closed" data-dfn-for="">closed</dfn>, the
       user agent MUST queue a task to run the following steps:</p>


### PR DESCRIPTION
This adds steps for the data channel *closing* procedure. Explicitly states that pending messages must be sent before the channel can be closed.

Resolves #1699 

I will write a WPT test for this but that will be bundled in one big data channel PR towards WPT (yes, sorry for that but I'm running out of time).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lgrahl/webrtc-pc/pull/1822.html" title="Last updated on Mar 31, 2018, 10:06 PM GMT (99c487a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1822/a86cc50...lgrahl:99c487a.html" title="Last updated on Mar 31, 2018, 10:06 PM GMT (99c487a)">Diff</a>