### PR TITLE
rtp media api: remove note

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4779,27 +4779,6 @@ interface RTCPeerConnectionIceErrorEvent : Event {
       <code>MediaStreamTrack</code> and <code><a>RTCRtpReceiver</a></code> are
       surfaced to the application via the <code><a>track</a></code> event.
     </p>
-    <div class="note">
-      <p>There are several ways to initiate the sending of a
-      <code>MediaStreamTrack</code> over a peer-to-peer connection.
-      One way is to use the <code>addTrack</code> method on the
-      <code><a>RTCPeerConnection</a></code>. Another way is to use
-      the <code>replaceTrack</code> method on an existing
-      <code><a>RTCRtpSender</a></code>. Yet another way is to
-      create a new <code><a>RTCRtpSender</a></code> via the
-      <code>addTransceiver</code> method (with or without a
-      <code>MediaStreamTrack</code> argument). While
-      <code>addTrack</code> checks if the <code>MediaStreamTrack</code>
-      given as an argument is already being sent to avoid sending
-      the same <code>MediaStreamTrack</code> twice, the other ways
-      do not, allowing the same <code>MediaStreamTrack</code> (possibly
-      using different <code><a>RTCRtpParameters</a></code> with different
-      <code><a>RTCRtpSender</a></code>s) to be sent several times
-      simultaneously. Doing this implies that at the receiving end of
-      the peer-to-peer connection there are several
-      <code>MediaStreamTrack</code>s with an identical
-      <code>id</code>.</p>
-    </div>
     <section>
       <h3>RTCPeerConnection Interface Extensions</h3>
       <p>The RTP media API extends the <code><a>RTCPeerConnection</a></code>


### PR DESCRIPTION
removes the note which no longer applies in the transceiver model
as track ids have become meaningless.

Originally I wanted to remove only `Doing this implies that at the receiving end of the peer-to-peer connection there are several MediaStreamTracks with an identical id.` which is no longer true in the transceiver model. But the whole note seems to be an attempt to explain "there can be tracks with identical id if the sender adds the same track multiple times"...


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-pc/pull/1832.html" title="Last updated on Apr 11, 2018, 12:15 PM GMT (7dc9dc7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1832/1b42a97...fippo:7dc9dc7.html" title="Last updated on Apr 11, 2018, 12:15 PM GMT (7dc9dc7)">Diff</a>