### PR TITLE
Add RTCStatsEventInit IDL definition

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9896,13 +9896,18 @@ interface RTCDTMFToneChangeEvent : Event {
             </dd>
           </dl>
         </section>
+      </div>
+      <div>
+        <pre class="idl">dictionary RTCStatsEventInit : EventInit {
+            required RTCStatsEvent report;
+          };</pre>
         <section>
           <h2>Dictionary <dfn>RTCStatsEventInit</dfn>
-            members</h2> 
-          <dl  data-link-for="RTCStatsEventInit"
+            members</h2>
+          <dl data-link-for="RTCStatsEventInit"
             data-dfn-for="RTCStatsEventInit"
-               class="dictionary-members">
-            <dt><code>report</code> of
+            class="dictionary-members">
+            <dt><dfn data-idl><code>report</code></dfn> of
             type <span class="idlMemberType"><a>RTCStatsReport</a></span>,
               required</dt>
             <dd>
@@ -9910,8 +9915,8 @@ interface RTCDTMFToneChangeEvent : Event {
                 stats for the objects whose lifetime have ended.</p>
             </dd>
           </dl>
-          </section>
-       </div>
+        </section>
+      </div>
     </section>
     <section>
       <h3>The stats selection algorithm</h3>

--- a/webrtc.html
+++ b/webrtc.html
@@ -9899,7 +9899,7 @@ interface RTCDTMFToneChangeEvent : Event {
       </div>
       <div>
         <pre class="idl">dictionary RTCStatsEventInit : EventInit {
-            required RTCStatsEvent report;
+            required RTCStatsReport report;
           };</pre>
         <section>
           <h2>Dictionary <dfn>RTCStatsEventInit</dfn>


### PR DESCRIPTION
Add `RTCStatsEventInit` IDL definition


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/a-tarasyuk/webrtc-pc/pull/1836.html" title="Last updated on Apr 19, 2018, 2:16 PM GMT (b68ccee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1836/1b42a97...a-tarasyuk:b68ccee.html" title="Last updated on Apr 19, 2018, 2:16 PM GMT (b68ccee)">Diff</a>