### PR TITLE
RTCDataChannel.send argument type clarification

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9174,6 +9174,9 @@ interface RTCTrackEvent : Event {
               of the <code>ArrayBufferView</code> in bytes.</p>
             </li>
           </ul>
+          <div class="note">Any data argument type this method has not been
+          overloaded with will result in a <code>TypeError</code>. This includes
+          <code>null</code> and <code>undefined</code>.</div>
         </li>
         <li>
           <p>If the size of <var>data</var> exceeds the value of <code><a


### PR DESCRIPTION
Adds a note to `RTCDataChannel.send` to clarify which argument types are acceptable.

Resolves #1835 

Tests for this exist as part of https://github.com/w3c/web-platform-tests/pull/10468 (see https://github.com/lgrahl/web-platform-tests/commit/d7c076fb94b78d15ee62e60a28c88094e4c56460).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lgrahl/webrtc-pc/pull/1841.html" title="Last updated on Apr 19, 2018, 7:22 PM GMT (f9663e1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1841/670a792...lgrahl:f9663e1.html" title="Last updated on Apr 19, 2018, 7:22 PM GMT (f9663e1)">Diff</a>