### PR TITLE
RTCPeerConnection.close procedure for SCTP & data channels

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3040,12 +3040,16 @@ interface RTCPeerConnection : EventTarget  {
                     <p>Set the <a>[[\ReadyState]]</a> slot of each of
                     <var>connection</var>'s <code><a>RTCDataChannel</a></code>s
                     to <code><a data-link-for=
-                    "RTCDataChannelState">"closed"</a></code>.</p>
+                    "RTCDataChannelState">"closed"</a></code></p>
+                    <div class="note">The <code><a>RTCDataChannel</a></code>s
+                    will be closed abruptly and the closing procedure
+                    will not be invoked.</div>
                   </li>
                   <li>
-                    <p>Set the <a>[[\SctpTransportState]]</a> slot of
-                    <var>connection</var>'s <a>[[\SctpTransport]]</a>
-                    to <code><a data-link-for=
+                    <p>If the <var>connection</var>'s <a>[[\SctpTransport]]</a>
+                    is not <code>null</code>, tear down the underlying SCTP
+                    association by sending an SCTP ABORT chunk and set the
+                    <a>[[\SctpTransportState]]</a> to <code><a data-link-for=
                     "RTCSctpTransportState">"closed"</a></code>.</p>
                   </li>
                   <li>


### PR DESCRIPTION
* Explicitly state to send an SCTP ABORT chunk when closing a peer connection.
* Add a note that the data channel closing procedure will not be invoked in case the peer connection is being closed.

Resolves #1821

Tests for the closing procedure exist as part of https://github.com/w3c/web-platform-tests/pull/10468.
Testing for an SCTP ABORT chunk is of course not possible in the API.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lgrahl/webrtc-pc/pull/1842.html" title="Last updated on Apr 19, 2018, 10:24 PM GMT (0f9e541)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1842/670a792...lgrahl:0f9e541.html" title="Last updated on Apr 19, 2018, 10:24 PM GMT (0f9e541)">Diff</a>