### PR TITLE
RTCDataChannel.send steps for bufferedAmount

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9148,36 +9148,29 @@ interface RTCTrackEvent : Event {
             <li>
               <p><code>string</code> object:</p>
               <p>Let <var>data</var> be a byte buffer that represents the
-              result of encoding the method's argument as UTF-8 and increase the
-              value of the <a>[[\BufferedAmount]]</a> slot with the length of
-              <var>data</var>.</p>
+              result of encoding the method's argument as UTF-8.</p>
             </li>
             <li>
               <p><code>Blob</code> object:</p>
               <p>Let <var>data</var> be the raw data represented by the
-              <code>Blob</code> object and increase the value of the
-              <a>[[\BufferedAmount]]</a> slot with the size of data, in bytes.</p>
+              <code>Blob</code> object.</p>
             </li>
             <li>
               <p><code>ArrayBuffer</code> object:</p>
               <p>Let <var>data</var> be the data stored in the buffer described
-              by the <code>ArrayBuffer</code> object and increase the value of
-              the <a>[[\BufferedAmount]]</a> slot with the the length of the
-              <code>ArrayBuffer</code> in bytes.</p>
+              by the <code>ArrayBuffer</code> object.</p>
             </li>
             <li>
               <p><code>ArrayBufferView</code> object:</p>
               <p>Let <var>data</var> be the data stored in the section of the
               buffer described by the <code>ArrayBuffer</code> object that the
-              <code>ArrayBufferView</code> object references and increase the
-              value of the <a>[[\BufferedAmount]]</a> slot with the the length
-              of the <code>ArrayBufferView</code> in bytes.</p>
+              <code>ArrayBufferView</code> object references.</p>
             </li>
           </ul>
         </li>
         <li>
-          <p>If the size of <var>data</var> exceeds the value of <code><a
-          data-link-for="RTCSctpTransport">maxMessageSize</a></code> on
+          <p>If the byte size of <var>data</var> exceeds the value of <code>
+          <a data-link-for="RTCSctpTransport">maxMessageSize</a></code> on
           <var>channel</var>'s associated <code>RTCSctpTransport</code>,
           <a>throw</a> a <code>TypeError</code>.</p>
         </li>
@@ -9190,6 +9183,10 @@ interface RTCTrackEvent : Event {
           parallel. If sending data leads to an SCTP-level error, the
           application will be notified asynchronously through <code><a
           data-link-for="RTCDataChannel">onerror</a></code>.</div>
+        </li>
+        <li>
+          <p>Increase the value of the <a>[[\BufferedAmount]]</a> slot by
+          the byte size of <var>data</var>.</p>
         </li>
       </ol>
       <div>


### PR DESCRIPTION
* Don't increase data channel's buffered amount before the data has been queued (and after potentially raising exceptions)
* Explicitly mention that *size of data* means the size in bytes

Resolves #1824


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lgrahl/webrtc-pc/pull/1843.html" title="Last updated on Apr 21, 2018, 11:27 PM GMT (78fa31f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1843/670a792...lgrahl:78fa31f.html" title="Last updated on Apr 21, 2018, 11:27 PM GMT (78fa31f)">Diff</a>