### PR TITLE
Fix setCodecPreferences note regarding offer/answer negotiation.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7188,15 +7188,14 @@ async function updateParameters() {
               fulfill these requirements, the user agent MUST <a>throw</a> an
               InvalidAccessError.</p>
               <p class="note">
-              Calls to <code>createAnswer</code> will likely use only the
-              common subset of the codec preferences and the codecs that appear
-              in the offer, due to a recommendation in [[!RFC3264]]. For
-              example, if codec preferences are "C, B, A", but only codecs "A,
-              B" were offered, the answer will probably only contain codecs "B,
-              A". Although <span data-jsep="initial-answers">[[!JSEP]]</span>
-              does allow adding codecs that were not in the offer, so this may
-              differ by implementation.</p>
-
+              Due to a recommendation in [[!RFC3264]], calls to
+              <code>createAnswer</code> SHOULD use only the common subset of
+              the codec preferences and the codecs that appear in the offer.
+              For example, if codec preferences are "C, B, A", but only codecs
+              "A, B" were offered, the answer should only contain codecs "B,
+              A". However, <span data-jsep="initial-answers">[[!JSEP]]</span>
+              allows adding codecs that were not in the offer, so
+              implementations can behave differently.</p>
             </dd>
           </dl>
         </section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -7167,9 +7167,7 @@ async function updateParameters() {
               <a>user agent</a> MUST use the indicated codecs, in the order
               specified in the <var>codecs</var> argument, for the media
               section corresponding to this <code>RTCRtpTransceiver</code>.
-              Note that calls to <code>createAnswer</code> will use only the
-              common subset of these codecs and the codecs that appear in the
-              offer.</p>
+              </p>
               <p>This method allows applications to disable the negotiation of
               specific codecs. It also allows an application to cause a remote
               peer to prefer the codec that appears first in the list for
@@ -7189,6 +7187,15 @@ async function updateParameters() {
               members cannot be modified. If <code>codecs</code> does not
               fulfill these requirements, the user agent MUST <a>throw</a> an
               InvalidAccessError.</p>
+              <p class="note">
+              Calls to <code>createAnswer</code> will likely use only the
+              common subset of the codec preferences and the codecs that appear
+              in the offer, due to a recommendation in [[!RFC3264]]. For
+              example, if codec preferences are "C, B, A", but only codecs "A,
+              B" were offered, the answer will probably only contain codecs "B,
+              A". Although <span data-jsep="initial-answers">[[!JSEP]]</span>
+              does allow adding codecs that were not in the offer, so this may
+              differ by implementation.</p>
 
             </dd>
           </dl>


### PR DESCRIPTION
Fixes #1838.

The note said that, even if codec preferences are set, the list of
codecs in the answer will be a subset of those in the offer. Which JSEP
required before, but now does not:

  [T]he media formats in the answer MUST include at least one format
  that is present in the offer, but MAY include formats that are locally
  supported but not present in the offer.

So now, the subset rule is only a SHOULD in RFC3264, and not a MUST in
JSEP. So although most implementations are expected to honor the
"SHOULD", implementations can technically offer codecs in the answer
that were not in the offer. Which is now clarified in this note, with a
brief example.

Also moving the note out of the normative portion of `setCodecPreferences`,
and putting in an actual "note" block.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/taylor-b/webrtc-pc/pull/1844.html" title="Last updated on Apr 25, 2018, 10:57 PM GMT (7308fbe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1844/670a792...taylor-b:7308fbe.html" title="Last updated on Apr 25, 2018, 10:57 PM GMT (7308fbe)">Diff</a>