### PR TITLE
Treat rejected m= sections (port of 0) as having "inactive" direction.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1640,7 +1640,8 @@
                         <p>Let <var>direction</var> be an <code>
                         <a>RTCRtpTransceiverDirection</a></code> value
                         representing the direction from the <a>media
-                        description</a>.</p>
+                        description</a>, or <code>"inactive"</code> if the
+                        <a>media description</a> section was rejected.</p>
                       </li>
                       <li>
                         <p>If <var>direction</var> is <code>"sendrecv"</code> or
@@ -1675,7 +1676,8 @@
                             representing the direction from the <a>media
                             description</a>, but with the send and receive
                             directions reversed to represent this peer's point
-                            of view.</p>
+                            of view, or <code>"inactive"</code> if the
+                            <a>media description</a> was rejected.</p>
                           </li>
                           <li>
                             <p>As described by <span data-jsep=


### PR DESCRIPTION
Fixes #1812.

This will:

- Cause `currentDirection` to change to `"inactive"`
- Cause the remote track to be removed from its stream(s), if
  applicable.

This seems pretty sensible, as the direction has no relevance for a
rejected m= section. No packets will be sent or received for a rejected
m= section (aka, stopped transceiver), so it's effecitvely `"inactive"`;
it would be odd if a different direction in a rejected m= section
produced different behavior.

This also resolves a problem where remote tracks were possibly never
being removed from their streams, which would happen if you set a remote
description with a rejected m= section with "sendrecv" or "sendonly"
direction.