### PR TITLE
Data channel receive procedure

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8787,6 +8787,54 @@ interface RTCTrackEvent : Event {
           <var>channel</var>.</p>
         </li>
       </ol>
+      <p>When an <dfn data-lt="receive an rtcdatachannel message">
+      <code><a>RTCDataChannel</a></code> message has been received</dfn> via
+      the <a>underlying data transport</a> with type <var>type</var> and data
+      <var>rawData</var>, the user agent MUST queue a task to run the following
+      steps:</p>
+      <ol>
+        <li>
+          <p>Let <var>channel</var> be the <code><a>RTCDataChannel</a></code>
+          object for which the user agent has received a message.</p>
+        </li>
+        <li>
+          <p>If <var>channel</var>'s <a>[[\ReadyState]]</a> slot is not
+          <code>open</code>, abort these steps and discard <var>rawData</var>.
+          </p>
+        </li>
+        <li>
+          <p>Execute the sub step by switching on <var>type</var> and the
+          <var>channel</var>'s <code>binaryType</code>:</p>
+          <ul>
+            <li>
+              <p>If <var>type</var> indicates that <var>rawData</var> is a
+              <code>string</code>:</p>
+              <p>Let <var>data</var> be a <span class=
+              "idlMemberType"><a>DOMString</a></span> that represents the
+              result of decoding <var>rawData</var> as UTF-8.</p>
+            </li>
+            <li>
+              <p>If <var>type</var> indicates that <var>rawData</var> is binary
+              and <code>binaryType</code> is <code>"blob"</code>:</p>
+              <p>Let <var>data</var> be a new <code>Blob</code> object
+              containing <var>rawData</var> as its raw data source.</p>
+            </li>
+            <li>
+              <p>If <var>type</var> indicates that <var>rawData</var> is binary
+              and <code>binaryType</code> is <code>"arraybuffer"</code>:</p>
+              <p>Let <var>data</var> be a new <code>ArrayBuffer</code> object
+              containing <var>rawData</var> as its raw data source.</p>
+            </li>
+          </ul>
+        </li>
+        <li>
+          <p>Fire an event named <code><a>message</a></code> at
+          <var>channel</var> with the <code>origin</code> attribute initialized
+          to the origin of the document that created the <var>channel</var>'s
+          associated <a>RTCPeerConnection</a>, and the <code>data</code>
+          attribute initialized to <var>data</var>.</p>
+        </li>
+      </ol>
       <div>
         <pre class="idl">[Exposed=Window] interface RTCDataChannel : EventTarget {
     readonly        attribute USVString           label;


### PR DESCRIPTION
This adds steps for receiving a data channel message. Also clarifies that messages can only be received as long as `.readyState` is `open`.

Resolves #1825 

Since implications on the closing procedure aren't trivial, here's an explanation:

1. Let peers A and B have a common data channel
2. B sends data in a tight loop.
3. A enqueues data to send and then closes the channel (which will enqueue to send an outgoing stream reset after all messages have been delivered). A's channel is now in the `closing` state.
    - **Important:** A cannot receive any more messages from B at this point! All incoming data from B will be discarded.
4. B's channel is still in the `open` state until it has received all messages that have been queued by A.
5. After having received all messages by A, B's channel will move into the `closing` state (due to having received an incoming stream reset and acknowledging it). B is allowed to discard any pending outgoing messages (if possible) and will send an outgoing stream reset.
6. A's channel will move into the `closed` state (due to having received acknowledgement for its outgoing stream reset and received an incoming stream reset).
7. B's channel will move into the `closed` state (due to having received acknowledgement for its outgoing stream reset).

Tests for *enqueue messages and close* exist as part of https://github.com/w3c/web-platform-tests/pull/10468.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lgrahl/webrtc-pc/pull/1849.html" title="Last updated on Apr 21, 2018, 11:25 PM GMT (af41c10)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1849/670a792...lgrahl:af41c10.html" title="Last updated on Apr 21, 2018, 11:25 PM GMT (af41c10)">Diff</a>