### PR TITLE
In-band negotiated channel should be open when dispatching

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8654,6 +8654,10 @@ interface RTCTrackEvent : Event {
           object to be announced.</p>
         </li>
         <li>
+          <p>If <var>channel</var>'s <a>[[\ReadyState]]</a> is <code>closing</code> or
+          <code>closed</code>, abort these steps.</p>
+        </li>
+        <li>
           <p>Set <var>channel</var>'s <a>[[\ReadyState]]</a> slot to
           <code>open</code>.</p>
         </li>
@@ -8735,9 +8739,8 @@ interface RTCTrackEvent : Event {
           <code><a>RTCPeerConnection</a></code> object.</p>
         </li>
         <li>
-          <p>If the <var>channel</var>'s <a>[[\ReadyState]]</a> is still
-          <code>open</code>, <a data-lt="announce the rtcdatachannel as open">
-          announce the data channel as open</a>.</p>
+          <p><a data-lt="announce the rtcdatachannel as open">Announce the data channel as
+          open</a>.</p>
         </li>
       </ol>
       <p>An <code><a>RTCDataChannel</a></code> object's <a>underlying data

--- a/webrtc.html
+++ b/webrtc.html
@@ -8722,9 +8722,20 @@ interface RTCTrackEvent : Event {
           </table>
         </li>
         <li>
+          <p>Set <var>channel</var>'s <a>[[\ReadyState]]</a> to
+          <code>open</code> (but do not fire the <code><a>open</a></code>
+          event, yet).</p>
+          <div class="note">This allows to start sending messages inside of the
+          <code><a>datachannel</a></code> event handler prior to the
+          <code><a>open</a></code> event being fired.</div>
+        </li>
+        <li>
           <p><a>Fire a datachannel event</a> named
           <code><a>datachannel</a></code> with <var>channel</var> at the
           <code><a>RTCPeerConnection</a></code> object.</p>
+        </li>
+        <li>
+          <p>If the <var>channel</var>'s <a>[[\ReadyState]]</a> is still <code>open</code>, <a data-lt="announce the rtcdatachannel as open">announce the data channel as open</a>.</p>
         </li>
       </ol>
       <p>An <code><a>RTCDataChannel</a></code> object's <a>underlying data

--- a/webrtc.html
+++ b/webrtc.html
@@ -8735,7 +8735,9 @@ interface RTCTrackEvent : Event {
           <code><a>RTCPeerConnection</a></code> object.</p>
         </li>
         <li>
-          <p>If the <var>channel</var>'s <a>[[\ReadyState]]</a> is still <code>open</code>, <a data-lt="announce the rtcdatachannel as open">announce the data channel as open</a>.</p>
+          <p>If the <var>channel</var>'s <a>[[\ReadyState]]</a> is still
+          <code>open</code>, <a data-lt="announce the rtcdatachannel as open">
+          announce the data channel as open</a>.</p>
         </li>
       </ol>
       <p>An <code><a>RTCDataChannel</a></code> object's <a>underlying data


### PR DESCRIPTION
These changes move the data channel that is about to be announced into the `open` state prior to firing the `datachannel` event. (Also explicitly announces the data channel as open now.)

Resolves #1761

I can write a WPT test for this once merged.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lgrahl/webrtc-pc/pull/1851.html" title="Last updated on Apr 22, 2018, 12:49 AM GMT (6648f92)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1851/670a792...lgrahl:6648f92.html" title="Last updated on Apr 22, 2018, 12:49 AM GMT (6648f92)">Diff</a>