### PR TITLE
Define the reference clock used for RTCRtpContributingSource.timestamp

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6820,10 +6820,10 @@ async function updateParameters() {
             "idlMemberType"><a>DOMHighResTimeStamp</a></span>, required</dt>
             <dd>
               <p>The timestamp of type DOMHighResTimeStamp [[!HIGHRES-TIME]],
-              indicating the most recent time of playout of media
-              originating from this source. The timestamp is defined as
-              <a>performance.timeOrigin</a> + <a>performance.now()</a> at
-              the time of playout.</p>
+              indicating the most recent time of playout of media that arrived
+              in an RTP packet originating from this source. The timestamp is
+              defined as <a>performance.timeOrigin</a> +
+              <a>performance.now()</a> at the time of playout.</p>
             </dd>
             <dt><dfn data-idl><code>source</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long</a></span>, required</dt>

--- a/webrtc.html
+++ b/webrtc.html
@@ -83,6 +83,9 @@
     <p>The terms <dfn>event</dfn>, <dfn data-cite="!HTML51/webappapis.html#events-event-handlers">event
     handlers</dfn> and <dfn data-cite="!HTML51/webappapis.html#event-handler-event-type">event
     handler event types</dfn> are defined in [[!HTML51]].</p>
+    <code><dfn data-cite="!HIGHRES-TIME#dom-performance-timeOrigin">performance.timeOrigin</dfn></code>
+    and <code><dfn data-cite="!HIGHRES-TIME#dom-performance-now">performance.now()</dfn></code>
+    are defined in [[!HIGHRES-TIME]].
     <p>The terms <dfn>MediaStream</dfn>, <dfn>MediaStreamTrack</dfn>, and
     <dfn>MediaStreamConstraints</dfn> are defined in [[!GETUSERMEDIA]].
     Note that <code><a>MediaStream</a></code> is extended in <code><a href="#mediastream-network-use">
@@ -6817,9 +6820,10 @@ async function updateParameters() {
             "idlMemberType"><a>DOMHighResTimeStamp</a></span>, required</dt>
             <dd>
               <p>The timestamp of type DOMHighResTimeStamp [[!HIGHRES-TIME]],
-              indicating the most recent time of playout of an RTP packet
-              containing the source. The timestamp is defined in
-              [[!HIGHRES-TIME]] and corresponds to a local clock.</p>
+              indicating the most recent time of playout of media
+              originating from this source. The timestamp is defined as
+              <a>performance.timeOrigin</a> + <a>performance.now()</a> at
+              the time of playout.</p>
             </dd>
             <dt><dfn data-idl><code>source</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long</a></span>, required</dt>

--- a/webrtc.html
+++ b/webrtc.html
@@ -83,9 +83,9 @@
     <p>The terms <dfn>event</dfn>, <dfn data-cite="!HTML51/webappapis.html#events-event-handlers">event
     handlers</dfn> and <dfn data-cite="!HTML51/webappapis.html#event-handler-event-type">event
     handler event types</dfn> are defined in [[!HTML51]].</p>
-    <code><dfn data-cite="!HIGHRES-TIME#dom-performance-timeOrigin">performance.timeOrigin</dfn></code>
+    <p><code><dfn data-cite="!HIGHRES-TIME#dom-performance-timeOrigin">performance.timeOrigin</dfn></code>
     and <code><dfn data-cite="!HIGHRES-TIME#dom-performance-now">performance.now()</dfn></code>
-    are defined in [[!HIGHRES-TIME]].
+    are defined in [[!HIGHRES-TIME]].</p>
     <p>The terms <dfn>MediaStream</dfn>, <dfn>MediaStreamTrack</dfn>, and
     <dfn>MediaStreamConstraints</dfn> are defined in [[!GETUSERMEDIA]].
     Note that <code><a>MediaStream</a></code> is extended in <code><a href="#mediastream-network-use">


### PR DESCRIPTION
Fixes #1690 and #1497.

Following the decision at the January VI, this timestamp uses
performance.timeOrigin + performance.now() (matching
RTCStats.timestamp).

This will allow an application to tell "how long ago did media from
this source play?", whereas previously it was only defined as "a
local clock", which meant it only supported comparing timestamps
between sources.

Also replacing "playout of an RTP packet containing the source"
with "playout of media originating from this source", since you
don't really "play out" an RTP packet directly.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/taylor-b/webrtc-pc/pull/1854.html" title="Last updated on Apr 25, 2018, 11:56 PM GMT (43c2895)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1854/53e0ef7...taylor-b:43c2895.html" title="Last updated on Apr 25, 2018, 11:56 PM GMT (43c2895)">Diff</a>