### PR TITLE
Require some codec dictionary members

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7138,7 +7138,7 @@ async function updateParameters() {
               <code>RTCRtpReceiver.getCapabilities(kind)</code>, where
               <code>kind</code> is the kind of the
               <code>RTCRtpTransceiver</code> on which the method is called.
-              Additionally, the <code>RTCRtpCodecParameters</code> dictionary
+              Additionally, the <code>RTCRtpCodecCapability</code> dictionary
               members cannot be modified. If <code>codecs</code> does not
               fulfill these requirements, the user agent MUST <a>throw</a> an
               InvalidAccessError.</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -6406,15 +6406,15 @@ async function updateParameters() {
       <h3><dfn>RTCRtpCapabilities</dfn> Dictionary</h3>
       <div>
         <pre class="idl">dictionary RTCRtpCapabilities {
-             sequence&lt;RTCRtpCodecCapability&gt;           codecs;
-             sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensions;
+             required sequence&lt;RTCRtpCodecCapability&gt;           codecs;
+             required sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensions;
 };</pre>
         <section>
           <h2>Dictionary <code><a>RTCRtpCapabilities</a></code> Members</h2>
           <dl data-link-for="RTCRtpCapabilities" data-dfn-for=
           "RTCRtpCapabilities" class="dictionary-members">
             <dt><dfn data-idl><code>codecs</code></dfn> of type <span class=
-            "idlMemberType">sequence&lt;<a>RTCRtpCodecCapability</a>&gt;</span></dt>
+            "idlMemberType">sequence&lt;<a>RTCRtpCodecCapability</a>&gt;</span>, required</dt>
             <dd>
               <p>Supported media codecs as well as entries for RTX, RED and FEC
               mechanisms. There will only be a single entry in
@@ -6422,7 +6422,7 @@ async function updateParameters() {
               <code>sdpFmtpLine</code> not present.</p>
             </dd>
             <dt><dfn data-idl><code>headerExtensions</code></dfn> of type <span class=
-            "idlMemberType">sequence&lt;<a>RTCRtpHeaderExtensionCapability</a>&gt;</span></dt>
+            "idlMemberType">sequence&lt;<a>RTCRtpHeaderExtensionCapability</a>&gt;</span>, required</dt>
             <dd>
               <p>Supported RTP header extensions.</p>
             </dd>
@@ -6434,8 +6434,8 @@ async function updateParameters() {
       <h3><dfn>RTCRtpCodecCapability</dfn> Dictionary</h3>
       <div>
         <pre class="idl">dictionary RTCRtpCodecCapability {
-             DOMString mimeType;
-             unsigned long  clockRate;
+             required DOMString mimeType;
+             required unsigned long  clockRate;
              unsigned short channels;
              DOMString      sdpFmtpLine;
 };</pre>
@@ -6453,20 +6453,20 @@ async function updateParameters() {
           <dl data-link-for="RTCRtpCodecCapability" data-dfn-for=
           "RTCRtpCodecCapability" class="dictionary-members">
             <dt><dfn data-idl><code>mimeType</code></dfn> of type <span class=
-            "idlMemberType"><a>DOMString</a></span></dt>
+            "idlMemberType"><a>DOMString</a></span>, required</dt>
             <dd>
               <p>The codec MIME media type/subtype. Valid media types and
               subtypes are listed in [[IANA-RTP-2]].</p>
             </dd>
             <dt><dfn data-idl><code>clockRate</code></dfn> of type <span class=
-            "idlMemberType"><a>unsigned long</a></span></dt>
+            "idlMemberType"><a>unsigned long</a></span>, required</dt>
             <dd>
               <p>The codec clock rate expressed in Hertz.</p>
             </dd>
             <dt><dfn data-idl><code>channels</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned short</a></span></dt>
             <dd>
-              <p>The maximum number of channels (mono=1, stereo=2).</p>
+              <p>If present, indicates the maximum number of channels (mono=1, stereo=2).</p>
             </dd>
             <dt><dfn data-idl><code>sdpFmtpLine</code></dfn> of type <span class=
             "idlMemberType"><a>DOMString</a></span></dt>

--- a/webrtc.html
+++ b/webrtc.html
@@ -6352,9 +6352,9 @@ async function updateParameters() {
       <h3><dfn>RTCRtpCodecParameters</dfn> Dictionary</h3>
       <div>
         <pre class="idl">dictionary RTCRtpCodecParameters {
-             octet          payloadType;
-             DOMString      mimeType;
-             unsigned long  clockRate;
+             required octet          payloadType;
+             required DOMString      mimeType;
+             required unsigned long  clockRate;
              unsigned short channels;
              DOMString      sdpFmtpLine;
 };</pre>
@@ -6384,7 +6384,7 @@ async function updateParameters() {
             <dt><dfn data-idl><code>channels</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned short</a></span></dt>
             <dd>
-              <p>The number of channels (mono=1, stereo=2). <a>Read-only
+              <p>When present, indicates the number of channels (mono=1, stereo=2). <a>Read-only
               parameter</a>.</p>
             </dd>
             <dt><dfn data-idl><code>sdpFmtpLine</code></dfn> of type <span class=


### PR DESCRIPTION
Added some required members to `RTCRtpCodecParameters` and `RTCRtpCapabilities`, as a follow-up fix to https://github.com/w3c/webrtc-pc/issues/1493.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/1861.html" title="Last updated on May 1, 2018, 2:12 PM GMT (6a7798a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1861/918b8d1...jan-ivar:6a7798a.html" title="Last updated on May 1, 2018, 2:12 PM GMT (6a7798a)">Diff</a>