### PR TITLE
Trim [[SendEncodings]] down to what user agent supports.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5533,6 +5533,12 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           <var>maxN</var>.</p>
         </li>
         <li>
+          <p>If the number of <code><a>RTCRtpEncodingParameters</a></code> now
+          stored in <a>[[\SendEncodings]]</a> is <code>1</code>, then remove any
+          <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>
+          member from the lone entry.</p>
+        </li>
+        <li>
           <p>Let <var>sender</var> have a <dfn>[[\LastReturnedParameters]]</dfn>
           internal slot, which will be used to match
           <code><a data-link-for="RTCRtpSender">getParameters()</a></code> and

--- a/webrtc.html
+++ b/webrtc.html
@@ -5523,8 +5523,9 @@ interface RTCPeerConnectionIceErrorEvent : Event {
         </li>
         <li>
           <p>Let <var>maxN</var> be the maximum number of total simultaneous
-          encodings the user agent supports for this <var>kind</var>, at minimum
-          <code>1</code>.</p>
+          encodings the user agent may support for this <var>kind</var>, at
+          minimum <code>1</code>.This should be an optimistic number since the
+          codec to be used is not known yet.</p>
         </li>
         <li>
           <p>If the number of <code><a>RTCRtpEncodingParameters</a></code>

--- a/webrtc.html
+++ b/webrtc.html
@@ -5158,7 +5158,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   <var>track.kind</var>.</p>
                 </li>
                 <li>
-                  <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">rid</a></code>
+                  <p>Verify that each <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>
                   value in <var>sendEncodings</var> is composed only of
                   alphanumeric characters (a-z, A-Z, 0-9) up to
                   a maximum of 16 characters. If one of the RIDs does not meet
@@ -5168,7 +5168,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   <p>If any <code><a>RTCRtpEncodingParameters</a></code>
                   dictionary in <var>sendEncodings</var> contains a
                   <a>read-only parameter</a> other than
-                  <code><a data-link-for="RTCRtpEncodingParameters">rid</a></code>,
+                  <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>,
                   <a>throw</a> an <code>InvalidAccessError</code>.</p>
                 </li>
                 <li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -5522,6 +5522,17 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           when simulcast isn't used.</div>
         </li>
         <li>
+          <p>Let <var>maxN</var> be the maximum number of total simultaneous
+          encodings the user agent supports for this <var>kind</var>, at minimum
+          <code>1</code>.</p>
+        </li>
+        <li>
+          <p>If the number of <code><a>RTCRtpEncodingParameters</a></code>
+          stored in <a>[[\SendEncodings]]</a> exceeds <var>maxN</var>, then trim
+          <a>[[\SendEncodings]]</a> from the tail until its length is
+          <var>maxN</var>.</p>
+        </li>
+        <li>
           <p>Let <var>sender</var> have a <dfn>[[\LastReturnedParameters]]</dfn>
           internal slot, which will be used to match
           <code><a data-link-for="RTCRtpSender">getParameters()</a></code> and


### PR DESCRIPTION
Fix for https://github.com/w3c/webrtc-pc/issues/1813.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/1862.html" title="Last updated on May 1, 2018, 5:06 PM GMT (c5bc7a6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1862/918b8d1...jan-ivar:c5bc7a6.html" title="Last updated on May 1, 2018, 5:06 PM GMT (c5bc7a6)">Diff</a>