### PR TITLE
Improve replaceTrack prose; restores lost pre-negotiation behavior.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5869,25 +5869,20 @@ async function updateParameters() {
                       <p>Run the following steps in parallel:</p>
                       <ol>
                         <li>
-                          <p>Determine if negotiation would be needed in order to
-                          replace <var>sender</var>'s existing track with
-                          <var>withTrack</var>. Ignore whether the sender already
-                          needs negotiation, in this determination.
-                          Negotiation is not needed if <var>withTrack</var>
-                          is null. Ignore which <code>MediaStream</code> the track
-                          resides in and the <code>id</code> attribute of the track
-                          in this determination. Also, ignore
-                          <var>transceiver</var>'s <a>[[\Direction]]</a> slot in
-                          this determination. If negotiation is needed, then
-                          <a>reject</a> <var>p</var> with a newly
+                          If <var>withTrack</var> is not <code>null</code> and
+                          <var>transceiver</var> is already associated with a
+                          media description, determine if <var>withTrack</var>
+                          can be sent immediately by the sender without violating
+                          the sender's already-negotiated envelope, and if it
+                          cannot, then <a>reject</a> <var>p</var> with a newly
                           <a data-link-for="exception" data-lt="create">created</a>
                           <code>InvalidModificationError</code> and abort these
                           steps.</p>
                         </li>
                         <li>
-                          <p>If <var>withTrack</var> is null, have the sender
-                          stop sending, without negotiating. Otherwise, have
-                          the sender switch seamlessly to transmitting
+                          <p>If <var>withTrack</var> is <code>null</code>, have
+                          the sender stop sending, without negotiating. Otherwise,
+                          have the sender switch seamlessly to transmitting
                           <var>withTrack</var> instead of the sender's existing
                           track, without negotiating. Note that the actual
                           transmission may currently be inhibited by


### PR DESCRIPTION
Fix for https://github.com/w3c/webrtc-pc/issues/1855.