### PR TITLE
Fix typo s/sdpCauseCode/sctpCauseCode/

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -11940,7 +11940,7 @@ if (sender.dtmf.canInsertDTMF) {
                 <td><dfn data-idl><code>sctp-failure</code></dfn></td>
                 <td>The SCTP negotiation has failed or the connection
                 has been terminated with a fatal error. The
-                <code>sdpCauseCode</code> attribute is set to the
+                <code>sctpCauseCode</code> attribute is set to the
                 SCTP cause code.</td>
               </tr>
               <tr>


### PR DESCRIPTION
Fix for https://github.com/w3c/webrtc-pc/issues/1158.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/1864.html" title="Last updated on May 1, 2018, 9:57 PM GMT (2f4a482)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1864/918b8d1...jan-ivar:2f4a482.html" title="Last updated on May 1, 2018, 9:57 PM GMT (2f4a482)">Diff</a>