### PR TITLE
Legacy methods do not throw exceptions.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3418,12 +3418,6 @@ interface RTCPeerConnection : EventTarget  {
         <p>All methods that return promises are governed by the standard error
         handling rules of promises. Methods that do not return promises may
         throw exceptions to indicate errors.</p>
-        <p>Legacy-methods may only throw exceptions to indicate invalid state
-        and other programming errors. For example, when a legacy-method is
-        called when the <code><a>RTCPeerConnection</a></code> is in an invalid
-        state or a state in which that particular method is not allowed to be
-        executed, it will throw an exception. In all other cases, legacy
-        methods MUST provide an error object to the error callback.</p>
       </section>
     </section>
     <section>


### PR DESCRIPTION
Fix for https://github.com/w3c/webrtc-pc/issues/1236.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/1865.html" title="Last updated on May 1, 2018, 10:20 PM GMT (5284d6a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1865/918b8d1...jan-ivar:5284d6a.html" title="Last updated on May 1, 2018, 10:20 PM GMT (5284d6a)">Diff</a>