### PR TITLE
Fix simulcast example

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -11468,7 +11468,7 @@ async function start() {
   // let the "negotiationneeded" event trigger offer generation
   pc.onnegotiationneeded = async () =&gt; {
     try {
-      await pc.setLocalDescription(pc.createOffer());
+      await pc.setLocalDescription(await pc.createOffer());
       // send the offer to the other peer
       signaling.send(JSON.stringify({desc: pc.localDescription}));
     } catch (err) {


### PR DESCRIPTION
`await` should be placed before `pc.createOffer()` in Simulcast example.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/iwashi/webrtc-pc/pull/1866.html" title="Last updated on May 2, 2018, 2:27 AM GMT (bd98952)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1866/918b8d1...iwashi:bd98952.html" title="Last updated on May 2, 2018, 2:27 AM GMT (bd98952)">Diff</a>