### PR TITLE
Invalidate [[LastReturnedParameters]] in RTCRtpSender.setParameters

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5642,8 +5642,8 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <a data-link-for="exception" data-lt="create">created</a>
                 <code>InvalidStateError</code>.</li>
                 <li>If <var>sender</var>'s <a>[[\LastReturnedParameters]]</a>
-                internal slot is empty, meaning <code><a>getParameters</a></code>
-                has never been called, return a promise <a>rejected</a> with a newly
+                internal slot is <code>null</code>, return a promise
+                <a>rejected</a> with a newly
                 <a data-link-for="exception" data-lt="create">created</a>
                 <code>InvalidStateError</code>.</li>
                 <li>If any of the following conditions are met, return a promise
@@ -5690,6 +5690,9 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                     <var>parameters</var>, queue a task to run the following
                     steps:
                       <ol>
+                        <li>Set <var>sender</var>'s internal
+                        <a>[[\LastReturnedParameters]]</a> slot to
+                        <code>null</code>.</li>
                         <li>Set <var>sender</var>'s internal
                         <a>[[\SendEncodings]]</a> slot to <code>
                         <var>parameters</var>.encodings</code>.</li>


### PR DESCRIPTION
This prevents sequences of getParameters() and then
multiple setParameters() call.

Fixes #1857