### PR TITLE
Correction for encodings attribute feature at risk

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -33,7 +33,7 @@
     <p>The following features are marked as at risk:</p>
     <ul>
       <li>The value <a href="#dom-rtcrtcpmuxpolicy-negotiate"><code>negotiate</code></a> of RTCRtcpMuxPolicy</li>
-      <li>The <code>encodings</code> attribute of <code><a>RTCRtpDecodingParameters</a></code></li>
+      <li>The <code>encodings</code> attribute of <code><a>RTCRtpReceiveParameters</a></code></li>
     </ul>
 
   </section>
@@ -5196,7 +5196,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   encodings negotiated.</p>
                   <div class="issue atrisk">
                     <p>Support for the <code>encodings</code> attribute of
-                    <code><a>RTCRtpDecodingParameters</a></code> is marked
+                    <code><a>RTCRtpReceiveParameters</a></code> is marked
                     as a feature at risk, since there is no clear
                     commitment from implementers.</p>
                   </div>


### PR DESCRIPTION
It is `RTCRtpReceiveParameters` rather than `RTCRtpDecodingParameters` that includes the `encodings` attribute.