### PR TITLE
Have pc.close() set connection states to "closed".

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3029,6 +3029,14 @@ interface RTCPeerConnection : EventTarget  {
                     to <code><a data-link-for=
                     "RTCIceTransportState">"closed"</a></code>.</p>
                   </li>
+                  <li>
+                    <p>Set <var>connection</var>'s <a>ICE connection state</a> to
+                    <code>"closed"</code>.</p>
+                  </li>
+                  <li>
+                    <p>Set <var>connection</var>'s <a>connection state</a> to
+                    <code>"closed"</code>.</p>
+                  </li>
                 </ol>
               </dd>
             </dl>


### PR DESCRIPTION
Fix for https://github.com/w3c/webrtc-pc/issues/1883.