### PR TITLE
Adding note about the dangers of RTCDataChannelInit.negotiated.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9309,6 +9309,13 @@ interface RTCTrackEvent : Event {
               create an <code><a>RTCDataChannel</a></code> object with the same
               <code><a data-link-for="RTCDataChannel">id</a></code> at the other
               peer.</p>
+              <div class="note">If set to true, the application must also take
+              care to not send a message until the other peer has created a
+              data channel to receive it. Receiving a message on an SCTP stream
+              with no associated data channel is undefined behavior, and it may
+              be silently dropped. This will not be possible as long as both
+              endpoints create their data channel before the first offer/answer
+              exchange is complete.</div>
             </dd>
             <dt><dfn data-idl><code>id</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned short</a></span></dt>


### PR DESCRIPTION
Fixes #1879.

If one peer creates an out-of-band negotiated data channel and tries to
send with it before the other peer creates its corresponding data
channel, messages may be lost (even if the channel is reliable).

Raised this issue on the rtcweb mailing list here:
https://mailarchive.ietf.org/arch/msg/rtcweb/lIuiu91_L2nOh935eAqifrs_ius

But there's no clear consensus, with more people suggesting "do nothing"
than anything else. Given that this has always been an issue in Chrome
and Firefox and no one has really complained, maybe just adding this
note is sufficient.