### PR TITLE
move handling of rtcpmuxpolicy from constructor to setConfiguration

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -989,12 +989,6 @@
             undefined for the subsequent steps.</p>
           </li>
           <li>
-            <p>If <code><var>configuration</var>.<a data-link-for=
-            "RTCConfiguration">rtcpMuxPolicy</a></code> is
-            <code>"negotiate"</code>, and the user agent does not implement
-            non-muxed RTCP, <a>throw</a> a <code>NotSupportedError</code>.</p>
-          </li>
-          <li>
             <p>Initialize <var>connection</var>'s <a>ICE Agent</a>.</p>
           </li>
           <li>
@@ -1907,7 +1901,9 @@
             <li>If the value of <code><var>configuration</var>.<a data-link-for=
             "RTCConfiguration">rtcpMuxPolicy</a></code> differs from the
             <var>connection</var>'s rtcpMux policy, <a>throw</a> an
-            <code>InvalidModificationError</code>.</li>
+            <code>InvalidModificationError</code>. If the value is
+            <code>"negotiate"</code> and the user agent does not implement
+            non-muxed RTCP, <a>throw</a> a <code>NotSupportedError</code>.</li>
             <li>If the value of <code><var>configuration</var>.<a data-link-for=
             "RTCConfiguration">iceCandidatePoolSize</a></code> differs from
             the <var>connection</var>'s previously set

--- a/webrtc.html
+++ b/webrtc.html
@@ -1895,18 +1895,19 @@
             when <var>connection</var> was constructed, <a>throw</a> an
             <code>InvalidModificationError</code>.</li>
             <li>If the value of <code><var>configuration</var>.<a data-link-for=
-            "RTCConfiguration">bundlePolicy</a></code> differs from the
-            <var>connection</var>'s bundle policy, <a>throw</a>
+            "RTCConfiguration">bundlePolicy</a></code> is set and its value
+            differs from the <var>connection</var>'s bundle policy, <a>throw</a>
             an <code>InvalidModificationError</code>.</li>
             <li>If the value of <code><var>configuration</var>.<a data-link-for=
-            "RTCConfiguration">rtcpMuxPolicy</a></code> differs from the
+            "RTCConfiguration">rtcpMuxPolicy</a></code> is set and its value
+            differs from the
             <var>connection</var>'s rtcpMux policy, <a>throw</a> an
             <code>InvalidModificationError</code>. If the value is
             <code>"negotiate"</code> and the user agent does not implement
             non-muxed RTCP, <a>throw</a> a <code>NotSupportedError</code>.</li>
             <li>If the value of <code><var>configuration</var>.<a data-link-for=
-            "RTCConfiguration">iceCandidatePoolSize</a></code> differs from
-            the <var>connection</var>'s previously set
+            "RTCConfiguration">iceCandidatePoolSize</a></code> is set and its
+            value differs from the <var>connection</var>'s previously set
             <code>iceCandidatePoolSize</code>, and <code><a data-link-for=
             "RTCPeerConnection">setLocalDescription</a></code> has
             already been called, <a>throw</a> an


### PR DESCRIPTION
as discussed in #1235 (but does not fix the issue)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-pc/pull/1907.html" title="Last updated on Jul 10, 2018, 6:55 PM GMT (9d4e115)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1907/dd52fdc...fippo:9d4e115.html" title="Last updated on Jul 10, 2018, 6:55 PM GMT (9d4e115)">Diff</a>