### PR TITLE
"direction" and rtcrtpheaderextensionparameters

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6478,7 +6478,6 @@ async function updateParameters() {
         <code><var>transceiver</var>.sender.getParameters().headerExtensions</code> nor 
         <code><var>transceiver</var>.receiver.getParameters().headerExtensions</code>.</li>
       </ol>
-      </p>
       </section>
       <section id="rtcrtpcodecparameters">
       <h3><dfn>RTCRtpCodecParameters</dfn> Dictionary</h3>

--- a/webrtc.html
+++ b/webrtc.html
@@ -6430,8 +6430,9 @@ async function updateParameters() {
       dictionary enables an application to determine whether a
       header extension is configured for use
       within an <code><a>RTCRtpSender</a></code> or
-      <code><a>RTCRtpReceiver</a></code>. The "direction" parameter
-      defined in [[!RFC5285]] Section 5 can be determined as follows:</p>
+      <code><a>RTCRtpReceiver</a></code>. An application can
+      determine the "direction" parameter (defined in Section 5
+      of [[RFC5285]]) of a header extension as follows:</p>
       <ol>
         <li>sendonly: The header extension is only included in
         <code>sender.getParameters().headerExtensions</code>.</li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -6426,6 +6426,24 @@ async function updateParameters() {
       </section>
       <section id="rtcrtpheaderextensionparameters">
       <h3><dfn>RTCRtpHeaderExtensionParameters</dfn> Dictionary</h3>
+      <p>The <code>RTCRtpHeaderExtensionParameters</code>
+      dictionary enables an application to determine whether a
+      header extension is configured for use
+      within an <code><a>RTCRtpSender</a></code> or
+      <code><a>RTCRtpReceiver</a></code>. The "direction" parameter
+      defined in [[!RFC5285]] Section 5 can be determined as follows:</p>
+      <ol>
+        <li>sendonly: The header extension is only included in
+        <code>sender.getParameters().headerExtensions</code>.</li>
+        <li>recvonly: The header extension is only included in
+        <code>receiver.getParameters().headerExtensions</code>.</li>
+        <li>sendrecv: The header extension is included in both
+        <code>sender.getParameters().headerExtensions</code> and 
+        <code>receiver.getParameters().headerExtensions</code>.</li>
+        <li>inactive: The header extension is included in neither
+        <code>sender.getParameters().headerExtensions</code> nor 
+        <code>receiver.getParameters().headerExtensions</code>.</li>
+      </ol>
       <div>
         <pre class="idl">dictionary RTCRtpHeaderExtensionParameters {
              required DOMString      uri;

--- a/webrtc.html
+++ b/webrtc.html
@@ -6427,23 +6427,25 @@ async function updateParameters() {
       <section id="rtcrtpheaderextensionparameters">
       <h3><dfn>RTCRtpHeaderExtensionParameters</dfn> Dictionary</h3>
       <p>The <code>RTCRtpHeaderExtensionParameters</code>
-      dictionary enables an application to determine whether a
-      header extension is configured for use
+      dictionary enables an application to determine whether
+      a header extension is configured for use
       within an <code><a>RTCRtpSender</a></code> or
-      <code><a>RTCRtpReceiver</a></code>. An application can
-      determine the "direction" parameter (defined in Section 5
-      of [[RFC5285]]) of a header extension as follows:</p>
+      <code><a>RTCRtpReceiver</a></code>. For an
+      <code>RTCRtpTransceiver</code> <var>transceiver</var>, an
+      application can determine the "direction" parameter
+      (defined in Section 5 of [[RFC5285]]) of a header
+      extension as follows:</p>
       <ol>
         <li>sendonly: The header extension is only included in
-        <code>sender.getParameters().headerExtensions</code>.</li>
+        <code><var>transceiver</var>.sender.getParameters().headerExtensions</code>.</li>
         <li>recvonly: The header extension is only included in
-        <code>receiver.getParameters().headerExtensions</code>.</li>
+        <code><var>transceiver</var>.receiver.getParameters().headerExtensions</code>.</li>
         <li>sendrecv: The header extension is included in both
-        <code>sender.getParameters().headerExtensions</code> and 
-        <code>receiver.getParameters().headerExtensions</code>.</li>
+        <code><var>transceiver</var>.sender.getParameters().headerExtensions</code> and 
+        <code><var>transceiver</var>.receiver.getParameters().headerExtensions</code>.</li>
         <li>inactive: The header extension is included in neither
-        <code>sender.getParameters().headerExtensions</code> nor 
-        <code>receiver.getParameters().headerExtensions</code>.</li>
+        <code><var>transceiver</var>.sender.getParameters().headerExtensions</code> nor 
+        <code><var>transceiver</var>.receiver.getParameters().headerExtensions</code>.</li>
       </ol>
       <div>
         <pre class="idl">dictionary RTCRtpHeaderExtensionParameters {

--- a/webrtc.html
+++ b/webrtc.html
@@ -6426,15 +6426,14 @@ async function updateParameters() {
       </section>
       <section id="rtcrtpheaderextensionparameters">
       <h3><dfn>RTCRtpHeaderExtensionParameters</dfn> Dictionary</h3>
-      <p>The <code>RTCRtpHeaderExtensionParameters</code>
-      dictionary enables an application to determine whether
-      a header extension is configured for use
-      within an <code><a>RTCRtpSender</a></code> or
-      <code><a>RTCRtpReceiver</a></code>. For an
+      <p>The <code>RTCRtpHeaderExtensionParameters</code> dictionary
+      enables an application to determine whether a header extension
+      is configured for use within an <code><a>RTCRtpSender</a></code>
+      or <code><a>RTCRtpReceiver</a></code>. For an
       <code>RTCRtpTransceiver</code> <var>transceiver</var>, an
-      application can determine the "direction" parameter
-      (defined in Section 5 of [[RFC5285]]) of a header
-      extension as follows:</p>
+      application can determine the "direction" parameter (defined in
+      Section 5 of [[RFC5285]]) of a header extension as follows
+      without having to parse SDP:</p>
       <ol>
         <li>sendonly: The header extension is only included in
         <code><var>transceiver</var>.sender.getParameters().headerExtensions</code>.</li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -6426,26 +6426,6 @@ async function updateParameters() {
       </section>
       <section id="rtcrtpheaderextensionparameters">
       <h3><dfn>RTCRtpHeaderExtensionParameters</dfn> Dictionary</h3>
-      <p>The <code>RTCRtpHeaderExtensionParameters</code> dictionary
-      enables an application to determine whether a header extension
-      is configured for use within an <code><a>RTCRtpSender</a></code>
-      or <code><a>RTCRtpReceiver</a></code>. For an
-      <code>RTCRtpTransceiver</code> <var>transceiver</var>, an
-      application can determine the "direction" parameter (defined in
-      Section 5 of [[RFC5285]]) of a header extension as follows
-      without having to parse SDP:</p>
-      <ol>
-        <li>sendonly: The header extension is only included in
-        <code><var>transceiver</var>.sender.getParameters().headerExtensions</code>.</li>
-        <li>recvonly: The header extension is only included in
-        <code><var>transceiver</var>.receiver.getParameters().headerExtensions</code>.</li>
-        <li>sendrecv: The header extension is included in both
-        <code><var>transceiver</var>.sender.getParameters().headerExtensions</code> and 
-        <code><var>transceiver</var>.receiver.getParameters().headerExtensions</code>.</li>
-        <li>inactive: The header extension is included in neither
-        <code><var>transceiver</var>.sender.getParameters().headerExtensions</code> nor 
-        <code><var>transceiver</var>.receiver.getParameters().headerExtensions</code>.</li>
-      </ol>
       <div>
         <pre class="idl">dictionary RTCRtpHeaderExtensionParameters {
              required DOMString      uri;
@@ -6478,6 +6458,27 @@ async function updateParameters() {
           </dl>
         </section>
       </div>
+      <p class="note">The <code>RTCRtpHeaderExtensionParameters</code> dictionary
+      enables an application to determine whether a header extension
+      is configured for use within an <code><a>RTCRtpSender</a></code>
+      or <code><a>RTCRtpReceiver</a></code>. For an
+      <code>RTCRtpTransceiver</code> <var>transceiver</var>, an
+      application can determine the "direction" parameter (defined in
+      Section 5 of [[RFC5285]]) of a header extension as follows
+      without having to parse SDP:
+      <ol>
+        <li>sendonly: The header extension is only included in
+        <code><var>transceiver</var>.sender.getParameters().headerExtensions</code>.</li>
+        <li>recvonly: The header extension is only included in
+        <code><var>transceiver</var>.receiver.getParameters().headerExtensions</code>.</li>
+        <li>sendrecv: The header extension is included in both
+        <code><var>transceiver</var>.sender.getParameters().headerExtensions</code> and 
+        <code><var>transceiver</var>.receiver.getParameters().headerExtensions</code>.</li>
+        <li>inactive: The header extension is included in neither
+        <code><var>transceiver</var>.sender.getParameters().headerExtensions</code> nor 
+        <code><var>transceiver</var>.receiver.getParameters().headerExtensions</code>.</li>
+      </ol>
+      </p>
       </section>
       <section id="rtcrtpcodecparameters">
       <h3><dfn>RTCRtpCodecParameters</dfn> Dictionary</h3>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/1912


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/1924.html" title="Last updated on Jul 16, 2018, 1:39 PM GMT (1b96b9c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1924/9400657...1b96b9c.html" title="Last updated on Jul 16, 2018, 1:39 PM GMT (1b96b9c)">Diff</a>