### PR TITLE
Explain why additional certificate checks are unnecessary

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1005,7 +1005,8 @@
             asynchronously and the value of <code>certificates</code> remains
             undefined for the subsequent steps. As noted in Section 4.3.2.3 of
             [[RTCWEB-SECURITY]], WebRTC utilizes self-signed rather than
-            Public Key Infrastructure (PKI) certificates, so that additional
+            Public Key Infrastructure (PKI) certificates, so that the expiration
+            check is to ensure that keys are not used indefinitely and additional
             certificate checks are unnecessary.</p>
           </li>
           <li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1005,7 +1005,7 @@
             asynchronously and the value of <code>certificates</code> remains
             undefined for the subsequent steps. As noted in Section 4.3.2.3 of
             [[RTCWEB-SECURITY]], WebRTC utilizes self-signed rather than
-            Public Key Infrastructure (PKI) certificates , so that additional
+            Public Key Infrastructure (PKI) certificates, so that additional
             certificate checks are unnecessary.</p>
           </li>
           <li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1004,9 +1004,9 @@
             with this <code>RTCPeerConnection</code> instance. This MAY happen
             asynchronously and the value of <code>certificates</code> remains
             undefined for the subsequent steps. As noted in Section 4.3.2.3 of
-            [[RTCWEB-SECURITY]], WebRTC utilizes self-signed certificates rather
-            than Public Key Infrastructure (PKI), so that additional certificate
-            checks are unnecessary.</p>
+            [[RTCWEB-SECURITY]], WebRTC utilizes self-signed rather than
+            Public Key Infrastructure (PKI) certificates , so that additional
+            certificate checks are unnecessary.</p>
           </li>
           <li>
             <p>If <code><var>configuration</var>.<a data-link-for=

--- a/webrtc.html
+++ b/webrtc.html
@@ -1003,7 +1003,10 @@
             new <code>RTCCertificate</code> instances are generated for use
             with this <code>RTCPeerConnection</code> instance. This MAY happen
             asynchronously and the value of <code>certificates</code> remains
-            undefined for the subsequent steps.</p>
+            undefined for the subsequent steps. As noted in Section 4.3.2.3 of
+            [[RTCWEB-SECURITY]], WebRTC utilizes self-signed certificates rather
+            than Public Key Infrastructure (PKI), so that additional certificate
+            checks are unnecessary.</p>
           </li>
           <li>
             <p>If <code><var>configuration</var>.<a data-link-for=


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/1808


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/1925.html" title="Last updated on Jul 11, 2018, 8:53 PM GMT (d9a519f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1925/9400657...d9a519f.html" title="Last updated on Jul 11, 2018, 8:53 PM GMT (d9a519f)">Diff</a>