### PR TITLE
What sender.getParameters().codecs returns before negotiation

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5833,7 +5833,9 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   The <code><a data-link-for="RTCRtpParameters">codecs</a></code>
                   sequence is populated based on the codecs that have been
                   negotiated for sending, and which the user agent is currently
-                  capable of sending.
+                  capable of sending. Prior to the completion of negotiation,
+                  the <code><a data-link-for="RTCRtpParameters">codecs</a></code>
+                  sequence is empty.
                 </li>
                 <li>
                   <code><a data-link-for="RTCRtpParameters">rtcp</a>.cname</code>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/1839


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/1927.html" title="Last updated on Jul 11, 2018, 2:04 AM GMT (0e3965c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1927/9400657...0e3965c.html" title="Last updated on Jul 11, 2018, 2:04 AM GMT (0e3965c)">Diff</a>