### PR TITLE
RTCSctpTransportState cleanup

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8668,38 +8668,33 @@ interface RTCTrackEvent : Event {
               </tr>
               <tr>
                 <td><dfn data-idl><code id=
-                "idl-def-RTCSctpTransportState.new">new</code></dfn></td>
-                <td>
-                  <p>The <code><a>RTCSctpTransport</a></code>
-                  has not started negotiating yet.</p>
-                </td>
-              </tr>
-              <tr>
-                <td><dfn data-idl><code id=
                 "idl-def-RTCSctpTransportState.connecting">connecting</code></dfn></td>
                 <td>
                   <p>The <code><a>RTCSctpTransport</a></code> is in the process of
-                  negotiating an association. This is the initial state when an
-                  <code><a>RTCSctpTransport</a></code> is created by applying
-                  an Answer.</p>
+                  negotiating an association. This is the initial state of the
+                  [[\SctpTransportState]] when an
+                  <code><a>RTCSctpTransport</a></code> is created.</p>
                 </td>
               </tr>
               <tr>
                 <td><dfn data-idl><code id=
                 "idl-def-RTCSctpTransportState.connected">connected</code></dfn></td>
                 <td>
-                  <p>The <code><a>RTCSctpTransport</a></code> has completed
-                  negotiation of an association.</p>
+                  <p>When the negotiation of an association is completed, a task is
+                  queued to update the [[\SctpTransportState]] slot to
+                  <code>"connected"</code>.</p>
                 </td>
               </tr>
               <tr>
                 <td><dfn data-idl><code id=
                 "idl-def-RTCSctpTransportState.closed">closed</code></dfn></td>
                 <td>
-                  <p>The SCTP association has been closed intentionally
+                  <p>When the SCTP association has been closed intentionally
                   (such as by closing the peer connection or applying a
                   remote description that rejects data or changes the
-                  SCTP port) or via receipt of a SHUTDOWN or ABORT chunk.</p>
+                  SCTP port) or when a SHUTDOWN or ABORT chunk is received,
+                  a task is queued to update the [[\SctpTransportState]]
+                  to <code>"closed"</code>.</p>
                 </td>
               </tr>
             </tbody>

--- a/webrtc.html
+++ b/webrtc.html
@@ -8655,7 +8655,6 @@ interface RTCTrackEvent : Event {
         transport.</p>
         <div>
           <pre class="idl">enum RTCSctpTransportState {
-    "new",
     "connecting",
     "connected",
     "closed"

--- a/webrtc.html
+++ b/webrtc.html
@@ -8672,7 +8672,7 @@ interface RTCTrackEvent : Event {
                 <td>
                   <p>The <code><a>RTCSctpTransport</a></code> is in the process of
                   negotiating an association. This is the initial state of the
-                  [[\SctpTransportState]] when an
+                  [[\SctpTransportState]] slot when an
                   <code><a>RTCSctpTransport</a></code> is created.</p>
                 </td>
               </tr>

--- a/webrtc.html
+++ b/webrtc.html
@@ -8689,14 +8689,13 @@ interface RTCTrackEvent : Event {
                 "idl-def-RTCSctpTransportState.closed">closed</code></dfn></td>
                 <td>
                   <p>A task is queued to update the [[\SctpTransportState]]
-                  to <code>"closed"</code> when a SHUTDOWN or ABORT chunk
+                  slot to <code>"closed"</code> when a SHUTDOWN or ABORT chunk
                   is received or when the SCTP association has been closed
                   intentionally, such as by closing the peer connection
                   or applying a remote description that rejects data or
                   changes the SCTP port.</p>
                 </td>
               </tr>
-            or when 
             </tbody>
           </table>
         </div>

--- a/webrtc.html
+++ b/webrtc.html
@@ -8688,14 +8688,15 @@ interface RTCTrackEvent : Event {
                 <td><dfn data-idl><code id=
                 "idl-def-RTCSctpTransportState.closed">closed</code></dfn></td>
                 <td>
-                  <p>When the SCTP association has been closed intentionally
-                  (such as by closing the peer connection or applying a
-                  remote description that rejects data or changes the
-                  SCTP port) or when a SHUTDOWN or ABORT chunk is received,
-                  a task is queued to update the [[\SctpTransportState]]
-                  to <code>"closed"</code>.</p>
+                  <p>A task is queued to update the [[\SctpTransportState]]
+                  to <code>"closed"</code> when a SHUTDOWN or ABORT chunk
+                  is received or when the SCTP association has been closed
+                  intentionally, such as by closing the peer connection
+                  or applying a remote description that rejects data or
+                  changes the SCTP port.</p>
                 </td>
               </tr>
+            or when 
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
Fix for Issues https://github.com/w3c/webrtc-pc/issues/1633 and https://github.com/w3c/webrtc-pc/issues/1874


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/1928.html" title="Last updated on Jul 11, 2018, 8:49 PM GMT (99c36f2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1928/9400657...99c36f2.html" title="Last updated on Jul 11, 2018, 8:49 PM GMT (99c36f2)">Diff</a>