### PR TITLE
Fix RTCRtpSender/Receiver.getCapabilities() return type

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5595,7 +5595,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
     readonly        attribute MediaStreamTrack? track;
     readonly        attribute RTCDtlsTransport?  transport;
     readonly        attribute RTCDtlsTransport? rtcpTransport;
-    static RTCRtpCapabilities getCapabilities (DOMString kind);
+    static RTCRtpCapabilities? getCapabilities (DOMString kind);
     Promise&lt;void&gt;             setParameters (RTCRtpSendParameters parameters);
     RTCRtpSendParameters          getParameters ();
     Promise&lt;void&gt;             replaceTrack (MediaStreamTrack? withTrack);
@@ -6679,7 +6679,7 @@ async function updateParameters() {
     readonly        attribute MediaStreamTrack  track;
     readonly        attribute RTCDtlsTransport? transport;
     readonly        attribute RTCDtlsTransport? rtcpTransport;
-    static RTCRtpCapabilities          getCapabilities (DOMString kind);
+    static RTCRtpCapabilities?         getCapabilities (DOMString kind);
     RTCRtpReceiveParameters            getParameters ();
     sequence&lt;RTCRtpContributingSource&gt;    getContributingSources ();
     sequence&lt;RTCRtpSynchronizationSource&gt; getSynchronizationSources ();


### PR DESCRIPTION
The prose mentions null is a possible value when there are no
capabilities for the value of the kind argument.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Orphis/webrtc-pc/pull/1932.html" title="Last updated on Jul 13, 2018, 12:08 PM GMT (1cce15e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1932/fbf23b7...Orphis:1cce15e.html" title="Last updated on Jul 13, 2018, 12:08 PM GMT (1cce15e)">Diff</a>