### PR TITLE
Reject promise at replaceTrack if TRX is stopped.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5969,7 +5969,10 @@ async function updateParameters() {
                           <ol>
                             <li>
                               <p>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot is
-                              <code>true</code>, abort these steps.</p>
+                              <code>true</code>, return a promise <a>rejected</a>
+                              with a newly <a data-link-for="exception"
+                              data-lt="create"> created</a>
+                              <code>InvalidStateError</code>, and abort these steps.</p>
                             </li>
                             <li>
                               <p>Set <var>sender</var>'s <code><a data-link-for=

--- a/webrtc.html
+++ b/webrtc.html
@@ -5916,7 +5916,7 @@ async function updateParameters() {
                   <a>transceiver kind</a> of <var>transceiver</var>, return a
                   promise <a>rejected</a> with a newly
                   <a data-link-for="exception" data-lt="create">created</a>
-                  <code>TypeError</code>.</p>
+                  <code>TypeError</code>, and abort these steps.</p>
                 </li>
                 <li>
                   <p>Return the result of <a href=
@@ -5927,7 +5927,8 @@ async function updateParameters() {
                     <p>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot is
                     <code>true</code>, return a promise <a>rejected</a>
                     with a newly <a data-link-for="exception" data-lt="create">
-                    created</a> <code>InvalidStateError</code>.</p>
+                    created</a> <code>InvalidStateError</code>, and abort
+                    these steps.</p>
                   </li>
                     <li>
                       <p>Let <var>p</var> be a new promise.</p>


### PR DESCRIPTION
Is the `abort these steps` part needed? If so, should is also be part of the step when `stopped` is first checked (6.1)?

Close #1938.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/stefhak/webrtc-pc/pull/1939.html" title="Last updated on Jul 18, 2018, 8:24 AM GMT (3fb27d1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1939/57235b3...stefhak:3fb27d1.html" title="Last updated on Jul 18, 2018, 8:24 AM GMT (3fb27d1)">Diff</a>