### PR TITLE
Clarify stats lifetimes and statsended event.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9937,24 +9937,34 @@ interface RTCDTMFToneChangeEvent : Event {
               <p>The event type of this event handler
                 is <code><a>statsended</a></code>.
               </p>
-              <p>To <dfn>delete stats</dfn> for a set of <a>monitored object</a>s,
-                the UA MUST queue a task to run the following steps:
-                <ul>
-                  <li>Create a new RTCStatsReport object called <var>report</var></li>
-                  <li>For each monitored object, create a new RTCStats
-                    object with the <a>stats object</a> for that monitored object, and
-                    add it to <var>report</var>
-                  </li>
-                  <li>
-                    Create a new <a>RTCStatsEvent</a>
-                    called <var>e</var>, with its name set to
-                    "statsended" and its "report" being set to <var>report</var>
-                  </li>
-                  <li>
-                    Fire <var>e</var>
-                  </li>
-                </ul>
-                
+              <p>To <dfn>delete stats</dfn> for a set of <a>monitored object</a>s
+              associated with an <code><a>RTCPeerConnection</a></code>,
+              <var>connection</var>, the UA MUST run the following steps in
+              parallel:</p>
+              <ol>
+                <li>
+                  <p>Gather stats only for the set of <a>monitored object</a>s
+                  to be deleted. These stats MUST represent final values at the
+                  time of deletion. Stats for these monitored objects MUST NOT
+                  appear in subsequent calls to getStats().</p>
+                </li>
+                <li>
+                  <p>Queue a task that runs the following steps:</p>
+                  <ol>
+                    <li>Let <var>report</var> be a new
+                      <code><a>RTCStatsReport</a></code> object.</li>
+                    <li>For each monitored object, create a new relevant
+                      <a>stats object</a> object with the stats gathered above
+                      for that monitored object, and add it to <var>report</var>.
+                    </li>
+                    <li>
+                      <p>Fire an <code><a>RTCStatsEvent</a></code> event named
+                      named <code><a>statsended</a></code> at <var>connection</var>
+                      with <code>report</code> set to <var>report</var>.</p>
+                    </li>
+                  </ol>
+                </li>
+              </ol>
             </dd>
           </dl>
         </section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -9895,19 +9895,27 @@ interface RTCDTMFToneChangeEvent : Event {
       (in the JavaScript) a set of statistics that are relevant to the selector,
       according to the <a>stats selection algorithm</a>. Note that that
       algorithm takes the sender or receiver of a selector.</p>
-      <p>The statistics returned are designed in such a way that repeated
-      queries can be linked by the <code><a>RTCStats</a></code> <a data-link-for=
-      "RTCStats">id</a> dictionary member. Thus, a Web application can make
-      measurements over a given time period by requesting measurements at the
-        beginning and end of that period.</p>
+      <p>The statistics returned in <a>stats object</a>s are designed in such a
+      way that repeated queries can be linked by the
+      <code><a>RTCStats</a></code> <a data-link-for="RTCStats">id</a> dictionary
+      member. Thus, a Web application can make measurements over a given time
+      period by requesting measurements at the beginning and end of that period.</p>
       <p>
-        <a>Stats object</a>s may have a limited lifetime. Until the end of
-        their lifetime, they are always present in the result from
-        getStats(). When their lifetime ends, a record of the
-        statistics for that object is emitted through a
-        "statsended" event, containing an RTCStats
-        dictionary. The object descriptions in [[WEBRTC-STATS]]
-        describe the lifetime of each stats object type.
+        With a few exceptions, <a>monitored object</a>s, once created, exist for
+        the duration of their associated <code><a>RTCPeerConnection</a></code>.
+        This ensures statistics from them are available in the result from getStats()
+        even past the associated peer connection being <a data-lt="close"
+          href="#dom-rtcdatachannel-close"><code>close</code></a>d.
+      </p>
+      <p>Only a few monitored objects have shorter lifetimes. For these objects,
+        their lifetime ends when they are <a href="#dfn-delete-stats">deleted</a>
+        by algorithms. At the time of deletion, a record of their statistics is
+        emitted in a single <code><a>statsended</a></code> event containing an
+        <code><a>RTCStatsReport</a></code> object with statistics from all
+        objects deleted at the same time. Statistics from these objects are no
+        longer available in subsequent getStats() results. The object descriptions in
+        [[WEBRTC-STATS]] describe when these monitored objects are
+        <a href="#dfn-delete-stats">deleted</a>.
       </p>
     </section>
     <section>
@@ -12613,7 +12621,8 @@ interface RTCErrorEvent : Event {
           <td><dfn id="event-statsended"><code>statsended</code></dfn></td>
           <td><code><a>RTCStatsEvent</a></code></td>
           <td>A new <code><a>RTCStatsEvent</a></code> is dispatched to
-          the script in response to the end of a stats object's lifetime.</td>
+          the script in response to one or more <a>monitored object</a>s
+          being <a href="#dfn-delete-stats">deleted</a> at the same time.</td>
       </tbody>
     </table>
     <p>The following events fire on <code><a>RTCDTMFSender</a></code>


### PR DESCRIPTION
Clarifications in service of fix for https://github.com/w3c/webrtc-stats/issues/357.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/1941.html" title="Last updated on Jul 19, 2018, 12:31 PM GMT (9751a44)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1941/9400657...jan-ivar:9751a44.html" title="Last updated on Jul 19, 2018, 12:31 PM GMT (9751a44)">Diff</a>