### PR TITLE
reject with InvalidAccessError when mux policy does not match

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1328,6 +1328,15 @@
                     the syntax error was detected) and abort these steps.</p>
                   </li>
                   <li>
+                    If <var>description</var> is set as a remote description,
+                    the <var>connection</var>'s <code><a>RTCRtcpMuxPolicy</a></code>
+                    is <code><a data-link-for="RTCRtcpMuxPolicy">require</a></code>
+                    and the remote description does not use RTCP mux,
+                    then <a>reject</a> <var>p</var> with a newly <a data-link-for="exception"
+                    data-lt="create">created</a>
+                    <code>NotSupportedError</code> and abort these steps.
+                  </li>
+                  <li>
                     <p>If the content of <var>description</var> is invalid,
                     then <a>reject</a> <var>p</var> with a newly
                     <a data-link-for="exception" data-lt="create">created</a>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1334,7 +1334,7 @@
                     and the remote description does not use RTCP mux,
                     then <a>reject</a> <var>p</var> with a newly <a data-link-for="exception"
                     data-lt="create">created</a>
-                    <code>NotSupportedError</code> and abort these steps.
+                    <code>InvalidAccessError</code> and abort these steps.
                   </li>
                   <li>
                     <p>If the content of <var>description</var> is invalid,


### PR DESCRIPTION
fixes #1235


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-pc/pull/1942.html" title="Last updated on Aug 2, 2018, 7:45 AM GMT (5443149)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1942/dd52fdc...fippo:5443149.html" title="Last updated on Aug 2, 2018, 7:45 AM GMT (5443149)">Diff</a>