### PR TITLE
RTCRtpSender.streamIds

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5597,6 +5597,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
     readonly        attribute MediaStreamTrack? track;
     readonly        attribute RTCDtlsTransport?  transport;
     readonly        attribute RTCDtlsTransport? rtcpTransport;
+    readonly        attribute sequence&lt;DOMString&gt; streamIds;
     static RTCRtpCapabilities? getCapabilities (DOMString kind);
     Promise&lt;void&gt;             setParameters (RTCRtpSendParameters parameters);
     RTCRtpSendParameters          getParameters ();
@@ -5653,6 +5654,13 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <code>transport</code>.</p>
               <p>On getting, the attribute MUST return the value of the
               <a>[[\SenderRtcpTransport]]</a> slot.</p>
+            </dd>
+            <dt><dfn data-idl><code>streamIds</code></dfn> of type <span class=
+            "idlAttrType"><a>sequence&lt;DOMString&gt;</a></span>, readonly</dt>
+            <dd>
+              <p>On getting, the attribute MUST return a new sequence consisting
+              of all the values present in the <a>[[\AssociatedMediaStreamIds]]</a>
+              slot.</p>
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
Partial fix for #1921


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/1943.html" title="Last updated on Jul 25, 2018, 3:58 PM GMT (c63be02)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1943/a22c04e...henbos:c63be02.html" title="Last updated on Jul 25, 2018, 3:58 PM GMT (c63be02)">Diff</a>