### PR TITLE
Add warning to RTCRtpTransceiver.stop(). Stop rejected transceivers at SLD().

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1654,6 +1654,11 @@
                               </li>
                             </ol>
                           </li>
+                          <li>
+                            <p>If the <a>media description</a> is rejected, and
+                            <var>transceiver</var> is not already stopped, <a>stop
+                            the RTCRtpTransceiver</a> <var>transceiver</var>.</p>
+                          </li>
                         </ol>
                       </li>
                     </ol>
@@ -7185,7 +7190,12 @@ async function updateParameters() {
               to <code>createOffer</code> to generate a zero port
               in the <a>media description</a> for the corresponding
               transceiver, as defined in <span data-jsep="stop">
-              [[!JSEP]]</span>.</p>
+              [[!JSEP]]</span>. If bundling is used, any <a>media description</a>
+              in the same bundle group must also be rejected (zero port
+              generated) if the offerer tagged <a>media description</a> was
+              rejected, as defined in [[!BUNDLE]]. This means that performing
+              <code>stop()</code> on one transceiver MAY cause other transceivers to
+              be stopped as well when performing <code>setLocalDescription</code>.</p>
               <p>When the <dfn data-idl><code>stop</code></dfn> method is invoked,
               the user agent MUST run the following steps:</p>
               <ol>

--- a/webrtc.html
+++ b/webrtc.html
@@ -7195,7 +7195,7 @@ async function updateParameters() {
               generated) if the offerer tagged <a>media description</a> was
               rejected, as defined in [[!BUNDLE]]. This means that performing
               <code>stop()</code> on one transceiver MAY cause other transceivers to
-              be stopped as well when performing <code>setLocalDescription</code>.</p>
+              be stopped as well when calling <code>setLocalDescription</code>.</p>
               <p>When the <dfn data-idl><code>stop</code></dfn> method is invoked,
               the user agent MUST run the following steps:</p>
               <ol>

--- a/webrtc.html
+++ b/webrtc.html
@@ -7193,7 +7193,7 @@ async function updateParameters() {
               [[!JSEP]]</span>. If bundling is used, any <a>media description</a>
               in the same bundle group must also be rejected (zero port
               generated) if the offerer tagged <a>media description</a> was
-              rejected, as defined in [[!BUNDLE]]. This means that performing
+              rejected, as noted in Section 7.3.3 of [[!BUNDLE]]. This means that performing
               <code>stop()</code> on one transceiver MAY cause other transceivers to
               be stopped as well when calling <code>setLocalDescription</code>.</p>
               <p>When the <dfn data-idl><code>stop</code></dfn> method is invoked,

--- a/webrtc.html
+++ b/webrtc.html
@@ -7179,8 +7179,8 @@ async function updateParameters() {
             <dt><code>stop</code></dt>
             <dd>
               <p>Irreversibly stops the <a><code>RTCRtpTransceiver</code></a>.
-              The sender of this transceiver will no longer send, the
-              receiver will no longer receive. Calling
+              The sender of this transceiver will no longer send,
+              the receiver will no longer receive. Calling
               <code>stop()</code> <a data-lt=
               "update the negotiation-needed flag">updates the
               negotiation-needed flag</a> for the
@@ -7193,9 +7193,10 @@ async function updateParameters() {
               [[!JSEP]]</span>. If bundling is used, any <a>media description</a>
               in the same bundle group must also be rejected (zero port
               generated) if the offerer tagged <a>media description</a> was
-              rejected, as noted in Section 7.3.3 of [[!BUNDLE]]. This means that performing
-              <code>stop()</code> on one transceiver MAY cause other transceivers to
-              be stopped as well when calling <code>setLocalDescription</code>.</p>
+              rejected, as noted in Section 7.3.3 of [[!BUNDLE]]. This means
+              that calling <code>stop()</code> on one transceiver MAY cause
+              other transceivers to be stopped as well when calling
+              <code>setLocalDescription</code>.</p>
               <p>When the <dfn data-idl><code>stop</code></dfn> method is invoked,
               the user agent MUST run the following steps:</p>
               <ol>


### PR DESCRIPTION
** Superseded by #2001 **

---

Related to #1919.

Because of bundling, "m=" sections may have been rejected by createOffer() or createAnswer() as a result of some transceiver having been stopped, affecting all other "m=" sections in that bundle. This change make sure that setLocalDescription() updates associated transceivers to be stopped if their "m=" section have been rejected. Otherwise the JSEP transceiver and the webrtc-pc don't have a matching state.

Because of this surprising behavior, a note is added to RTCRtpTransceiver.stop().

The issue about stop() being unpredictable is still unresolved.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/1946.html" title="Last updated on Oct 4, 2018, 11:30 AM GMT (e0be50b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1946/a22c04e...henbos:e0be50b.html" title="Last updated on Oct 4, 2018, 11:30 AM GMT (e0be50b)">Diff</a>