### PR TITLE
Fire track event in response to remote sender.setStreams() changes.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1642,9 +1642,21 @@
                                 and <var>transceiver</var>'s
                                 <a>[[\FiredDirection]]</a> slot is either
                                 <code>"sendrecv"</code> or <code>"recvonly"</code>,
-                                <a>process the removal of a remote track</a> for
-                                the <a>media description</a>, given <var>transceiver</var>,
-                                <var>removeList</var>, and <var>muteTracks</var>.</p>
+                                then run the following steps:</p>
+                                <ol>
+                                  <li>
+                                    <p><a>Set the associated remote streams</a> given
+                                    <var>transceiver</var>.<a>[[\Receiver]]</a>,
+                                    an empty list, another empty list, and
+                                    <var>removeList</var>.</p>
+                                  </li>
+                                  <li>
+                                    <a>process the removal of a remote track</a>
+                                    for the <a>media description</a>, given
+                                    <var>transceiver</var> and
+                                    <var>muteTracks</var>.</p>
+                                  </li>
+                                </ol>
                               </li>
                               <li>
                                 <p>Set <var>transceiver</var>'s
@@ -1714,14 +1726,27 @@
                             "applying-a-remote-desc">[[!JSEP]]</span>.</p>
                           </li>
                           <li>
-                            <p>If <var>direction</var> is <code>"sendrecv"</code> or
-                            <code>"recvonly"</code>, and
-                            <var>transceiver</var>'s
+                            <p>If <var>direction</var> is <code>"sendrecv"</code>
+                            or <code>"recvonly"</code>, let <var>msids</var> be a
+                            list of the MSIDs that the media description indicates
+                            <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\ReceiverTrack]]</a></var>
+                            is to be associated with. Otherwise, let
+                            <var>msids</var> be an empty list.</p>
+                          </li>
+                          <li>
+                            <p><a>Set the associated remote streams</a> given
+                            <var>transceiver</var>.<a>[[\Receiver]]</a>,
+                            <var>msids</var>, <var>addList</var>, and
+                            <var>removeList</var>.</p>
+                          </li>
+                          <li>
+                            <p>If the previous step increased the length of
+                            <var>addList</var>, or if <var>transceiver</var>'s
                             <a>[[\FiredDirection]]</a> slot
                             is neither <code>"sendrecv"</code> nor <code>"recvonly"</code>,
                             <a>process the addition of a remote track</a> for
-                            the <a>media description</a>, given <var>transceiver</var>,
-                            <var>addList</var>, and <var>trackEvents</var>.</p>
+                            the <a>media description</a>, given <var>transceiver</var>
+                            and <var>trackEvents</var>.</p>
                           </li>
                           <li>
                             <p>If <var>direction</var> is <code>"sendonly"</code> or
@@ -1736,8 +1761,8 @@
                             <a>[[\FiredDirection]]</a> slot
                             is either <code>"sendrecv"</code> or <code>"recvonly"</code>,
                             <a>process the removal of a remote track</a> for
-                            the <a>media description</a>, given <var>transceiver</var>,
-                            <var>removeList</var>, and <var>muteTracks</var>.</p>
+                            the <a>media description</a>, given <var>transceiver</var>
+                            and <var>muteTracks</var>.</p>
                           </li>
                           <li>
                             <p>Set <var>transceiver</var>'s
@@ -5366,27 +5391,13 @@ interface RTCPeerConnectionIceErrorEvent : Event {
         process the addition of a remote track</dfn> for
         an incoming media description <span data-jsep=
         "applying-a-remote-desc">[[!JSEP]]</span> given
-        <code>RTCRtpTransceiver</code> <var>transceiver</var>,
-        <var>addList</var>, and <var>trackEvents</var>, the user agent MUST run
-        the following steps:</p>
+        <code>RTCRtpTransceiver</code> <var>transceiver</var> and
+        <var>trackEvents</var>, the user agent MUST run the following steps:</p>
         <ol>
           <li>
             <p>Let <var>receiver</var> be <var>transceiver</var>'s
             <a>[[\Receiver]]</a>.
             </p>
-          </li>
-          <li>
-            <p>Let <var>msids</var> be a list of the MSIDs that the
-            media description indicates <var>track</var> is to be associated
-            with.</p>
-          </li>
-          <li>
-            <p>Let <var>removeList</var> be an empty list.</p>
-          </li>
-          <li>
-            <p><a>Set the associated remote streams</a> given
-            <var>receiver</var>, <var>msids</var>, <var>addList</var>, and
-            <var>removeList</var>.</p>
           </li>
           <li>
             <p>Let <var>track</var> be <var>receiver</var>'s
@@ -5395,7 +5406,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           </li>
           <li>
             <p>Let <var>streams</var> be <var>receiver</var>'s
-            <dfn>[[\AssociatedRemoteMediaStreams]]</dfn> slot.
+            <a>[[\AssociatedRemoteMediaStreams]]</a> slot.
             </p>
           </li>
           <li>
@@ -5409,23 +5420,13 @@ interface RTCPeerConnectionIceErrorEvent : Event {
         process the removal of a remote track</dfn> for
         an incoming media description <span data-jsep=
         "applying-a-remote-desc">[[!JSEP]]</span> given
-        <code>RTCRtpTransceiver</code> <var>transceiver</var>,
-        <var>removeList</var>, and <var>muteTracks</var>, the user agent MUST
-        run the following steps:</p>
+        <code>RTCRtpTransceiver</code> <var>transceiver</var> and
+        <var>muteTracks</var>, the user agent MUST run the following steps:</p>
         <ol>
           <li>
             <p>Let <var>receiver</var> be <var>transceiver</var>'s
             <a>[[\Receiver]]</a>.
             </p>
-          </li>
-          <li>
-            <p>Let <var>msids</var> and <var>addList</var> be empty lists.
-            </p>
-          </li>
-          <li>
-            <p><a>Set the associated remote streams</a>, given
-            <var>receiver</var>, <var>msids</var>, <var>addList</var>, and
-            <var>removeList</var>.</p>
           </li>
           <li>
             <p>Let <var>track</var> be <var>receiver</var>'s
@@ -6689,9 +6690,9 @@ async function updateParameters() {
         </li>
         <li>
           <p>Let <var>receiver</var> have an
-          <a>[[\AssociatedRemoteMediaStreams]]</a> internal slot, representing a
-          list of <code><a>MediaStream</a></code> objects that the
-          <code><a>MediaStreamTrack</a></code> object of this receiver is
+          <dfn>[[\AssociatedRemoteMediaStreams]]</dfn> internal slot,
+          representing a list of <code><a>MediaStream</a></code> objects that
+          the <code><a>MediaStreamTrack</a></code> object of this receiver is
           associated with, and initialized to an empty list.</p>
         </li>
         <li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1651,7 +1651,7 @@
                                     <var>removeList</var>.</p>
                                   </li>
                                   <li>
-                                    <a>process the removal of a remote track</a>
+                                    <p><a>process the removal of a remote track</a>
                                     for the <a>media description</a>, given
                                     <var>transceiver</var> and
                                     <var>muteTracks</var>.</p>
@@ -1729,7 +1729,7 @@
                             <p>If <var>direction</var> is <code>"sendrecv"</code>
                             or <code>"recvonly"</code>, let <var>msids</var> be a
                             list of the MSIDs that the media description indicates
-                            <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\ReceiverTrack]]</a></var>
+                            <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\ReceiverTrack]]</a>
                             is to be associated with. Otherwise, let
                             <var>msids</var> be an empty list.</p>
                           </li>


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/1609, https://github.com/w3c/webrtc-pc/issues/1744 and https://github.com/w3c/webrtc-pc/issues/1921.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/1947.html" title="Last updated on Jul 25, 2018, 9:07 PM GMT (1e18d26)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1947/a22c04e...jan-ivar:1e18d26.html" title="Last updated on Jul 25, 2018, 9:07 PM GMT (1e18d26)">Diff</a>