### PR TITLE
Made maxFramerate and scaleResolutionDownBy unsigned long (were: doub…

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6238,8 +6238,8 @@ async function updateParameters() {
              RTCPriorityType     priority = "low";
              unsigned long       ptime;
              unsigned long       maxBitrate;
-             double              maxFramerate;
-             double              scaleResolutionDownBy;
+             unsigned long       maxFramerate;
+             unsigned long       scaleResolutionDownBy;
 };</pre>
         <section>
           <h2>Dictionary <code><a>RTCRtpEncodingParameters</a></code>


### PR DESCRIPTION
…le).

This is for #1834. I changed to `unsigned` as proposed in https://www.w3.org/2011/04/webrtc/wiki/images/5/54/WebRTCWG-2018-05-22.pdf, however I'm not sure what more that can be reliable checked, so leaving it at that for now.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/stefhak/webrtc-pc/pull/1948.html" title="Last updated on Jul 30, 2018, 7:56 AM GMT (98a8c64)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1948/f385034...stefhak:98a8c64.html" title="Last updated on Jul 30, 2018, 7:56 AM GMT (98a8c64)">Diff</a>