### PR TITLE
Added checks to make sure maxFramerate is not negative.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5249,6 +5249,12 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   this requirement, <a>throw</a> a <code>RangeError</code>.</p>
                 </li>
                 <li>
+                  <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">maxFramerate</a></code>
+                  value in <var>sendEncodings</var> is greater than or equal to 0.0. If
+                  one of the <code>maxFramerate</code> values does not meet
+                  this requirement, <a>throw</a> a <code>RangeError</code>.</p>
+                </li>
+                <li>
                   <p><a>Create an RTCRtpSender</a> with <var>track</var>,
                   <var>kind</var>, <var>streams</var> and <var>sendEncodings</var>
                   and let <var>sender</var> be the result.</p>
@@ -5750,6 +5756,11 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 </li>
                 <li>If the <code>scaleResolutionDownBy</code> parameter in the
                 <var>parameters</var> argument has a value less than 1.0,
+                return a promise <a>rejected</a> with a newly
+                <a data-link-for="exception" data-lt="create">created</a>
+                <code>RangeError</code>.</li>
+                <li>If the <code>maxFramerate</code> parameter in the
+                <var>parameters</var> argument has a value less than 0.0,
                 return a promise <a>rejected</a> with a newly
                 <a data-link-for="exception" data-lt="create">created</a>
                 <code>RangeError</code>.</li>


### PR DESCRIPTION
(partial?) fix for #1834


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/stefhak/webrtc-pc/pull/1953.html" title="Last updated on Aug 3, 2018, 12:51 PM GMT (5068b0c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1953/06345b0...stefhak:5068b0c.html" title="Last updated on Aug 3, 2018, 12:51 PM GMT (5068b0c)">Diff</a>