### PR TITLE
Remove superfluous union on addIceCandidate

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2111,7 +2111,7 @@ interface RTCPeerConnection : EventTarget  {
     readonly        attribute RTCSessionDescription?    remoteDescription;
     readonly        attribute RTCSessionDescription?    currentRemoteDescription;
     readonly        attribute RTCSessionDescription?    pendingRemoteDescription;
-    Promise&lt;void&gt;                      addIceCandidate ((RTCIceCandidateInit or RTCIceCandidate) candidate);
+    Promise&lt;void&gt;                      addIceCandidate (RTCIceCandidateInit candidate);
     readonly        attribute RTCSignalingState         signalingState;
     readonly        attribute RTCIceGatheringState      iceGatheringState;
     readonly        attribute RTCIceConnectionState     iceConnectionState;
@@ -3104,7 +3104,7 @@ interface RTCPeerConnection : EventTarget  {
     Promise&lt;void&gt; setLocalDescription (RTCSessionDescriptionInit description, VoidFunction successCallback, RTCPeerConnectionErrorCallback failureCallback);
     Promise&lt;void&gt; createAnswer (RTCSessionDescriptionCallback successCallback, RTCPeerConnectionErrorCallback failureCallback);
     Promise&lt;void&gt; setRemoteDescription (RTCSessionDescriptionInit description, VoidFunction successCallback, RTCPeerConnectionErrorCallback failureCallback);
-    Promise&lt;void&gt; addIceCandidate ((RTCIceCandidateInit or RTCIceCandidate) candidate, VoidFunction successCallback, RTCPeerConnectionErrorCallback failureCallback);
+    Promise&lt;void&gt; addIceCandidate (RTCIceCandidateInit candidate, VoidFunction successCallback, RTCPeerConnectionErrorCallback failureCallback);
 };</pre>
           <section>
             <h2>Methods</h2>


### PR DESCRIPTION
Fix for https://github.com/w3c/webrtc-pc/issues/1954.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/1955.html" title="Last updated on Aug 3, 2018, 3:44 PM GMT (4366160)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1955/06345b0...jan-ivar:4366160.html" title="Last updated on Aug 3, 2018, 3:44 PM GMT (4366160)">Diff</a>