### PR TITLE
Make Section references more specific

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4464,22 +4464,22 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               </tr>
               <tr>
                 <td><dfn data-idl><code>very-low</code></dfn></td>
-                <td>See [[!RTCWEB-TRANSPORT]], Section 4. Corresponds to "below
+                <td>See [[!RTCWEB-TRANSPORT]], Sections 4.1 and 4.2. Corresponds to "below
                 normal" as defined in [[!RTCWEB-DATA]].</td>
               </tr>
               <tr>
                 <td><dfn data-idl><code>low</code></dfn></td>
-                <td>See [[!RTCWEB-TRANSPORT]], Section 4. Corresponds to
+                <td>See [[!RTCWEB-TRANSPORT]], Sections 4.1 and 4.2. Corresponds to
                 "normal" as defined in [[!RTCWEB-DATA]].</td>
               </tr>
               <tr>
                 <td><dfn data-idl><code>medium</code></dfn></td>
-                <td>See [[!RTCWEB-TRANSPORT]], Section 4. Corresponds to "high"
+                <td>See [[!RTCWEB-TRANSPORT]], Sections 4.1 and 4.2. Corresponds to "high"
                 as defined in [[!RTCWEB-DATA]].</td>
               </tr>
               <tr>
                 <td><dfn data-idl><code>high</code></dfn></td>
-                <td>See [[!RTCWEB-TRANSPORT]], Section 4. Corresponds to "extra
+                <td>See [[!RTCWEB-TRANSPORT]], Sections 4.1 and 4.2. Corresponds to "extra
                 high" as defined in [[!RTCWEB-DATA]].</td>
               </tr>
             </tbody>


### PR DESCRIPTION
Editorial partial fix for Issue https://github.com/w3c/webrtc-pc/issues/1888


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/1956.html" title="Last updated on Aug 6, 2018, 10:21 PM GMT (4366e96)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1956/06345b0...4366e96.html" title="Last updated on Aug 6, 2018, 10:21 PM GMT (4366e96)">Diff</a>