### PR TITLE
Changed to use respec's [Default] definition of toJSON.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3585,10 +3585,11 @@ interface RTCSessionDescription {
             <h2>Methods</h2>
             <dl data-link-for="RTCSessionDescription" data-dfn-for=
             "RTCSessionDescription" class="methods">
-              <dt><dfn data-idl><code>toJSON()</code></dfn></dt>
-              <dd>When called, run [[!WEBIDL-1]]'s <a data-cite=
-              "WEBIDL#default-tojson-operation">default toJSON
-              operation</a>.</dd>
+              <dt><dfn><code>toJSON()</code></dfn></dt>
+              <dd>
+                When called, run [[!WEBIDL]]'s <a data-cite=
+                "WEBIDL#default-tojson-operation">default toJSON operation</a>.
+              </dd>
             </dl>
           </section>
         </div>


### PR DESCRIPTION
Fix for #1546


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/stefhak/webrtc-pc/pull/1960.html" title="Last updated on Aug 12, 2018, 5:28 AM GMT (34f14e9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1960/4843304...stefhak:34f14e9.html" title="Last updated on Aug 12, 2018, 5:28 AM GMT (34f14e9)">Diff</a>