### PR TITLE
Added error detail "datachannel-id-generation-error", using in error …

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1525,9 +1525,9 @@
                           <li>
                             <p><a>Fire an event</a> named <code><a data-link-for=
                             "RTCDataChannel">error</a></code> using the
-                            <code><a>RTCErrorEvent</a></code> interface with an
-                            <code>OperationError</code> exception at
-                            <var>channel</var>.</p>
+                            <code><a>RTCErrorEvent</a></code> interface with the
+                            <code><a>errorDetail</a></code> attribute set to
+                            "data-channel-failure" at <var>channel</var>.</p>
                           </li>
                           <li>
                             <p><a>Fire an event</a> named


### PR DESCRIPTION
…event. Fix for #1970.

Would any test have to be added or changed?

Also, `"sctp-id-generation-error"` might be better than `"datachannel-id-generation-error"` - WDYT?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/stefhak/webrtc-pc/pull/1971.html" title="Last updated on Sep 7, 2018, 5:47 AM GMT (a45ef37)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1971/f458914...stefhak:a45ef37.html" title="Last updated on Sep 7, 2018, 5:47 AM GMT (a45ef37)">Diff</a>