### PR TITLE
Have getSenders()/getReceivers() return only non-stopped ones.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4855,7 +4855,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             <dt><code>getSenders</code></dt>
             <dd>
               <p>Returns a sequence of <code><a>RTCRtpSender</a></code> objects
-              representing the RTP senders that are part of non-stopped
+              representing the RTP senders that belong to non-stopped
               <code><a>RTCRtpTransceiver</a></code> objects currently attached
               to this <code><a>RTCPeerConnection</a></code> object.</p>
               <p>When the <dfn id=
@@ -4879,7 +4879,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             <dt><code>getReceivers</code></dt>
             <dd>
               <p>Returns a sequence of <code><a>RTCRtpReceiver</a></code> objects
-              representing the RTP receivers that are part of non-stopped
+              representing the RTP receivers that belong to non-stopped
               <code><a>RTCRtpTransceiver</a></code> objects currently attached
               to this <code><a>RTCPeerConnection</a></code> object.</p>
               <p>When the <dfn id=

--- a/webrtc.html
+++ b/webrtc.html
@@ -4855,24 +4855,22 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             <dt><code>getSenders</code></dt>
             <dd>
               <p>Returns a sequence of <code><a>RTCRtpSender</a></code> objects
-              representing the RTP senders that are currently attached to this
-              <code><a>RTCPeerConnection</a></code> object.</p>
-              <p>The <dfn id=
+              representing the RTP senders that are part of non-stopped
+              <code><a>RTCRtpTransceiver</a></code> objects currently attached
+              to this <code><a>RTCPeerConnection</a></code> object.</p>
+              <p>When the <dfn id=
               "dom-peerconnection-getsenders"><code>getSenders</code></dfn>
-              method MUST return the result of executing the
-              <code><a>CollectSenders</a></code> algorithm.</p>
-              <p></p>
-              <p>We define the <dfn>CollectSenders</dfn> algorithm as
-              follows:</p>
+              method is invoked, the user agent MUST run the following steps:</p>
               <ol>
                 <li>Let <var>transceivers</var> be the result of executing the
                 <code><a>CollectTransceivers</a></code> algorithm.</li>
                 <li>Let <var>senders</var> be a new empty sequence.</li>
                 <li>For each <var>transceiver</var> in <var>transceivers</var>,
                   <ol>
-                    <li>Let <var>sender</var> be
-                    <var>transceiver</var>'s <a>[[\Sender]]</a>.</li>
-                    <li>Add <var>sender</var> to <var>senders</var>.</li>
+                    <li>If <var>transceiver</var>.<a>[[\Stopped]]</a> is
+                      <code>false</code> add
+                      <var>transceiver</var>.<a>[[\Sender]]</a> to
+                      <var>receivers</var>.</li>
                   </ol>
                 </li>
                 <li>Return <var>senders</var>.</li>
@@ -4880,26 +4878,23 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             </dd>
             <dt><code>getReceivers</code></dt>
             <dd>
-              <p>Returns a sequence of <code><a>RTCRtpReceiver</a></code>
-              objects representing the RTP receivers that are currently
-              attached to this <code><a>RTCPeerConnection</a></code>
-              object.</p>
-              <p>The <dfn id=
+              <p>Returns a sequence of <code><a>RTCRtpReceiver</a></code> objects
+              representing the RTP receivers that are part of non-stopped
+              <code><a>RTCRtpTransceiver</a></code> objects currently attached
+              to this <code><a>RTCPeerConnection</a></code> object.</p>
+              <p>When the <dfn id=
               "dom-peerconnection-getreceivers"><code>getReceivers</code></dfn>
-              method MUST return the result of executing the
-              <code><a>CollectReceivers</a></code> algorithm.</p>
-              <p></p>
-              <p>We define the <dfn>CollectReceivers</dfn> algorithm as
-              follows:</p>
+              method is invoked, the user agent MUST run the following steps:</p>
               <ol>
                 <li>Let <var>transceivers</var> be the result of executing the
                 <code><a>CollectTransceivers</a></code> algorithm.</li>
                 <li>Let <var>receivers</var> be a new empty sequence.</li>
                 <li>For each <var>transceiver</var> in <var>transceivers</var>,
                   <ol>
-                    <li>Let <var>receiver</var> be <var>transceiver</var>'s
-                    <a>[[\Receiver]]</a>.</li>
-                    <li>Add <var>receiver</var> to <var>receivers</var>.</li>
+                    <li>If <var>transceiver</var>.<a>[[\Stopped]]</a> is
+                      <code>false</code> add
+                      <var>transceiver</var>.<a>[[\Receiver]]</a> to
+                      <var>receivers</var>.</li>
                   </ol>
                 </li>
                 <li>Return <var>receivers</var>.</li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -4870,7 +4870,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                     <li>If <var>transceiver</var>.<a>[[\Stopped]]</a> is
                       <code>false</code> add
                       <var>transceiver</var>.<a>[[\Sender]]</a> to
-                      <var>receivers</var>.</li>
+                      <var>senders</var>.</li>
                   </ol>
                 </li>
                 <li>Return <var>senders</var>.</li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -4860,7 +4860,9 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               to this <code><a>RTCPeerConnection</a></code> object.</p>
               <p>When the <dfn id=
               "dom-peerconnection-getsenders"><code>getSenders</code></dfn>
-              method is invoked, the user agent MUST run the following steps:</p>
+              method is invoked, the user agent MUST return the result of
+              executing the <code><a>CollectSenders</a></code> algorithm.</p>
+             <p>We define the <dfn>CollectSenders</dfn> algorithm as follows:</p>
               <ol>
                 <li>Let <var>transceivers</var> be the result of executing the
                 <code><a>CollectTransceivers</a></code> algorithm.</li>


### PR DESCRIPTION
Fix for https://github.com/w3c/webrtc-pc/issues/1975.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/1977.html" title="Last updated on Sep 7, 2018, 7:06 PM GMT (950cc15)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1977/e19d64f...jan-ivar:950cc15.html" title="Last updated on Sep 7, 2018, 7:06 PM GMT (950cc15)">Diff</a>