### PR TITLE
Throw SyntaxError on {urls:[]}.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2008,13 +2008,19 @@
                   element.</p>
                 </li>
                 <li>
-                  <p>If <code><var>server</var>.urls</code> is a string,
-                  let <code><var>server</var>.urls</code> be a list
-                  consisting of just that string.</p>
+                  <p>Let <var>urls</var> be <code><var>server</var>.urls</code>.</p>
                 </li>
                 <li>
-                  <p>For each <var>url</var> in
-                  <code><var>server</var>.urls</code> run the following steps:
+                  <p>If <var>urls</var> is a string, set <var>urls</var> to a
+                  list consisting of just that string.</p>
+                </li>
+                <li>
+                  <p>If <var>urls</var> is empty, <a>throw</a> a
+                  <code>SyntaxError</code>.</p>
+                </li>
+                <li>
+                  <p>For each <var>url</var> in <var>urls</var> run the
+                  following steps:
                   <ol>
                     <li>
                       <p>Parse the


### PR DESCRIPTION
Fix for https://github.com/w3c/webrtc-pc/issues/1949.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/1978.html" title="Last updated on Aug 30, 2018, 8:50 PM GMT (1c08cc0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1978/e19d64f...jan-ivar:1c08cc0.html" title="Last updated on Aug 30, 2018, 8:50 PM GMT (1c08cc0)">Diff</a>