### PR TITLE
change link of mediastreamtrack definition

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6700,8 +6700,8 @@ async function updateParameters() {
         </li>
         <li>
           <p>Initialize <var>track.muted</var> to <code>true</code>. See the
-          <a><code>MediaStreamTrack</code></a> section about how the
-          <code>muted</code> attribute reflects if a
+          <a href="#mediastreamtrack-network-use">MediaStreamTrack</a> section
+          about how the <code>muted</code> attribute reflects if a
           <code><a>MediaStreamTrack</a></code> is receiving media data or
           not.</p>
         </li>


### PR DESCRIPTION
the text intends to point to the MST network extension section
but points to mediacapture-main


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-pc/pull/1984.html" title="Last updated on Sep 12, 2018, 2:45 PM GMT (5fd2d6c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1984/ae0d095...fippo:5fd2d6c.html" title="Last updated on Sep 12, 2018, 2:45 PM GMT (5fd2d6c)">Diff</a>