### PR TITLE
Rename RTCIceCandidate.ip to address.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4417,7 +4417,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <dt><dfn data-idl><code>hostCandidate</code></dfn> of type <span class=
               "idlMemberType"><a>DOMString</a></span></dt>
               <dd>
-                <p>The local IP address and port used to communicate
+                <p>The local address and port used to communicate
                  with the STUN or TURN server.</p>
               </dd>
               <dt><dfn data-idl><code>url</code></dfn> of type <span class=

--- a/webrtc.html
+++ b/webrtc.html
@@ -3952,8 +3952,9 @@ interface RTCIceCandidate {
               <dt><dfn data-idl><code>address</code></dfn> of type <span class=
               "idlAttrType"><a>DOMString</a></span>, readonly, nullable</dt>
               <dd>
-                <p>The IP address of the candidate. This corresponds to the
-                <code>connection-address</code> field in
+                <p>The IP address of the candidate, allowing for IPv4 addresses,
+                IPv6 addresses, and fully qualified domain names (FQDNs). This
+                corresponds to the <code>connection-address</code> field in
                 <a><code>candidate-attribute</code></a>.</p>
                 <div class="note">
                   <p>The IP addresses exposed in candidates gathered via ICE

--- a/webrtc.html
+++ b/webrtc.html
@@ -3952,33 +3952,33 @@ interface RTCIceCandidate {
               <dt><dfn data-idl><code>address</code></dfn> of type <span class=
               "idlAttrType"><a>DOMString</a></span>, readonly, nullable</dt>
               <dd>
-                <p>The IP address of the candidate, allowing for IPv4 addresses,
+                <p>The address of the candidate, allowing for IPv4 addresses,
                 IPv6 addresses, and fully qualified domain names (FQDNs). This
                 corresponds to the <code>connection-address</code> field in
                 <a><code>candidate-attribute</code></a>.</p>
                 <div class="note">
-                  <p>The IP addresses exposed in candidates gathered via ICE
+                  <p>The addresses exposed in candidates gathered via ICE
                   and made visibile to the application in
                   <code>RTCIceCandidate</code> instances can reveal more
                   information about the device and the user (e.g. location,
                   local network topology) than the user might have expected in
                   a non-WebRTC enabled browser.</p>
-                  <p>These IP addresses are always exposed to the application,
+                  <p>These addresses are always exposed to the application,
                   and potentially exposed to the communicating party, and can
                   be exposed without any specific user consent (e.g. for peer
                   connections used with data channels, or to receive media
                   only).</p>
-                  <p class="fingerprint">These IP addresses can also be used as
+                  <p class="fingerprint">These addresses can also be used as
                   temporary or persistent cross-origin states, and thus
                   contribute to the fingerprinting surface of the device.</p>
-                  <p>Applications can avoid exposing IP addresses to the
+                  <p>Applications can avoid exposing addresses to the
                   communicating party, either temporarily or permanently, by
                   forcing the <a>ICE Agent</a> to report only relay candidates
                   via the <code>iceTransportPolicy</code> member of
                   <code><a>RTCConfiguration</a></code>.</p>
-                  <p>To limit the IP addresses exposed to the application
+                  <p>To limit the addresses exposed to the application
                   itself, browsers can offer their users different policies
-                  regarding sharing local IP addresses, as defined in
+                  regarding sharing local addresses, as defined in
                   [[RTCWEB-IP-HANDLING]].</p>
                 </div>
               </dd>

--- a/webrtc.html
+++ b/webrtc.html
@@ -511,7 +511,7 @@
                     The implementation can still use its own candidate
                     filtering policy in order to limit the IP addresses exposed
                     to the application, as noted in the description of
-                    <code>RTCIceCandidate.<a data-link-for="RTCIceCandidate">ip</a></code>.
+                    <code>RTCIceCandidate.<a data-link-for="RTCIceCandidate">address</a></code>.
                   </div>
                 </td>
               </tr>
@@ -3834,7 +3834,7 @@ interface RTCIceCandidate {
     readonly        attribute DOMString?              foundation;
     readonly        attribute RTCIceComponent?        component;
     readonly        attribute unsigned long?          priority;
-    readonly        attribute DOMString?              ip;
+    readonly        attribute DOMString?              address;
     readonly        attribute RTCIceProtocol?         protocol;
     readonly        attribute unsigned short?         port;
     readonly        attribute RTCIceCandidateType?    type;
@@ -3866,7 +3866,7 @@ interface RTCIceCandidate {
                   <li>Initialize the following attributes of <var>iceCandidate</var> to
                   <code>null</code>: <a><code>foundation</code></a>,
                   <a><code>component</code></a>, <a><code>priority</code></a>,
-                  <a><code>ip</code></a>, <a><code>protocol</code></a>,
+                  <a><code>address</code></a>, <a><code>protocol</code></a>,
                   <a><code>port</code></a>, <a><code>type</code></a>,
                   <a><code>tcpType</code></a>, <a><code>relatedAddress</code></a>,
                   and <a><code>relatedPort</code></a>.</li>
@@ -3949,7 +3949,7 @@ interface RTCIceCandidate {
               <dt><dfn data-idl><code>priority</code></dfn> of type <span class=
               "idlAttrType"><a>unsigned long</a></span>, readonly, nullable</dt>
               <dd>The assigned priority of the candidate.</dd>
-              <dt><dfn data-idl><code>ip</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>address</code></dfn> of type <span class=
               "idlAttrType"><a>DOMString</a></span>, readonly, nullable</dt>
               <dd>
                 <p>The IP address of the candidate. This corresponds to the
@@ -10330,7 +10330,7 @@ interface RTCDTMFToneChangeEvent : Event {
         <li>RTCIceCandidatePairStats, with attributes transportId,
         localCandidateId, remoteCandidateId, state, priority, nominated,
         bytesSent, bytesReceived, totalRoundTripTime, currentRoundTripTime</li>
-        <li>RTCIceCandidateStats, with attributes ip, port, protocol,
+        <li>RTCIceCandidateStats, with attributes address, port, protocol,
         candidateType, url</li>
         <li>RTCCertificateStats, with attributes fingerprint,
         fingerprintAlgorithm, base64Certificate, issuerCertificateId</li>


### PR DESCRIPTION
Fix for https://github.com/w3c/webrtc-pc/issues/1913.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/1985.html" title="Last updated on Sep 12, 2018, 7:26 PM GMT (a93717c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1985/ae0d095...jan-ivar:a93717c.html" title="Last updated on Sep 12, 2018, 7:26 PM GMT (a93717c)">Diff</a>