### PR TITLE
Restructure simulcast material

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5235,32 +5235,35 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   <code>true</code>, <a>throw</a> an
                   <code>InvalidStateError</code>.</p>
                 </li>
-                <li>
-                  <p>Verify that each <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>
-                  value in <var>sendEncodings</var> is composed only of
-                  alphanumeric characters (a-z, A-Z, 0-9) up to
-                  a maximum of 16 characters. If one of the RIDs does not meet
-                  these requirements, <a>throw</a> a <code>TypeError</code>.</p>
-                </li>
-                <li>
-                  <p>If any <code><a>RTCRtpEncodingParameters</a></code>
-                  dictionary in <var>sendEncodings</var> contains a
-                  <a>read-only parameter</a> other than
-                  <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>,
-                  <a>throw</a> an <code>InvalidAccessError</code>.</p>
-                </li>
-                <li>
-                  <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">scaleResolutionDownBy</a></code>
-                  value in <var>sendEncodings</var> is greater than or equal to 1.0. If
-                  one of the <code>scaleResolutionDownBy</code> values does not meet
-                  this requirement, <a>throw</a> a <code>RangeError</code>.</p>
-                </li>
-                <li>
-                  <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">maxFramerate</a></code>
-                  value in <var>sendEncodings</var> is greater than or equal to 0.0. If
-                  one of the <code>maxFramerate</code> values does not meet
-                  this requirement, <a>throw</a> a <code>RangeError</code>.</p>
-                </li>
+                <li><dfn>validate sendEncodings</dfn> using the following steps:</li>
+                  <ol>
+                      <li>
+                        <p>Verify that each <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>
+                        value in <var>sendEncodings</var> is composed only of
+                        alphanumeric characters (a-z, A-Z, 0-9) up to
+                        a maximum of 16 characters. If one of the RIDs does not meet
+                        these requirements, <a>throw</a> a <code>TypeError</code>.</p>
+                      </li>
+                      <li>
+                        <p>If any <code><a>RTCRtpEncodingParameters</a></code>
+                        dictionary in <var>sendEncodings</var> contains a
+                        <a>read-only parameter</a> other than
+                        <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>,
+                        <a>throw</a> an <code>InvalidAccessError</code>.</p>
+                     </li>
+                     <li>
+                       <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">scaleResolutionDownBy</a></code>
+                       value in <var>sendEncodings</var> is greater than or equal to 1.0. If
+                       one of the <code>scaleResolutionDownBy</code> values does not meet
+                       this requirement, <a>throw</a> a <code>RangeError</code>.</p>
+                     </li>
+                     <li>
+                       <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">maxFramerate</a></code>
+                       value in <var>sendEncodings</var> is greater than or equal to 0.0. If
+                       one of the <code>maxFramerate</code> values does not meet
+                       this requirement, <a>throw</a> a <code>RangeError</code>.</p>
+                     </li>
+                </ol>
                 <li>
                   <p><a>Create an RTCRtpSender</a> with <var>track</var>,
                   <var>kind</var>, <var>streams</var> and <var>sendEncodings</var>
@@ -5280,22 +5283,16 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 </li>
                 <li>
                   <p><a>Create an RTCRtpReceiver</a> with <var>kind</var> and
-                  let <var>receiver</var> be the result. This specification
-                  does not define how to configure <code>createOffer</code> to
-                  receive multiple RTP encodings. However when
-                  <code>setRemoteDescription</code> is called with a
-                  corresponding remote description that is able to send
-                  multiple RTP encodings as defined in [[!JSEP]], the
+                  let <var>receiver</var> be the result.</p>
+                  <p>This specification does not define how to configure
+                  <code>createOffer</code> to receive multiple RTP encodings.
+                  However when <code>setRemoteDescription</code> is called
+                  with a corresponding remote description that is able to
+                  send multiple RTP encodings as defined in [[!JSEP]], the
                   <code><a>RTCRtpReceiver</a></code> may receive multiple RTP
                   encodings and the parameters retrieved via the transceiver's
                   <code>receiver.getParameters()</code> will reflect the
                   encodings negotiated.</p>
-                  <div class="issue atrisk">
-                    <p>Support for the <code>encodings</code> attribute of
-                    <code><a>RTCRtpReceiveParameters</a></code> is marked
-                    as a feature at risk, since there is no clear
-                    commitment from implementers.</p>
-                  </div>
                 </li>
                 <li>
                   <p><a>Create an RTCRtpTransceiver</a> with <var>sender</var>,
@@ -5718,10 +5715,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <code><a>RTCRtpTransceiver</a></code> object associated
                 with <var>sender</var> (i.e. <var>sender</var> is
                 <var>transceiver</var>'s <a>[[\Sender]]</a>).</li>
-                <li>Let <var>N</var> be the number of
-                <code><a>RTCRtpEncodingParameters</a></code> stored in
-                <var>sender</var>'s internal <a>[[\SendEncodings]]</a>
-                slot.</li>
+
                 <li>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot is
                 <code>true</code>, return a promise <a>rejected</a> with a newly
                 <a data-link-for="exception" data-lt="create">created</a>
@@ -5731,46 +5725,65 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <a>rejected</a> with a newly
                 <a data-link-for="exception" data-lt="create">created</a>
                 <code>InvalidStateError</code>.</li>
-                <li>If any of the following conditions are met, return a promise
-                <a>rejected</a> with a newly
-                <a data-link-for="exception" data-lt="create">created</a>
-                <code>InvalidModificationError</code>:
-                <ol>  
-                   <li><code><var>parameters</var>.encodings.length</code>
-                   is different from <var>N</var>.</li>
-                   <li><code><var>parameters</var>.encodings</code> has been
-                   re-ordered.</li>
-                   <li>Any parameter in <var>parameters</var> is marked as a
-                   <dfn>Read-only parameter</dfn> and has a value that is different
-                   from the corresponding parameter value in <var>sender</var>'s
-                   <a>[[\LastReturnedParameters]]</a> internal slot. Note that
-                   this also applies to <var>transactionId</var>.</li>
-                </ol>
-                </li>
-                <li>
-                  <p>For each value of <var>i</var> from 0 to the number of encodings,
-                  check whether
-                  <code><var>parameters</var>.encodings[<var>i</var>].codecPayloadType</code>
-                  (if set) corresponds to a value of
-                  <code><var>parameters</var>.codecs[<var>j</var>].payloadType</code> where
-                  <var>j</var> goes from 0 to the number of codecs. If there is no
-                  correspondence, or if the MIME subtype portion of
-                  <code><var>parameters</var>.codecs[<var>j</var>].mimeType</code> is equal to
-                  "red", "cn", "telephone-event", "rtx" or a forward error correction
-                  codec ("ulpfec" [[RFC5109]] or "flexfec" [[FLEXFEC]]), reject <var>p</var> with
-                  a newly <a data-link-for="exception" data-lt="create">created</a>
-                  <code>InvalidAccessError</code>.</p>
-                </li>
-                <li>If the <code>scaleResolutionDownBy</code> parameter in the
-                <var>parameters</var> argument has a value less than 1.0,
-                return a promise <a>rejected</a> with a newly
-                <a data-link-for="exception" data-lt="create">created</a>
-                <code>RangeError</code>.</li>
-                <li>If the <code>maxFramerate</code> parameter in the
-                <var>parameters</var> argument has a value less than 0.0,
-                return a promise <a>rejected</a> with a newly
-                <a data-link-for="exception" data-lt="create">created</a>
-                <code>RangeError</code>.</li>
+                <li><dfn>validate encodings</dfn> by running the following steps:
+                  <ol>
+                    <li>
+                      Let <var>N</var> be the number of
+                      <code><a>RTCRtpEncodingParameters</a></code> stored in
+                      <var>sender</var>'s internal <a>[[\SendEncodings]]</a> slot.
+                    </li>
+                    <li>
+                      If any of the following conditions are met, return a promise
+                      <a>rejected</a> with a newly
+                      <a data-link-for="exception" data-lt="create">created</a>
+                      <code>InvalidModificationError</code>:
+                      <ol>  
+                        <li>
+                          <code><var>parameters</var>.encodings.length</code>
+                          is different from <var>N</var>.
+                        </li>
+                        <li>
+                          <code><var>parameters</var>.encodings</code> has been
+                          re-ordered.
+                        </li>
+                        <li>
+                          Any parameter in <var>parameters</var> is marked as a
+                          <dfn>Read-only parameter</dfn> and has a value that is different
+                          from the corresponding parameter value in <var>sender</var>'s
+                          <a>[[\LastReturnedParameters]]</a> internal slot. Note that
+                          this also applies to <var>transactionId</var>.
+                        </li>
+                    </ol>
+                   </li>
+                   <li>
+                     <p>For each value of <var>i</var> from 0 to the number of encodings,
+                     check whether
+                     <code><var>parameters</var>.encodings[<var>i</var>].codecPayloadType</code>
+                     (if set) corresponds to a value of
+                     <code><var>parameters</var>.codecs[<var>j</var>].payloadType</code> where
+                     <var>j</var> goes from 0 to the number of codecs. If there is no
+                     correspondence, or if the MIME subtype portion of
+                     <code><var>parameters</var>.codecs[<var>j</var>].mimeType</code> is equal to
+                     "red", "cn", "telephone-event", "rtx" or a forward error correction
+                     codec ("ulpfec" [[RFC5109]] or "flexfec" [[FLEXFEC]]), reject <var>p</var> with
+                     a newly <a data-link-for="exception" data-lt="create">created</a>
+                     <code>InvalidAccessError</code>.</p>
+                   </li>
+                   <li>
+                     If the <code>scaleResolutionDownBy</code> parameter in the
+                     <var>parameters</var> argument has a value less than 1.0,
+                     return a promise <a>rejected</a> with a newly
+                     <a data-link-for="exception" data-lt="create">created</a>
+                     <code>RangeError</code>.
+                   </li>
+                   <li>
+                     If the <code>maxFramerate</code> parameter in the
+                     <var>parameters</var> argument has a value less than 0.0,
+                     return a promise <a>rejected</a> with a newly
+                     <a data-link-for="exception" data-lt="create">created</a>
+                     <code>RangeError</code>.
+                   </li>
+                 </ol>
                 <li>Let <var>p</var> be a new promise.</li>
                 <li>In parallel, configure the media stack to use
                 <var>parameters</var> to transmit <var>sender</var>'s
@@ -5817,7 +5830,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               and this codec is removed from a subsequent offer/answer
               negotiation, <code><a data-link-for="RTCRtpEncodingParameters">codecPayloadType</a></code>
               will be unset in the next call to <code><a
-                  data-link-for="RTCRtpSender">getParameters</a></code>,
+              data-link-for="RTCRtpSender">getParameters</a></code>,
               and the implementation will fall back to its default codec
               selection policy until a new codec is selected.</p>
               <p><code>setParameters</code> does not cause SDP renegotiation
@@ -6218,6 +6231,12 @@ async function updateParameters() {
             <dd>
               <p>A sequence containing information about incoming RTP encodings
               of media.</p>
+              <div class="issue atrisk">
+                <p>Support for the <code>encodings</code> attribute of
+                <code><a>RTCRtpReceiveParameters</a></code> is marked
+                as a feature at risk, since there is no clear
+                commitment from implementers.</p>
+              </div>
             </dd>
           </dl>
         </section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -5280,6 +5280,11 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                      stored in <var>sendEncodings</var> is <code>1</code>, then remove any
                      <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>
                      member from the lone entry.</p>
+                     <div class="note">Providing a single, default
+                     <code><a>RTCRtpEncodingParameters</a></code> in <var>sendEncodings</var>
+                     allows the application to subsequently set encoding parameters using
+                     <code><a data-link-for="RTCRtpSender">setParameters</a></code>, even
+                     when simulcast isn't used.</div>
                    </li>
                 </ol>
                 </li>
@@ -5596,12 +5601,6 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           <var>sendEncodings</var>. Otherwise, set it to a list containing a
           single <code><a>RTCRtpEncodingParameters</a></code> with
           <code>active</code> set to <code>true</code>.</p>
-
-          <div class="note">Providing a single, default
-          <code><a>RTCRtpEncodingParameters</a></code> allows the application
-          to set encoding parameters using
-          <code><a data-link-for="RTCRtpSender">setParameters</a></code>, even
-          when simulcast isn't used.</div>
         </li>
         <li>
           <p>Let <var>sender</var> have a <dfn>[[\LastReturnedParameters]]</dfn>
@@ -5752,10 +5751,10 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                      </li>
                      <li>
                        Any parameter in <var>parameters</var> is marked as a
-                       <dfn>Read-only parameter</dfn> and has a value that is different
-                       from the corresponding parameter value in <var>sender</var>'s
-                       <a>[[\LastReturnedParameters]]</a> internal slot. Note that
-                       this also applies to <var>transactionId</var>.
+                       <dfn>Read-only parameter</dfn> (such as RID) and has a
+                       value that is different from the corresponding parameter
+                       value in <var>sender</var>'s <a>[[\LastReturnedParameters]]</a>
+                       internal slot. Note that this also applies to <var>transactionId</var>.
                      </li>
                    </ol>
                  </li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -5235,7 +5235,54 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   <code>true</code>, <a>throw</a> an
                   <code>InvalidStateError</code>.</p>
                 </li>
-                <li><a>Validate sendEncodings</a>.</li>
+                <li>Validate <code>sendEncodings</code> by running the following steps:
+                <ol>
+                  <li>
+                    <p>Verify that each <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>
+                    value in <var>sendEncodings</var> is composed only of
+                    alphanumeric characters (a-z, A-Z, 0-9) up to
+                    a maximum of 16 characters. If one of the RIDs does not meet
+                    these requirements, <a>throw</a> a <code>TypeError</code>.</p>
+                  </li>
+                  <li>
+                    <p>If any <code><a>RTCRtpEncodingParameters</a></code>
+                    dictionary in <var>sendEncodings</var> contains a
+                    <a>read-only parameter</a> other than
+                    <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>,
+                    <a>throw</a> an <code>InvalidAccessError</code>.</p>
+                  </li>
+                  <li>
+                    <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">scaleResolutionDownBy</a></code>
+                    value in <var>sendEncodings</var> is greater than or equal to 1.0. If
+                    one of the <code>scaleResolutionDownBy</code> values does not meet
+                    this requirement, <a>throw</a> a <code>RangeError</code>.</p>
+                  </li>
+                  <li>
+                    <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">maxFramerate</a></code>
+                    value in <var>sendEncodings</var> is greater than or equal to 0.0. If
+                    one of the <code>maxFramerate</code> values does not meet
+                    this requirement, <a>throw</a> a <code>RangeError</code>.</p>
+                  </li>
+                  <li>
+                    <p>Let <var>maxN</var> be the maximum number of total simultaneous
+                    encodings the user agent may support for this <var>kind</var>, at
+                    minimum <code>1</code>.This should be an optimistic number since the
+                    codec to be used is not known yet.</p>
+                  </li>
+                  <li>
+                    <p>If the number of <code><a>RTCRtpEncodingParameters</a></code>
+                    stored in <var>sendEncodings</var> exceeds <var>maxN</var>,
+                    then trim <var>sendEncodings</var> from the tail until its length
+                    is <var>maxN</var>.</p>
+                   </li>
+                   <li>
+                     <p>If the number of <code><a>RTCRtpEncodingParameters</a></code> now
+                     stored in <var>sendEncodings</var> is <code>1</code>, then remove any
+                     <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>
+                     member from the lone entry.</p>
+                   </li>
+                </ol>
+                </li>
                 <li>
                   <p><a>Create an RTCRtpSender</a> with <var>track</var>,
                   <var>kind</var>, <var>streams</var> and <var>sendEncodings</var>
@@ -5282,53 +5329,6 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <li>
                   <p>Return <var>transceiver</var>.</p>
                 </li>
-              </ol>
-              <p>To <dfn>Validate sendEncodings</dfn> the user agent MUST run the following steps:</p>
-              <ol>
-                  <li>
-                    <p>Verify that each <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>
-                    value in <var>sendEncodings</var> is composed only of
-                    alphanumeric characters (a-z, A-Z, 0-9) up to
-                    a maximum of 16 characters. If one of the RIDs does not meet
-                    these requirements, <a>throw</a> a <code>TypeError</code>.</p>
-                  </li>
-                  <li>
-                    <p>If any <code><a>RTCRtpEncodingParameters</a></code>
-                    dictionary in <var>sendEncodings</var> contains a
-                    <a>read-only parameter</a> other than
-                    <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>,
-                    <a>throw</a> an <code>InvalidAccessError</code>.</p>
-                  </li>
-                  <li>
-                    <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">scaleResolutionDownBy</a></code>
-                    value in <var>sendEncodings</var> is greater than or equal to 1.0. If
-                    one of the <code>scaleResolutionDownBy</code> values does not meet
-                    this requirement, <a>throw</a> a <code>RangeError</code>.</p>
-                  </li>
-                  <li>
-                    <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">maxFramerate</a></code>
-                    value in <var>sendEncodings</var> is greater than or equal to 0.0. If
-                    one of the <code>maxFramerate</code> values does not meet
-                    this requirement, <a>throw</a> a <code>RangeError</code>.</p>
-                  </li>
-                  <li>
-                    <p>Let <var>maxN</var> be the maximum number of total simultaneous
-                    encodings the user agent may support for this <var>kind</var>, at
-                    minimum <code>1</code>.This should be an optimistic number since the
-                    codec to be used is not known yet.</p>
-                  </li>
-                  <li>
-                    <p>If the number of <code><a>RTCRtpEncodingParameters</a></code>
-                    stored in <var>sendEncodings</var> exceeds <var>maxN</var>,
-                    then trim <var>sendEncodings</var> from the tail until its length
-                    is <var>maxN</var>.</p>
-                   </li>
-                   <li>
-                     <p>If the number of <code><a>RTCRtpEncodingParameters</a></code> now
-                     stored in <var>sendEncodings</var> is <code>1</code>, then remove any
-                     <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>
-                     member from the lone entry.</p>
-                   </li>
               </ol>
             </dd>
           </dl>
@@ -5731,7 +5731,67 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <li>
                   Let <var>codecs</var> be <code><var>parameters</var>.codecs</code>.
                 </li>
-                <li><a>Validate parameters</a>.</li>
+                <li>Validate <var>parameters</var> by running the following steps:
+                <ol>
+                 <li>
+                   Let <var>N</var> be the number of
+                   <code><a>RTCRtpEncodingParameters</a></code> stored in
+                   <var>sender</var>'s internal <a>[[\SendEncodings]]</a> slot.
+                 </li>
+                 <li>
+                   If any of the following conditions are met, return a promise
+                   <a>rejected</a> with a newly
+                   <a data-link-for="exception" data-lt="create">created</a>
+                   <code>InvalidModificationError</code>:
+                   <ol>  
+                     <li>
+                       <code><var>encodings</var>.length</code> is different from <var>N</var>.
+                     </li>
+                     <li>
+                       <var>encodings</var> has been re-ordered.
+                     </li>
+                     <li>
+                       Any parameter in <var>parameters</var> is marked as a
+                       <dfn>Read-only parameter</dfn> and has a value that is different
+                       from the corresponding parameter value in <var>sender</var>'s
+                       <a>[[\LastReturnedParameters]]</a> internal slot. Note that
+                       this also applies to <var>transactionId</var>.
+                     </li>
+                   </ol>
+                 </li>
+                 <li>
+                   <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">scaleResolutionDownBy</a></code>
+                   value in <var>encodings</var> is greater than or equal to 1.0. If
+                   one of the <code>scaleResolutionDownBy</code> values does not meet
+                   this requirement, return a promise <a>rejected</a> with a newly
+                   <a data-link-for="exception" data-lt="create">created</a>
+                   <code>RangeError</code>.</p>
+                 </li>
+                 <li>
+                   <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">maxFramerate</a></code>
+                   value in <var>encodings</var> is greater than or equal to 0.0. If
+                   one of the <code>maxFramerate</code> values does not meet
+                   this requirement, return a promise <a>rejected</a> with a newly
+                   <a data-link-for="exception" data-lt="create">created</a>
+                   <code>RangeError</code>.</p>
+                 </li>
+                 <li>
+                   <p>For each value of <var>i</var> from 0 to the number of encodings,
+                   check whether
+                   <code><var>encodings</var>[<var>i</var>].codecPayloadType</code>
+                   (if set) corresponds to a value of
+                   <code><var>codecs</var>[<var>j</var>].payloadType</code> where
+                   <var>j</var> goes from 0 to the number of codecs. If there is no
+                   correspondence, or if the MIME subtype portion of
+                   <code><var>codecs</var>[<var>j</var>].mimeType</code> is equal to
+                   "red", "cn", "telephone-event", "rtx" or a forward error correction
+                   codec ("ulpfec" [[RFC5109]] or "flexfec" [[FLEXFEC]]), reject
+                   <var>p</var> with a newly
+                   <a data-link-for="exception" data-lt="create">created</a>
+                   <code>InvalidAccessError</code>.</p>
+                 </li>
+                </ol>               
+                </li>
                 <li>Let <var>p</var> be a new promise.</li>
                 <li>In parallel, configure the media stack to use
                 <var>parameters</var> to transmit <var>sender</var>'s
@@ -5793,66 +5853,6 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <code>maxBitrate</code>, while at the same time making sure it
               satisfies constraints on bitrate specified in other places such
               as the SDP.</p>
-              <p>To <dfn>Validate parameters</dfn> the user agent MUST run the following steps:</p>
-              <ol>
-                 <li>
-                   Let <var>N</var> be the number of
-                   <code><a>RTCRtpEncodingParameters</a></code> stored in
-                   <var>sender</var>'s internal <a>[[\SendEncodings]]</a> slot.
-                 </li>
-                 <li>
-                   If any of the following conditions are met, return a promise
-                   <a>rejected</a> with a newly
-                   <a data-link-for="exception" data-lt="create">created</a>
-                   <code>InvalidModificationError</code>:
-                   <ol>  
-                     <li>
-                       <code><var>encodings</var>.length</code> is different from <var>N</var>.
-                     </li>
-                     <li>
-                       <var>encodings</var> has been re-ordered.
-                     </li>
-                     <li>
-                       Any parameter in <var>parameters</var> is marked as a
-                       <dfn>Read-only parameter</dfn> and has a value that is different
-                       from the corresponding parameter value in <var>sender</var>'s
-                       <a>[[\LastReturnedParameters]]</a> internal slot. Note that
-                       this also applies to <var>transactionId</var>.
-                     </li>
-                   </ol>
-                 </li>
-                 <li>
-                   <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">scaleResolutionDownBy</a></code>
-                   value in <var>encodings</var> is greater than or equal to 1.0. If
-                   one of the <code>scaleResolutionDownBy</code> values does not meet
-                   this requirement, return a promise <a>rejected</a> with a newly
-                   <a data-link-for="exception" data-lt="create">created</a>
-                   <code>RangeError</code>.</p>
-                 </li>
-                 <li>
-                   <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">maxFramerate</a></code>
-                   value in <var>encodings</var> is greater than or equal to 0.0. If
-                   one of the <code>maxFramerate</code> values does not meet
-                   this requirement, return a promise <a>rejected</a> with a newly
-                   <a data-link-for="exception" data-lt="create">created</a>
-                   <code>RangeError</code>.</p>
-                 </li>
-                 <li>
-                   <p>For each value of <var>i</var> from 0 to the number of encodings,
-                   check whether
-                   <code><var>encodings</var>[<var>i</var>].codecPayloadType</code>
-                   (if set) corresponds to a value of
-                   <code><var>codecs</var>[<var>j</var>].payloadType</code> where
-                   <var>j</var> goes from 0 to the number of codecs. If there is no
-                   correspondence, or if the MIME subtype portion of
-                   <code><var>codecs</var>[<var>j</var>].mimeType</code> is equal to
-                   "red", "cn", "telephone-event", "rtx" or a forward error correction
-                   codec ("ulpfec" [[RFC5109]] or "flexfec" [[FLEXFEC]]), reject
-                   <var>p</var> with a newly
-                   <a data-link-for="exception" data-lt="create">created</a>
-                   <code>InvalidAccessError</code>.</p>
-                 </li>
-              </ol>
             </dd>
             <dt><code>getParameters</code></dt>
             <dd>

--- a/webrtc.html
+++ b/webrtc.html
@@ -5235,35 +5235,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   <code>true</code>, <a>throw</a> an
                   <code>InvalidStateError</code>.</p>
                 </li>
-                <li>Validate <var>sendEncodings</var> by running the following steps:</li>
-                  <ol>
-                      <li>
-                        <p>Verify that each <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>
-                        value in <var>sendEncodings</var> is composed only of
-                        alphanumeric characters (a-z, A-Z, 0-9) up to
-                        a maximum of 16 characters. If one of the RIDs does not meet
-                        these requirements, <a>throw</a> a <code>TypeError</code>.</p>
-                      </li>
-                      <li>
-                        <p>If any <code><a>RTCRtpEncodingParameters</a></code>
-                        dictionary in <var>sendEncodings</var> contains a
-                        <a>read-only parameter</a> other than
-                        <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>,
-                        <a>throw</a> an <code>InvalidAccessError</code>.</p>
-                     </li>
-                     <li>
-                       <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">scaleResolutionDownBy</a></code>
-                       value in <var>sendEncodings</var> is greater than or equal to 1.0. If
-                       one of the <code>scaleResolutionDownBy</code> values does not meet
-                       this requirement, <a>throw</a> a <code>RangeError</code>.</p>
-                     </li>
-                     <li>
-                       <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">maxFramerate</a></code>
-                       value in <var>sendEncodings</var> is greater than or equal to 0.0. If
-                       one of the <code>maxFramerate</code> values does not meet
-                       this requirement, <a>throw</a> a <code>RangeError</code>.</p>
-                     </li>
-                </ol>
+                <li><a>Validate sendEncodings</a>.</li>
                 <li>
                   <p><a>Create an RTCRtpSender</a> with <var>track</var>,
                   <var>kind</var>, <var>streams</var> and <var>sendEncodings</var>
@@ -5310,6 +5282,35 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <li>
                   <p>Return <var>transceiver</var>.</p>
                 </li>
+              </ol>
+              <p>To <dfn>validate sendEncodings</dfn> run the following steps:</p>
+              <ol>
+                  <li>
+                    <p>Verify that each <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>
+                    value in <var>sendEncodings</var> is composed only of
+                    alphanumeric characters (a-z, A-Z, 0-9) up to
+                    a maximum of 16 characters. If one of the RIDs does not meet
+                    these requirements, <a>throw</a> a <code>TypeError</code>.</p>
+                  </li>
+                  <li>
+                    <p>If any <code><a>RTCRtpEncodingParameters</a></code>
+                    dictionary in <var>sendEncodings</var> contains a
+                    <a>read-only parameter</a> other than
+                    <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>,
+                    <a>throw</a> an <code>InvalidAccessError</code>.</p>
+                  </li>
+                  <li>
+                    <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">scaleResolutionDownBy</a></code>
+                    value in <var>sendEncodings</var> is greater than or equal to 1.0. If
+                    one of the <code>scaleResolutionDownBy</code> values does not meet
+                    this requirement, <a>throw</a> a <code>RangeError</code>.</p>
+                  </li>
+                  <li>
+                     <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">maxFramerate</a></code>
+                      value in <var>sendEncodings</var> is greater than or equal to 0.0. If
+                      one of the <code>maxFramerate</code> values does not meet
+                      this requirement, <a>throw</a> a <code>RangeError</code>.</p>
+                    </li>
               </ol>
             </dd>
           </dl>

--- a/webrtc.html
+++ b/webrtc.html
@@ -5715,7 +5715,6 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <code><a>RTCRtpTransceiver</a></code> object associated
                 with <var>sender</var> (i.e. <var>sender</var> is
                 <var>transceiver</var>'s <a>[[\Sender]]</a>).</li>
-
                 <li>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot is
                 <code>true</code>, return a promise <a>rejected</a> with a newly
                 <a data-link-for="exception" data-lt="create">created</a>
@@ -5725,7 +5724,13 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <a>rejected</a> with a newly
                 <a data-link-for="exception" data-lt="create">created</a>
                 <code>InvalidStateError</code>.</li>
-                <li><dfn>validate encodings</dfn> by running the following steps:
+                <li>
+                  Let <var>encodings</var> be <code><var>parameters</var>.encodings</code>.
+                </li>
+                <li>
+                  Let <var>codecs</var> be <code><var>parameters</var>.codecs</code>.
+                </li>
+                <li>Validate <var>parameters</var> by running the following steps:
                   <ol>
                     <li>
                       Let <var>N</var> be the number of
@@ -5739,12 +5744,11 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                       <code>InvalidModificationError</code>:
                       <ol>  
                         <li>
-                          <code><var>parameters</var>.encodings.length</code>
-                          is different from <var>N</var>.
+                          <code><var>encodings</var>.length</code> is different
+                          from <var>N</var>.
                         </li>
                         <li>
-                          <code><var>parameters</var>.encodings</code> has been
-                          re-ordered.
+                          <var>encodings</var> has been re-ordered.
                         </li>
                         <li>
                           Any parameter in <var>parameters</var> is marked as a
@@ -5756,32 +5760,33 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                     </ol>
                    </li>
                    <li>
+                     If any <code>scaleResolutionDownBy</code> attribute in
+                     <var>encodings</var> has a value less than 1.0,
+                     return a promise <a>rejected</a> with a newly
+                     <a data-link-for="exception" data-lt="create">created</a>
+                     <code>RangeError</code>.
+                   </li>
+                   <li>
+                     If any <code>maxFramerate</code> attribute in
+                     <var>encodings</var> has a value less than 0.0,
+                     return a promise <a>rejected</a> with a newly
+                     <a data-link-for="exception" data-lt="create">created</a>
+                     <code>RangeError</code>.
+                   </li>
+                   <li>
                      <p>For each value of <var>i</var> from 0 to the number of encodings,
                      check whether
-                     <code><var>parameters</var>.encodings[<var>i</var>].codecPayloadType</code>
+                     <code><var>encodings</var>[<var>i</var>].codecPayloadType</code>
                      (if set) corresponds to a value of
-                     <code><var>parameters</var>.codecs[<var>j</var>].payloadType</code> where
+                     <code><var>codecs</var>[<var>j</var>].payloadType</code> where
                      <var>j</var> goes from 0 to the number of codecs. If there is no
                      correspondence, or if the MIME subtype portion of
-                     <code><var>parameters</var>.codecs[<var>j</var>].mimeType</code> is equal to
+                     <code><var>codecs</var>[<var>j</var>].mimeType</code> is equal to
                      "red", "cn", "telephone-event", "rtx" or a forward error correction
-                     codec ("ulpfec" [[RFC5109]] or "flexfec" [[FLEXFEC]]), reject <var>p</var> with
-                     a newly <a data-link-for="exception" data-lt="create">created</a>
+                     codec ("ulpfec" [[RFC5109]] or "flexfec" [[FLEXFEC]]), reject
+                     <var>p</var> with a newly
+                     <a data-link-for="exception" data-lt="create">created</a>
                      <code>InvalidAccessError</code>.</p>
-                   </li>
-                   <li>
-                     If the <code>scaleResolutionDownBy</code> parameter in the
-                     <var>parameters</var> argument has a value less than 1.0,
-                     return a promise <a>rejected</a> with a newly
-                     <a data-link-for="exception" data-lt="create">created</a>
-                     <code>RangeError</code>.
-                   </li>
-                   <li>
-                     If the <code>maxFramerate</code> parameter in the
-                     <var>parameters</var> argument has a value less than 0.0,
-                     return a promise <a>rejected</a> with a newly
-                     <a data-link-for="exception" data-lt="create">created</a>
-                     <code>RangeError</code>.
                    </li>
                  </ol>
                 <li>Let <var>p</var> be a new promise.</li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -5731,67 +5731,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <li>
                   Let <var>codecs</var> be <code><var>parameters</var>.codecs</code>.
                 </li>
-                <li>Validate <var>parameters</var> by running the following steps:
-                  <ol>
-                    <li>
-                      Let <var>N</var> be the number of
-                      <code><a>RTCRtpEncodingParameters</a></code> stored in
-                      <var>sender</var>'s internal <a>[[\SendEncodings]]</a> slot.
-                    </li>
-                    <li>
-                      If any of the following conditions are met, return a promise
-                      <a>rejected</a> with a newly
-                      <a data-link-for="exception" data-lt="create">created</a>
-                      <code>InvalidModificationError</code>:
-                      <ol>  
-                        <li>
-                          <code><var>encodings</var>.length</code> is different
-                          from <var>N</var>.
-                        </li>
-                        <li>
-                          <var>encodings</var> has been re-ordered.
-                        </li>
-                        <li>
-                          Any parameter in <var>parameters</var> is marked as a
-                          <dfn>Read-only parameter</dfn> and has a value that is different
-                          from the corresponding parameter value in <var>sender</var>'s
-                          <a>[[\LastReturnedParameters]]</a> internal slot. Note that
-                          this also applies to <var>transactionId</var>.
-                        </li>
-                    </ol>
-                   </li>
-                   <li>
-                     <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">scaleResolutionDownBy</a></code>
-                     value in <var>encodings</var> is greater than or equal to 1.0. If
-                     one of the <code>scaleResolutionDownBy</code> values does not meet
-                     this requirement, return a promise <a>rejected</a> with a newly
-                     <a data-link-for="exception" data-lt="create">created</a>
-                     <code>RangeError</code>.</p>
-                   </li>
-                   <li>
-                     <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">maxFramerate</a></code>
-                     value in <var>encodings</var> is greater than or equal to 0.0. If
-                     one of the <code>maxFramerate</code> values does not meet
-                     this requirement, return a promise <a>rejected</a> with a newly
-                     <a data-link-for="exception" data-lt="create">created</a>
-                     <code>RangeError</code>.</p>
-                   </li>
-                   <li>
-                     <p>For each value of <var>i</var> from 0 to the number of encodings,
-                     check whether
-                     <code><var>encodings</var>[<var>i</var>].codecPayloadType</code>
-                     (if set) corresponds to a value of
-                     <code><var>codecs</var>[<var>j</var>].payloadType</code> where
-                     <var>j</var> goes from 0 to the number of codecs. If there is no
-                     correspondence, or if the MIME subtype portion of
-                     <code><var>codecs</var>[<var>j</var>].mimeType</code> is equal to
-                     "red", "cn", "telephone-event", "rtx" or a forward error correction
-                     codec ("ulpfec" [[RFC5109]] or "flexfec" [[FLEXFEC]]), reject
-                     <var>p</var> with a newly
-                     <a data-link-for="exception" data-lt="create">created</a>
-                     <code>InvalidAccessError</code>.</p>
-                   </li>
-                 </ol>
+                <li><a>validate parameters</a>.</li>
                 <li>Let <var>p</var> be a new promise.</li>
                 <li>In parallel, configure the media stack to use
                 <var>parameters</var> to transmit <var>sender</var>'s
@@ -5853,6 +5793,66 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <code>maxBitrate</code>, while at the same time making sure it
               satisfies constraints on bitrate specified in other places such
               as the SDP.</p>
+              <p>To <dfn>validate parameters</dfn> run the following steps:</p>
+              <ol>
+                 <li>
+                   Let <var>N</var> be the number of
+                   <code><a>RTCRtpEncodingParameters</a></code> stored in
+                   <var>sender</var>'s internal <a>[[\SendEncodings]]</a> slot.
+                 </li>
+                 <li>
+                   If any of the following conditions are met, return a promise
+                   <a>rejected</a> with a newly
+                   <a data-link-for="exception" data-lt="create">created</a>
+                   <code>InvalidModificationError</code>:
+                   <ol>  
+                     <li>
+                       <code><var>encodings</var>.length</code> is different from <var>N</var>.
+                     </li>
+                     <li>
+                       <var>encodings</var> has been re-ordered.
+                     </li>
+                     <li>
+                       Any parameter in <var>parameters</var> is marked as a
+                       <dfn>Read-only parameter</dfn> and has a value that is different
+                       from the corresponding parameter value in <var>sender</var>'s
+                       <a>[[\LastReturnedParameters]]</a> internal slot. Note that
+                       this also applies to <var>transactionId</var>.
+                     </li>
+                   </ol>
+                 </li>
+                 <li>
+                   <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">scaleResolutionDownBy</a></code>
+                   value in <var>encodings</var> is greater than or equal to 1.0. If
+                   one of the <code>scaleResolutionDownBy</code> values does not meet
+                   this requirement, return a promise <a>rejected</a> with a newly
+                   <a data-link-for="exception" data-lt="create">created</a>
+                   <code>RangeError</code>.</p>
+                 </li>
+                 <li>
+                   <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">maxFramerate</a></code>
+                   value in <var>encodings</var> is greater than or equal to 0.0. If
+                   one of the <code>maxFramerate</code> values does not meet
+                   this requirement, return a promise <a>rejected</a> with a newly
+                   <a data-link-for="exception" data-lt="create">created</a>
+                   <code>RangeError</code>.</p>
+                 </li>
+                 <li>
+                   <p>For each value of <var>i</var> from 0 to the number of encodings,
+                   check whether
+                   <code><var>encodings</var>[<var>i</var>].codecPayloadType</code>
+                   (if set) corresponds to a value of
+                   <code><var>codecs</var>[<var>j</var>].payloadType</code> where
+                   <var>j</var> goes from 0 to the number of codecs. If there is no
+                   correspondence, or if the MIME subtype portion of
+                   <code><var>codecs</var>[<var>j</var>].mimeType</code> is equal to
+                   "red", "cn", "telephone-event", "rtx" or a forward error correction
+                   codec ("ulpfec" [[RFC5109]] or "flexfec" [[FLEXFEC]]), reject
+                   <var>p</var> with a newly
+                   <a data-link-for="exception" data-lt="create">created</a>
+                   <code>InvalidAccessError</code>.</p>
+                 </li>
+              </ol>
             </dd>
             <dt><code>getParameters</code></dt>
             <dd>

--- a/webrtc.html
+++ b/webrtc.html
@@ -5235,7 +5235,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   <code>true</code>, <a>throw</a> an
                   <code>InvalidStateError</code>.</p>
                 </li>
-                <li><dfn>validate sendEncodings</dfn> using the following steps:</li>
+                <li>Validate <var>sendEncodings</var> by running the following steps:</li>
                   <ol>
                       <li>
                         <p>Verify that each <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>
@@ -5760,18 +5760,20 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                     </ol>
                    </li>
                    <li>
-                     If any <code>scaleResolutionDownBy</code> attribute in
-                     <var>encodings</var> has a value less than 1.0,
-                     return a promise <a>rejected</a> with a newly
+                     <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">scaleResolutionDownBy</a></code>
+                     value in <var>encodings</var> is greater than or equal to 1.0. If
+                     one of the <code>scaleResolutionDownBy</code> values does not meet
+                     this requirement, return a promise <a>rejected</a> with a newly
                      <a data-link-for="exception" data-lt="create">created</a>
-                     <code>RangeError</code>.
+                     <code>RangeError</code>.</p>
                    </li>
                    <li>
-                     If any <code>maxFramerate</code> attribute in
-                     <var>encodings</var> has a value less than 0.0,
-                     return a promise <a>rejected</a> with a newly
+                     <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">maxFramerate</a></code>
+                     value in <var>encodings</var> is greater than or equal to 0.0. If
+                     one of the <code>maxFramerate</code> values does not meet
+                     this requirement, return a promise <a>rejected</a> with a newly
                      <a data-link-for="exception" data-lt="create">created</a>
-                     <code>RangeError</code>.
+                     <code>RangeError</code>.</p>
                    </li>
                    <li>
                      <p>For each value of <var>i</var> from 0 to the number of encodings,

--- a/webrtc.html
+++ b/webrtc.html
@@ -5731,7 +5731,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <li>
                   Let <var>codecs</var> be <code><var>parameters</var>.codecs</code>.
                 </li>
-                <li><a>validate parameters</a>.</li>
+                <li><a>Validate parameters</a>.</li>
                 <li>Let <var>p</var> be a new promise.</li>
                 <li>In parallel, configure the media stack to use
                 <var>parameters</var> to transmit <var>sender</var>'s
@@ -5793,7 +5793,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <code>maxBitrate</code>, while at the same time making sure it
               satisfies constraints on bitrate specified in other places such
               as the SDP.</p>
-              <p>To <dfn>validate parameters</dfn> run the following steps:</p>
+              <p>To <dfn>Validate parameters</dfn> the user agent MUST run the following steps:</p>
               <ol>
                  <li>
                    Let <var>N</var> be the number of

--- a/webrtc.html
+++ b/webrtc.html
@@ -5283,7 +5283,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   <p>Return <var>transceiver</var>.</p>
                 </li>
               </ol>
-              <p>To <dfn>validate sendEncodings</dfn> run the following steps:</p>
+              <p>To <dfn>Validate sendEncodings</dfn> the user agent MUST run the following steps:</p>
               <ol>
                   <li>
                     <p>Verify that each <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>
@@ -5306,11 +5306,29 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                     this requirement, <a>throw</a> a <code>RangeError</code>.</p>
                   </li>
                   <li>
-                     <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">maxFramerate</a></code>
-                      value in <var>sendEncodings</var> is greater than or equal to 0.0. If
-                      one of the <code>maxFramerate</code> values does not meet
-                      this requirement, <a>throw</a> a <code>RangeError</code>.</p>
-                    </li>
+                    <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">maxFramerate</a></code>
+                    value in <var>sendEncodings</var> is greater than or equal to 0.0. If
+                    one of the <code>maxFramerate</code> values does not meet
+                    this requirement, <a>throw</a> a <code>RangeError</code>.</p>
+                  </li>
+                  <li>
+                    <p>Let <var>maxN</var> be the maximum number of total simultaneous
+                    encodings the user agent may support for this <var>kind</var>, at
+                    minimum <code>1</code>.This should be an optimistic number since the
+                    codec to be used is not known yet.</p>
+                  </li>
+                  <li>
+                    <p>If the number of <code><a>RTCRtpEncodingParameters</a></code>
+                    stored in <var>sendEncodings</var> exceeds <var>maxN</var>,
+                    then trim <var>sendEncodings</var> from the tail until its length
+                    is <var>maxN</var>.</p>
+                   </li>
+                   <li>
+                     <p>If the number of <code><a>RTCRtpEncodingParameters</a></code> now
+                     stored in <var>sendEncodings</var> is <code>1</code>, then remove any
+                     <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>
+                     member from the lone entry.</p>
+                   </li>
               </ol>
             </dd>
           </dl>
@@ -5584,24 +5602,6 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           to set encoding parameters using
           <code><a data-link-for="RTCRtpSender">setParameters</a></code>, even
           when simulcast isn't used.</div>
-        </li>
-        <li>
-          <p>Let <var>maxN</var> be the maximum number of total simultaneous
-          encodings the user agent may support for this <var>kind</var>, at
-          minimum <code>1</code>.This should be an optimistic number since the
-          codec to be used is not known yet.</p>
-        </li>
-        <li>
-          <p>If the number of <code><a>RTCRtpEncodingParameters</a></code>
-          stored in <a>[[\SendEncodings]]</a> exceeds <var>maxN</var>, then trim
-          <a>[[\SendEncodings]]</a> from the tail until its length is
-          <var>maxN</var>.</p>
-        </li>
-        <li>
-          <p>If the number of <code><a>RTCRtpEncodingParameters</a></code> now
-          stored in <a>[[\SendEncodings]]</a> is <code>1</code>, then remove any
-          <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>
-          member from the lone entry.</p>
         </li>
         <li>
           <p>Let <var>sender</var> have a <dfn>[[\LastReturnedParameters]]</dfn>


### PR DESCRIPTION
This is an attempt to reorganize the simulcast-related material so that it is easier to add more detail in future.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/1989.html" title="Last updated on Sep 17, 2018, 9:06 PM GMT (ef50da8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1989/35328b6...ef50da8.html" title="Last updated on Sep 17, 2018, 9:06 PM GMT (ef50da8)">Diff</a>