### PR TITLE
Move priority from RTCRtpEncodingParameters to RTCRtpSendParameters

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6180,6 +6180,7 @@ async function updateParameters() {
              required DOMString             transactionId;
              required sequence&lt;RTCRtpEncodingParameters&gt;  encodings;
              RTCDegradationPreference       degradationPreference = "balanced";
+             RTCPriorityType                priority = "low";
 };</pre>
         <section>
           <h2>Dictionary <code><a>RTCRtpSendParameters</a></code> Members</h2>
@@ -6208,6 +6209,13 @@ async function updateParameters() {
               resolution or degrading framerate,
               <code>degradationPreference</code> indicates which is
               preferred.</p>
+            </dd>
+            <dt><dfn data-idl><code>priority</code></dfn> of type <span class=
+            "idlMemberType"><a>RTCPriorityType</a></span>, defaulting to
+            <code>"low"</code></dt>
+            <dd>
+              <p>Indicates the priority of this encoding. It is specified in
+              [[!RTCWEB-TRANSPORT]], Section 4.</p>
             </dd>
           </dl>
         </section>
@@ -6279,7 +6287,6 @@ async function updateParameters() {
              octet               codecPayloadType;
              RTCDtxStatus        dtx;
              boolean             active = true;
-             RTCPriorityType     priority = "low";
              unsigned long       ptime;
              unsigned long       maxBitrate;
              double              maxFramerate;
@@ -6324,13 +6331,6 @@ async function updateParameters() {
               encoding is actively being sent. Setting it to <code>false</code>
               causes this encoding to no longer be sent. Setting it to <code>true</code>
               causes this encoding to be sent.
-            </dd>
-            <dt><dfn data-idl><code>priority</code></dfn> of type <span class=
-            "idlMemberType"><a>RTCPriorityType</a></span>, defaulting to
-            <code>"low"</code></dt>
-            <dd>
-              <p>Indicates the priority of this encoding. It is specified in
-              [[!RTCWEB-TRANSPORT]], Section 4.</p>
             </dd>
             <dt><dfn data-idl><code>ptime</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long</a></span></dt>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/1888


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/1995.html" title="Last updated on Sep 27, 2018, 10:58 PM GMT (2000e24)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1995/8878a9c...2000e24.html" title="Last updated on Sep 27, 2018, 10:58 PM GMT (2000e24)">Diff</a>