### PR TITLE
Add [EnforceRange]] to RTCDataChannel writable attributes.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9188,6 +9188,7 @@ interface RTCTrackEvent : Event {
     readonly        attribute RTCPriorityType     priority;
     readonly        attribute RTCDataChannelState readyState;
     readonly        attribute unsigned long       bufferedAmount;
+                    [EnforceRange]
                     attribute unsigned long       bufferedAmountLowThreshold;
                     attribute EventHandler        onopen;
                     attribute EventHandler        onbufferedamountlow;
@@ -9449,7 +9450,9 @@ interface RTCTrackEvent : Event {
       <div>
         <pre class="idl">dictionary RTCDataChannelInit {
              boolean         ordered = true;
+             [EnforceRange]
              unsigned short  maxPacketLifeTime;
+             [EnforceRange]
              unsigned short  maxRetransmits;
              USVString       protocol = "";
              boolean         negotiated = false;


### PR DESCRIPTION
Fixes #1974.

This includes "unsigned foo" attributes on RTCDataChannel and RTCDataChannelInit that are writable. On readonly attributes this is not applicable.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/1999.html" title="Last updated on Oct 3, 2018, 2:35 PM GMT (f952f28)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/1999/8878a9c...henbos:f952f28.html" title="Last updated on Oct 3, 2018, 2:35 PM GMT (f952f28)">Diff</a>