### PR TITLE
Describing which media description is offerer tagged.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1679,6 +1679,11 @@
                               </li>
                             </ol>
                           </li>
+                          <li>
+                            <p>If the <a>media description</a> is rejected, and
+                            <var>transceiver</var> is not already stopped, <a>stop
+                            the RTCRtpTransceiver</a> <var>transceiver</var>.</p>
+                          </li>
                         </ol>
                       </li>
                     </ol>
@@ -2500,6 +2505,19 @@ interface RTCPeerConnection : EventTarget  {
                     identity assertion from <var>provider</var> (if non-null),
                     generate an SDP offer, <var>sdpString</var>, as described
                     in <span data-jsep="create-offer">[[!JSEP]]</span>.</p>
+                    <p>As described in [[!BUNDLE]] (Section 7), if bundling is
+                    used (see <a>RTCBundlePolicy</a>) an offerer tagged m=
+                    section must be selected in order to negotiate a BUNDLE
+                    group. The user agent MUST choose the m= section that
+                    correspond to the first non-stopped transciever in the
+                    <a>set of transceivers</a> as the offerer tagged m=
+                    section. This allows the remote endpoint to predict which
+                    transciever is the offerer tagged m= section without having
+                    to parse the SDP. This is relevant when rejecting an m=
+                    section by stopping an
+                    <code><a>RTCRtpTransceiver</a></code>, see the NOTE in
+                    <code><a>RTCRtpTransceiver</a>.stop()</code> for more
+                    information.</p>
                   </li>
                   <li>
                     <p>Let <var>offer</var> be a newly created
@@ -7235,12 +7253,21 @@ async function updateParameters() {
               remote offer and creating an answer, and the transceiver is
               associated with the "offerer tagged" <a>media description</a> as
               defined in [[!BUNDLE]], this will cause all other transceivers
-              in the bundle group to be stopped as well. To avoid this, one
-              could instead stop the transceiver when
+              in the BUNDLE group to be rejected as well. This will cause them
+              to become stopped when applying the answer in
+              <code>setLocalDescription</code>. To avoid this, one could instead
+              stop the transceiver when
               <code><a data-link-for="RTCPeerConnection">signalingState</a></code>
               is <code>"<a data-link-for="RTCSignalingState">stable</a>"</code>
-              and perform a subsequent offer/answer exchange.
-              </p>
+              and perform a subsequent offer/answer exchange. In
+              <code>createOffer</code>, the "offerer tagged" <a>media
+              description</a> is defined as the the offerer's first non-stopped
+              transceiver. This allows the application to predict which
+              transcievers can be rejected without also rejecting other
+              transceivers in the same BUNDLE group even when the
+              <code><a data-link-for="RTCPeerConnection">signalingState</a></code>
+              is not
+              <code>"<a data-link-for="RTCSignalingState">stable</a>"</code>.</p>
               <p>When the <dfn data-idl><code>stop</code></dfn> method is invoked,
               the user agent MUST run the following steps:</p>
               <ol>

--- a/webrtc.html
+++ b/webrtc.html
@@ -7255,16 +7255,16 @@ async function updateParameters() {
               defined in [[!BUNDLE]], this will cause all other transceivers
               in the BUNDLE group to be rejected as well. This will cause them
               to become stopped when applying the answer in
-              <code>setLocalDescription</code>. To avoid this, one could instead
-              stop the transceiver when
+              <code>setLocalDescription</code>. To avoid this, the transceiver
+              can be stopped when
               <code><a data-link-for="RTCPeerConnection">signalingState</a></code>
               is <code>"<a data-link-for="RTCSignalingState">stable</a>"</code>
-              and perform a subsequent offer/answer exchange. In
+              and a subsequent offer/answer exchange can be performed. In
               <code>createOffer</code>, the "offerer tagged" <a>media
-              description</a> is defined as the the offerer's first non-stopped
+              description</a> is defined as the offerer's first non-stopped
               transceiver. This allows the application to predict which
-              transcievers can be rejected without also rejecting other
-              transceivers in the same BUNDLE group even when the
+              transceivers can be rejected without also rejecting other
+              transceivers in the same BUNDLE group, even when the
               <code><a data-link-for="RTCPeerConnection">signalingState</a></code>
               is not
               <code>"<a data-link-for="RTCSignalingState">stable</a>"</code>.</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -2509,10 +2509,10 @@ interface RTCPeerConnection : EventTarget  {
                     used (see <a>RTCBundlePolicy</a>) an offerer tagged m=
                     section must be selected in order to negotiate a BUNDLE
                     group. The user agent MUST choose the m= section that
-                    correspond to the first non-stopped transciever in the
+                    corresponds to the first non-stopped transceiver in the
                     <a>set of transceivers</a> as the offerer tagged m=
                     section. This allows the remote endpoint to predict which
-                    transciever is the offerer tagged m= section without having
+                    transceiver is the offerer tagged m= section without having
                     to parse the SDP. This is relevant when rejecting an m=
                     section by stopping an
                     <code><a>RTCRtpTransceiver</a></code>, see the NOTE in


### PR DESCRIPTION
Fixes #1919.

This PR...
- Makes sure that rejected transceivers are marked as stopped in setLocalDescription, as is necessary because the offerer tagged m= section might have been rejected between setRemoteDescription(offer) and setLocalDescription(answer).
- Mandates that the first non-stopped transceiver is picked as the "offerer tagged" m= section. (The BUNDLE spec does not say which one you should pick, it just suggests that you pick one that you think is unlikely be rejected.)
- Clarifies the existing NOTE in RTCRtpTransceiver.stop() that rejected m= sections causes their transceivers to be stopped when applying the answer at setLocalDescription and that this can be avoided by predicting which transceiver is offerer tagged per how it must have been picked.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2001.html" title="Last updated on Oct 4, 2018, 1:59 PM GMT (460bfe2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2001/8878a9c...henbos:460bfe2.html" title="Last updated on Oct 4, 2018, 1:59 PM GMT (460bfe2)">Diff</a>