### PR TITLE
Add link to "run-to-completion" in terminology

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -128,6 +128,16 @@
       <dfn>peeridentity</dfn>, <dfn>request an identity assertion</dfn> and
       <dfn>validate the identity</dfn> are defined in [[!WEBRTC-IDENTITY]].
     </p>
+    <p class="note">
+      The general principles for Javascript APIs apply, including the principle
+      of <a href="https://w3ctag.github.io/design-principles/#js-rtc">
+        run-to-completion</a> and no-data-races as defined in [[API-DESIGN-PRINCIPLES]].
+      That is, between microtask checkpoints, external events do
+      not influence what's visible to the Javascript application. For example,
+      the amount of data buffered on a data channel will increase due to
+      "send" calls while Javascript is executing, but will only decrease due
+      to packets being sent at a microtask checkpoint.
+    </p>
   </section>
   <section>
     <h2>Peer-to-peer connections</h2>

--- a/webrtc.html
+++ b/webrtc.html
@@ -132,11 +132,16 @@
       The general principles for Javascript APIs apply, including the principle
       of <a href="https://w3ctag.github.io/design-principles/#js-rtc">
         run-to-completion</a> and no-data-races as defined in [[API-DESIGN-PRINCIPLES]].
-      That is, between microtask checkpoints, external events do
+      That is, while a task is running, external events do
       not influence what's visible to the Javascript application. For example,
       the amount of data buffered on a data channel will increase due to
-      "send" calls while Javascript is executing, but will only decrease due
-      to packets being sent at a microtask checkpoint.
+      "send" calls while Javascript is executing, and the decrease due to
+      packets being sent will be visible after a task checkpoint.
+      <br>
+      It is the responsibility of the user agent to make sure the set of
+      values presented to the application is consistent - for instance that
+      getContributingSources() (which is synchronous) returns values for all
+      sources measured at the same time.
     </p>
   </section>
   <section>


### PR DESCRIPTION
Fixes #1111


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2002.html" title="Last updated on Oct 9, 2018, 2:29 PM GMT (6d888b1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2002/8878a9c...6d888b1.html" title="Last updated on Oct 9, 2018, 2:29 PM GMT (6d888b1)">Diff</a>