### PR TITLE
Add preferredPayloadType to RTCRtpCodecCapability

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6640,6 +6640,7 @@ async function updateParameters() {
         <pre class="idl">dictionary RTCRtpCodecCapability {
              required DOMString mimeType;
              required unsigned long  clockRate;
+             required octet preferredPayloadType;
              unsigned short channels;
              DOMString      sdpFmtpLine;
 };</pre>
@@ -6666,6 +6667,17 @@ async function updateParameters() {
             "idlMemberType"><a>unsigned long</a></span>, required</dt>
             <dd>
               <p>The codec clock rate expressed in Hertz.</p>
+            </dd>
+            <dt><dfn data-idl><code>preferredPayloadType</code></dfn> of type <span class=
+            "idlMemberType"><a>octet</a></span>, required</dt>
+            <dd>
+              <p>The preferred RTP payload type for the codec. For an
+              <code><a>RTCRtpSender</a></code> this represents the
+              preferred RTP payload type for sending. For an
+              <code><a>RTCRtpReceiver</a></code> this represents the
+              preferred RTP payload type for receiving. To avoid
+              conflicts the value of <code>preferredPayloadType</code>
+              MUST be unique for each codec entry.</p>
             </dd>
             <dt><dfn data-idl><code>channels</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned short</a></span></dt>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/2008


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2010.html" title="Last updated on Oct 19, 2018, 4:40 PM GMT (3afd880)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2010/8495678...3afd880.html" title="Last updated on Oct 19, 2018, 4:40 PM GMT (3afd880)">Diff</a>