### PR TITLE
Cleanup connection states.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -826,12 +826,12 @@
         <h4><dfn>RTCPeerConnectionState</dfn> Enum</h4>
         <div>
           <pre class="idl">enum RTCPeerConnectionState {
+    "closed",
+    "failed",
+    "disconnected",
     "new",
     "connecting",
-    "connected",
-    "disconnected",
-    "failed",
-    "closed"
+    "connected"
 };</pre>
           <table data-link-for="RTCPeerConnectionState" data-dfn-for=
           "RTCPeerConnectionState" class="simple">
@@ -840,50 +840,48 @@
                 <th colspan="2">Enumeration description</th>
               </tr>
               <tr>
-                <td><dfn data-idl><code>new</code></dfn></td>
-                <td>Any of the <code><a>RTCIceTransport</a></code>s or
-                <code><a>RTCDtlsTransport</a></code>s are in the
-                <code>"new"</code> state and none of the transports are in the
-                <code>"connecting"</code>, <code>"checking"</code>,
-                <code>"failed"</code> or <code>"disconnected"</code> state, or all
-                transports are in the <code>"closed"</code> state, or there are
-                no transports.</td>
-              </tr>
-              <tr>
-                <td><dfn data-idl><code>connecting</code></dfn></td>
-                <td>Any of the <code><a>RTCIceTransport</a></code>s or
-                <code><a>RTCDtlsTransport</a></code>s are in the
-                <code>"connecting"</code> or <code>"checking"</code> state and none
-                of them is in the <code>"failed"</code> state.</td>
-              </tr>
-              <tr>
-                <td><dfn data-idl><code>connected</code></dfn></td>
-                <td>All <code><a>RTCIceTransport</a></code>s and
-                <code><a>RTCDtlsTransport</a></code>s are in the
-                <code>"connected"</code>, <code>"completed"</code> or
-                <code>"closed"</code> state and at least one of them is in the
-                <code>"connected"</code> or <code>"completed"</code> state.</td>
-              </tr>
-              <tr>
-                <td><dfn data-idl><code>disconnected</code></dfn></td>
-                <td>Any of the <code><a>RTCIceTransport</a></code>s or
-                <code><a>RTCDtlsTransport</a></code>s are in the
-                <code>"disconnected"</code> state and none of them are in the
-                <code>"failed"</code> or <code>"connecting"</code> or
-                <code>"checking"</code> state.</td>
-              </tr>
-              <tr>
-                <td><dfn data-idl><code>failed</code></dfn></td>
-                <td>Any of the <code><a>RTCIceTransport</a></code>s or
-                <code><a>RTCDtlsTransport</a></code>s are in a
-                <code>"failed"</code> state.</td>
-              </tr>
-              <tr>
                 <td><dfn data-idl><code>closed</code></dfn></td>
                 <td>
                   The <code><a>RTCPeerConnection</a></code> object's
                   <a>[[\IsClosed]]</a> slot is <code>true</code>.
                 </td>
+              </tr>
+              <tr>
+                <td><dfn data-idl><code>failed</code></dfn></td>
+                <td>The previous state doesn't apply and any
+                <code><a>RTCIceTransport</a></code>s or
+                <code><a>RTCDtlsTransport</a></code>s are in the
+                <code>"failed"</code> state.</td>
+              </tr>
+              <tr>
+                <td><dfn data-idl><code>disconnected</code></dfn></td>
+                <td>None of the previous states apply and any
+                <code><a>RTCIceTransport</a></code>s or
+                <code><a>RTCDtlsTransport</a></code>s are in the
+                <code>"disconnected"</code> state.</td>
+              </tr>
+              <tr>
+                <td><dfn data-idl><code>new</code></dfn></td>
+                <td>None of the previous states apply and all
+                <code><a>RTCIceTransport</a></code>s and
+                <code><a>RTCDtlsTransport</a></code>s are in the
+                <code>"new"</code> or <code>"closed"</code> state, or there are
+                no transports.</td>
+              </tr>
+              <tr>
+                <td><dfn data-idl><code>connecting</code></dfn></td>
+                <td>None of the previous states apply and all
+                <code><a>RTCIceTransport</a></code>s or
+                <code><a>RTCDtlsTransport</a></code>s are in the
+                <code>"new"</code>, <code>"connecting"</code> or <code>"checking"</code> state.</td>
+              </tr>
+              <tr>
+                <td><dfn data-idl><code>connected</code></dfn></td>
+                <td>None of the previous states apply and all
+                <code><a>RTCIceTransport</a></code>s and
+                <code><a>RTCDtlsTransport</a></code>s are in the
+                <code>"connected"</code>, <code>"completed"</code> or
+                <code>"closed"</code> state.</td>
               </tr>
             </tbody>
           </table>
@@ -893,13 +891,13 @@
         <h4><dfn>RTCIceConnectionState</dfn> Enum</h4>
         <div>
           <pre class="idl">enum RTCIceConnectionState {
+    "closed",
+    "failed",
+    "disconnected",
     "new",
     "checking",
-    "connected",
     "completed",
-    "disconnected",
-    "failed",
-    "closed"
+    "connected"
 };</pre>
           <table data-link-for="RTCIceConnectionState" data-dfn-for=
           "RTCIceConnectionState" class="simple">
@@ -908,50 +906,49 @@
                 <th colspan="2">Enumeration description</th>
               </tr>
               <tr>
-                <td><dfn data-idl><code>new</code></dfn></td>
-                <td>Any of the <code><a>RTCIceTransport</a></code>s are in the
-                <code>"new"</code> state and none of them are in the
-                <code>"checking"</code>, <code>"disconnected"</code> or
-                <code>"failed"</code> state, or all
-                <code><a>RTCIceTransport</a></code>s are in the
-                <code>"closed"</code> state, or there are no transports.</td>
-              </tr>
-              <tr>
-                <td><dfn data-idl><code>checking</code></dfn></td>
-                <td>Any of the <code><a>RTCIceTransport</a></code>s are in the
-                <code>"checking"</code> state and none of them are in the
-                <code>"disconnected"</code> or <code>"failed"</code> state.</td>
-              </tr>
-              <tr>
-                <td><dfn data-idl><code>connected</code></dfn></td>
-                <td>All <code><a>RTCIceTransport</a></code>s are in the
-                <code>"connected"</code>, <code>"completed"</code> or
-                <code>"closed"</code> state and at least one of them is in the
-                <code>"connected"</code> state.</td>
-              </tr>
-              <tr>
-                <td><dfn data-idl><code>completed</code></dfn></td>
-                <td>All <code><a>RTCIceTransport</a></code>s are in the
-                <code>"completed"</code> or <code>"closed"</code> state and at
-                least one of them is in the <code>"completed"</code> state.</td>
-              </tr>
-              <tr>
-                <td><dfn data-idl><code>disconnected</code></dfn></td>
-                <td>Any of the <code><a>RTCIceTransport</a></code>s are in the
-                <code>"disconnected"</code> state and none of them are in the
-                <code>"failed"</code> state.</td>
-              </tr>
-              <tr>
-                <td><dfn data-idl><code>failed</code></dfn></td>
-                <td>Any of the <code><a>RTCIceTransport</a></code>s are in the
-                <code>"failed"</code> state.</td>
-              </tr>
-              <tr>
                 <td><dfn data-idl><code>closed</code></dfn></td>
                 <td>
                   The <code><a>RTCPeerConnection</a></code> object's
                   <a>[[\IsClosed]]</a> slot is <code>true</code>.
                 </td>
+              </tr>
+              <tr>
+                <td><dfn data-idl><code>failed</code></dfn></td>
+                <td>The previous state doesn't apply and any
+                <code><a>RTCIceTransport</a></code>s are in the
+                <code>"failed"</code> state.</td>
+              </tr>
+              <tr>
+                <td><dfn data-idl><code>disconnected</code></dfn></td>
+                <td>None of the previous states apply and any
+                <code><a>RTCIceTransport</a></code>s are in the
+                <code>"disconnected"</code> state.</td>
+              </tr>
+              <tr>
+                <td><dfn data-idl><code>new</code></dfn></td>
+                <td>None of the previous states apply and all
+                <code><a>RTCIceTransport</a></code>s are in the
+                <code>"new"</code> or <code>"closed"</code> state,
+                or there are no transports.</td>
+              </tr>
+              <tr>
+                <td><dfn data-idl><code>checking</code></dfn></td>
+                <td>None of the previous states apply and any
+                <code><a>RTCIceTransport</a></code>s are in the
+                <code>"new"</code> or <code>"checking"</code> state.</td>
+              </tr>
+              <tr>
+                <td><dfn data-idl><code>completed</code></dfn></td>
+                <td>None of the previous states apply and all
+                <code><a>RTCIceTransport</a></code>s are in the
+                <code>"completed"</code> or <code>"closed"</code> state.</td>
+              </tr>
+              <tr>
+                <td><dfn data-idl><code>connected</code></dfn></td>
+                <td>None of the previous states apply and all
+                <code><a>RTCIceTransport</a></code>s are in the
+                <code>"connected"</code>, <code>"completed"</code> or
+                <code>"closed"</code> state.</td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
Here's the changes suggested in https://github.com/w3c/webrtc-pc/issues/2031.

These are the effective changes:

- In RTCPeerConnectionState we now prefer "disconnected" over "connecting", that is to say, we no longer do the 'and none of them are in the "connecting" or "checking"' thing. This was done to ensure that the two connection states behave similarly, unlike now.
- Neither of the "new" states allow transports to be "connected" or "completed" any more. The states that would have previously ended up covered here are now "connected" instead.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jonasesolsson/webrtc-pc/pull/2036.html" title="Last updated on Dec 3, 2018, 3:20 PM GMT (7f406d3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2036/3b4dcc4...jonasesolsson:7f406d3.html" title="Last updated on Dec 3, 2018, 3:20 PM GMT (7f406d3)">Diff</a>