### PR TITLE
Make codecPayloadType read-only

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5779,21 +5779,6 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                    <a data-link-for="exception" data-lt="create">created</a>
                    <code>RangeError</code>.</p>
                  </li>
-                 <li>
-                   <p>For each value of <var>i</var> from 0 to the number of encodings,
-                   check whether
-                   <code><var>encodings</var>[<var>i</var>].codecPayloadType</code>
-                   (if set) corresponds to a value of
-                   <code><var>codecs</var>[<var>j</var>].payloadType</code> where
-                   <var>j</var> goes from 0 to the number of codecs. If there is no
-                   correspondence, or if the MIME subtype portion of
-                   <code><var>codecs</var>[<var>j</var>].mimeType</code> is equal to
-                   "red", "cn", "telephone-event", "rtx" or a forward error correction
-                   codec ("ulpfec" [[RFC5109]] or "flexfec" [[FLEXFEC]]), reject
-                   <var>p</var> with a newly
-                   <a data-link-for="exception" data-lt="create">created</a>
-                   <code>InvalidAccessError</code>.</p>
-                 </li>
                 </ol>               
                 </li>
                 <li>Let <var>p</var> be a new promise.</li>
@@ -5837,14 +5822,6 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 </li>
                 <li>Return <var>p</var>.</li>
               </ol>
-              <p>If the application selects a codec via <code><a
-              data-link-for="RTCRtpEncodingParameters">codecPayloadType</a></code>,
-              and this codec is removed from a subsequent offer/answer
-              negotiation, <code><a data-link-for="RTCRtpEncodingParameters">codecPayloadType</a></code>
-              will be unset in the next call to <code><a
-              data-link-for="RTCRtpSender">getParameters</a></code>,
-              and the implementation will fall back to its default codec
-              selection policy until a new codec is selected.</p>
               <p><code>setParameters</code> does not cause SDP renegotiation
               and can only be used to change what the media stack is sending or
               receiving within the envelope negotiated by Offer/Answer. The
@@ -6310,12 +6287,10 @@ async function updateParameters() {
             <dt><dfn data-idl><code>codecPayloadType</code></dfn> of type <span class=
             "idlMemberType"><a>octet</a></span></dt>
             <dd>
-              <p>Used to select a
-              codec to be sent. Must reference a payload type from the <code><a
+              <p>References a payload type from the <code><a
               data-link-for="RTCRtpParameters">codecs</a></code> member of
-              <code><a>RTCRtpParameters</a></code>. If left unset, the
-              implementation will select a codec according to its default policy.
-              </p>
+              <code><a>RTCRtpParameters</a></code>. <a>Read-only
+              parameter</a>.</p>
             </dd>
             <dt><dfn data-idl><code>dtx</code></dfn> of type <span class=
             "idlMemberType"><a>RTCDtxStatus</a></span></dt>


### PR DESCRIPTION
Fixes #2008


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2037.html" title="Last updated on Dec 6, 2018, 12:08 PM GMT (b8841bc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2037/3b4dcc4...henbos:b8841bc.html" title="Last updated on Dec 6, 2018, 12:08 PM GMT (b8841bc)">Diff</a>