### PR TITLE
getRemoteCertificates() to use an internal slot.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7529,7 +7529,8 @@ async function onOffHold() {
 
       <p>An <code><a>RTCDtlsTransport</a></code> has a
       <dfn>[[\DtlsTransportState]]</dfn> internal slot initialized to <code>
-      <a data-link-for="RTCDtlsTransportState">new</a></code>.</p>
+      <a data-link-for="RTCDtlsTransportState">new</a></code> and a
+      <dfn>[[\RemoteCertificates]]</dfn> slot initialized to an empty list.</p>
       <p>When the underlying DTLS transport needs to update the state of the
       corresponding <code><a>RTCDtlsTransport</a></code> object, the user agent
       MUST queue a task that runs the following steps:</p>
@@ -7543,7 +7544,16 @@ async function onOffHold() {
         </li>
         <li>
           <p>Set <var>transport</var>'s <a>[[\DtlsTransportState]]</a> slot to
-            <var>newState</var>.</p>
+          <var>newState</var>.</p>
+        </li>
+        <li>
+          <p>If <var>newState</var> is
+          <code><a data-link-for="RTCDtlsTransportState">connected</a></code>
+          then let <var>newRemoteCertificates</var> be the certificate chain in
+          use by the remote side, with each certificate encoded in binary
+          Distinguished Encoding Rules (DER) [[!X690]], and set
+          <var>transport</var>'s <a>[[\RemoteCertificates]]</a> slot to
+          <var>newRemoteCertificates</var>.</p>
         </li>
         <li>
           <p><a>Fire an event</a> named <code><a data-lt="RTCDtlsTransport state change">statechange</a></code>
@@ -7595,13 +7605,7 @@ async function onOffHold() {
           class="methods">
             <dt><dfn data-idl><code>getRemoteCertificates</code></dfn></dt>
             <dd>
-              <p>Returns the certificate chain in use by the remote side, with
-              each certificate encoded in binary Distinguished Encoding Rules
-              (DER) [[!X690]]. <code>getRemoteCertificates()</code> will return
-              an empty list prior to selection of the remote certificate, which
-              will be completed by the time
-              <code><a>RTCDtlsTransportState</a></code> transitions to
-              "connected".</p>
+              <p>Returns the value of <a>[[\RemoteCertificates]]</a>.</p>
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
Fixes #2034.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2038.html" title="Last updated on Dec 6, 2018, 1:02 PM GMT (ebf90da)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2038/3b4dcc4...henbos:ebf90da.html" title="Last updated on Dec 6, 2018, 1:02 PM GMT (ebf90da)">Diff</a>