### PR TITLE
Define which m= section is offerer tagged.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2531,6 +2531,17 @@ interface RTCPeerConnection : EventTarget  {
                     in <span data-jsep="create-offer">[[!JSEP]]</span>.</p>
                     <ol>
                       <li>
+                        <p>As described in [[!BUNDLE]] (Section 7), if bundling
+                        is used (see <a>RTCBundlePolicy</a>) an offerer tagged
+                        m= section must be selected in order to negotiate a
+                        BUNDLE group. The user agent MUST choose the m= section
+                        that corresponds to the first non-stopped transceiver in
+                        the <a>set of transceivers</a> as the offerer tagged m=
+                        section. This allows the remote endpoint to predict
+                        which transceiver is the offerer tagged m= section
+                        without having to parse the SDP.</p>
+                      </li>
+                      <li>
                         <p>The <i>codec preferences</i> of an m= section's
                         associated transceiver is said to be the value of the
                         <code>RTCRtpTranceiver</code>'s


### PR DESCRIPTION
Fixes #2047


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2048.html" title="Last updated on Jan 10, 2019, 12:47 PM UTC (c78952b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2048/5b1f4cf...henbos:c78952b.html" title="Last updated on Jan 10, 2019, 12:47 PM UTC (c78952b)">Diff</a>