### PR TITLE
Stop bundled transceivers when the offerer tagged is stopped.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7349,6 +7349,16 @@ async function updateParameters() {
                     Stop the RTCRtpTransceiver</a> specified by
                   <var>transceiver</var>.</p>
                 </li>
+                  <p>If <var>connection</var>'s <a>signaling state</a> is
+                  <code>have-remote-offer</code> and <var>transceiver</var> is
+                  associated with the "offerer tagged" <a>media description</a>
+                  as defined in [[!BUNDLE]], then for each transceiver
+                  <var>associatedTransceiver</var> that is associated with a
+                  <a>media description</a> in the same BUNDLE group as
+                  <var>transceiver</var>,
+                  <a data-lt="stop the RTCRtpTransceiver">stop the
+                  RTCRtpTransceiver</a> specified by
+                  <var>associatedTransceiver</var>.</p>
                 <li>
                   <p><a>Update the negotiation-needed flag</a> for
                   <var>connection</var>.</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -7360,6 +7360,7 @@ async function updateParameters() {
                     Stop the RTCRtpTransceiver</a> specified by
                   <var>transceiver</var>.</p>
                 </li>
+                <li>
                   <p>If <var>connection</var>'s <a>signaling state</a> is
                   <code>have-remote-offer</code> and <var>transceiver</var> is
                   associated with the "offerer tagged" <a>media description</a>
@@ -7371,6 +7372,7 @@ async function updateParameters() {
                   <a data-lt="stop the RTCRtpTransceiver">stop the
                   RTCRtpTransceiver</a> specified by
                   <var>associatedTransceiver</var>.</p>
+                </li>
                 <li>
                   <p><a>Update the negotiation-needed flag</a> for
                   <var>connection</var>.</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -7352,7 +7352,8 @@ async function updateParameters() {
                   <p>If <var>connection</var>'s <a>signaling state</a> is
                   <code>have-remote-offer</code> and <var>transceiver</var> is
                   associated with the "offerer tagged" <a>media description</a>
-                  as defined in [[!BUNDLE]], then for each transceiver
+                  as defined in [[!BUNDLE]], then for each
+                  <code>RTCRtpTransceiver</code>
                   <var>associatedTransceiver</var> that is associated with a
                   <a>media description</a> in the same BUNDLE group as
                   <var>transceiver</var>,


### PR DESCRIPTION
Fixes #2049


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2050.html" title="Last updated on Jan 14, 2019, 1:13 PM UTC (95ed8b5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2050/d433c54...henbos:95ed8b5.html" title="Last updated on Jan 14, 2019, 1:13 PM UTC (95ed8b5)">Diff</a>