### PR TITLE
Set rtcpTransport to null when multiplexing.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1615,14 +1615,13 @@
                                   <var>rtcpTransport</var> be newly created
                                   <code><a>RTCDtlsTransport</a></code> objects, each
                                   with a new underlying
-                                  <code><a>RTCIceTransport</a></code>. Though if RTCP
+                                  <code><a>RTCIceTransport</a></code>. If RTCP
                                   multiplexing is negotiated according to [[!RFC5761]],
                                   or if <var>connection</var>'s
                                   <code><a>RTCRtcpMuxPolicy</a></code> is <code><a
                                   data-link-for="RTCRtcpMuxPolicy">require</a></code>,
                                   do not create any RTCP-specific transport objects,
-                                  and instead let <var>rtcpTransport</var> equal
-                                  <var>transport</var>.
+                                  and instead let <var>rtcpTransport</var> be <code>null</code>.
                                 </p>
                               </li>
                               <li>


### PR DESCRIPTION
Fixes #2057


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2058.html" title="Last updated on Jan 16, 2019, 1:46 PM UTC (339e02c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2058/aa8bfc3...339e02c.html" title="Last updated on Jan 16, 2019, 1:46 PM UTC (339e02c)">Diff</a>