### PR TITLE
Reference draft-ietf-mmusic-rid Section 10

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5350,9 +5350,8 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <ol>
                   <li>
                     <p>Verify that each <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>
-                    value in <var>sendEncodings</var> is composed only of
-                    alphanumeric characters (a-z, A-Z, 0-9) up to
-                    a maximum of 16 characters. If one of the RIDs does not meet
+                    value in <var>sendEncodings</var> is conforms to the grammar specified in
+                    [[!MMUSIC-RID]] Section 10. If one of the RIDs does not meet
                     these requirements, <a>throw</a> a <code>TypeError</code>.</p>
                   </li>
                   <li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -5351,7 +5351,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   <li>
                     <p>Verify that each <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>
                     value in <var>sendEncodings</var> conforms to the grammar specified in
-                    [[!MMUSIC-RID]] Section 10. If one of the RIDs does not meet
+                    Section 10 of [[!MMUSIC-RID]]. If one of the RIDs does not meet
                     these requirements, <a>throw</a> a <code>TypeError</code>.</p>
                   </li>
                   <li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -5350,7 +5350,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <ol>
                   <li>
                     <p>Verify that each <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>
-                    value in <var>sendEncodings</var> is conforms to the grammar specified in
+                    value in <var>sendEncodings</var> conforms to the grammar specified in
                     [[!MMUSIC-RID]] Section 10. If one of the RIDs does not meet
                     these requirements, <a>throw</a> a <code>TypeError</code>.</p>
                   </li>


### PR DESCRIPTION
Reference draft-ietf-mmusic-rid Section 10 instead of including a (potentially contradictory) RID grammar in the specification.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2066.html" title="Last updated on Jan 18, 2019, 9:34 PM UTC (25bd07e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2066/e132c6e...25bd07e.html" title="Last updated on Jan 18, 2019, 9:34 PM UTC (25bd07e)">Diff</a>