### PR TITLE
Remove getDefaultIceServers().

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2163,7 +2163,6 @@ interface RTCPeerConnection : EventTarget  {
     readonly        attribute RTCIceConnectionState     iceConnectionState;
     readonly        attribute RTCPeerConnectionState    connectionState;
     readonly        attribute boolean?                  canTrickleIceCandidates;
-    static sequence&lt;RTCIceServer&gt;      getDefaultIceServers ();
     RTCConfiguration                   getConfiguration ();
     void                               setConfiguration (RTCConfiguration configuration);
     void                               close ();
@@ -3047,23 +3046,6 @@ interface RTCPeerConnection : EventTarget  {
                 above algorithm, indicates end-of-candidates for all media
                 descriptions and ICE candidate generation. This is by design for
                 legacy reasons.</p>
-              </dd>
-              <dt><dfn data-idl><code>getDefaultIceServers</code></dfn></dt>
-              <dd>
-                <p>Returns a list of ICE servers that are configured into the
-                browser. A browser might be configured to use local or private
-                STUN or TURN servers. This method allows an application to learn
-                about these servers and optionally use them.</p>
-                <p class="fingerprint">This list is likely to be persistent and
-                is the same across origins. It thus increases the
-                fingerprinting surface of the browser. In privacy-sensitive
-                contexts, browsers can consider mitigations such as only
-                providing this data to whitelisted origins (or not providing it
-                at all.)</p>
-                <p class="note">Since the use of this information is left to
-                the discretion of application developers, configuring a user
-                agent with these defaults does not per se increase a user's
-                ability to limit the exposure of their IP addresses.</p>
               </dd>
               <dt><dfn data-idl><code>getConfiguration</code></dfn></dt>
               <dd>
@@ -12127,11 +12109,6 @@ interface RTCErrorEvent : Event {
       transmitted during <a href="#session-negotiation-model">session
       negotiation</a>. That information is in most cases persistent across time
       and origins, and increases the fingerprint surface of a given device.</p>
-      <p>If set, the configured default ICE servers exposed by <a data-link-for=
-      "RTCPeerConnection">getDefaultIceServers</a> on
-      <code>RTCPeerConnection</code> instances also provides persistent across
-      time and origins information which increases the fingerprinting surface
-      of a given browser.</p>
       <p>When establishing DTLS connections, the WebRTC API can generate
       certificates that can be persisted by the application (e.g. in
       IndexedDB). These certificates are not shared across origins, and get


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2023.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2068.html" title="Last updated on Jan 18, 2019, 11:54 PM UTC (27af2e0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2068/bfe4b29...jan-ivar:27af2e0.html" title="Last updated on Jan 18, 2019, 11:54 PM UTC (27af2e0)">Diff</a>