### PR TITLE
Effect of RTCRtpSendParameters on Simulcast

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7541,6 +7541,30 @@ async function updateParameters() {
         therefore need to be able to correctly order the received packets, recognize potential loss events and
         react to them. Correct operation in this scenario is non-trivial and therefore is optional for
         implementations of this specification.</p>
+        <section id="encodingbehavior">
+           <h3>Parameter behavior</h3>
+           <section id="priorityinsimulcast">
+             <h3>priority</h3>
+             <p><code><a>RTCRtpSendParameters</a></code> dictionary member <code>priority</code>
+             can be utilized to set the priority of an <code><a>RTCRtpSender</a></code>.
+             This enables <code>priority</code> to be used to influence the bandwidth allocation
+             among <code><a>RTCRtpSender</a></code> objects.</p>
+           </section>
+           <section id="maxbitrateinsimulcast">
+             <h3>maxBitrate</h3>
+             <p><code><a>RTCRtpEncodingParameters</a></code> dictionary member <code>maxBitrate</code>
+             can be utilized to set the maximum bitrate of a simulcast stream. The user agent is free
+             to allocate bandwidth between the encodings, as long as the <code>maxBitrate</code>
+             value is not exceeded.</p>
+           </section>
+           <section id="maxframerateinsimulcast">
+             <h3>maxFramerate</h3>
+             <p><code><a>RTCRtpEncodingParameters</a></code> dictionary member <code>maxFramerate</code>
+             can be utilized to set the maximum framerate of a simulcast stream. The user agent is free
+             to allocate bandwidth between the encodings, as long as the <code>maxFramerate</code> value
+             is not exceeded.</p>
+           </section>
+        </section>
      <section class="informative" id="rtcrtpencodingspatialsim-example*">
      <h3>Encoding Parameter Examples</h3>
      <div>

--- a/webrtc.html
+++ b/webrtc.html
@@ -6298,8 +6298,12 @@ async function updateParameters() {
             "idlMemberType"><a>RTCPriorityType</a></span>, defaulting to
             <code>"low"</code></dt>
             <dd>
-              <p>Indicates the priority of this encoding. It is specified in
-              [[!RTCWEB-TRANSPORT]], Section 4.</p>
+              <p>
+                Indicates the priority of an <code><a>RTCRtpSender</a></code>, which influences the
+                bandwidth allocation among <code><a>RTCRtpSender</a></code> objects. It is specified
+                in [[!RTCWEB-TRANSPORT]], Section 4. The user agent is free to sub-allocate bandwidth
+                between the encodings of an <code><a>RTCRtpSender</a></code>.
+              </p>
             </dd>
           </dl>
         </section>
@@ -6432,7 +6436,9 @@ async function updateParameters() {
             "idlMemberType"><a>unsigned long</a></span></dt>
             <dd>
               <p>When present, indicates the maximum bitrate that can be used to send this
-              encoding. The encoding may also be further constrained by other
+              encoding. The user agent is free to allocate bandwidth between the encodings,
+              as long as the <code>maxBitrate</code> value is not exceeded.
+              The encoding may also be further constrained by other
               limits (such as maxFramerate or per-transport or per-session
               bandwidth limits) below the maximum specified here. maxBitrate is
               computed the same way as the Transport Independent Application Specific Maximum (TIAS)
@@ -6444,7 +6450,10 @@ async function updateParameters() {
             "idlMemberType"><a>double</a></span></dt>
             <dd>
               <p>When present, indicates the maximum framerate that can be used to send this
-                encoding, in frames per second.</p>
+                encoding, in frames per second. The user agent is free to allocate bandwidth
+                between the encodings, as long as the <code>maxFramerate</code> value is not
+                exceeded.
+              </p>
               <p>
                 If changed with <code>setParameters</code>, the new framerate
                 takes effect after the current
@@ -7541,30 +7550,6 @@ async function updateParameters() {
         therefore need to be able to correctly order the received packets, recognize potential loss events and
         react to them. Correct operation in this scenario is non-trivial and therefore is optional for
         implementations of this specification.</p>
-        <section id="encodingbehavior">
-           <h3>Parameter behavior</h3>
-           <section id="priorityinsimulcast">
-             <h3>priority</h3>
-             <p><code><a>RTCRtpSendParameters</a></code> dictionary member <code>priority</code>
-             sets the priority of an <code><a>RTCRtpSender</a></code>, which influences the
-             bandwidth allocation among <code><a>RTCRtpSender</a></code> objects. The user agent is
-             free to sub-allocate bandwidth between the encodings of an <code><a>RTCRtpSender</a></code>.</p>
-           </section>
-           <section id="maxbitrateinsimulcast">
-             <h3>maxBitrate</h3>
-             <p><code><a>RTCRtpEncodingParameters</a></code> dictionary member <code>maxBitrate</code>
-             sets the maximum bitrate of a simulcast stream. The user agent is free to allocate
-             bandwidth between the encodings, as long as the <code>maxBitrate</code> value is not
-             exceeded.</p>
-           </section>
-           <section id="maxframerateinsimulcast">
-             <h3>maxFramerate</h3>
-             <p><code><a>RTCRtpEncodingParameters</a></code> dictionary member <code>maxFramerate</code>
-             sets the maximum framerate of a simulcast stream. The user agent is free to allocate
-             bandwidth between the encodings, as long as the <code>maxFramerate</code> value is not
-             exceeded.</p>
-           </section>
-        </section>
      <section class="informative" id="rtcrtpencodingspatialsim-example*">
      <h3>Encoding Parameter Examples</h3>
      <div>

--- a/webrtc.html
+++ b/webrtc.html
@@ -7546,23 +7546,22 @@ async function updateParameters() {
            <section id="priorityinsimulcast">
              <h3>priority</h3>
              <p><code><a>RTCRtpSendParameters</a></code> dictionary member <code>priority</code>
-             can be utilized to set the priority of an <code><a>RTCRtpSender</a></code>.
-             This enables <code>priority</code> to be used to influence the bandwidth allocation
-             among <code><a>RTCRtpSender</a></code> objects.</p>
+             sets the priority of an <code><a>RTCRtpSender</a></code>, which influences the
+             bandwidth allocation among <code><a>RTCRtpSender</a></code> objects.</p>
            </section>
            <section id="maxbitrateinsimulcast">
              <h3>maxBitrate</h3>
              <p><code><a>RTCRtpEncodingParameters</a></code> dictionary member <code>maxBitrate</code>
-             can be utilized to set the maximum bitrate of a simulcast stream. The user agent is free
-             to allocate bandwidth between the encodings, as long as the <code>maxBitrate</code>
-             value is not exceeded.</p>
+             sets the maximum bitrate of a simulcast stream. The user agent is free to allocate
+             bandwidth between the encodings, as long as the <code>maxBitrate</code> value is not
+             exceeded.</p>
            </section>
            <section id="maxframerateinsimulcast">
              <h3>maxFramerate</h3>
              <p><code><a>RTCRtpEncodingParameters</a></code> dictionary member <code>maxFramerate</code>
-             can be utilized to set the maximum framerate of a simulcast stream. The user agent is free
-             to allocate bandwidth between the encodings, as long as the <code>maxFramerate</code> value
-             is not exceeded.</p>
+             sets the maximum framerate of a simulcast stream. The user agent is free to allocate
+             bandwidth between the encodings, as long as the <code>maxFramerate</code> value is not
+             exceeded.</p>
            </section>
         </section>
      <section class="informative" id="rtcrtpencodingspatialsim-example*">

--- a/webrtc.html
+++ b/webrtc.html
@@ -7547,7 +7547,8 @@ async function updateParameters() {
              <h3>priority</h3>
              <p><code><a>RTCRtpSendParameters</a></code> dictionary member <code>priority</code>
              sets the priority of an <code><a>RTCRtpSender</a></code>, which influences the
-             bandwidth allocation among <code><a>RTCRtpSender</a></code> objects.</p>
+             bandwidth allocation among <code><a>RTCRtpSender</a></code> objects. The user agent is
+             free to sub-allocate bandwidth between the encodings of an <code><a>RTCRtpSender</a></code>.</p>
            </section>
            <section id="maxbitrateinsimulcast">
              <h3>maxBitrate</h3>


### PR DESCRIPTION
Fixes #1964


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2073.html" title="Last updated on Jan 24, 2019, 7:31 PM UTC (f735be8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2073/1084b12...f735be8.html" title="Last updated on Jan 24, 2019, 7:31 PM UTC (f735be8)">Diff</a>