### PR TITLE
Make RTCErrorEvent's error member non-nullable

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -11711,7 +11711,7 @@ if (sender.dtmf.canInsertDTMF) {
             Exposed=Window,
             Constructor (DOMString type, RTCErrorEventInit eventInitDict)
         ] interface RTCErrorEvent : Event {
-            readonly attribute RTCError? error;
+            [SameObject] readonly attribute RTCError error;
         };</pre>
       </div>
       <section>
@@ -11734,7 +11734,7 @@ if (sender.dtmf.canInsertDTMF) {
           nullable</dt>
           <dd>
             <p>The <code><a>RTCError</a></code> describing the error that
-            triggered the event (if any).</p>
+            triggered the event.</p>
           </dd>
         </dl>
       </section>
@@ -11744,7 +11744,7 @@ if (sender.dtmf.canInsertDTMF) {
       <div>
         <pre class="idl">
         dictionary RTCErrorEventInit : EventInit {
-             RTCError? error = null;
+             required RTCError error;
         };</pre>
       </div>
       <section>


### PR DESCRIPTION
Fixes #2094 

By making it required in the RTCErrorEventInit dictionary, it can never
be null and so can be made both non-nullable and marked [SameObject].


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/webrtc-pc/pull/2099.html" title="Last updated on Feb 14, 2019, 12:31 PM UTC (c35bed0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2099/e9bc988...foolip:c35bed0.html" title="Last updated on Feb 14, 2019, 12:31 PM UTC (c35bed0)">Diff</a>