### PR TITLE
User agents MUST send audioLevel. If other endpoint is legacy, don't calculate it.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7141,9 +7141,11 @@ async function updateParameters() {
               in [[!RFC6465]] if the RFC 6465 header extension is present,
               otherwise this member MUST be absent.</p>
               <p>For SSRCs, this MUST be converted from the level value defined
-              in [[!RFC6464]] if the RFC 6464 header extension is present,
-              otherwise the user agent must compute the value from the audio
-              data (the member must never be absent for audio receivers).</p>
+              in [[!RFC6464]]. This extension MUST be sent by user agents, and
+              as such should be present. But if the RFC 6464 header extension is
+              not present in the received packets (such as if the other endpoint
+              is not a user agent or is a legacy endpoint), this value SHOULD be
+              absent.</p>
 
               <p>Both RFCs define the level as an integral value from 0 to 127
               representing the audio level in negative decibels relative to the

--- a/webrtc.html
+++ b/webrtc.html
@@ -7141,11 +7141,9 @@ async function updateParameters() {
               in [[!RFC6465]] if the RFC 6465 header extension is present,
               otherwise this member MUST be absent.</p>
               <p>For SSRCs, this MUST be converted from the level value defined
-              in [[!RFC6464]]. This extension MUST be sent by user agents, and
-              as such should be present. But if the RFC 6464 header extension is
-              not present in the received packets (such as if the other endpoint
-              is not a user agent or is a legacy endpoint), this value SHOULD be
-              absent.</p>
+              in [[!RFC6464]]. If the RFC 6464 header extension is not present
+              in the received packets (such as if the other endpoint is not a
+              user agent or is a legacy endpoint), this value SHOULD be absent.</p>
 
               <p>Both RFCs define the level as an integral value from 0 to 127
               representing the audio level in negative decibels relative to the


### PR DESCRIPTION
Fixes #2046


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2104.html" title="Last updated on Feb 19, 2019, 9:15 PM UTC (dcbe9ef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2104/9b5bb5b...henbos:dcbe9ef.html" title="Last updated on Feb 19, 2019, 9:15 PM UTC (dcbe9ef)">Diff</a>