### PR TITLE
Block replaceTrack on pc.close() like the others, not tc.stop().

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6196,8 +6196,8 @@ async function updateParameters() {
                           <p>Queue a task that runs the following steps:</p>
                           <ol>
                             <li>
-                              <p>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot is
-                              <code>true</code>, abort these steps.</p>
+                              <p>If <var>connection</var>'s <a>[[\IsClosed]]</a>
+                              slot is <code>true</code>, abort these steps.</p>
                             </li>
                             <li>
                               <p>Set <var>sender</var>'s <code><a data-link-for=


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2106.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2107.html" title="Last updated on Feb 16, 2019, 1:04 AM UTC (7ab0e11)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2107/76a6464...jan-ivar:7ab0e11.html" title="Last updated on Feb 16, 2019, 1:04 AM UTC (7ab0e11)">Diff</a>