### PR TITLE
Switch order of arguments to RTCError

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -11474,7 +11474,7 @@ if (sender.dtmf.canInsertDTMF) {
         <pre class="idl">
           [
               Exposed=Window,
-              Constructor(DOMString message, RTCErrorInit init)
+              Constructor(RTCErrorInit init, optional DOMString message = "")
           ] interface RTCError /*: DOMException*/ {
               readonly attribute RTCErrorDetailType errorDetail;
               readonly attribute long? sdpLineNumber;
@@ -11493,11 +11493,11 @@ if (sender.dtmf.canInsertDTMF) {
             <p>Run the following steps:</p>
             <ol>
               <li>
-                <p>Let <var>message</var> be the constructor's first
-                argument.</p>
+                <p>Let <var>init</var> be the constructor's first argument.</p>
               </li>
               <li>
-                <p>Let <var>init</var> be the constructor's second argument.</p>
+                <p>Let <var>message</var> be the constructor's second
+                argument.</p>
               </li>
               <li>
                 <p>Let <var>e</var> be a new <code><a>RTCError</a></code>


### PR DESCRIPTION
Fixes #2111.

I matched the signature @henbos suggested [here](https://github.com/w3c/webrtc-pc/issues/2111#issuecomment-469292973). I just edited `webrtc.html` directly, and did not rebuild or anything; if there's some other process I should follow let me know (or just push to this branch directly).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bakkot/webrtc-pc/pull/2112.html" title="Last updated on Mar 4, 2019, 7:51 PM UTC (c380597)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2112/0e1f5b9...bakkot:c380597.html" title="Last updated on Mar 4, 2019, 7:51 PM UTC (c380597)">Diff</a>