### PR TITLE
Clarifying how setConfiguration checks certificate values

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2061,9 +2061,21 @@
             identity</a>, <a>throw</a> an <code>InvalidModificationError</code>.</p>
             </li>
             <li><p>If <code><var>configuration</var>.certificates</code> is
-            set and the set of certificates differs from the ones used
-            when <var>connection</var> was constructed, <a>throw</a> an
-            <code>InvalidModificationError</code>.</p></li>
+              set, run the following steps:</p>
+              <ol>
+                <li>If the length of <code><var>configuration</var>.certificates</code>
+                  is different from the length of
+                  <code><var>connection</var>.[[\Configuration]].certificates</code>,
+                  <a>throw</a> an <code>InvalidModificationError</code>.
+                </li>
+                <li>If any ECMAScript object represented in
+                  <code><var>configuration</var>.certificates</code>
+                  is not represented in
+                  <code><var>connection</var>.[[\Configuration]].certificates</code>
+                  <a>throw</a> an <code>InvalidModificationError</code>.
+                </li>
+              </ol>
+            </li>
             <li><p>If the value of <code><var>configuration</var>.<a data-link-for=
             "RTCConfiguration">bundlePolicy</a></code> is set and its value
             differs from the <var>connection</var>'s bundle policy, <a>throw</a>

--- a/webrtc.html
+++ b/webrtc.html
@@ -2064,27 +2064,28 @@
               <p>If <code><var>configuration</var>.certificates</code> is
               set, run the following steps:</p>
               <ol>
-                <li>If the length of <code><var>configuration</var>.certificates</code>
+                <li>
+                  <p>If the length of <code><var>configuration</var>.certificates</code>
                   is different from the length of
                   <code><var>connection</var>.[[\Configuration]].certificates</code>,
-                  <a>throw</a> an <code>InvalidModificationError</code>.
+                  <a>throw</a> an <code>InvalidModificationError</code>.</p>
                 </li>
-                <li>Let <var>index</var> be initialized to 0.</li>
-                <li>Let <var>size</var> be initialized to the length of
-                <code><var>configuration</var>.certificates</code>.</li>
+                <li><p>Let <var>index</var> be initialized to 0.</p></li>
+                <li><p>Let <var>size</var> be initialized to the length of
+                  <code><var>configuration</var>.certificates</code>.</p></li>
                 <li>
                   <p>While <var>index</var> is less than <var>size</var>,
                   run the following steps:</p>
                   <ol>
-                    <li>If the ECMAScript object represented by the value of
-                    <code><var>configuration</var>.certificates</code> at
-                    <var>index</var> is not the same as the ECMAScript
-                    object represented by the value of
-                    <code><var>connection</var>.[[\Configuration]].certificates</code>
-                    at <var>index</var>, <a>throw</a> an
-                    <code>InvalidModificationError</code>.
+                    <li><p>If the ECMAScript object represented by the value of
+                      <code><var>configuration</var>.certificates</code> at
+                      <var>index</var> is not the same as the ECMAScript
+                      object represented by the value of
+                      <code><var>connection</var>.[[\Configuration]].certificates</code>
+                      at <var>index</var>, <a>throw</a> an
+                      <code>InvalidModificationError</code>.</p>
                     </li>
-                    <li>Increment <var>index</var> by 1.</li>
+                    <li><p>Increment <var>index</var> by 1.</p></li>
                   </ol>
                 </li>
               </ol>

--- a/webrtc.html
+++ b/webrtc.html
@@ -2060,7 +2060,8 @@
             set and its value differs from the <a>target peer
             identity</a>, <a>throw</a> an <code>InvalidModificationError</code>.</p>
             </li>
-            <li><p>If <code><var>configuration</var>.certificates</code> is
+            <li>
+              <p>If <code><var>configuration</var>.certificates</code> is
               set, run the following steps:</p>
               <ol>
                 <li>If the length of <code><var>configuration</var>.certificates</code>
@@ -2068,11 +2069,23 @@
                   <code><var>connection</var>.[[\Configuration]].certificates</code>,
                   <a>throw</a> an <code>InvalidModificationError</code>.
                 </li>
-                <li>If any ECMAScript object represented in
-                  <code><var>configuration</var>.certificates</code>
-                  is not represented in
-                  <code><var>connection</var>.[[\Configuration]].certificates</code>
-                  <a>throw</a> an <code>InvalidModificationError</code>.
+                <li>Let <var>index</var> be initialized to 0.</li>
+                <li>Let <var>size</var> be initialized to the length of
+                <code><var>configuration</var>.certificates</code>.</li>
+                <li>
+                  <p>While <var>index</var> is less than <var>size</var>,
+                  run the following steps:</p>
+                  <ol>
+                    <li>If the ECMAScript object represented by the value of
+                    <code><var>configuration</var>.certificates</code> at
+                    <var>index</var> is not the same as the ECMAScript
+                    object represented by the value of
+                    <code><var>connection</var>.[[\Configuration]].certificates</code>
+                    at <var>index</var>, <a>throw</a> an
+                    <code>InvalidModificationError</code>.
+                    </li>
+                    <li>Increment <var>index</var> by 1.</li>
+                  </ol>
                 </li>
               </ol>
             </li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -2070,14 +2070,19 @@
                   <code><var>connection</var>.[[\Configuration]].certificates</code>,
                   <a>throw</a> an <code>InvalidModificationError</code>.</p>
                 </li>
-                <li><p>Let <var>index</var> be initialized to 0.</p></li>
-                <li><p>Let <var>size</var> be initialized to the length of
-                  <code><var>configuration</var>.certificates</code>.</p></li>
+                <li>
+                  <p>Let <var>index</var> be initialized to 0.</p>
+                </li>
+                <li>
+                  <p>Let <var>size</var> be initialized to the length of
+                  <code><var>configuration</var>.certificates</code>.</p>
+                </li>
                 <li>
                   <p>While <var>index</var> is less than <var>size</var>,
                   run the following steps:</p>
                   <ol>
-                    <li><p>If the ECMAScript object represented by the value of
+                    <li>
+                      <p>If the ECMAScript object represented by the value of
                       <code><var>configuration</var>.certificates</code> at
                       <var>index</var> is not the same as the ECMAScript
                       object represented by the value of
@@ -2085,7 +2090,9 @@
                       at <var>index</var>, <a>throw</a> an
                       <code>InvalidModificationError</code>.</p>
                     </li>
-                    <li><p>Increment <var>index</var> by 1.</p></li>
+                    <li>
+                      <p>Increment <var>index</var> by 1.</p>
+                    </li>
                   </ol>
                 </li>
               </ol>


### PR DESCRIPTION
Certificate comparison is based on JS ===.
The order of the certificates in the sequence is insignificant.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-pc/pull/2113.html" title="Last updated on Mar 14, 2019, 4:32 AM UTC (9a7217a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2113/76a6464...youennf:9a7217a.html" title="Last updated on Mar 14, 2019, 4:32 AM UTC (9a7217a)">Diff</a>