### PR TITLE
Make the certificate "in the future check" be based on the current time

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1017,7 +1017,7 @@
             <ol>
               <li>
                 <p>If the value of the certificate <code>expires</code>
-                attribute is not in the future, <a>throw</a> an
+                attribute is less than the current time, <a>throw</a> an
                 <code>InvalidAccessError</code>.</p> </li>
               <li>
                 <p>If the certificate [[\Origin]] internal slot is not <a


### PR DESCRIPTION
The expires value is computed from the current time.
For consistency, use the current time for checking whether the certificate is expired or not.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-pc/pull/2117.html" title="Last updated on Mar 6, 2019, 8:08 PM UTC (4404b4b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2117/0e1f5b9...youennf:4404b4b.html" title="Last updated on Mar 6, 2019, 8:08 PM UTC (4404b4b)">Diff</a>