### PR TITLE
Set direction="inactive" if rejected

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1827,6 +1827,10 @@
                             <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\ReceiverTrack]]</a>
                             is to be associated with. Otherwise, let
                             <var>msids</var> be an empty list.</p>
+                            <div class="note">
+                            <var>msids</var> will be an empty list here if
+                            <a>media description</a> is rejected.
+                            </div>
                           </li>
                           <li>
                             <p><a>Set the associated remote streams</a> given

--- a/webrtc.html
+++ b/webrtc.html
@@ -1736,7 +1736,9 @@
                             representing the direction from the <a>media
                             description</a>, but with the send and receive
                             directions reversed to represent this peer's point
-                            of view.</p>
+                            of view. If the <a>media description</a> is rejected
+                            set <var>direction</var> to <code>"inactive"</code>.
+                            </p>
                           </li>
                           <li>
                             <p>As described by <span data-jsep=


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/1812.

This treats *direction* as `"inactive"` in SRD(offer) if m-section is rejected.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2118.html" title="Last updated on Mar 6, 2019, 9:35 PM UTC (2f1e865)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2118/0e1f5b9...jan-ivar:2f1e865.html" title="Last updated on Mar 6, 2019, 9:35 PM UTC (2f1e865)">Diff</a>