### PR TITLE
Reuse stop algo in close(), fixing currentDirection = null

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3235,34 +3235,12 @@ interface RTCPeerConnection : EventTarget  {
                     <ol>
                       <li>
                         <p>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot
-                        is <code>true</code>, abort these steps.</p>
+                        is <code>true</code>, abort these sub steps.</p>
                       </li>
                       <li>
-                        <p>Let <var>sender</var> be <var>transceiver</var>'s
-                        <a>[[\Sender]]</a>.</p>
-                      </li>
-                      <li>
-                        <p>Let <var>receiver</var> be <var>transceiver</var>'s
-                        <a>[[\Receiver]]</a>.</p>
-                      </li>
-                      <li>
-                        <p>Stop sending media with <var>sender</var>.</p>
-                      </li>
-                      <li>
-                        <p>Send an RTCP BYE for each RTP stream that was being
-                        sent by <var>sender</var>, as specified in [[!RFC3550]].</p>
-                      </li>
-                      <li>
-                        <p>Stop receiving media with <var>receiver</var>.</p>
-                      </li>
-                      <li>
-                        <p>Set the <code>readyState</code> of
-                        <var>receiver</var>'s <a>[[\ReceiverTrack]]</a> to
-                        <code>"ended"</code>.</p>
-                      </li>
-                      <li>
-                        <p>Set <var>transceiver</var>'s <a>[[\Stopped]]</a> slot
-                        to <code>true</code>.</p>
+                        <p><a data-lt="stop the RTCRtpTransceiver">
+                        Stop the RTCRtpTransceiver</a> with <var>transceiver</var>
+                        and the value <code>true</code>.</p>
                       </li>
                     </ol>
                   </li>
@@ -7498,7 +7476,8 @@ async function updateParameters() {
                 </li>
               </ol>
               <p>The <dfn>stop the RTCRtpTransceiver</dfn> algorithm given a
-              <var>transceiver</var> is as follows:</p>
+              <var>transceiver</var> and an optional <var>abruptly</var>
+              boolean defaulting to <code>false</code>, is as follows:</p>
               <ol>
                 <li>
                   <p>Let <var>sender</var> be <var>transceiver</var>'s
@@ -7519,7 +7498,10 @@ async function updateParameters() {
                   <p>Stop receiving media with <var>receiver</var>.</p>
                 </li>
                 <li>
-                  <p>Execute the steps for <var>receiver</var>'s
+                  <p>If <var>abruptly</var> is <code>true</code>, set the
+                  <code>readyState</code> of <var>receiver</var>'s
+                  <a>[[\ReceiverTrack]]</a> to <code>"ended"</code>.
+                  Otherwise, execute the steps for <var>receiver</var>'s
                   <a>[[\ReceiverTrack]]</a> to be
                   <a data-cite="!GETUSERMEDIA#track-ended">ended</a>.</p>
                 </li>


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2122.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2123.html" title="Last updated on Mar 8, 2019, 4:04 AM UTC (3fc6d18)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2123/53f5cb3...jan-ivar:3fc6d18.html" title="Last updated on Mar 8, 2019, 4:04 AM UTC (3fc6d18)">Diff</a>