### PR TITLE
Make RTCIceCandidateInit optional in addIceCandidate (fixes #2125)

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2226,7 +2226,7 @@ interface RTCPeerConnection : EventTarget  {
     readonly        attribute RTCSessionDescription?    remoteDescription;
     readonly        attribute RTCSessionDescription?    currentRemoteDescription;
     readonly        attribute RTCSessionDescription?    pendingRemoteDescription;
-    Promise&lt;void&gt;                      addIceCandidate (RTCIceCandidateInit candidate);
+    Promise&lt;void&gt;                      addIceCandidate (optional RTCIceCandidateInit candidate);
     readonly        attribute RTCSignalingState         signalingState;
     readonly        attribute RTCIceGatheringState      iceGatheringState;
     readonly        attribute RTCIceConnectionState     iceConnectionState;


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2125.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/docfaraday/webrtc-pc/pull/2127.html" title="Last updated on Mar 13, 2019, 8:40 PM UTC (5dfa2ef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2127/53f5cb3...docfaraday:5dfa2ef.html" title="Last updated on Mar 13, 2019, 8:40 PM UTC (5dfa2ef)">Diff</a>