### PR TITLE
Fix for Issue 2126 - misalignment with -stats.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1966,7 +1966,7 @@
                         "rollback">[[!JSEP]]</span>.</p>
                       </li>
                       <li>
-                        <p>For the <code><a>RTCRtpTransceiver</a></code>s 
+                        <p>For the <code><a>RTCRtpTransceiver</a></code>s
                         remaining on <var>connection</var>, revert
                         any changes to the <a>[[\CurrentDirection]]</a> and
                         <a>[[\Receptive]]</a> internal slots made by the application
@@ -2008,11 +2008,11 @@
                     "event-track"><a>track</a></code> using the
                     <code><a>RTCTrackEvent</a></code> interface with its
                     <code>receiver</code> attribute initialized to
-                    <var>entry</var>.<code>receiver</code>, its 
+                    <var>entry</var>.<code>receiver</code>, its
                     <code>track</code> attribute initialized to
-                    <var>entry</var>.<code>track</code>, its 
+                    <var>entry</var>.<code>track</code>, its
                     <code>streams</code> attribute initialized to
-                    <var>entry</var>.<code>streams</code> and its 
+                    <var>entry</var>.<code>streams</code> and its
                     <code>transceiver</code> attribute initialized to
                     <var>entry</var>.<code>transceiver</code>
                     at the <var>connection</var> object.</p>
@@ -4392,7 +4392,7 @@ interface RTCIceCandidate {
               </tbody>
             </table>
           </div>
-          <p class="note">The user agent will typically only gather <code>active</code> 
+          <p class="note">The user agent will typically only gather <code>active</code>
           ICE TCP candidates.</p>
         </section>
         <section>
@@ -5015,10 +5015,10 @@ interface RTCPeerConnectionIceErrorEvent : Event {
     NOT be upscaled to create fake data that did not occur in the input source,
     the media MUST NOT be cropped except as needed to satisfy constraints on
     pixel counts, and the aspect ratio MUST NOT be changed.</p>
-    <p class="note">The WebRTC Working Group is seeking implementation 
-    feedback on the need and timeline for a more complex handling of this 
-    situation. Some possible designs have been discussed in <a 
-    href="https://github.com/w3c/webrtc-pc/issues/1283">GitHub issue 
+    <p class="note">The WebRTC Working Group is seeking implementation
+    feedback on the need and timeline for a more complex handling of this
+    situation. Some possible designs have been discussed in <a
+    href="https://github.com/w3c/webrtc-pc/issues/1283">GitHub issue
     1283</a>.</p>
     <p>When video is rescaled, for example for certain combinations
     of width or height and
@@ -5970,7 +5970,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                    <a>rejected</a> with a newly
                    <a data-link-for="exception" data-lt="create">created</a>
                    <code>InvalidModificationError</code>:
-                   <ol>  
+                   <ol>
                      <li>
                        <code><var>encodings</var>.length</code> is different from <var>N</var>.
                      </li>
@@ -6002,7 +6002,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                    <a data-link-for="exception" data-lt="create">created</a>
                    <code>RangeError</code>.</p>
                  </li>
-                </ol>               
+                </ol>
                 </li>
                 <li>Let <var>p</var> be a new promise.</li>
                 <li>In parallel, configure the media stack to use
@@ -6742,10 +6742,10 @@ async function updateParameters() {
         <li>recvonly: The header extension is only included in
         <code><var>transceiver</var>.receiver.getParameters().headerExtensions</code>.</li>
         <li>sendrecv: The header extension is included in both
-        <code><var>transceiver</var>.sender.getParameters().headerExtensions</code> and 
+        <code><var>transceiver</var>.sender.getParameters().headerExtensions</code> and
         <code><var>transceiver</var>.receiver.getParameters().headerExtensions</code>.</li>
         <li>inactive: The header extension is included in neither
-        <code><var>transceiver</var>.sender.getParameters().headerExtensions</code> nor 
+        <code><var>transceiver</var>.sender.getParameters().headerExtensions</code> nor
         <code><var>transceiver</var>.receiver.getParameters().headerExtensions</code>.</li>
       </ol>
       </div>
@@ -7704,7 +7704,7 @@ async function updateParameters() {
      <div>
      <p>Examples of simulcast scenarios implemented with encoding parameters:</p>
    <pre class="example highlight">
-   
+
 // Example of 3-layer spatial simulcast with all but the lowest resolution layer disabled
 var encodings = [
   {rid: 'f', active: false},
@@ -9514,7 +9514,7 @@ interface RTCTrackEvent : Event {
           </ul>
         </li>
         <li>
-          <p><a>Fire an event</a> named <code><a>message</a></code> using the 
+          <p><a>Fire an event</a> named <code><a>message</a></code> using the
           <code title="event-datachannel-message"><a>MessageEvent</a></code> interface
           with its <code>origin</code> attribute initialized
           to the origin of the document that created the <var>channel</var>'s
@@ -10212,7 +10212,7 @@ interface RTCDataChannelEvent : Event {
                 <li>Let <var>tones</var> be the method's first argument.</li>
                 <li>If <var>tones</var> contains any <a>unrecognized</a>
                 characters, <a>throw</a> an <code>InvalidCharacterError</code>.
-                </li>                
+                </li>
                 <li>Set the object's <a>[[\ToneBuffer]]</a> slot to
                 <var>tones</var>.</li>
                 <li>Set <var>dtmf</var>'s <a>[[\Duration]]</a> slot to the
@@ -10486,7 +10486,7 @@ interface RTCDTMFToneChangeEvent : Event {
                   <var>selector</var> be <code>null</code>.</p>
                 </li>
                 <li>
-                  <p>If <var>selectorArg</var> is a <a>MediaStreamTrack</a> 
+                  <p>If <var>selectorArg</var> is a <a>MediaStreamTrack</a>
                   let <var>selector</var> be an <a>RTCRtpSender</a> or
                   <a>RTCRtpReceiver</a> on <var>connection</var> which
                   <code>track</code> member matches <var>selectorArg</var>.
@@ -10763,7 +10763,7 @@ interface RTCDTMFToneChangeEvent : Event {
         <li>RTCVideoHandlerStats with attributes frameWidth, frameHeight, framesPerSecond</li>
         <li>RTCVideoSenderStats with attribute framesSent</li>
         <li>RTCVideoReceiverStats with attributes framesReceived, framesDecoded, framesDropped,
-        framesCorrupted</li>
+        partialFramesLost</li>
         <li>RTCCodecStats, with attributes payloadType, codec, clockRate,
         channels, sdpFmtpLine</li>
         <li>RTCTransportStats, with attributes bytesSent, bytesReceived,
@@ -10913,7 +10913,7 @@ async function gatherStats() {
       an <code><a>RTCRtpReceiver</a></code>) is always strong.</p>
       <p>Whenever an <code><a>RTCRtpReceiver</a></code> receives data on an RTP
       source whose corresponding <code><a>MediaStreamTrack</a></code> is muted,
-      and the <a>[[\Receptive]]</a> slot of the 
+      and the <a>[[\Receptive]]</a> slot of the
       <a><code>RTCRtpTransceiver</code></a> object the
       <a><code>RTCRtpReceiver</code></a> is a member of is <code>true</code>,
       it MUST queue a task to <a>set the muted state</a> of the corresponding
@@ -11545,7 +11545,7 @@ if (sender.dtmf.canInsertDTMF) {
           </dd>
         </dl>
       </section>
-      <section>  
+      <section>
         <h2>Attributes</h2>
         <dl data-link-for="RTCError" data-dfn-for="RTCError" class="attributes">
           <dt><dfn data-idl><code>errorDetail</code></dfn> of type <span


### PR DESCRIPTION
Fix #2126. I don't know why white spaces are removed with this PR - perhaps it's easier if one of the editors edits directly rather than using this PR.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/stefhak/webrtc-pc/pull/2128.html" title="Last updated on Mar 15, 2019, 1:54 PM UTC (b05d088)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2128/8135bd9...stefhak:b05d088.html" title="Last updated on Mar 15, 2019, 1:54 PM UTC (b05d088)">Diff</a>