### PR TITLE
Fix exception name in RTCRtpTransceiver.setCodecPreferences

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7586,7 +7586,7 @@ async function updateParameters() {
               Additionally, the <code>RTCRtpCodecCapability</code> dictionary
               members cannot be modified. If <code>codecs</code> does not
               fulfill these requirements, the user agent MUST <a>throw</a> an
-              InvalidAccessError.</p>
+              <code>InvalidModificationError</code>.</p>
               <p class="note">
               Due to a recommendation in [[!SDP]], calls to
               <code>createAnswer</code> SHOULD use only the common subset of


### PR DESCRIPTION
Step 8 of the algorithm already specifies IllegalModificationError which is probably a better match.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Orphis/webrtc-pc/pull/2129.html" title="Last updated on Mar 19, 2019, 3:31 PM UTC (cb05005)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2129/8135bd9...Orphis:cb05005.html" title="Last updated on Mar 19, 2019, 3:31 PM UTC (cb05005)">Diff</a>