### PR TITLE
Make RTCSctpTransport an EventTarget

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8882,7 +8882,7 @@ interface RTCTrackEvent : Event {
           </ol>
         </section>
         <div>
-          <pre class="idl">[Exposed=Window] interface RTCSctpTransport {
+          <pre class="idl">[Exposed=Window] interface RTCSctpTransport : EventTarget {
     readonly        attribute RTCDtlsTransport transport;
     readonly        attribute RTCSctpTransportState state;
     readonly        attribute unrestricted double maxMessageSize;


### PR DESCRIPTION
Fixes #2130


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2133.html" title="Last updated on Mar 21, 2019, 10:55 AM UTC (c5c9010)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2133/da3b684...c5c9010.html" title="Last updated on Mar 21, 2019, 10:55 AM UTC (c5c9010)">Diff</a>