### PR TITLE
Add a note detailing that prflx candidates are not exposed by getRemoteCandidates

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8374,6 +8374,11 @@ async function onOffHold() {
               received by this <code><a>RTCIceTransport</a></code> via
               <code><a data-link-for=
               "RTCPeerConnection">addIceCandidate()</a></code></p>
+              <div class="note">
+                <code>getRemoteCandidates</code> will not expose peer reflexive
+                candidates since they are not received via <code><a
+                data-link-for="RTCPeerConnection">addIceCandidate()</a></code>.
+              </div>
             </dd>
             <dt><dfn data-idl><code>getSelectedCandidatePair</code></dfn></dt>
             <dd>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-pc/pull/2135.html" title="Last updated on Mar 21, 2019, 4:43 PM UTC (a348efa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2135/589e451...youennf:a348efa.html" title="Last updated on Mar 21, 2019, 4:43 PM UTC (a348efa)">Diff</a>