### PR TITLE
Add setTargetJitterBufferDelay method to the RTCRtpReceiver

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6975,6 +6975,7 @@ async function updateParameters() {
     sequence&lt;RTCRtpContributingSource&gt;    getContributingSources ();
     sequence&lt;RTCRtpSynchronizationSource&gt; getSynchronizationSources ();
     Promise&lt;RTCStatsReport&gt;   getStats();
+    Promise&lt;void&gt; setTargetJitterBufferDelay (double delay);
 };</pre>
         <section>
           <h2>Attributes</h2>
@@ -7132,6 +7133,31 @@ async function updateParameters() {
                 </li>
                 <li>
                   <p>Return <var>p</var>.</p>
+                </li>
+              </ol>
+            </dd>
+            <dt><code>setTargetJitterBufferDelay</code></dt>
+            <dd>
+              <p>Asynchronously provides a preference for the target jitter
+              buffer delay in seconds. The user agent SHOULD aim to match this
+              preference but due to congestion control and other network related
+              reasons the actual delay MAY be different.</p>
+              <p>When the <dfn data-idl id=
+              "widl-RTCRtpReceiver-setTargetJitterBufferDelay-Promise-void">
+              <code>setTargetJitterBufferDelay()</code></dfn> method is called:
+              </p>
+              <ol>
+                <li>
+                  <p>Let <var>delay</var> be the target jitter buffer delay in
+                  seconds</p>
+                </li>
+                <li>
+                  <p>Let <var>p</var> be a new promise which is <a>resolved</a>
+                  with <code>undefined</code> unless <var>delay</var> is a
+                  negative number. If the <var>delay</var> is a negative number
+                  then <a> reject</a> <var>p</var> with a newly <a
+                  data-link-for="exception" data-lt="create">created</a> <code>
+                  OperationError</code>.</p>
                 </li>
               </ol>
             </dd>

--- a/webrtc.html
+++ b/webrtc.html
@@ -6196,8 +6196,8 @@ async function updateParameters() {
                           <p>Queue a task that runs the following steps:</p>
                           <ol>
                             <li>
-                              <p>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot is
-                              <code>true</code>, abort these steps.</p>
+                              <p>If <var>connection</var>'s <a>[[\IsClosed]]</a>
+                              slot is <code>true</code>, abort these steps.</p>
                             </li>
                             <li>
                               <p>Set <var>sender</var>'s <code><a data-link-for=


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kuddai/webrtc-pc/pull/2136.html" title="Last updated on Mar 22, 2019, 2:05 PM UTC (82ccef2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2136/8135bd9...kuddai:82ccef2.html" title="Last updated on Mar 22, 2019, 2:05 PM UTC (82ccef2)">Diff</a>