### PR TITLE
Allow createOffer() only in "stable" and "have-local-offer"

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2554,6 +2554,14 @@ interface RTCPeerConnection : EventTarget  {
                     steps to <var>connection</var>'s operation queue:</p>
                     <ol>
                       <li>
+                        <p>If <var>connection</var>'s <a>signaling state</a>
+                        is neither <code>"stable"</code> nor
+                        <code>"have-local-offer"</code>, return a promise
+                        <a>rejected</a> with a newly <a data-link-for="exception"
+                          data-lt="create">created</a>
+                        <code>InvalidStateError</code>.</p>
+                      </li>
+                      <li>
                         <p>Let <var>p</var> be a new promise.</p>
                       </li>
                       <li>


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2145.

This guards against `"have-remote-offer"`, `"have-remote-pranswer"`, `"have-local-pranswer"` and `"closed"`.

![image](http://w3c.github.io/webrtc-pc/images/peerstates.svg)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2146.html" title="Last updated on Mar 26, 2019, 8:38 PM UTC (74ffb22)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2146/589e451...jan-ivar:74ffb22.html" title="Last updated on Mar 26, 2019, 8:38 PM UTC (74ffb22)">Diff</a>