### PR TITLE
Fix name of MTI stats in RTCDataChannelStats

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -10861,7 +10861,7 @@ interface RTCDTMFToneChangeEvent : Event {
         <li>RTCPeerConnectionStats, with attributes dataChannelsOpened,
         dataChannelsClosed</li>
         <li>RTCDataChannelStats, with attributes label, protocol,
-        datachannelId, state, messagesSent, bytesSent, messagesReceived,
+        dataChannelIdentifier, state, messagesSent, bytesSent, messagesReceived,
         bytesReceived</li>
         <li>RTCMediaStreamStats, with attributes streamIdentifer, trackIds</li>
         <li>RTCMediaStreamTrackStats, with attribute detached</li>


### PR DESCRIPTION
s/datachannelId/dataChannelIdentifier per https://www.w3.org/TR/webrtc-stats/#dom-rtcdatachannelstats-datachannelidentifier


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dontcallmedom/webrtc-pc/pull/2151.html" title="Last updated on Apr 1, 2019, 2:53 PM UTC (48a160b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2151/943ebd1...dontcallmedom:48a160b.html" title="Last updated on Apr 1, 2019, 2:53 PM UTC (48a160b)">Diff</a>