### PR TITLE
Remove redundant steps in setCodecParameters

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7717,18 +7717,6 @@ async function updateParameters() {
                   something to offer, regardless of <code><var>transceiver</var>.<a data-link-for="RTCRTPTransceiver">direction</a></code>.</p>
                 </li>
                 <li>
-                  <p>Let <var>codecCapabilities</var> be the union of
-                  <code>RTCRtpSender.getCapabilities(kind).codecs</code> and
-                  <code>RTCRtpReceiver.getCapabilities(kind).codecs</code>.</p>
-                </li>
-                <li>
-                  <p>For each <var>codec</var> in <var>codecs</var>,</p>
-                  <ol>
-                    <li>If <var>codec</var> is not in <var>codecCapabilities</var>, throw
-                    <code>InvalidModificationError</code>.</li>
-                  </ol>
-                </li>
-                <li>
                   <p>Set <var>transceiver</var>'s <a>[[\PreferredCodecs]]</a> slot to
                   <var>codecs</var>.</p>
                 </li>


### PR DESCRIPTION
Could not detect a difference these 2 additional steps make beyond what the previous step does.

(I found this during the webrtc testing hackathon and asked @henbos who seemed to agree this was redundant on a quick look)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dontcallmedom/webrtc-pc/pull/2152.html" title="Last updated on Apr 1, 2019, 3:32 PM UTC (6af5614)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2152/943ebd1...dontcallmedom:6af5614.html" title="Last updated on Apr 1, 2019, 3:32 PM UTC (6af5614)">Diff</a>