### PR TITLE
Add in-line references to relevant test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ mailing list.
 [RTCWeb IETF Working Group](https://tools.ietf.org/wg/rtcweb/)
 
 [Contribution Guidelines](CONTRIBUTING.md)
+
+### Test coverage
+Parts of the specification that need or have tests are marked with the `data-tests` attribute. If one or several tests exist for the said part in the [webrtc directory of WPT](https://github.com/web-platform-tests/wpt/tree/master/webrtc), fill the attribute with the comma-separated list of their filenames. If no test exists but tests are needed, keep the attribute with no value.
+
+Thumbrules for where to put the `data-tests` attribute in the DOM:
+* apply it only to content with normative language
+* put it as high in the DOM as possible
+* when set on an element, you assert that the said test case provides reasonable coverage of the entire content of the element

--- a/webrtc.html
+++ b/webrtc.html
@@ -181,20 +181,20 @@
             <h2>Dictionary <a class="idlType">RTCConfiguration</a> Members</h2>
             <dl data-link-for="RTCConfiguration" data-dfn-for=
             "RTCConfiguration" class="dictionary-members">
-              <dt><dfn data-idl><code>iceServers</code></dfn> of type <span class=
+              <dt data-tests="RTCConfiguration-iceServers.html"><dfn data-idl><code>iceServers</code></dfn> of type <span class=
               "idlMemberType">sequence&lt;<a>RTCIceServer</a>&gt;</span></dt>
               <dd>
                 <p>An array of objects describing servers available to be used
                 by ICE, such as STUN and TURN servers.</p>
               </dd>
-              <dt><dfn data-idl><code>iceTransportPolicy</code></dfn> of type
+              <dt data-tests="RTCConfiguration-iceTransportPolicy.html"><dfn data-idl><code>iceTransportPolicy</code></dfn> of type
               <span class="idlMemberType"><a>RTCIceTransportPolicy</a></span>,
               defaulting to <code>"all"</code></dt>
               <dd>
                 <p>Indicates which candidates the <a>ICE Agent</a> is allowed
                 to use.</p>
               </dd>
-              <dt><dfn data-idl><code>bundlePolicy</code></dfn> of type <span class=
+              <dt data-tests="RTCConfiguration-bundlePolicy.html"><dfn data-idl><code>bundlePolicy</code></dfn> of type <span class=
               "idlMemberType"><a>RTCBundlePolicy</a></span>, defaulting to
               <code>"balanced"</code></dt>
               <dd>
@@ -216,7 +216,7 @@
                 establish a connection to a remote peer unless it can be
                 successfully authenticated with the provided name.</p>
               </dd>
-              <dt><dfn data-idl><code>certificates</code></dfn> of type <span class=
+              <dt data-tests="RTCPeerConnection-constructor.html"><dfn data-idl><code>certificates</code></dfn> of type <span class=
               "idlMemberType">sequence&lt;<a>RTCCertificate</a>&gt;</span></dt>
               <dd>
                 <p>A set of certificates that the
@@ -244,7 +244,7 @@
                 <p>The value for this configuration option cannot change after
                 its value is initially selected.</p>
               </dd>
-              <dt><dfn data-idl><code>iceCandidatePoolSize</code></dfn> of type
+              <dt data-tests="RTCPeerConnection-constructor.html"><dfn data-idl><code>iceCandidatePoolSize</code></dfn> of type
               <span class="idlMemberType">octet</span>, defaulting to
               <code>0</code></dt>
               <dd>
@@ -270,13 +270,13 @@
                 <th colspan="2">Enumeration description</th>
               </tr>
               <tr>
-                <td><dfn data-idl><code>password</code></dfn></td>
+                <td data-tests="RTCConfiguration-iceServers.html"><dfn data-idl><code>password</code></dfn></td>
                 <td>The credential is a long-term authentication username and
                 password, as described in [[!RFC5389]], Section 10.2.
                 </td>
               </tr>
               <tr>
-                <td><dfn data-idl><code>oauth</code></dfn></td>
+                <td data-tests="RTCConfiguration-iceServers.html"><dfn data-idl><code>oauth</code></dfn></td>
                 <td><p>An OAuth 2.0 based authentication method, as described
                 in [[!RFC7635]].
                 </p>
@@ -348,7 +348,7 @@
             </h2>
             <dl data-link-for="RTCOAuthCredential"
             data-dfn-for="RTCOAuthCredential" class="dictionary-members">
-              <dt><dfn data-idl><code>macKey</code></dfn> of type <span class=
+              <dt data-tests="RTCConfiguration-iceServers.html"><dfn data-idl><code>macKey</code></dfn> of type <span class=
               "idlMemberType">DOMString</span>, required</dt>
               <dd>
                 <p>The "mac_key", as described in [[!RFC7635]], Section 6.2, in
@@ -361,7 +361,7 @@
                 parameter value from the JWK, which contains the needed
                 base64-encoded "mac_key".</p>
               </dd>
-              <dt><dfn data-idl><code>accessToken</code></dfn> of type <span class=
+              <dt data-tests="RTCConfiguration-iceServers.html"><dfn data-idl><code>accessToken</code></dfn> of type <span class=
               "idlMemberType">DOMString</span>, required</dt>
               <dd>
                 <p>The "access_token", as described in [[!RFC7635]], Section
@@ -478,7 +478,7 @@
 ];
         </code></pre>
       </section>
-      <section>
+      <section data-tests="RTCConfiguration-iceTransportPolicy.html">
         <h4><dfn>RTCIceTransportPolicy</dfn> Enum</h4>
         <p>As described in <span data-jsep="constructor">[[!JSEP]]</span>, if the
         <a data-link-for='RTCConfiguration'>iceTransportPolicy</a> member of
@@ -554,20 +554,20 @@
                 <th colspan="2">Enumeration description (non-normative)</th>
               </tr>
               <tr>
-                <td><dfn data-idl><code>balanced</code></dfn></td>
+                <td data-tests="RTCRtpSender-transport.https.html"><dfn data-idl><code>balanced</code></dfn></td>
                 <td>Gather ICE candidates for each media type in use (audio,
                 video, and data). If the remote endpoint is not bundle-aware,
                 negotiate only one audio and video track on separate
                 transports.</td>
               </tr>
               <tr>
-                <td><dfn data-idl><code>max-compat</code></dfn></td>
+                <td data-tests="RTCRtpSender-transport.https.html"><dfn data-idl><code>max-compat</code></dfn></td>
                 <td>Gather ICE candidates for each track. If the remote
                 endpoint is not bundle-aware, negotiate all media tracks on
                 separate transports.</td>
               </tr>
               <tr>
-                <td><dfn data-idl><code>max-bundle</code></dfn></td>
+                <td data-tests="RTCRtpSender-transport.https.html"><dfn data-idl><code>max-bundle</code></dfn></td>
                 <td>Gather ICE candidates for only one track. If the remote
                 endpoint is not bundle-aware, negotiate only one media
                 track.</td>
@@ -722,18 +722,18 @@
                 <th colspan="2">Enumeration description</th>
               </tr>
               <tr>
-                <td><dfn data-idl><code>stable</code></dfn></td>
+                <td data-tests="RTCPeerConnection-onsignalingstatechanged.https.html,RTCPeerConnection-setRemoteDescription.html"><dfn data-idl><code>stable</code></dfn></td>
                 <td>There is no offer/answer exchange in progress. This is
                 also the initial state, in which case the local and remote
                 descriptions are empty.</td>
               </tr>
               <tr>
-                <td><dfn data-idl><code>have-local-offer</code></dfn></td>
+                <td data-tests="RTCPeerConnection-createOffer.html, RTCPeerConnection-setLocalDescription-offer.html,RTCPeerConnection-setLocalDescription.html,RTCPeerConnection-setRemoteDescription.html"><dfn data-idl><code>have-local-offer</code></dfn></td>
                 <td>A local description, of type <code>"offer"</code>, has been successfully
                 applied.</td>
               </tr>
               <tr>
-                <td><dfn data-idl><code>have-remote-offer</code></dfn></td>
+                <td data-tests="RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setRemoteDescription-offer.html,RTCPeerConnection-setRemoteDescription-rollback.html,RTCPeerConnection-setRemoteDescription.html"><dfn data-idl><code>have-remote-offer</code></dfn></td>
                 <td>A remote description, of type <code>"offer"</code>, has been
                 successfully applied.</td>
               </tr>
@@ -744,7 +744,7 @@
                 successfully applied.</td>
               </tr>
               <tr>
-                <td><dfn data-idl><code>have-remote-pranswer</code></dfn></td>
+                <td data-tests="RTCPeerConnection-setRemoteDescription-pranswer.html,RTCPeerConnection-setRemoteDescription.html"><dfn data-idl><code>have-remote-pranswer</code></dfn></td>
                 <td>A local description of type <code>"offer"</code> has been successfully
                 applied and a remote description of type <code>"pranswer"</code> has been
                 successfully applied.</td>
@@ -801,19 +801,19 @@
                 <th colspan="2">Enumeration description</th>
               </tr>
               <tr>
-                <td><dfn data-idl><code>new</code></dfn></td>
+                <td data-tests="RTCPeerConnection-iceGatheringState.html"><dfn data-idl><code>new</code></dfn></td>
                 <td>Any of the <code><a>RTCIceTransport</a></code>s are in the
                 <code>"new"</code> gathering state and none of the transports are
                 in the <code>"gathering"</code> state, or there are no
                 transports.</td>
               </tr>
               <tr>
-                <td><dfn data-idl><code>gathering</code></dfn></td>
+                <td data-tests="RTCPeerConnection-iceGatheringState.html"><dfn data-idl><code>gathering</code></dfn></td>
                 <td>Any of the <code><a>RTCIceTransport</a></code>s are in the
                 <code>"gathering"</code> state.</td>
               </tr>
               <tr>
-                <td><dfn data-idl><code>complete</code></dfn></td>
+                <td data-tests="RTCPeerConnection-iceGatheringState.html"><dfn data-idl><code>complete</code></dfn></td>
                 <td>At least one <code><a>RTCIceTransport</a></code> exists,
                 and all <code><a>RTCIceTransport</a></code>s are in the
                 <code>"completed"</code> gathering state.</td>
@@ -869,14 +869,14 @@
                 no transports.</td>
               </tr>
               <tr>
-                <td><dfn data-idl><code>connecting</code></dfn></td>
+                <td data-tests="RTCPeerConnection-connectionState.html"><dfn data-idl><code>connecting</code></dfn></td>
                 <td>None of the previous states apply and all
                 <code><a>RTCIceTransport</a></code>s or
                 <code><a>RTCDtlsTransport</a></code>s are in the
                 <code>"new"</code>, <code>"connecting"</code> or <code>"checking"</code> state.</td>
               </tr>
               <tr>
-                <td><dfn data-idl><code>connected</code></dfn></td>
+                <td data-tests="RTCPeerConnection-connectionState.html"><dfn data-idl><code>connected</code></dfn></td>
                 <td>None of the previous states apply and all
                 <code><a>RTCIceTransport</a></code>s and
                 <code><a>RTCDtlsTransport</a></code>s are in the
@@ -906,7 +906,7 @@
                 <th colspan="2">Enumeration description</th>
               </tr>
               <tr>
-                <td><dfn data-idl><code>closed</code></dfn></td>
+                <td data-tests="RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl><code>closed</code></dfn></td>
                 <td>
                   The <code><a>RTCPeerConnection</a></code> object's
                   <a>[[\IsClosed]]</a> slot is <code>true</code>.
@@ -925,26 +925,26 @@
                 <code>"disconnected"</code> state.</td>
               </tr>
               <tr>
-                <td><dfn data-idl><code>new</code></dfn></td>
+                <td data-tests="RTCPeerConnection-iceConnectionState.https.html,no-media-call.html"><dfn data-idl><code>new</code></dfn></td>
                 <td>None of the previous states apply and all
                 <code><a>RTCIceTransport</a></code>s are in the
                 <code>"new"</code> or <code>"closed"</code> state,
                 or there are no transports.</td>
               </tr>
               <tr>
-                <td><dfn data-idl><code>checking</code></dfn></td>
+                <td data-tests="RTCPeerConnection-iceConnectionState.https.html,no-media-call.html"><dfn data-idl><code>checking</code></dfn></td>
                 <td>None of the previous states apply and any
                 <code><a>RTCIceTransport</a></code>s are in the
                 <code>"new"</code> or <code>"checking"</code> state.</td>
               </tr>
               <tr>
-                <td><dfn data-idl><code>completed</code></dfn></td>
+                <td data-tests="RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl><code>completed</code></dfn></td>
                 <td>None of the previous states apply and all
                 <code><a>RTCIceTransport</a></code>s are in the
                 <code>"completed"</code> or <code>"closed"</code> state.</td>
               </tr>
               <tr>
-                <td><dfn data-idl><code>connected</code></dfn></td>
+                <td data-tests="RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl><code>connected</code></dfn></td>
                 <td>None of the previous states apply and all
                 <code><a>RTCIceTransport</a></code>s are in the
                 <code>"connected"</code>, <code>"completed"</code> or
@@ -1010,8 +1010,8 @@
             <p>Let <var>connection</var> be a newly created
             <code><a>RTCPeerConnection</a></code> object.</p>
           </li>
-          <li>
-            <p>If the <code>certificates</code> value in
+          <li data-tests="RTCCertificate.html">
+            <p id="certificate-validation">If the <code>certificates</code> value in
             <var>configuration</var> is non-empty, run the following steps for
             each certificate in certificates:
             <ol>
@@ -1076,38 +1076,38 @@
             <p>Let <var>connection</var> have an <dfn>[[\LastCreatedAnswer]]</dfn>
               internal slot, initialized to <code>""</code>.</p>
           </li>
-          <li>
+          <li data-tests="RTCPeerConnection-constructor.html">
             <p>Set <var>connection</var>'s <a>signaling state</a> to
             <code>"stable"</code>.</p>
           </li>
-          <li>
+          <li data-tests="RTCPeerConnection-constructor.html">
             <p>Set <var>connection</var>'s <a>ICE connection state</a> to
             <code>"new"</code>.</p>
           </li>
-          <li>
+          <li data-tests="RTCPeerConnection-constructor.html">
             <p>Set <var>connection</var>'s <a>ICE gathering state</a> to
             <code>"new"</code>.</p>
           </li>
-          <li>
+          <li data-tests="RTCPeerConnection-constructor.html">
             <p>Set <var>connection</var>'s <a>connection state</a> to
             <code>"new"</code>.</p>
           </li>
-          <li>
+          <li data-tests="RTCPeerConnection-constructor.html">
             <p>Let <var>connection</var> have a
             <dfn>[[\PendingLocalDescription]]</dfn> internal slot, initialized
             to <code>null</code>.</p>
           </li>
-          <li>
+          <li data-tests="RTCPeerConnection-constructor.html">
             <p>Let <var>connection</var> have a
             <dfn>[[\CurrentLocalDescription]]</dfn> internal slot, initialized
             to <code>null</code>.</p>
           </li>
-          <li>
+          <li data-tests="RTCPeerConnection-constructor.html">
             <p>Let <var>connection</var> have a
             <dfn>[[\PendingRemoteDescription]]</dfn> internal slot, initialized
             to <code>null</code>.</p>
           </li>
-          <li>
+          <li data-tests="RTCPeerConnection-constructor.html">
             <p>Let <var>connection</var> have a
             <dfn>[[\CurrentRemoteDescription]]</dfn> internal slot, initialized
             to <code>null</code>.</p>
@@ -1127,7 +1127,7 @@
         call is still not <a>settled</a>, they are added to the queue and executed
         when all the previous calls have finished executing and their promises
         have <a>settled</a>.</p>
-        <p>To <dfn>enqueue an operation</dfn> to an
+        <p data-tests="RTCPeerConnection-createOffer.html">To <dfn>enqueue an operation</dfn> to an
         <a><code>RTCPeerConnection</code></a> object's operation queue, run
         the following steps:</p>
         <ol>
@@ -1206,7 +1206,7 @@
         <a>[[\IsClosed]]</a> slot turns <code>true</code>, the user agent MUST
         <dfn>update the connection state</dfn> by queueing a task that runs the
         following steps:</p>
-        <ol>
+        <ol data-tests="RTCPeerConnection-connectionState.html">
           <li>
             <p>Let <var>connection</var> be this
             <code><a>RTCPeerConnection</a></code> object.</p>
@@ -1316,7 +1316,7 @@
         "#enqueue-an-operation">enqueue</a> the following steps to
         <var>connection</var>'s operation queue:</p>
         <ol>
-          <li>
+          <li data-tests="RTCPeerConnection-setLocalDescription-offer.html">
             <p>If <var>description</var> is set as a local description,
             if <code><var>description</var>.type</code> is
             <code>"offer"</code> and <code><var>description</var>.sdp</code>
@@ -1325,7 +1325,7 @@
             <a data-link-for="exception" data-lt="create">created</a>
             <code>InvalidModificationError</code> and abort these steps.</p>
           </li>
-          <li>
+          <li data-tests="RTCPeerConnection-setLocalDescription-answer.html">
             <p>If <var>description</var> is set as a local description,
             if <code><var>description</var>.type</code> is
             <code>"answer"</code> or <code>"pranswer"</code> and
@@ -1352,7 +1352,7 @@
                     <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
                     <code>true</code>, then abort these steps.</p>
                   </li>
-                  <li>
+                  <li data-tests="RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setLocalDescription-pranswer.html,RTCPeerConnection-setRemoteDescription-answer.html,RTCPeerConnection-setRemoteDescription-offer.html,RTCPeerConnection-setRemoteDescription-pranswer.html">
                     <p>If the <var>description</var>'s <code><a data-link-for=
                     "RTCSessionDescription">type</a></code> is invalid for the
                     current <a>signaling state</a> of <var>connection</var>
@@ -1362,7 +1362,7 @@
                     <a data-link-for="exception" data-lt="create">created</a>
                     <code>InvalidStateError</code> and abort these steps.</p>
                   </li>
-                  <li>
+                  <li data-tests="RTCPeerConnection-setLocalDescription-rollback.html">
                     <p>If <var>description</var> is set as a local description,
                     if <code><var>description</var>.type</code> is <code>"rollback"</code>
                     and <a>signaling state</a> is <code>"stable"</code>
@@ -1370,7 +1370,7 @@
                     data-lt="create">created</a>
                     <code>InvalidStateError</code> and abort these steps.</p>
                   </li>
-                  <li>
+                  <li data-tests="RTCPeerConnection-setRemoteDescription-offer.html,RTCPeerConnection-setRemoteDescription.html">
                     <p>If the content of <var>description</var> is not
                     valid SDP syntax, then <a>reject</a> <var>p</var> with an
                     <code><a>RTCError</a></code> (with <code>errorDetail</code>
@@ -1411,9 +1411,9 @@
                   <li>
                     <p>If <var>description</var> is set as a local description,
                     then run one of the following steps:</p>
-                    <ul>
+                    <ol>
                       <!-- A) transition stable to haveLocalOffer -->
-                      <li>
+                      <li data-tests="RTCPeerConnection-setLocalDescription-offer.html,RTCPeerConnection-setLocalDescription.html">
                         <p>If <var>description</var> is of type <code>"offer"</code>, set
                         <var>connection</var>.<a>[[\PendingLocalDescription]]</a>
                         to a new <code><a>RTCSessionDescription</a></code> object
@@ -1422,7 +1422,7 @@
                       </li>
                       <!-- C) transition haveRemoteOffer or haveLocalProvAnswer to
                       stable -->
-                      <li>
+                      <li data-tests="RTCPeerConnection-setLocalDescription-answer.html">
                         <p>If <var>description</var> is of type <code>"answer"</code>, then
                         this completes an offer answer negotiation. Set
                         <var>connection</var>.<a>[[\CurrentLocalDescription]]</a>
@@ -1439,7 +1439,7 @@
                         <a>signaling state</a> to <code>"stable"</code>.</p>
                       </li>
                       <!-- B) transition rollback to haveLocalOffer to stable -->
-                      <li>
+                      <li data-tests="RTCPeerConnection-setLocalDescription-rollback.html">
                         <p>If <var>description</var> is of type <code>"rollback"</code>,
                         then this is a rollback. Set
                         <var>connection</var>.<a>[[\PendingLocalDescription]]</a>
@@ -1447,20 +1447,20 @@
                         <code>"stable"</code>.</p>
                       </li>
                       <!-- G) transition haveRemoteOffer to haveLocalProvAnswer -->
-                      <li>
+                      <li data-tests="RTCPeerConnection-setLocalDescription-pranswer.html">
                         <p>If <var>description</var> is of type <code>"pranswer"</code>,
                         then set <var>connection</var>.<a>[[\PendingLocalDescription]]</a>
                         to a new <code><a>RTCSessionDescription</a></code> object
                         constructed from <var>description</var>, and set <a>signaling state</a>
                         to <code>"have-local-pranswer"</code>.</p>
                       </li>
-                    </ul>
+                    </ol>
                   </li>
                   <li>
                     <p>Otherwise, if <var>description</var> is set as a remote
                     description, then run one of the following steps:</p>
-                    <ul>
-                      <li>
+                    <ol>
+                      <li data-tests="RTCPeerConnection-setRemoteDescription-rollback.html">
                         <p>If <var>description</var> is set as a remote description,
                         if <code><var>description</var>.type</code> is <code>"rollback"</code>
                         and <a>signaling state</a> is <code>"stable"</code>
@@ -1469,7 +1469,7 @@
                         <code>InvalidStateError</code> and abort these steps.</p>
                       </li>
                       <!-- D) transition stable to haveRemoteOffer -->
-                      <li>
+                      <li data-tests="RTCPeerConnection-setRemoteDescription-offer.html">
                         <p>If <var>description</var> is of type <code>"offer"</code>, set
                         <var>connection</var>.<a>[[\PendingRemoteDescription]]</a>
                         attribute to a new <code><a>RTCSessionDescription</a></code>
@@ -1478,7 +1478,7 @@
                       </li>
                       <!-- F) transition haveRemoteOffer or haveLocalProvAnswer to
                       stable -->
-                      <li>
+                      <li data-tests="RTCPeerConnection-setRemoteDescription-answer.html">
                         <p>If <var>description</var> is of type <code>"answer"</code>, then
                         this completes an offer answer negotiation. Set
                         <var>connection</var>.<a>[[\CurrentRemoteDescription]]</a>
@@ -1492,7 +1492,7 @@
                         <a>signaling state</a> to <code>"stable"</code>.</p>
                       </li>
                       <!-- E) transition rollback to haveRemoteOffer to stable -->
-                      <li>
+                      <li data-tests="RTCPeerConnection-setRemoteDescription-rollback.html">
                         <p>If <var>description</var> is of type <code>"rollback"</code>,
                         then this is a rollback. Set
                         <var>connection</var>.<a>[[\PendingRemoteDescription]]</a>
@@ -1500,14 +1500,14 @@
                         <code>"stable"</code>.</p>
                       </li>
                       <!-- H) transition haveRemoteOffer to haveLocalProvAnswer -->
-                      <li>
+                      <li data-tests="RTCPeerConnection-setRemoteDescription-pranswer.html">
                         <p>If <var>description</var> is of type <code>"pranswer"</code>,
                         then set <var>connection</var>.<a>[[\PendingRemoteDescription]]</a>
                         to a new <code><a>RTCSessionDescription</a></code> object
                         constructed from <var>description</var> and
                         <a>signaling state</a> to <code>"have-remote-pranswer"</code>.</p>
                       </li>
-                    </ul>
+                    </ol>
                   </li>
                   <li>
                     <p>If <var>description</var> is of type <code>"answer"</code>, and it
@@ -1521,7 +1521,7 @@
                     <p>If <var>description</var> is of type <code>"answer"</code> or
                       <code>"pranswer"</code>, then run the following steps:</p>
                     <ol>
-                      <li>
+                      <li data-tests="RTCPeerConnection-createDataChannel.html,RTCSctpTransport-constructor.html">
                         <p>If <var>description</var> initiates the
                         establishment of a new SCTP association, as defined in
                         [[!SCTP-SDP]], Sections 10.3 and 10.4, <a>create an
@@ -1534,7 +1534,7 @@
                         <var>connection</var>'s <a>[[\SctpTransport]]</a>.</p>
                       </li>
                       <li>
-                        <p>If <var>description</var> negotiates the DTLS role
+                        <p data-tests="RTCPeerConnection-createDataChannel.html">If <var>description</var> negotiates the DTLS role
                         of the SCTP transport, and there is an
                         <code><a>RTCDataChannel</a></code> with a <code>null</code>
                         <code><a data-link-for="RTCDataChannel">id</a></code>,
@@ -1585,17 +1585,17 @@
                             with an <code><a>RTCRtpTransceiver</a></code> object then run
                             the following steps:</p>
                             <ol>
-                              <li>
+                              <li data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-transceivers.https.html">
                                 <p>Let <var>transceiver</var> be the <code>
                                 <a>RTCRtpTransceiver</a></code> used to create the
                                 <a>media description</a>.</p>
                               </li>
-                              <li>
+                              <li data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html">
                                 <p>Set <var>transceiver</var>'s <code><a data-link-for=
                                 "RTCRtpTransceiver">mid</a></code> value to the mid of
                                 the <a>media description</a>.</p>
                               </li>
-                              <li>
+                              <li data-tests="RTCRtpTransceiver-stop.html">
                                 <p>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot
                                 is <code>true</code>, abort these sub steps.</p>
                               </li>
@@ -1625,7 +1625,7 @@
                                   and instead let <var>rtcpTransport</var> be <code>null</code>.
                                 </p>
                               </li>
-                              <li>
+                              <li data-tests="RTCRtpSender-transport.https.html">
                                 <p>
                                   Set <var>transceiver</var>.<a>[[\Sender]]</a>.<a>[[\SenderTransport]]</a>
                                   to <var>transport</var>.
@@ -1656,7 +1656,7 @@
                             <a>RTCRtpTransceiver</a></code> <a>associated</a> with the
                             <a>media description</a>.</p>
                           </li>
-                          <li>
+                          <li data-tests="RTCRtpTransceiver.https.html">
                             <p>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot
                             is <code>true</code>, abort these sub steps.</p>
                           </li>
@@ -1705,7 +1705,7 @@
                                     an empty list, another empty list, and
                                     <var>removeList</var>.</p>
                                   </li>
-                                  <li>
+                                  <li data-tests="RTCRtpTransceiver.https.html">
                                     <p><a>process the removal of a remote track</a>
                                     for the <a>media description</a>, given
                                     <var>transceiver</var> and
@@ -1713,7 +1713,7 @@
                                   </li>
                                 </ol>
                               </li>
-                              <li>
+                              <li data-tests="RTCPeerConnection-transceivers.https.html">
                                 <p>Set <var>transceiver</var>'s
                                 <a>[[\CurrentDirection]]</a> and
                                 <a>[[\FiredDirection]]</a> slots to
@@ -1780,22 +1780,22 @@
                             (<var>transceiver</var> is unset), run the following
                             steps:</p>
                             <ol>
-                              <li>
+                              <li data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-transceivers.https.html,RTCRtpParameters-encodings.html">
                                 <p><a>Create an RTCRtpSender</a>, <var>sender</var>,
                                 from the <a>media description</a> using <var>sendEncodings</var>.</p>
                               </li>
-                              <li>
+                              <li data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-transceivers.https.html">
                                 <p><a>Create an RTCRtpReceiver</a>,
                                 <var>receiver</var>, from the <a>media description</a>.</p>
                               </li>
-                              <li>
+                              <li data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-transceivers.https.html">
                                 <p><a>Create an RTCRtpTransceiver</a> with
                                 <var>sender</var>, <var>receiver</var> and
                                 an <code><a>RTCRtpTransceiverDirection</a></code>
                                 value of <code>"recvonly"</code>, and let
                                 <var>transceiver</var> be the result.</p>
                               </li>
-                              <li>
+                              <li data-tests="RTCPeerConnection-setDescription-transceiver.html">
                                 <p>Add <var>transceiver</var> to the
                                 <var>connection</var>'s
                                 <a href="#transceivers-set">
@@ -1830,7 +1830,7 @@
                               </li>
                             </ol>
                           </li>
-                          <li>
+                          <li data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCRtpTransceiver.https.html">
                             <p>Set <var>transceiver</var>'s <code><a data-link-for=
                             "RTCRtpTransceiver">mid</a></code> value to the mid of
                             the corresponding <a>media description</a>. If the <a>media
@@ -1840,7 +1840,7 @@
                             described in <span data-jsep=
                             "applying-a-remote-desc">[[!JSEP]]</span>.</p>
                           </li>
-                          <li>
+                          <li data-tests="RTCPeerConnection-ontrack.https.html,RTCTrackEvent-fire.html">
                             <p>If <var>direction</var> is <code>"sendrecv"</code>
                             or <code>"recvonly"</code>, let <var>msids</var> be a
                             list of the MSIDs that the media description indicates
@@ -1852,13 +1852,13 @@
                             <a>media description</a> is rejected.
                             </div>
                           </li>
-                          <li>
+                          <li data-tests="RTCPeerConnection-ontrack.https.html,RTCPeerConnection-setRemoteDescription-tracks.https.html,RTCTrackEvent-fire.html">
                             <p><a>Set the associated remote streams</a> given
                             <var>transceiver</var>.<a>[[\Receiver]]</a>,
                             <var>msids</var>, <var>addList</var>, and
                             <var>removeList</var>.</p>
                           </li>
-                          <li>
+                          <li data-tests="RTCPeerConnection-ontrack.https.html,RTCPeerConnection-setRemoteDescription-tracks.https.html,RTCPeerConnection-transceivers.https.html">
                             <p>If the previous step increased the length of
                             <var>addList</var>, or if <var>transceiver</var>'s
                             <a>[[\FiredDirection]]</a> slot
@@ -1873,7 +1873,7 @@
                             set <var>transceiver</var>'s <a>[[\Receptive]]</a> slot
                             to <code>false</code>.</p>
                           </li>
-                          <li>
+                          <li data-tests="RTCPeerConnection-remote-track-mute.https.html">
                             <p>If <var>direction</var> is
                             <code>"sendonly"</code> or <code>"inactive"</code>, and
                             <var>transceiver</var>'s
@@ -1961,7 +1961,7 @@
                     <p>If <var>description</var> is of type <code>"rollback"</code>, then run
                     the following steps:</p>
                     <ol>
-                      <li>
+                      <li data-tests="RTCPeerConnection-setDescription-transceiver.html">
                         <p>If the <code><a data-link-for=
                         "RTCRtpTransceiver">mid</a></code> value of an
                         <code><a>RTCRtpTransceiver</a></code> was set to a
@@ -1972,7 +1972,7 @@
                         transceiver to null, as described by <span data-jsep=
                         "rollback">[[!JSEP]]</span>.</p>
                       </li>
-                      <li>
+                      <li data-tests="RTCPeerConnection-setDescription-transceiver.html">
                         <p>If an <code><a>RTCRtpTransceiver</a></code> was
                         created by applying the
                         <code><a>RTCSessionDescription</a></code> that is
@@ -2005,12 +2005,12 @@
                     <code><a>signalingstatechange</a></code> at
                     <var>connection</var>.</p>
                   </li>
-                  <li>
+                  <li id="remote-mute" data-tests="RTCPeerConnection-remote-track-mute.https.html">
                     <p>For each <var>track</var> in <var>muteTracks</var>,
                     <a>set the muted state</a> of <var>track</var> to the
                     value <code>true</code>.</p>
                   </li>
-                  <li>
+                  <li data-tests="RTCPeerConnection-setRemoteDescription-tracks.https.html">
                     <p>For each <var>stream</var> and <var>track</var> pair
                     in <var>removeList</var>, <a>remove the track</a>
                     <var>track</var> from <var>stream</var>.</p>
@@ -2020,7 +2020,7 @@
                     in <var>addList</var>, <a>add the track</a>
                     <var>track</var> to <var>stream</var>.</p>
                   </li>
-                  <li>
+                  <li data-tests="RTCPeerConnection-ontrack.https.html,RTCPeerConnection-setRemoteDescription-tracks.https.html,RTCTrackEvent-fire.html">
                     <p>For each entry <var>entry</var> in <var>trackEventInits</var>,
                     <a>fire an event</a> named <code title=
                     "event-track"><a>track</a></code> using the
@@ -2035,7 +2035,7 @@
                     <var>entry</var>.<code>transceiver</code>
                     at the <var>connection</var> object.</p>
                   </li>
-                  <li>
+                  <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
                     <p>If <var>connection</var>'s <a>signaling state</a> is now
                     <code>"stable"</code>, <a>update the negotiation-needed
                     flag</a>. If <var>connection</var>'s
@@ -2057,7 +2057,7 @@
                       </li>
                     </ol>
                   </li>
-                  <li>
+                  <li data-tests="RTCPeerConnection-setLocalDescription.html">
                     <p><a>Resolve</a> <var>p</var> with <var>undefined</var>.</p>
                   </li>
                 </ol>
@@ -2084,8 +2084,8 @@
             set and its value differs from the <a>target peer
             identity</a>, <a>throw</a> an <code>InvalidModificationError</code>.</p>
             </li>
-            <li>
-              <p>If <code><var>configuration</var>.certificates</code> is
+            <li data-tests="RTCCertificate.html">
+              <p id="setconfig-certificate">If <code><var>configuration</var>.certificates</code> is
               set, run the following steps:</p>
               <ol>
                 <li>
@@ -2121,25 +2121,25 @@
                 </li>
               </ol>
             </li>
-            <li><p>If the value of <code><var>configuration</var>.<a data-link-for=
+            <li><p id="config-bundle" data-tests="RTCConfiguration-bundlePolicy.html">If the value of <code><var>configuration</var>.<a data-link-for=
             "RTCConfiguration">bundlePolicy</a></code> is set and its value
             differs from the <var>connection</var>'s bundle policy, <a>throw</a>
             an <code>InvalidModificationError</code>.</p></li>
-            <li><p>If the value of <code><var>configuration</var>.<a data-link-for=
+            <li><p id="config-rtcpmux" data-tests="RTCConfiguration-rtcpMuxPolicy.html">If the value of <code><var>configuration</var>.<a data-link-for=
             "RTCConfiguration">rtcpMuxPolicy</a></code> is set and its value
             differs from the <var>connection</var>'s rtcpMux policy, <a>throw</a> an
             <code>InvalidModificationError</code>. If the value is
             <code>"negotiate"</code> and the user agent does not implement
             non-muxed RTCP, <a>throw</a> a <code>NotSupportedError</code>.</p></li>
-            <li><p>If the value of <code><var>configuration</var>.<a data-link-for=
+            <li><p  id="config-icepool" data-tests="RTCConfiguration-iceCandidatePoolSize.html">If the value of <code><var>configuration</var>.<a data-link-for=
             "RTCConfiguration">iceCandidatePoolSize</a></code> is set and its
             value differs from the <var>connection</var>'s previously set
             <code>iceCandidatePoolSize</code>, and <code><a data-link-for=
             "RTCPeerConnection">setLocalDescription</a></code> has
             already been called, <a>throw</a> an
             <code>InvalidModificationError</code>.</p></li>
-            <li>
-              <p>Set the <a>ICE Agent</a>'s <dfn id=
+            <li data-tests="RTCConfiguration-iceTransportPolicy.html">
+              <p id="config-icetransportpolicy" >Set the <a>ICE Agent</a>'s <dfn id=
               "ice-transports-setting">ICE transports setting</dfn> to
               the value of <code><var>configuration</var>.<a data-link-for=
               "RTCConfiguration">iceTransportPolicy</a></code>. As defined
@@ -2164,8 +2164,8 @@
             <li>
               <p>Let <var>validatedServers</var> be an empty list.</p>
             </li>
-            <li>
-              <p>If <code><var>configuration</var>.<a data-link-for=
+            <li data-tests="RTCConfiguration-iceServers.html">
+              <p id="config-iceservers">If <code><var>configuration</var>.<a data-link-for=
               "RTCConfiguration">iceServers</a></code> is defined, then
               run the following steps for each element:</p>
               <ol>
@@ -2270,7 +2270,7 @@
         the APIs to send and receive <code><a>MediaStreamTrack</a></code>
         objects.</p>
         <div>
-          <pre class="idl">
+          <pre class="idl" data-tests="idlharness.https.window.js">
           [ Constructor (optional RTCConfiguration configuration), Exposed=Window]
 interface RTCPeerConnection : EventTarget  {
     Promise&lt;RTCSessionDescriptionInit&gt; createOffer (optional RTCOfferOptions options);
@@ -2359,7 +2359,7 @@ interface RTCPeerConnection : EventTarget  {
                 answer was created. If the <code>RTCPeerConnection</code> is in
                 the stable state, the value is <code>null</code>.</p>
               </dd>
-              <dt><code>remoteDescription</code> of type <span class=
+              <dt data-tests="RTCPeerConnection-setRemoteDescription-answer.html,RTCPeerConnection-setRemoteDescription-offer.html"><code>remoteDescription</code> of type <span class=
               "idlAttrType"><a>RTCSessionDescription</a></span>, readonly,
               nullable</dt>
               <dd>
@@ -2376,7 +2376,7 @@ interface RTCPeerConnection : EventTarget  {
                 may be parsed and reformatted, and ICE candidates may be
                 added).</p>
               </dd>
-              <dt><code>currentRemoteDescription</code> of type <span class=
+              <dt data-tests="RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setRemoteDescription-answer.html,RTCPeerConnection-setRemoteDescription-offer.html"><code>currentRemoteDescription</code> of type <span class=
               "idlAttrType"><a>RTCSessionDescription</a></span>, readonly,
               nullable</dt>
               <dd>
@@ -2390,7 +2390,7 @@ interface RTCPeerConnection : EventTarget  {
                 "RTCPeerConnection">addIceCandidate()</a></code> since the
                 offer or answer was created.</p>
               </dd>
-              <dt><code>pendingRemoteDescription</code> of type <span class=
+              <dt data-tests="RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setRemoteDescription-answer.html,RTCPeerConnection-setRemoteDescription-offer.html"><code>pendingRemoteDescription</code> of type <span class=
               "idlAttrType"><a>RTCSessionDescription</a></span>, readonly,
               nullable</dt>
               <dd>
@@ -2414,7 +2414,7 @@ interface RTCPeerConnection : EventTarget  {
                 "RTCPeerConnection">RTCPeerConnection</a></code> object's
                 <a>signaling state</a>.</p>
               </dd>
-              <dt><code>iceGatheringState</code> of type <span class=
+              <dt data-tests="RTCPeerConnection-iceGatheringState.html"><code>iceGatheringState</code> of type <span class=
               "idlAttrType"><a>RTCIceGatheringState</a></span>, readonly</dt>
               <dd>
                 <p>The <dfn id=
@@ -2422,7 +2422,7 @@ interface RTCPeerConnection : EventTarget  {
                 attribute MUST return the <a>ICE gathering state</a> of the
                 <code>RTCPeerConnection</code> instance.</p>
               </dd>
-              <dt><code>iceConnectionState</code> of type <span class=
+              <dt data-tests="RTCPeerConnection-iceConnectionState.https.html,no-media-call.html"><code>iceConnectionState</code> of type <span class=
               "idlAttrType"><a>RTCIceConnectionState</a></span>, readonly</dt>
               <dd>
                 <p>The <dfn id=
@@ -2430,7 +2430,7 @@ interface RTCPeerConnection : EventTarget  {
                 attribute MUST return the <a>ICE connection state</a> of the
                 <code>RTCPeerConnection</code> instance.</p>
               </dd>
-              <dt><code>connectionState</code> of type <span class=
+              <dt data-tests="RTCPeerConnection-connectionState.html"><code>connectionState</code> of type <span class=
               "idlAttrType"><a>RTCPeerConnectionState</a></span>, readonly</dt>
               <dd>
                 <p>The <dfn id=
@@ -2438,7 +2438,7 @@ interface RTCPeerConnection : EventTarget  {
                 attribute MUST return the <a>connection state</a> of the
                 <code><a>RTCPeerConnection</a></code> instance.</p>
               </dd>
-              <dt><code>canTrickleIceCandidates</code> of type <span class=
+              <dt data-tests="RTCPeerConnection-canTrickleIceCandidates.html, RTCPeerConnection-constructor.html"><code>canTrickleIceCandidates</code> of type <span class=
               "idlAttrType">boolean</span>, readonly, nullable</dt>
               <dd>
                 <p>The <dfn data-idl><code>canTrickleIceCandidates</code></dfn>
@@ -2451,11 +2451,11 @@ interface RTCPeerConnection : EventTarget  {
                 "RTCPeerConnection"><code>setRemoteDescription</code></a>, this
                 value is <code>null</code>.</p>
               </dd>
-              <dt><dfn data-idl><code>onnegotiationneeded</code></dfn> of type
+              <dt data-tests="RTCPeerConnection-onnegotiationneeded.html"><dfn data-idl><code>onnegotiationneeded</code></dfn> of type
               <span class="idlAttrType">EventHandler</span></dt>
               <dd>The event type of this event handler is
               <code><a>negotiationneeded</a></code>.</dd>
-              <dt><dfn data-idl><code>onicecandidate</code></dfn> of type <span class=
+              <dt data-tests="promises-call.html"><dfn data-idl><code>onicecandidate</code></dfn> of type <span class=
               "idlAttrType">EventHandler</span></dt>
               <dd>The event type of this event handler is
               <code><a>icecandidate</a></code>.</dd>
@@ -2463,15 +2463,15 @@ interface RTCPeerConnection : EventTarget  {
               <span class="idlAttrType">EventHandler</span></dt>
               <dd>The event type of this event handler is
               <code><a>icecandidateerror</a></code>.</dd>
-              <dt><dfn data-idl><code>onsignalingstatechange</code></dfn> of type
+              <dt data-tests="RTCPeerConnection-createOffer.html,RTCPeerConnection-onsignalingstatechanged.https.html"><dfn data-idl><code>onsignalingstatechange</code></dfn> of type
               <span class="idlAttrType">EventHandler</span></dt>
               <dd>The event type of this event handler is
-              <code><a>signalingstatechange</a></code>.</dd>
-              <dt><dfn data-idl><code>oniceconnectionstatechange</code></dfn> of type
+                <code><a>signalingstatechange</a></code>.</dd>
+              <dt data-tests="RTCPeerConnection-connectionState.html,RTCPeerConnection-iceConnectionState.https.html,no-media-call.html"><dfn data-idl><code>oniceconnectionstatechange</code></dfn> of type
               <span class="idlAttrType">EventHandler</span></dt>
               <dd>The event type of this event handler is
               <code><a>iceconnectionstatechange</a></code></dd>
-              <dt><dfn data-idl><code>onicegatheringstatechange</code></dfn> of type
+              <dt data-tests="RTCPeerConnection-iceGatheringState.html"><dfn data-idl><code>onicegatheringstatechange</code></dfn> of type
               <span class="idlAttrType">EventHandler</span></dt>
               <dd>The event type of this event handler is
               <code><a>icegatheringstatechange</a></code>.</dd>
@@ -2485,7 +2485,7 @@ interface RTCPeerConnection : EventTarget  {
             <h2>Methods</h2>
             <dl data-link-for="RTCPeerConnection" data-dfn-for=
             "RTCPeerConnection" class="methods">
-              <dt><dfn data-idl><code>createOffer</code></dfn></dt>
+              <dt data-tests="RTCPeerConnection-createOffer.html,promises-call.html"><dfn data-idl><code>createOffer</code></dfn></dt>
               <dd>
                 <p>The <code>createOffer</code> method generates a blob of SDP that contains
                 an RFC 3264 offer with the supported configurations for the
@@ -2504,7 +2504,7 @@ interface RTCPeerConnection : EventTarget  {
                 remain usable by <code>setLocalDescription</code> without
                 causing an error until at least the end of the <a>fulfillment</a>
                 callback of the returned promise.</p>
-                <p>Creating the SDP MUST follow the appropriate process for
+                <p data-tests="sdp-offer.html">Creating the SDP MUST follow the appropriate process for
                 generating an offer described in [[!JSEP]].
                 As an offer, the generated SDP will contain the full set of
                 codec/RTP/RTCP capabilities supported or preferred by the session (as
@@ -2551,7 +2551,7 @@ interface RTCPeerConnection : EventTarget  {
                     <code><a>RTCPeerConnection</a></code> object on which the
                     method was invoked.</p>
                   </li>
-                  <li>
+                  <li data-tests="RTCPeerConnection-createOffer.html">
                     <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
                     <code>true</code>, return a promise <a>rejected</a> with a newly
                     <a data-link-for="exception" data-lt="create">created</a>
@@ -2613,13 +2613,13 @@ interface RTCPeerConnection : EventTarget  {
                     <a data-link-for="exception" data-lt="create">created</a>
                     <code>NotReadableError</code> and abort these steps.</p>
                   </li>
-                  <li>
+                  <li class=untestable>
                     <p>Inspect the system state to determine the currently
                     available resources as necessary for generating the offer,
                     as described in <span data-jsep=
                     "createoffer">[[!JSEP]]</span>.</p>
                   </li>
-                  <li>
+                  <li class=untestable>
                     <p>If this inspection failed for any reason, <a>reject</a>
                     <var>p</var> with a newly
                     <a data-link-for="exception" data-lt="create">created</a>
@@ -2637,7 +2637,7 @@ interface RTCPeerConnection : EventTarget  {
                     <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
                     <code>true</code>, then abort these steps.</p>
                   </li>
-                  <li>
+                  <li data-tests="RTCPeerConnection-createOffer.html">
                     <p>If <var>connection</var> was modified in such a way that
                     additional inspection of the system state is necessary, or
                     if its configured indentity provider is no longer
@@ -2656,14 +2656,14 @@ interface RTCPeerConnection : EventTarget  {
                     </div>
                   </li>
                   <li>
-                    <p>Given the information that was obtained from previous
+                    <p class=untestable>Given the information that was obtained from previous
                     inspection, the current state of <var>connection</var>
                     and its <code><a>RTCRtpTransceiver</a></code>s, and the
                     identity assertion from <var>provider</var> (if non-null),
                     generate an SDP offer, <var>sdpString</var>, as described
                     in <span data-jsep="create-offer">[[!JSEP]]</span>.</p>
                     <ol>
-                      <li>
+                      <li data-tests="RTCRtpSender-transport.https.html">
                         <p>As described in [[!BUNDLE]] (Section 7), if bundling
                         is used (see <a>RTCBundlePolicy</a>) an offerer tagged
                         m= section must be selected in order to negotiate a
@@ -2728,7 +2728,7 @@ interface RTCPeerConnection : EventTarget  {
                       </li>
                     </ol>
                   </li>
-                  <li>
+                  <li data-tests="RTCPeerConnection-createOffer.html">
                     <p>Let <var>offer</var> be a newly created
                     <code><a>RTCSessionDescriptionInit</a></code> dictionary
                     with its <code>type</code> member initialized to the string
@@ -2743,7 +2743,7 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                 </ol>
               </dd>
-              <dt><dfn data-idl><code>createAnswer</code></dfn></dt>
+              <dt data-tests="RTCPeerConnection-createAnswer.html,promises-call.html"><dfn data-idl><code>createAnswer</code></dfn></dt>
               <dd>
                 <p>The <code>createAnswer</code> method generates an [[!SDP]]
                 answer with the supported configuration for the session that is
@@ -2802,7 +2802,7 @@ interface RTCPeerConnection : EventTarget  {
                     <a data-link-for="exception" data-lt="create">created</a>
                     <code>InvalidStateError</code>.</p>
                   </li>
-                  <li>
+                  <li data-tests=''>
                     <p>If <var>connection</var> is configured with an identity
                     provider, then begin <a data-cite="!WEBRTC-IDENTITY#sec.identity-verify-assertion">the identity
                     assertion request process</a> if it has not already
@@ -2813,7 +2813,7 @@ interface RTCPeerConnection : EventTarget  {
                     "#enqueue-an-operation">enqueuing</a> the following
                     steps to <var>connection</var>'s operation queue:</p>
                     <ol>
-                      <li>
+                      <li data-tests="RTCPeerConnection-createAnswer.html,RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setLocalDescription-pranswer.html">
                         <p>If <var>connection</var>'s <a>signaling state</a>
                         is neither <code>"have-remote-offer"</code> nor
                         <code>"have-local-pranswer"</code>, return a promise
@@ -2858,13 +2858,13 @@ interface RTCPeerConnection : EventTarget  {
                     <a data-link-for="exception" data-lt="create">created</a>
                     <code>NotReadableError</code> and abort these steps.</p>
                   </li>
-                  <li>
+                  <li class=untestable>
                     <p>Inspect the system state to determine the currently
                     available resources as necessary for generating the answer,
                     as described in <span data-jsep=
                     "createanswer">[[!JSEP]]</span>.</p>
                   </li>
-                  <li>
+                  <li class=untestable>
                     <p>If this inspection failed for any reason, <a>reject</a>
                     <var>p</var> with a newly
                     <a data-link-for="exception" data-lt="create">created</a>
@@ -2953,7 +2953,7 @@ interface RTCPeerConnection : EventTarget  {
                        </li>
                     </ol>
                   </li>
-                  <li>
+                  <li data-tests="RTCPeerConnection-createAnswer.html">
                     <p>Let <var>answer</var> be a newly created
                     <code><a>RTCSessionDescriptionInit</a></code> dictionary
                     with its <code>type</code> member initialized to the string
@@ -2968,7 +2968,7 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                 </ol>
               </dd>
-              <dt><code>setLocalDescription</code></dt>
+              <dt data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setLocalDescription-offer.html,promises-call.html"><code>setLocalDescription</code></dt>
               <dd>
                 <p>The <dfn id=
                 "dom-peerconnection-setlocaldescription"><code>setLocalDescription</code></dfn>
@@ -2995,12 +2995,12 @@ interface RTCPeerConnection : EventTarget  {
                 <ol>
                   <li>Let <var>description</var> be the first argument to
                   <code>setLocalDescription</code>.</li>
-                  <li>If <code><var>description</var>.sdp</code> is the
+                  <li data-tests="RTCPeerConnection-setLocalDescription-answer.html">If <code><var>description</var>.sdp</code> is the
                   empty string and <code><var>description</var>.type</code>
                   is <code>"answer"</code> or <code>"pranswer"</code>,
                   set <code><var>description</var>.sdp</code> to the value of
                   <var>connection</var>'s <a>[[\LastCreatedAnswer]]</a> slot.</li>
-                  <li>If <code><var>description</var>.sdp</code> is the
+                  <li data-tests="RTCPeerConnection-setLocalDescription-offer.html">If <code><var>description</var>.sdp</code> is the
                   empty string and <code><var>description</var>.type</code>
                   is <code>"offer"</code>, set <code><var>description</var>.sdp</code>
                   to the value of <var>connection</var>'s
@@ -3015,7 +3015,7 @@ interface RTCPeerConnection : EventTarget  {
                   by the <a>ICE Agent</a>.</p>
                 </div>
               </dd>
-              <dt><code>setRemoteDescription</code></dt>
+              <dt data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-setLocalDescription-answer.html,promises-call.html,simplecall-no-ssrcs.https.html,simplecall.https.html"><code>setRemoteDescription</code></dt>
               <dd>
                 <p>The <dfn id=
                 "dom-peerconnection-setremotedescription"><code>setRemoteDescription</code></dfn>
@@ -3029,7 +3029,7 @@ interface RTCPeerConnection : EventTarget  {
                 argument.</p>
                 <p>In addition, a remote description is processed to determine
                 and verify the identity of the peer.</p>
-                <p>If an <code>a=identity</code> attribute is present in the
+                <p data-tests>If an <code>a=identity</code> attribute is present in the
                 session description, the browser <a data-cite="!WEBRTC-IDENTITY##sec.identity-verify-assertion">validates the identity
                 assertion.</a>.</p>
                 <p>If the <a data-link-for="RTCConfiguration">peerIdentity</a> configuration is applied to the
@@ -3051,7 +3051,7 @@ interface RTCPeerConnection : EventTarget  {
                 <code>setRemoteDescription</code> does not await the completion
                 of identity validation.</p>
               </dd>
-              <dt><code>addIceCandidate</code></dt>
+              <dt data-tests="RTCPeerConnection-addIceCandidate.html,promises-call.html"><code>addIceCandidate</code></dt>
               <dd>
                 <p>The <dfn id=
                 "dom-peerconnection-addicecandidate"><code>addIceCandidate</code></dfn>
@@ -3088,7 +3088,7 @@ interface RTCPeerConnection : EventTarget  {
                     "#enqueue-an-operation">enqueuing</a> the following
                     steps to <var>connection</var>'s operation queue:</p>
                     <ol>
-                      <li>
+                      <li data-tests="RTCPeerConnection-addIceCandidate.html">
                         <p>If <code><a data-link-for=
                         "RTCPeerConnection">remoteDescription</a></code> is
                         <code>null</code> return a promise <a>rejected</a> with a newly
@@ -3102,7 +3102,7 @@ interface RTCPeerConnection : EventTarget  {
                         <p>If <var>candidate.sdpMid</var> is not null, run the
                         following steps:</p>
                         <ol>
-                          <li>
+                          <li data-tests="RTCPeerConnection-addIceCandidate.html">
                             <p>If <var>candidate.sdpMid</var> is not equal to
                             the mid of any media description in
                             <code><a data-link-for=
@@ -3114,7 +3114,7 @@ interface RTCPeerConnection : EventTarget  {
                           </li>
                         </ol>
                       </li>
-                      <li>
+                      <li data-tests="RTCPeerConnection-addIceCandidate.html">
                         <p>Else, if <var>candidate.sdpMLineIndex</var> is not
                         null, run the following steps:</p>
                         <ol>
@@ -3130,7 +3130,7 @@ interface RTCPeerConnection : EventTarget  {
                           </li>
                         </ol>
                       </li>
-                      <li>
+                      <li data-tests="RTCPeerConnection-addIceCandidate.html">
                         <p>If <code><var>candidate</var>.usernameFragment</code>
                         is not <code>null</code>, and is not
                         equal to any username fragment present in the corresponding
@@ -3174,7 +3174,7 @@ interface RTCPeerConnection : EventTarget  {
                               </li>
                             </ol>
                           </li>
-                          <li>
+                          <li data-tests="RTCPeerConnection-addIceCandidate.html">
                             <p>If <var>candidate</var> is applied successfully,
                             the user agent MUST queue a task that runs the
                             following steps:</p>
@@ -3216,7 +3216,7 @@ interface RTCPeerConnection : EventTarget  {
                 descriptions and ICE candidate generation. This is by design for
                 legacy reasons.</p>
               </dd>
-              <dt><dfn data-idl><code>getDefaultIceServers</code></dfn></dt>
+              <dt data-tests="RTCPeerConnection-getDefaultIceServers.html"><dfn data-idl><code>getDefaultIceServers</code></dfn></dt>
               <dd>
                 <p>Returns a list of ICE servers that are configured into the
                 browser. A browser might be configured to use local or private
@@ -3270,7 +3270,7 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                 </ol>
               </dd>
-              <dt><code>close</code></dt>
+              <dt data-tests="RTCPeerConnection-transceivers.https.html"><code>close</code></dt>
               <dd>
                 <p>When the <dfn data-idl><code>close</code></dfn> method is invoked,
                 the user agent MUST run the following steps:</p>
@@ -3292,7 +3292,7 @@ interface RTCPeerConnection : EventTarget  {
                     <p>Set <var>connection</var>'s <a>signaling state</a> to
                     <code>"closed"</code>.</p>
                   </li>
-                  <li>
+                  <li data-tests="RTCPeerConnection-transceivers.https.html">
                     <p>Let <var>transceivers</var> be the result of executing the
                     <code><a>CollectTransceivers</a></code> algorithm. For every
                     <code><a>RTCRtpTransceiver</a></code> <var>transceiver</var> in
@@ -3375,7 +3375,7 @@ interface RTCPeerConnection : EventTarget  {
         <section>
           <h4>Method extensions</h4>
         <div>
-          <pre class="idl">partial interface RTCPeerConnection {
+          <pre class="idl" data-tests="idlharness.https.window.js">partial interface RTCPeerConnection {
     Promise&lt;void&gt; createOffer (RTCSessionDescriptionCallback successCallback, RTCPeerConnectionErrorCallback failureCallback, optional RTCOfferOptions options);
     Promise&lt;void&gt; setLocalDescription (RTCSessionDescriptionInit description, VoidFunction successCallback, RTCPeerConnectionErrorCallback failureCallback);
     Promise&lt;void&gt; createAnswer (RTCSessionDescriptionCallback successCallback, RTCPeerConnectionErrorCallback failureCallback);
@@ -3386,7 +3386,7 @@ interface RTCPeerConnection : EventTarget  {
             <h2>Methods</h2>
             <dl data-link-for="RTCPeerConnection" data-dfn-for=
             "RTCPeerConnection" class="methods">
-              <dt><dfn data-lt="createOffer!overload-1" data-lt-nodefault=
+              <dt data-tests="legacy/RTCPeerConnection-createOffer-offerToReceive.html"><dfn data-lt="createOffer!overload-1" data-lt-nodefault=
               "true"><code>createOffer</code></dfn></dt>
               <dd>
                 <p>When the <code>createOffer</code> method is called, the user
@@ -3404,14 +3404,14 @@ interface RTCPeerConnection : EventTarget  {
                     <p>Let <var>options</var> be the callback indicated by the
                     method's third argument.</p>
                   </li>
-                  <li>
+                  <li data-tests="legacy/RTCPeerConnection-createOffer-offerToReceive.html">
                     <p>Run the steps specified by
                     <code><a>RTCPeerConnection</a></code>'s <a data-link-for=
                     "RTCPeerConnection">createOffer()</a> method with
                     <var>options</var> as the sole argument, and let
                     <var>p</var> be the resulting promise.</p>
                   </li>
-                  <li>
+                  <li data-tests="legacy/RTCPeerConnection-createOffer-offerToReceive.html">
                     <p>Upon <a>fulfillment</a> of <var>p</var> with value
                     <var>offer</var>, invoke <var>successCallback</var> with
                     <var>offer</var> as the argument.</p>
@@ -3659,13 +3659,13 @@ interface RTCPeerConnection : EventTarget  {
               <li>
                 <p>If the value of the dictionary member is false,</p>
                 <ol>
-                  <li>
+                  <li data-tests="legacy/RTCPeerConnection-createOffer-offerToReceive.html,legacy/RTCRtpTransceiver-with-OfferToReceive-options.https.html">
                     <p>For each non-stopped "sendrecv" transceiver of
                     <a>transceiver kind</a> <var>kind</var>, set
                     <var>transceiver</var>'s <a>[[\Direction]]</a> slot to
                     "sendonly".</p>
                   </li>
-                  <li>
+                  <li data-tests="legacy/RTCPeerConnection-createOffer-offerToReceive.html,legacy/RTCRtpTransceiver-with-OfferToReceive-options.https.html">
                     <p>For each non-stopped "recvonly" transceiver of
                     <a>transceiver kind</a> <var>kind</var>, set
                     <var>transceiver</var>'s <a>[[\Direction]]</a> slot to
@@ -3696,7 +3696,7 @@ interface RTCPeerConnection : EventTarget  {
               </li>
             </ol>
           </li>
-          <li>
+          <li data-tests="legacy/RTCPeerConnection-createOffer-offerToReceive.html">
             <p>Run the steps specified by <a href=
             "#dom-rtcpeerconnection-createoffer">createOffer</a> to create
           the offer.</p>
@@ -3711,14 +3711,14 @@ interface RTCPeerConnection : EventTarget  {
           <section>
             <h2>Attributes</h2>
             <dl data-link-for="RTCOfferOptions" data-dfn-for="RTCOfferOptions" class="dictionary-members">
-              <dt><dfn>offerToReceiveAudio</dfn> of type <span class="idlMemberType">boolean</span></dt>
+              <dt data-tests="legacy/RTCPeerConnection-createOffer-offerToReceive.html,legacy/RTCRtpTransceiver-with-OfferToReceive-options.https.html"><dfn>offerToReceiveAudio</dfn> of type <span class="idlMemberType">boolean</span></dt>
               <dd>
                 <p>This setting provides additional control over the
                 directionality of audio. For example, it can be used to ensure
                 that audio can be received, regardless if audio is
                 sent or not.</p>
               </dd>
-              <dt><dfn>offerToReceiveVideo</dfn> of type <span class="idlMemberType">boolean</span></dt>
+              <dt data-tests="legacy/RTCPeerConnection-createOffer-offerToReceive.html,legacy/RTCRtpTransceiver-with-OfferToReceive-options.https.html"><dfn>offerToReceiveVideo</dfn> of type <span class="idlMemberType">boolean</span></dt>
               <dd>
                 <p>This setting provides additional control over the
                 directionality of video. For example, it can be used to ensure
@@ -3773,14 +3773,14 @@ interface RTCPeerConnection : EventTarget  {
                 <th colspan="2">Enumeration description</th>
               </tr>
               <tr>
-                <td><dfn data-idl><code>offer</code></dfn></td>
+                <td data-tests="RTCPeerConnection-setLocalDescription-offer.html"><dfn data-idl><code>offer</code></dfn></td>
                 <td>
                   <p>An <code>RTCSdpType</code> of <code>offer</code> indicates
                   that a description MUST be treated as an [[!SDP]] offer.</p>
                 </td>
               </tr>
               <tr>
-                <td><dfn data-idl><code>pranswer</code></dfn></td>
+                <td data-tests="RTCPeerConnection-setLocalDescription-pranswer.html"><dfn data-idl><code>pranswer</code></dfn></td>
                 <td>
                   <p>An <code>RTCSdpType</code> of <code>pranswer</code>
                   indicates that a description MUST be treated as an [[!SDP]]
@@ -3789,7 +3789,7 @@ interface RTCPeerConnection : EventTarget  {
                   offer, or an update to a previously sent SDP pranswer.</p>
                 </td>
               </tr>
-              <tr>
+              <tr data-tests="RTCPeerConnection-setLocalDescription-answer.html">
                 <td><dfn data-idl><code>answer</code></dfn></td>
                 <td>
                   <p>An <code>RTCSdpType</code> of <code>answer</code>
@@ -3801,7 +3801,7 @@ interface RTCPeerConnection : EventTarget  {
                 </td>
               </tr>
               <tr>
-                <td><dfn data-idl><code>rollback</code></dfn></td>
+                <td data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-setLocalDescription-rollback.html"><dfn data-idl><code>rollback</code></dfn></td>
                 <td>
                   <p>An <code>RTCSdpType</code> of <code>rollback</code>
                   indicates that a description MUST be treated as canceling the
@@ -3822,7 +3822,7 @@ interface RTCPeerConnection : EventTarget  {
         <code><a>RTCPeerConnection</a></code> to expose local and remote
         session descriptions.</p>
         <div>
-          <pre class="idl">
+          <pre class="idl" data-tests="idlharness.https.window.js">
           [ Constructor (RTCSessionDescriptionInit descriptionInitDict), Exposed=Window]
 interface RTCSessionDescription {
     readonly        attribute RTCSdpType type;
@@ -3852,7 +3852,7 @@ interface RTCSessionDescription {
               <dt><dfn data-idl><code>type</code></dfn> of type <span class=
               "idlAttrType"><a>RTCSdpType</a></span>, readonly</dt>
               <dd>The type of this RTCSessionDescription.</dd>
-              <dt><dfn data-idl><code>sdp</code></dfn> of type <span class=
+              <dt data-tests="RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setLocalDescription-offer.html,RTCPeerConnection-setLocalDescription-pranswer.html"><dfn data-idl><code>sdp</code></dfn> of type <span class=
               "idlAttrType">DOMString</span>, readonly</dt>
               <dd>The string representation of the SDP [[!SDP]].</dd>
             </dl>
@@ -3882,7 +3882,7 @@ interface RTCSessionDescription {
               <dt><dfn data-idl><code>type</code></dfn> of type <span class=
               "idlMemberType"><a>RTCSdpType</a></span>, required</dt>
               <dd>DOMString sdp</dd>
-              <dt><dfn data-idl><code>sdp</code></dfn> of type <span class=
+              <dt data-tests="RTCPeerConnection-setLocalDescription-rollback.html"><dfn data-idl><code>sdp</code></dfn> of type <span class=
               "idlMemberType">DOMString</span></dt>
               <dd>The string representation of the SDP [[!SDP]]; if
               <code>type</code> is <code>"rollback"</code>, this member is unused.
@@ -3942,13 +3942,13 @@ interface RTCSessionDescription {
         <p>To <dfn>update the negotiation-needed flag</dfn> for
         <var>connection</var>, run the following steps:</p>
         <ol>
-          <li>
+          <li class=untestable>
             <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
             <code>true</code>, abort these steps.</p>
           </li>
-          <li>
+          <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
             <p>If <var>connection</var>'s <a>signaling state</a> is not
-            <code>"stable"</code>, abort these steps.<p>
+            <code>"stable"</code>, abort these steps.</p>
 
             <p class="note">The negotiation-needed flag will be
             updated once the state transitions to "stable", as part of the steps
@@ -3962,11 +3962,11 @@ interface RTCSessionDescription {
             <var>connection</var>'s <a>[[\NegotiationNeeded]]</a> slot to
             <code>false</code>, and abort these steps.</p>
           </li>
-          <li>
+          <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
             <p>If <var>connection</var>'s <a>[[\NegotiationNeeded]]</a> slot is
             already <code>true</code>, abort these steps.</p>
           </li>
-          <li>
+          <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
             <p>Set <var>connection</var>'s <a>[[\NegotiationNeeded]]</a> slot to
             <code>true</code>.</p>
           </li>
@@ -3974,14 +3974,14 @@ interface RTCSessionDescription {
             <p>Queue a task that runs the following steps:</p>
             <ol>
               <li>
-                <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot
+                <p class="untestable">If <var>connection</var>'s <a>[[\IsClosed]]</a> slot
                 is <code>true</code>, abort these steps.</p>
               </li>
               <li>
                 <p>If <var>connection</var>'s <a>[[\NegotiationNeeded]]</a>
                 slot is <code>false</code>, abort these steps.</p>
               </li>
-              <li>
+              <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
                 <p><a>Fire an event</a> named <code><a>negotiationneeded</a></code>
                 at <var>connection</var>.</p>
               </li>
@@ -4003,7 +4003,7 @@ interface RTCSessionDescription {
               <p>Let <var>description</var> be
               <var>connection</var>.<a>[[\CurrentLocalDescription]]</a>.</p>
             </li>
-          <li>
+          <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
             <p>If <var>connection</var> has created any
             <code><a>RTCDataChannel</a></code>s, and no m= section in
             <var>description</var> has been negotiated yet for data, return
@@ -4013,7 +4013,7 @@ interface RTCSessionDescription {
             <p>For each <var>transceiver</var> in <var>connection</var>'s
             <a>set of transceivers</a>, perform the following checks:</p>
             <ol>
-              <li>
+              <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
                 <p>If <var>transceiver</var> isn't <a data-link-for="RTCRtpTransceiver">
                 stopped</a> and isn't yet <a>associated</a> with an m= section
                 in <var>description</var>, return <code>true</code>.</p>
@@ -4085,7 +4085,7 @@ interface RTCSessionDescription {
         if it is well formed.</p>
 
         <div>
-          <pre class="idl">
+          <pre class="idl" data-tests="idlharness.https.window.js">
           [ Constructor (optional RTCIceCandidateInit candidateInitDict), Exposed=Window]
 interface RTCIceCandidate {
     readonly        attribute DOMString               candidate;
@@ -4116,12 +4116,12 @@ interface RTCIceCandidate {
                 "idlType"><code>RTCIceCandidate</code></a> object.</p>
                 <p>When invoked, run the following steps:</p>
                 <ol>
-                  <li>If both the <code><a
+                  <li data-tests="RTCIceCandidate-constructor.html">If both the <code><a
                   data-link-for="RTCIceCandidateInit">sdpMid</a></code> and
                   <code><a data-link-for="RTCIceCandidateInit">sdpMLineIndex</a></code>
                   members of <var>candidateInitDict</var> are <code>null</code>,
                   <a>throw</a> a <code>TypeError</code>.</li>
-                  <li><p>Return the result of
+                  <li data-tests="RTCIceCandidate-constructor.html"><p>Return the result of
                   <a href="#dfn-create-an-rtcicecandidate">creating an RTCIceCandidate</a>
                   with <var>candidateInitDict</var>.</p></li>
                 </ol>
@@ -4147,7 +4147,7 @@ interface RTCIceCandidate {
                     <a data-link-for="RTCIceCandidateInit">candidate</a></code>
                   dictionary member of <var>candidateInitDict</var>. If
                   <var>candidate</var> is not an empty string, run the following steps:
-                  <ol>
+                  <ol data-tests="RTCIceCandidate-constructor.html">
                     <li>Parse <var>candidate</var> using the <a><code>candidate-attribute</code>
                     </a> grammar.</li>
                     <li>If parsing of <a><code>candidate-attribute</code></a> has failed, abort
@@ -4479,7 +4479,7 @@ interface RTCIceCandidate {
         <h4><dfn>RTCPeerConnectionIceEvent</dfn></h4>
         <p>The <code>icecandidate</code> event of the RTCPeerConnection uses
         the <code><a>RTCPeerConnectionIceEvent</a></code> interface.</p>
-        <p>When firing an <code><a>RTCPeerConnectionIceEvent</a></code> event
+        <p data-tests="RTCPeerConnectionIceEvent-constructor.html">When firing an <code><a>RTCPeerConnectionIceEvent</a></code> event
         that contains an <code><a>RTCIceCandidate</a></code> object, it MUST
         include values for both <a data-link-for=
         "RTCIceCandidate"><code>sdpMid</code></a> and <a data-link-for=
@@ -4530,7 +4530,7 @@ interface RTCIceCandidate {
           </ul>
         </div>
         <div>
-          <pre class="idl">
+          <pre class="idl" data-tests="idlharness.https.window.js">
           [ Constructor (DOMString type, optional RTCPeerConnectionIceEventInit eventInitDict), Exposed=Window]
 interface RTCPeerConnectionIceEvent : Event {
     readonly        attribute RTCIceCandidate? candidate;
@@ -4540,7 +4540,7 @@ interface RTCPeerConnectionIceEvent : Event {
             <h2>Constructors</h2>
             <dl data-link-for="RTCPeerConnectionIceEvent" data-dfn-for=
             "RTCPeerConnectionIceEvent" class="constructors">
-              <dt><code>RTCPeerConnectionIceEvent</code></dt>
+              <dt data-tests="RTCPeerConnectionIceEvent-constructor.html"><code>RTCPeerConnectionIceEvent</code></dt>
               <dd>
               </dd>
             </dl>
@@ -4549,7 +4549,7 @@ interface RTCPeerConnectionIceEvent : Event {
             <h2>Attributes</h2>
             <dl data-link-for="RTCPeerConnectionIceEvent" data-dfn-for=
             "RTCPeerConnectionIceEvent" class="attributes">
-              <dt><dfn data-idl><code>candidate</code></dfn> of type <span class=
+              <dt data-tests="RTCPeerConnectionIceEvent-constructor.html"><dfn data-idl><code>candidate</code></dfn> of type <span class=
               "idlAttrType"><a>RTCIceCandidate</a></span>, readonly,
               nullable</dt>
               <dd>
@@ -4562,7 +4562,7 @@ interface RTCPeerConnectionIceEvent : Event {
                 only one event containing a <code>null</code> candidate is
                 fired.</p>
               </dd>
-              <dt><dfn data-idl><code>url</code></dfn> of type <span class=
+              <dt data-tests="RTCPeerConnectionIceEvent-constructor.html"><dfn data-idl><code>url</code></dfn> of type <span class=
               "idlAttrType">DOMString</span>, readonly, nullable</dt>
               <dd>
                 <p>The <code>url</code> attribute is the STUN or TURN URL that
@@ -4585,14 +4585,14 @@ interface RTCPeerConnectionIceEvent : Event {
             Members</h2>
             <dl data-link-for="RTCPeerConnectionIceEventInit" data-dfn-for=
             "RTCPeerConnectionIceEventInit" class="dictionary-members">
-              <dt><dfn data-idl><code>candidate</code></dfn> of type <span class=
+              <dt data-tests="RTCPeerConnectionIceEvent-constructor.html"><dfn data-idl><code>candidate</code></dfn> of type <span class=
               "idlMemberType"><a>RTCIceCandidate</a></span>, nullable</dt>
               <dd>
                 <p>See the
                   <code><a data-link-for="RTCPeerConnectionIceEvent">candidate</a></code> attribute of the
                 <code>RTCPeerConnectionIceEvent</code> interface.</p>
               </dd>
-              <dt><dfn data-idl><code>url</code></dfn> of type <span class=
+              <dt data-tests="RTCPeerConnectionIceEvent-constructor.html"><dfn data-idl><code>url</code></dfn> of type <span class=
               "idlMemberType">DOMString</span>, nullable</dt>
               <dd>The <code>url</code> attribute is the STUN or TURN URL that
               identifies the STUN or TURN server used to gather this
@@ -4607,7 +4607,7 @@ interface RTCPeerConnectionIceEvent : Event {
         uses the <code><a>RTCPeerConnectionIceErrorEvent</a></code>
         interface.</p>
         <div>
-          <pre class="idl">
+          <pre class="idl" data-tests="idlharness.https.window.js">
           [ Constructor (DOMString type, RTCPeerConnectionIceErrorEventInit eventInitDict), Exposed=Window]
 interface RTCPeerConnectionIceErrorEvent : Event {
     readonly        attribute DOMString      hostCandidate;
@@ -4790,14 +4790,14 @@ interface RTCPeerConnectionIceErrorEvent : Event {
       certificate with a private key on the P-256 curve and a signature with a
       SHA-256 hash.</p>
       <div>
-        <pre class="idl">partial interface RTCPeerConnection {
+        <pre class="idl" data-tests="idlharness.https.window.js">partial interface RTCPeerConnection {
     static Promise&lt;RTCCertificate&gt; generateCertificate (AlgorithmIdentifier keygenAlgorithm);
 };</pre>
         <section>
           <h2>Methods</h2>
           <dl data-link-for="RTCPeerConnection" data-dfn-for=
           "RTCPeerConnection" class="methods">
-            <dt><dfn data-idl><code>generateCertificate</code></dfn>, static</dt>
+            <dt data-tests="RTCPeerConnection-generateCertificate.html"><dfn data-idl><code>generateCertificate</code></dfn>, static</dt>
             <dd>
               <p>The <code>generateCertificate</code> function causes the
               <a>user agent</a> to create an X.509 certificate
@@ -4813,7 +4813,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               [[!WebCryptoAPI]] <a data-cite=
               "!WebCryptoAPI#dfn-AlgorithmIdentifier">
               <code>AlgorithmIdentifier</code></a> type.</p>
-              <p>The following values MUST be supported by a <a>user agent</a>:
+              <p data-tests="RTCPeerConnection-generateCertificate.html">The following values MUST be supported by a <a>user agent</a>:
               <code>{ name: "<a data-cite=
               "!WebCryptoAPI#rsassa-pkcs1">RSASSA-PKCS1-v1_5</a>",
               modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]),
@@ -4860,7 +4860,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                       the ECMAScript object represented by <var>keygenAlgorithm</var> to an
                       <code>RTCCertificateExpiration</code> dictionary.</p>
                     </li>
-                    <li>
+                    <li data-tests="RTCPeerConnection-generateCertificate.html">
                       <p>If the conversion fails with an <var>error</var>,
                       return a promise that is <a>rejected</a> with <var>error</var>.</p>
                     </li>
@@ -4883,7 +4883,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   <p>If the above normalization step fails with an <var>error</var>,
                   return a promise that is <a>rejected</a> with <var>error</var>.</p>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-generateCertificate.html">
                   <p>If the <var>normalizedKeygenAlgorithm</var> parameter
                   identifies an algorithm that the <a>user agent</a> cannot
                   or will not use to generate a certificate for
@@ -4957,7 +4957,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
 };</pre>
         <dl data-link-for="RTCCertificateExpiration" data-dfn-for=
         "RTCCertificateExpiration" class="methods">
-          <dt><dfn>expires</dfn></dt>
+          <dt data-tests="RTCPeerConnection-generateCertificate.html"><dfn>expires</dfn></dt>
           <dd>
             <p>An optional <code>expires</code> attribute MAY be added to the
             definition of the algorithm that is passed to <a data-link-for=
@@ -4978,7 +4978,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
         uses to authenticate with a peer, and the origin (<dfn>[[\Origin]]</dfn>)
         that created the object.</p>
         <div>
-          <pre class="idl">[Exposed=Window, Serializable] interface RTCCertificate {
+          <pre class="idl" data-tests="idlharness.https.window.js">[Exposed=Window, Serializable] interface RTCCertificate {
     readonly        attribute DOMTimeStamp expires;
     static sequence&lt;AlgorithmIdentifier&gt; getSupportedAlgorithms();
     sequence&lt;RTCDtlsFingerprint&gt; getFingerprints ();
@@ -5021,7 +5021,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   (such as 1024 and 65537, respectively).</p>
                 </div>
               </dd>
-              <dt><dfn data-idl><code>getFingerprints</code></dfn></dt>
+              <dt data-tests="RTCCertificate.html"><dfn data-idl><code>getFingerprints</code></dfn></dt>
               <dd>
                 <p>Returns the list of certificate fingerprints, one of which is
                 computed with the digest algorithm used in the certificate
@@ -5040,7 +5040,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
         secure module), a reference to the private key can be held in
         the <a>[[\KeyingMaterial]]</a> internal slot, allowing the
         private key to be stored and used.</p>
-        <p><code>RTCCertificate</code> objects are <a>serializable objects</a>
+        <p id="serializable-certificate" data-tests="RTCCertificate-postMessage.html"><code>RTCCertificate</code> objects are <a>serializable objects</a>
         [[!HTML]]. Their <a>serialization steps</a>, given <var>value</var> and
         <var>serialized</var>, are:</p>
 
@@ -5149,9 +5149,9 @@ interface RTCPeerConnectionIceErrorEvent : Event {
       An <code><a>RTCPeerConnection</a></code> object contains a <dfn id=
       "transceivers-set" data-lt="set of transceivers">set of
       <code><a>RTCRtpTransceiver</a></code>s</dfn>, representing the paired
-      senders and receivers with some shared state. This set is initialized to
+      senders and receivers with some shared state. <span data-tests="RTCPeerConnection-getTransceivers.html">This set is initialized to
       the empty set when the <code><a>RTCPeerConnection</a></code> object is
-      created. <code><a>RTCRtpSender</a></code>s and
+      created.</span> <code><a>RTCRtpSender</a></code>s and
       <code><a>RTCRtpReceiver</a></code>s are always created at the same time
       as an <code><a>RTCRtpTransceiver</a></code>, which they will remain
       attached to for their lifetime.
@@ -5171,7 +5171,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
       <p>The RTP media API extends the <code><a>RTCPeerConnection</a></code>
       interface as described below.</p>
       <div>
-        <pre class="idl">partial interface RTCPeerConnection {
+        <pre class="idl" data-tests="idlharness.https.window.js">partial interface RTCPeerConnection {
     sequence&lt;RTCRtpSender&gt;      getSenders ();
     sequence&lt;RTCRtpReceiver&gt;    getReceivers ();
     sequence&lt;RTCRtpTransceiver&gt; getTransceivers ();
@@ -5184,7 +5184,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           <h2>Attributes</h2>
           <dl data-link-for="RTCPeerConnection" data-dfn-for=
           "RTCPeerConnection" class="attributes">
-            <dt><dfn data-idl><code>ontrack</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-ontrack.https.html,RTCPeerConnection-transceivers.https.html"><dfn data-idl><code>ontrack</code></dfn> of type <span class=
             "idlAttrType">EventHandler</span></dt>
             <dd>
               <p>The event type of this event handler is
@@ -5196,7 +5196,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           <h2>Methods</h2>
           <dl data-link-for="RTCPeerConnection" data-dfn-for=
           "RTCPeerConnection" class="methods">
-            <dt><code>getSenders</code></dt>
+            <dt data-tests="RTCPeerConnection-getTransceivers.html,RTCPeerConnection-transceivers.https.html"><code>getSenders</code></dt>
             <dd>
               <p>Returns a sequence of <code><a>RTCRtpSender</a></code> objects
               representing the RTP senders that belong to non-stopped
@@ -5222,7 +5222,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <li>Return <var>senders</var>.</li>
               </ol>
             </dd>
-            <dt><code>getReceivers</code></dt>
+            <dt data-tests="RTCPeerConnection-addTransceiver.https.html,RTCPeerConnection-getTransceivers.html,RTCPeerConnection-transceivers.https.html"><code>getReceivers</code></dt>
             <dd>
               <p>Returns a sequence of <code><a>RTCRtpReceiver</a></code> objects
               representing the RTP receivers that belong to non-stopped
@@ -5246,7 +5246,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <li>Return <var>receivers</var>.</li>
               </ol>
             </dd>
-            <dt><code>getTransceivers</code></dt>
+            <dt data-tests="RTCPeerConnection-getTransceivers.html,RTCPeerConnection-transceivers.https.html"><code>getTransceivers</code></dt>
             <dd>
               <p>Returns a sequence of <code><a>RTCRtpTransceiver</a></code>
               objects representing the RTP transceivers that are currently
@@ -5256,7 +5256,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               "dom-peerconnection-gettranseceivers"><code>getTransceivers</code></dfn>
               method MUST return the result of executing the
               <code><a>CollectTransceivers</a></code> algorithm.</p>
-              <p></p>
+
               <p>We define the <dfn>CollectTransceivers</dfn> algorithm as
               follows:</p>
               <ol>
@@ -5268,7 +5268,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <li>Return <var>transceivers</var>.</li>
               </ol>
             </dd>
-            <dt><code>addTrack</code></dt>
+            <dt data-tests="RTCPeerConnection-add-track-no-deadlock.https.html"><code>addTrack</code></dt>
             <dd>
               <p>Adds a new track to the <code><a>RTCPeerConnection</a></code>,
               and indicates that it is contained in the specified
@@ -5289,25 +5289,25 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <li>
                   <p>Let <var>kind</var> be <var>track.kind</var>.</p>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-setRemoteDescription-tracks.https.html">
                   <p>Let <var>streams</var> be a list of
                   <code><a>MediaStream</a></code> objects constructed from the
                   method's remaining arguments, or an empty list if the method
                   was called with a single argument.</p>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-addTrack.https.html">
                   <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
                   <code>true</code>, <a>throw</a> an
                   <code>InvalidStateError</code>.</p>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-addTrack.https.html">
                   <p>Let <var>senders</var> be the result of executing the
                   <code><a>CollectSenders</a></code> algorithm. If an
                   <code><a>RTCRtpSender</a></code> for <var>track</var> already
                   exists in <var>senders</var>, <a>throw</a> an
                   <code>InvalidAccessError</code>.</p>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-addTrack.https.html,RTCPeerConnection-transceivers.https.html">
                   <p>The steps below describe how to determine if an existing
                   sender can be reused. Doing so will cause future calls to
                   <code>createOffer</code> and <code>createAnswer</code> to
@@ -5343,7 +5343,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                     </li>
                   </ul>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-addTrack.https.html,RTCPeerConnection-setRemoteDescription-tracks.https.html,RTCPeerConnection-transceivers.https.html">
                   <p>If <var>sender</var> is not <code>null</code>, run the
                   following steps to use that sender:</p>
                   <ol>
@@ -5380,7 +5380,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                     </li>
                   </ol>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-addTrack.https.html,RTCPeerConnection-transceivers.https.html">
                   <p>If <var>sender</var> is <code>null</code>, run the
                   following steps:</p>
                   <ol>
@@ -5434,7 +5434,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 </li>
               </ol>
             </dd>
-            <dt><code>removeTrack</code></dt>
+            <dt data-tests="RTCPeerConnection-removeTrack.https.html"><code>removeTrack</code></dt>
             <dd>
               <p>Stops sending media from <var>sender</var>. The
               <code><a>RTCRtpSender</a></code> will still appear
@@ -5462,12 +5462,12 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   <code><a>RTCPeerConnection</a></code> object on which
                   the method was invoked.</p>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-removeTrack.https.html,RTCRtpTransceiver.https.html">
                   <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
                   <code>true</code>, <a>throw</a> an
                   <code>InvalidStateError</code>.</p>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-removeTrack.https.html">
                   <p>If <var>sender</var> was not created by
                   <var>connection</var>, <a>throw</a> an
                   <code>InvalidAccessError</code>.</p>
@@ -5486,7 +5486,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   <p>If <var>sender</var>'s <a>[[\SenderTrack]]</a> is null,
                   abort these steps.
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-removeTrack.https.html">
                   <p>Set <var>sender</var>'s <a>[[\SenderTrack]]</a> to null.
                 </li>
                 <li>
@@ -5494,15 +5494,15 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   <code><a>RTCRtpTransceiver</a></code> object corresponding
                   to <var>sender</var>.</p>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-removeTrack.https.html">
                   <p>If <var>transceiver</var>'s <a>[[\Direction]]</a> slot is
                   <code>sendrecv</code>, set <var>transceiver</var>'s
                   <a>[[\Direction]]</a> slot to <code>recvonly</code>.</p>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-removeTrack.https.html">
                   <p>If <var>transceiver</var>'s <a>[[\Direction]]</a> slot
                   is <code>sendonly</code>, set <var>transceiver</var>'s
-                  <a>[[\Direction]]</a> slot to <code>inactive</code>.</p>
+                    <a>[[\Direction]]</a> slot to <code>inactive</code>.</p>
                 </li>
                 <li>
                   <p><a data-lt="update the negotiation-needed flag">Update the
@@ -5510,7 +5510,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 </li>
               </ol>
             </dd>
-            <dt><dfn data-idl><code>addTransceiver</code></dfn></dt>
+            <dt data-tests="RTCRtpTransceiver.https.html"><dfn data-idl><code>addTransceiver</code></dfn></dt>
             <dd>
               <p>Create a new <code><a>RTCRtpTransceiver</a></code> and add it
               to the <a>set of transceivers</a>.</p>
@@ -5518,7 +5518,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <code>createOffer</code> to add a <a>media description</a> for
               the corresponding transceiver, as defined in <span data-jsep=
               "subsequent-offers">[[!JSEP]]</span>.</p>
-              <p>The initial value of <code><a data-link-for=
+              <p data-tests="RTCPeerConnection-addTransceiver.https.html">The initial value of <code><a data-link-for=
               "RTCRtpTransceiver">mid</a></code> is null. Setting a new
               <code><a>RTCSessionDescription</a></code> may change it to a
               non-null value, as defined in <span data-jsep=
@@ -5544,7 +5544,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   <p>Let <var>direction</var> be <var>init</var>'s
                   <code>direction</code> member.</p>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-addTransceiver.https.html,RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html">
                   <p>If the first argument is a string, let it be
                   <var>kind</var> and run the following steps:</p>
                   <ol>
@@ -5558,7 +5558,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                     </li>
                   </ol>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-addTransceiver.https.html,RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html">
                   <p>If the first argument is a
                   <code><a>MediaStreamTrack</a></code>, let it be
                   <var>track</var> and let <var>kind</var> be
@@ -5571,7 +5571,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 </li>
                 <li>Validate <var>sendEncodings</var> by running the following steps:
                 <ol>
-                  <li>
+                  <li data-tests="RTCPeerConnection-addTransceiver.https.html">
                     <p>Verify that each <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>
                     value in <var>sendEncodings</var> conforms to the grammar specified in
                     Section 10 of [[!MMUSIC-RID]]. If one of the RIDs does not meet
@@ -5584,7 +5584,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                     <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>,
                     <a>throw</a> an <code>InvalidAccessError</code>.</p>
                   </li>
-                  <li>
+                  <li data-tests="RTCRtpParameters-encodings.html">
                     <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">scaleResolutionDownBy</a></code>
                     value in <var>sendEncodings</var> is greater than or equal to 1.0. If
                     one of the <code>scaleResolutionDownBy</code> values does not meet
@@ -5621,7 +5621,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                    </li>
                 </ol>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-addTransceiver.https.html,RTCRtpParameters-encodings.html,RTCRtpTransceiver.https.html">
                   <p><a>Create an RTCRtpSender</a> with <var>track</var>,
                   <var>kind</var>, <var>streams</var> and <var>sendEncodings</var>
                   and let <var>sender</var> be the result.</p>
@@ -5638,20 +5638,20 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   <code>sender.getParameters()</code> will reflect the
                   encodings negotiated.</p>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-addTransceiver.https.html,RTCRtpTransceiver.https.html">
                   <p><a>Create an RTCRtpReceiver</a> with <var>kind</var> and
                   let <var>receiver</var> be the result.</p>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-addTransceiver.https.html,RTCRtpTransceiver.https.html">
                   <p><a>Create an RTCRtpTransceiver</a> with <var>sender</var>,
                   <var>receiver</var> and <var>direction</var>, and let
                   <var>transceiver</var> be the result.</p>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-addTransceiver.https.html,RTCRtpTransceiver.https.html">
                   <p>Add <var>transceiver</var> to <var>connection</var>'s
                   <a href="#transceivers-set">set of transceivers</a></p>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
                   <p><a data-lt="update the negotiation-needed flag">Update the
                   negotiation-needed flag</a> for <var>connection</var>.</p>
                 </li>
@@ -5674,7 +5674,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           Members</h2>
           <dl data-link-for="RTCRtpTransceiverInit" data-dfn-for=
           "RTCRtpTransceiverInit" class="dictionary-members">
-            <dt><dfn data-idl><code>direction</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-addTransceiver.https.html, RTCRtpTransceiver-direction.html"><dfn data-idl><code>direction</code></dfn> of type <span class=
             "idlMemberType"><a>RTCRtpTransceiverDirection</a></span>,
             defaulting to <code>"sendrecv"</code></dt>
             <dd>The direction of the <code>RTCRtpTransceiver</code>.</dd>
@@ -5685,7 +5685,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               corresponding to the <code><a>RTCRtpReceiver</a></code> being
               added, these are the streams that will be put in the event.</p>
             </dd>
-            <dt><dfn data-idl><code>sendEncodings</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-encodings.html"><dfn data-idl><code>sendEncodings</code></dfn> of type <span class=
             "idlMemberType">sequence&lt;<a>RTCRtpEncodingParameters</a>&gt;</span></dt>
             <dd>
               <p>A sequence containing parameters for sending RTP encodings of
@@ -5708,7 +5708,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <th colspan="2"><dfn>RTCRtpTransceiverDirection</dfn> Enumeration description</th>
             </tr>
             <tr>
-              <td><dfn data-idl><code>sendrecv</code></dfn></td>
+              <td data-tests="RTCPeerConnection-transceivers.https.html"><dfn data-idl><code>sendrecv</code></dfn></td>
               <td>The <code><a>RTCRtpTransceiver</a></code>'s
               <code><a>RTCRtpSender</a></code> <var>sender</var> will offer to
               send RTP, and will send RTP if the remote peer accepts and
@@ -5719,7 +5719,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               will receive RTP if the remote peer accepts.</td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>sendonly</code></dfn></td>
+              <td data-tests="RTCPeerConnection-transceivers.https.html"><dfn data-idl><code>sendonly</code></dfn></td>
               <td>The <code><a>RTCRtpTransceiver</a></code>'s
               <code><a>RTCRtpSender</a></code> <var>sender</var> will offer to
               send RTP, and will send RTP if the remote peer accepts and
@@ -5730,7 +5730,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               and will not receive RTP.</td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>recvonly</code></dfn></td>
+              <td data-tests="RTCPeerConnection-transceivers.https.html"><dfn data-idl><code>recvonly</code></dfn></td>
               <td>The <code><a>RTCRtpTransceiver</a></code>'s
               <code><a>RTCRtpSender</a></code> will not offer to send RTP, and
               will not send RTP. The <code><a>RTCRtpTransceiver</a></code>'s
@@ -5738,7 +5738,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               will receive RTP if the remote peer accepts.</td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>inactive</code></dfn></td>
+              <td data-tests="RTCPeerConnection-transceivers.https.html"><dfn data-idl><code>inactive</code></dfn></td>
               <td>The <code><a>RTCRtpTransceiver</a></code>'s
               <code><a>RTCRtpSender</a></code> will not offer to send RTP, and
               will not send RTP. The <code><a>RTCRtpTransceiver</a></code>'s
@@ -5760,7 +5760,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
         "applying-a-remote-desc">[[!JSEP]]</span> given
         <code>RTCRtpTransceiver</code> <var>transceiver</var> and
         <var>trackEventInits</var>, the user agent MUST run the following steps:</p>
-        <ol>
+        <ol data-tests="RTCPeerConnection-transceivers.https.html">
           <li>
             <p>Let <var>receiver</var> be <var>transceiver</var>'s
             <a>[[\Receiver]]</a>.
@@ -5789,7 +5789,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
         "applying-a-remote-desc">[[!JSEP]]</span> given
         <code>RTCRtpTransceiver</code> <var>transceiver</var> and
         <var>muteTracks</var>, the user agent MUST run the following steps:</p>
-        <ol>
+        <ol data-tests="RTCPeerConnection-remote-track-mute.https.html">
           <li>
             <p>Let <var>receiver</var> be <var>transceiver</var>'s
             <a>[[\Receiver]]</a>.
@@ -5800,7 +5800,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             <a>[[\ReceiverTrack]]</a>.
             </p>
           </li>
-          <li>
+          <li data-tests="RTCRtpTransceiver.https.html">
             <p>If <var>track.muted</var> is <code>false</code>,
             add <var>track</var> to <var>muteTracks</var>.</p>
           </li>
@@ -5815,7 +5815,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             <code><a>RTCPeerConnection</a></code> object associated with
             <var>receiver</var>.</p>
           </li>
-          <li>
+          <li data-tests="RTCPeerConnection-ontrack.https.html">
             <p>For each MSID in <var>msids</var>, unless a
             <code><a>MediaStream</a></code> object has previously been created
             with that <code>id</code> for this <var>connection</var>, create a
@@ -5840,13 +5840,13 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             pair to <var>removeList</var>.
             </p>
           </li>
-          <li>
+          <li data-tests="RTCPeerConnection-ontrack.https.html">
             <p>For each <var>stream</var> in
             <var>streams</var> that is not present in <var>receiver</var>'s
             <a>[[\AssociatedRemoteMediaStreams]]</a>, add <var>stream</var> and
             <var>track</var> as a pair to <var>addList</var>.</p>
           </li>
-          <li>
+          <li data-tests="RTCPeerConnection-ontrack.https.html">
             <p>Set <var>receiver</var>'s
             <a>[[\AssociatedRemoteMediaStreams]]</a> slot to
             <var>streams</var>.
@@ -5874,7 +5874,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           <p>Let <var>sender</var> be a new <code><a>RTCRtpSender</a></code>
           object.</p>
         </li>
-        <li>
+        <li data-tests="RTCPeerConnection-addTransceiver.https.html">
           <p>Let <var>sender</var> have a <dfn>[[\SenderTrack]]</dfn> internal
           slot initialized to <var>track</var>.</p>
         </li>
@@ -5919,7 +5919,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           internal slot, representing a list of
           <code><a>RTCRtpEncodingParameters</a></code> dictionaries.</p>
         </li>
-        <li>
+        <li data-tests="RTCPeerConnection-transceivers.https.html">
           <p>If <var>sendEncodings</var> is given as input to this algorithm,
           and is non-empty, set the <a>[[\SendEncodings]]</a> slot to
           <var>sendEncodings</var>. Otherwise, set it to a list containing a
@@ -5943,7 +5943,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
         </li>
       </ol>
       <div>
-        <pre class="idl">[Exposed=Window] interface RTCRtpSender {
+        <pre class="idl" data-tests="idlharness.https.window.js">[Exposed=Window] interface RTCRtpSender {
     readonly        attribute MediaStreamTrack? track;
     readonly        attribute RTCDtlsTransport?  transport;
     readonly        attribute RTCDtlsTransport? rtcpTransport;
@@ -5974,7 +5974,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               attribute MUST return the value of the <a>[[\SenderTrack]]</a>
               slot.</p>
             </dd>
-            <dt><dfn data-idl><code>transport</code></dfn> of type <span class=
+            <dt data-tests="RTCDtlsTransport-state.html,RTCRtpSender-transport.https.html"><dfn data-idl><code>transport</code></dfn> of type <span class=
             "idlAttrType"><a>RTCDtlsTransport</a></span>, readonly,
             nullable</dt>
             <dd>
@@ -6010,9 +6010,9 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           <h2>Methods</h2>
           <dl data-link-for="RTCRtpSender" data-dfn-for="RTCRtpSender" class=
           "methods">
-            <dt><code>getCapabilities</code>, static</dt>
+            <dt data-tests="RTCRtpSender-getCapabilities.html"><code>getCapabilities</code>, static</dt>
             <dd>
-              <p>The <dfn data-idl>getCapabilities()</dfn>
+              <p data-tests="RTCRtpSender-getCapabilities.html">The <dfn data-idl>getCapabilities()</dfn>
               method returns the most optimistic view of the capabilities of the
               system for sending media of the given kind. It does not reserve
               any resources, ports, or other state but is meant to provide a
@@ -6028,7 +6028,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               privacy-sensitive contexts, browsers can consider mitigations
               such as reporting only a common subset of the capabilities.</p>
             </dd>
-            <dt><dfn data-idl><code>setParameters</code></dfn></dt>
+            <dt data-tests="RTCRtpParameters-codecs.html,RTCRtpSender-setParameters.html"><dfn data-idl><code>setParameters</code></dfn></dt>
             <dd>
               <p>The <code>setParameters</code> method updates how
               <code>track</code> is encoded and transmitted to a remote
@@ -6045,11 +6045,11 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <code><a>RTCRtpTransceiver</a></code> object associated
                 with <var>sender</var> (i.e. <var>sender</var> is
                 <var>transceiver</var>'s <a>[[\Sender]]</a>).</li>
-                <li>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot is
+                <li data-tests="RTCRtpSender-setParameters.html,RTCRtpTransceiver.https.html">If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot is
                 <code>true</code>, return a promise <a>rejected</a> with a newly
                 <a data-link-for="exception" data-lt="create">created</a>
                 <code>InvalidStateError</code>.</li>
-                <li>If <var>sender</var>'s <a>[[\LastReturnedParameters]]</a>
+                <li data-tests="RTCRtpParameters-transactionId.html">If <var>sender</var>'s <a>[[\LastReturnedParameters]]</a>
                 internal slot is <code>null</code>, return a promise
                 <a>rejected</a> with a newly
                 <a data-link-for="exception" data-lt="create">created</a>
@@ -6073,13 +6073,13 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                    <a data-link-for="exception" data-lt="create">created</a>
                    <code>InvalidModificationError</code>:
                    <ol>
-                     <li>
+                     <li data-tests="RTCRtpParameters-encodings.html">
                        <code><var>encodings</var>.length</code> is different from <var>N</var>.
                      </li>
                      <li>
                        <var>encodings</var> has been re-ordered.
                      </li>
-                     <li>
+                     <li data-tests="RTCRtpParameters-codecs.html,RTCRtpParameters-encodings.html,RTCRtpParameters-headerExtensions.html,RTCRtpParameters-rtcp.html,RTCRtpParameters-transactionId.html">
                        Any parameter in <var>parameters</var> is marked as a
                        <dfn>Read-only parameter</dfn> (such as RID) and has a
                        value that is different from the corresponding parameter
@@ -6088,7 +6088,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                      </li>
                    </ol>
                  </li>
-                 <li>
+                 <li data-tests="RTCRtpParameters-encodings.html">
                    <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">scaleResolutionDownBy</a></code>
                    value in <var>encodings</var> is greater than or equal to 1.0. If
                    one of the <code>scaleResolutionDownBy</code> values does not meet
@@ -6115,7 +6115,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                     <var>parameters</var>, queue a task to run the following
                     steps:
                       <ol>
-                        <li>Set <var>sender</var>'s internal
+                        <li data-tests="RTCRtpParameters-degradationPreference.html">Set <var>sender</var>'s internal
                         <a>[[\LastReturnedParameters]]</a> slot to
                         <code>null</code>.</li>
                         <li>Set <var>sender</var>'s internal
@@ -6160,7 +6160,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               satisfies constraints on bitrate specified in other places such
               as the SDP.</p>
             </dd>
-            <dt><code>getParameters</code></dt>
+            <dt data-tests="RTCRtpParameters-codecs.html"><code>getParameters</code></dt>
             <dd>
               <p>The <dfn data-idl>getParameters()</dfn> method
               returns the <code><a>RTCRtpSender</a></code> object's current
@@ -6171,27 +6171,27 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <code><a>RTCRtpSendParameters</a></code> dictionary is
               constructed as follows:</p>
               <ul>
-                <li>
+                <li data-tests="RTCRtpParameters-codecs.html,RTCRtpParameters-encodings.html,RTCRtpParameters-transactionId.html">
                   <code><a data-link-for="RTCRtpSendParameters">transactionId</a></code>
                   is set to a new unique identifier, used to match this
                   <code>getParameters</code> call to a
                   <code>setParameters</code> call that may occur later.
                 </li>
-                <li>
+                <li data-tests="RTCRtpParameters-encodings.html">
                   <code><a data-link-for="RTCRtpSendParameters">encodings</a></code>
                   is set to the value of the <a>[[\SendEncodings]]</a> internal
                   slot.
                 </li>
-                <li>
+                <li data-tests="RTCRtpParameters-headerExtensions.html">
                   The <code><a data-link-for="RTCRtpParameters">headerExtensions</a></code>
                   sequence is populated based on the header extensions that
                   have been negotiated for sending.
                 </li>
-                <li>
+                <li data-tests="RTCRtpParameters-codecs.html">
                   <code><a data-link-for="RTCRtpParameters">codecs</a></code>
                   is set to the value of the <a>[[\SendCodecs]]</a> internal slot.
                 </li>
-                <li>
+                <li data-tests="RTCRtpParameters-encodings.html">
                   <code><a data-link-for="RTCRtpParameters">rtcp</a>.cname</code>
                   is set to the CNAME of the associated
                   <code><a>RTCPeerConnection</a></code>.
@@ -6207,7 +6207,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 </li>
               </ul>
 
-              <p>The returned <code><a>RTCRtpSendParameters</a></code> dictionary
+              <p data-tests="RTCRtpParameters-codecs.html">The returned <code><a>RTCRtpSendParameters</a></code> dictionary
               MUST be stored in the <code><a>RTCRtpSender</a></code> object's
               <a>[[\LastReturnedParameters]]</a> internal slot.</p>
 
@@ -6230,7 +6230,7 @@ async function updateParameters() {
               subsequent calls to <code>getParameters</code> will return the
               modified set of parameters.</p>
             </dd>
-            <dt><code>replaceTrack</code></dt>
+            <dt data-tests="RTCPeerConnection-setRemoteDescription-replaceTrack.https.html,RTCRtpSender-replaceTrack.https.html"><code>replaceTrack</code></dt>
             <dd>
               <p>Attempts to replace the <code><a>RTCRtpSender</a></code>'s
               current <code>track</code> with another track provided (or
@@ -6257,7 +6257,7 @@ async function updateParameters() {
                   <p>Let <var>withTrack</var> be the argument to this
                   method.</p>
                 </li>
-                <li>
+                <li data-tests="RTCRtpSender-replaceTrack.https.html">
                   <p>If <code><var>withTrack</var></code> is non-null and
                   <code><var>withTrack</var>.kind</code> differs from the
                   <a>transceiver kind</a> of <var>transceiver</var>, return a
@@ -6270,7 +6270,7 @@ async function updateParameters() {
                     "#enqueue-an-operation">enqueuing</a> the following
                   steps to <var>connection</var>'s operation queue:</p>
                   <ol>
-                  <li>
+                  <li data-tests="RTCPeerConnection-setRemoteDescription-replaceTrack.https.html,RTCRtpSender-replaceTrack.https.html,RTCRtpTransceiver.https.html">
                     <p>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot is
                     <code>true</code>, return a promise <a>rejected</a>
                     with a newly <a data-link-for="exception" data-lt="create">
@@ -6288,12 +6288,12 @@ async function updateParameters() {
                     <li>
                       <p>Run the following steps in parallel:</p>
                       <ol>
-                        <li>
+                        <li data-tests="RTCRtpSender-replaceTrack.https.html">
                           <p>If <var>sending</var> is <code>true</code>, and
                           <var>withTrack</var> is <code>null</code>, have the
                           sender stop sending.</p>
                         </li>
-                        <li>
+                        <li data-tests="RTCRtpSender-replaceTrack.https.html">
                           <p>If <var>sending</var> is <code>true</code>, and
                           <var>withTrack</var> is not <code>null</code>,
                           determine if <var>withTrack</var> can be sent
@@ -6312,13 +6312,13 @@ async function updateParameters() {
                           track.</p>
                         </li>
                         <li>
-                          <p>Queue a task that runs the following steps:</p>
+                          <p data-tests="RTCPeerConnection-setRemoteDescription-replaceTrack.https.html,RTCRtpSender-replaceTrack.https.html">Queue a task that runs the following steps:</p>
                           <ol>
                             <li>
                               <p>If <var>connection</var>'s <a>[[\IsClosed]]</a>
                               slot is <code>true</code>, abort these steps.</p>
                             </li>
-                            <li>
+                            <li data-tests="RTCPeerConnection-setRemoteDescription-replaceTrack.https.html">
                               <p>Set <var>sender</var>'s <code><a data-link-for=
                               "RTCRtpSender">track</a></code> attribute to
                               <var>withTrack</var>.</p>
@@ -6403,7 +6403,7 @@ async function updateParameters() {
                 </li>
               </ol>
             </dd>
-            <dt><code>getStats</code></dt>
+            <dt data-tests="RTCPeerConnection-getStats.https.html,RTCRtpSender-getStats.https.html"><code>getStats</code></dt>
             <dd>
               <p>Gathers stats for this sender only and reports the result
               asynchronously.</p>
@@ -6411,7 +6411,7 @@ async function updateParameters() {
               "widl-RTCRtpSender-getStats-Promise-RTCStatsReport">
               <code>getStats()</code></dfn> method is invoked, the user
               agent MUST run the following steps:</p>
-              <ol>
+              <ol data-tests="RTCRtpSender-getStats.https.html">
                 <li>
                   <p>Let <var>selector</var> be the
                   <code><a>RTCRtpSender</a></code> object on which the method
@@ -6452,19 +6452,19 @@ async function updateParameters() {
           <h2>Dictionary <code><a>RTCRtpParameters</a></code> Members</h2>
           <dl data-link-for="RTCRtpParameters" data-dfn-for="RTCRtpParameters"
           class="dictionary-members">
-            <dt><dfn data-idl><code>headerExtensions</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-headerExtensions.html"><dfn data-idl><code>headerExtensions</code></dfn> of type <span class=
             "idlMemberType">sequence&lt;<a>RTCRtpHeaderExtensionParameters</a>&gt;</span>,
             required</dt>
             <dd>
               <p>A sequence containing parameters for RTP header
               extensions. <a>Read-only parameter</a>.</p>
             </dd>
-            <dt><dfn data-idl><code>rtcp</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-rtcp.html"><dfn data-idl><code>rtcp</code></dfn> of type <span class=
             "idlMemberType"><a>RTCRtcpParameters</a></span>, required</dt>
             <dd>
               <p>Parameters used for RTCP. <a>Read-only parameter</a>.</p>
             </dd>
-            <dt><dfn data-idl><code>codecs</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-codecs.html"><dfn data-idl><code>codecs</code></dfn> of type <span class=
             "idlMemberType">sequence&lt;<a>RTCRtpCodecParameters</a>&gt;</span>,
             required</dt>
             <dd>
@@ -6494,7 +6494,7 @@ async function updateParameters() {
           <h2>Dictionary <code><a>RTCRtpSendParameters</a></code> Members</h2>
           <dl data-link-for="RTCRtpSendParameters" data-dfn-for="RTCRtpSendParameters"
           class="dictionary-members">
-            <dt><dfn data-idl><code>transactionId</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-transactionId.html"><dfn data-idl><code>transactionId</code></dfn> of type <span class=
             "idlMemberType">DOMString</span>, required</dt>
             <dd>
               <p>An unique identifier for the last set of parameters applied.
@@ -6508,7 +6508,7 @@ async function updateParameters() {
               <p>A sequence containing parameters for RTP encodings of
               media.</p>
             </dd>
-            <dt><dfn data-idl><code>degradationPreference</code></dfn> of type
+            <dt data-tests="RTCRtpParameters-degradationPreference.html"><dfn data-idl><code>degradationPreference</code></dfn> of type
             <span class="idlMemberType"><a>RTCDegradationPreference</a></span>,
             defaulting to <code>"balanced"</code></dt>
             <dd>
@@ -6571,7 +6571,7 @@ async function updateParameters() {
           Members</h2>
           <dl data-link-for="RTCRtpCodingParameters" data-dfn-for=
           "RTCRtpCodingParameters" class="dictionary-members">
-            <dt><dfn data-idl><code>rid</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-encodings.html"><dfn data-idl><code>rid</code></dfn> of type <span class=
             "idlMemberType">DOMString</span></dt>
             <dd>
               <p>If set, this RTP encoding will be sent with the RID header
@@ -6617,7 +6617,7 @@ async function updateParameters() {
               <code><a>RTCRtpParameters</a></code>. <a>Read-only
               parameter</a>.</p>
             </dd>
-            <dt><dfn data-idl><code>dtx</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-encodings.html"><dfn data-idl><code>dtx</code></dfn> of type <span class=
             "idlMemberType"><a>RTCDtxStatus</a></span></dt>
             <dd>
               <p>This member is only used if the sender's <code>kind</code>
@@ -6633,7 +6633,7 @@ async function updateParameters() {
               value of <code>dtx</code>, and media will be sent even when silence
               is detected.</p>
             </dd>
-            <dt><dfn data-idl><code>active</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-transceivers.https.html,RTCRtpParameters-encodings.html"><dfn data-idl><code>active</code></dfn> of type <span class=
             "idlMemberType">boolean</span>, defaulting to
             <code>true</code></dt>
             <dd>
@@ -6642,7 +6642,7 @@ async function updateParameters() {
               causes this encoding to no longer be sent. Setting it to <code>true</code>
               causes this encoding to be sent.
             </dd>
-            <dt><dfn data-idl><code>ptime</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-encodings.html"><dfn data-idl><code>ptime</code></dfn> of type <span class=
             "idlMemberType">unsigned long</span></dt>
             <dd>
               <p>When present, indicates the
@@ -6656,7 +6656,7 @@ async function updateParameters() {
               the user agent MUST still respect the limit imposed by any
               "maxptime" attribute, as defined in [[!RFC4566]], Section 6.</p>
             </dd>
-            <dt><dfn data-idl><code>maxBitrate</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-encodings.html"><dfn data-idl><code>maxBitrate</code></dfn> of type <span class=
             "idlMemberType">unsigned long</span></dt>
             <dd>
               <p>When present, indicates the maximum bitrate that can be used to send this
@@ -6670,7 +6670,7 @@ async function updateParameters() {
               maximum bandwidth needed without counting IP or other transport
               layers like TCP or UDP.</p>
             </dd>
-            <dt><dfn data-idl><code>maxFramerate</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-encodings.html"><dfn data-idl><code>maxFramerate</code></dfn> of type <span class=
             "idlMemberType">double</span></dt>
             <dd>
               <p>When present, indicates the maximum framerate that can be used to send this
@@ -6685,7 +6685,7 @@ async function updateParameters() {
                 the effect of freezing the video on the next frame.
               </p>
             </dd>
-            <dt><dfn data-idl><code>scaleResolutionDownBy</code></dfn> of type
+            <dt data-tests="RTCRtpParameters-encodings.html"><dfn data-idl><code>scaleResolutionDownBy</code></dfn> of type
             <span class="idlMemberType">double</span></dt>
             <dd>
               <p>This member is only present if the sender's <code>kind</code>
@@ -6722,7 +6722,7 @@ async function updateParameters() {
               </td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>enabled</code></dfn></td>
+              <td data-tests="RTCRtpParameters-encodings.html"><dfn data-idl><code>enabled</code></dfn></td>
               <td>
                 <p>Discontinuous transmission is enabled if negotiated.</p>
               </td>
@@ -6746,7 +6746,7 @@ async function updateParameters() {
               <th colspan="2"><code><a>RTCDegradationPreference</a></code> Enumeration description</th>
             </tr>
             <tr>
-              <td><dfn data-idl><code>maintain-framerate</code></dfn></td>
+              <td data-tests="RTCRtpParameters-degradationPreference.html"><dfn data-idl><code>maintain-framerate</code></dfn></td>
               <td>
                 <p>Degrade resolution in order to maintain framerate.</p>
               </td>
@@ -6758,7 +6758,7 @@ async function updateParameters() {
               </td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>balanced</code></dfn></td>
+              <td data-tests="RTCRtpParameters-degradationPreference.html"><dfn data-idl><code>balanced</code></dfn></td>
               <td>
                 <p>Degrade a balance of framerate and resolution.</p>
               </td>
@@ -6778,13 +6778,13 @@ async function updateParameters() {
           <h2>Dictionary <code><a>RTCRtcpParameters</a></code> Members</h2>
           <dl data-link-for="RTCRtcpParameters" data-dfn-for=
           "RTCRtcpParameters" class="dictionary-members">
-            <dt><dfn data-idl><code>cname</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-encodings.html, RTCRtpParameters-rtcp.html,RTCRtpReceiver-getParameters.html"><dfn data-idl><code>cname</code></dfn> of type <span class=
             "idlMemberType">DOMString</span></dt>
             <dd>
               <p>The Canonical Name (CNAME) used by RTCP (e.g. in SDES
               messages). <a>Read-only parameter</a>.</p>
             </dd>
-            <dt><dfn data-idl><code>reducedSize</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-encodings.html,RTCRtpParameters-rtcp.html,RTCRtpReceiver-getParameters.html"><dfn data-idl><code>reducedSize</code></dfn> of type <span class=
             "idlMemberType">boolean</span></dt>
             <dd>
               <p>Whether reduced size RTCP [[RFC5506]] is configured (if true)
@@ -6808,19 +6808,19 @@ async function updateParameters() {
           Members</h2>
           <dl data-link-for="RTCRtpHeaderExtensionParameters" data-dfn-for=
           "RTCRtpHeaderExtensionParameters" class="dictionary-members">
-            <dt><dfn data-idl><code>uri</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-headerExtensions.html,RTCRtpReceiver-getParameters.html"><dfn data-idl><code>uri</code></dfn> of type <span class=
             "idlMemberType">DOMString</span>, required</dt>
             <dd>
               <p>The URI of the RTP header extension, as defined in
               [[RFC5285]]. <a>Read-only parameter</a>.</p>
             </dd>
-            <dt><dfn data-idl><code>id</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-headerExtensions.html,RTCRtpReceiver-getParameters.html"><dfn data-idl><code>id</code></dfn> of type <span class=
             "idlMemberType">unsigned short</span>, required</dt>
             <dd>
               <p>The value put in the RTP packet to identify the header
               extension. <a>Read-only parameter</a>.</p>
             </dd>
-            <dt><dfn data-idl><code>encrypted</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-headerExtensions.html,RTCRtpReceiver-getParameters.html"><dfn data-idl><code>encrypted</code></dfn> of type <span class=
             "idlMemberType">boolean</span></dt>
             <dd>
               <p>Whether the header extension is encrypted or not. <a>Read-only
@@ -6866,32 +6866,32 @@ async function updateParameters() {
           <h2>Dictionary <code><a>RTCRtpCodecParameters</a></code> Members</h2>
           <dl data-link-for="RTCRtpCodecParameters" data-dfn-for=
           "RTCRtpCodecParameters" class="dictionary-members">
-            <dt><dfn data-idl><code>payloadType</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-codecs.html"><dfn data-idl><code>payloadType</code></dfn> of type <span class=
             "idlMemberType">octet</span></dt>
             <dd>
               <p>The RTP payload type used to identify this codec. <a>Read-only
               parameter</a>.</p>
             </dd>
-            <dt><dfn data-idl><code>mimeType</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-codecs.html"><dfn data-idl><code>mimeType</code></dfn> of type <span class=
             "idlMemberType">DOMString</span></dt>
             <dd>
               <p>The codec MIME media type/subtype. Valid media types and
               subtypes are listed in [[IANA-RTP-2]]. <a>Read-only
               parameter</a>.</p>
             </dd>
-            <dt><dfn data-idl><code>clockRate</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-codecs.html"><dfn data-idl><code>clockRate</code></dfn> of type <span class=
             "idlMemberType">unsigned long</span></dt>
             <dd>
               <p>The codec clock rate expressed in Hertz. <a>Read-only
               parameter</a>.</p>
             </dd>
-            <dt><dfn data-idl><code>channels</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-codecs.html"><dfn data-idl><code>channels</code></dfn> of type <span class=
             "idlMemberType">unsigned short</span></dt>
             <dd>
               <p>When present, indicates the number of channels (mono=1, stereo=2). <a>Read-only
               parameter</a>.</p>
             </dd>
-            <dt><dfn data-idl><code>sdpFmtpLine</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-codecs.html"><dfn data-idl><code>sdpFmtpLine</code></dfn> of type <span class=
             "idlMemberType">DOMString</span></dt>
             <dd>
               <p>The "format specific parameters" field from the "a=fmtp" line
@@ -6917,7 +6917,7 @@ async function updateParameters() {
           <h2>Dictionary <code><a>RTCRtpCapabilities</a></code> Members</h2>
           <dl data-link-for="RTCRtpCapabilities" data-dfn-for=
           "RTCRtpCapabilities" class="dictionary-members">
-            <dt><dfn data-idl><code>codecs</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpReceiver-getCapabilities.html"><dfn data-idl><code>codecs</code></dfn> of type <span class=
             "idlMemberType">sequence&lt;<a>RTCRtpCodecCapability</a>&gt;</span>, required</dt>
             <dd>
               <p>Supported media codecs as well as entries for RTX, RED and FEC
@@ -6925,7 +6925,7 @@ async function updateParameters() {
               <code>codecs[]</code> for retransmission via RTX, with
               <code>sdpFmtpLine</code> not present.</p>
             </dd>
-            <dt><dfn data-idl><code>headerExtensions</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpReceiver-getCapabilities.html"><dfn data-idl><code>headerExtensions</code></dfn> of type <span class=
             "idlMemberType">sequence&lt;<a>RTCRtpHeaderExtensionCapability</a>&gt;</span>, required</dt>
             <dd>
               <p>Supported RTP header extensions.</p>
@@ -6956,23 +6956,23 @@ async function updateParameters() {
           </ol>
           <dl data-link-for="RTCRtpCodecCapability" data-dfn-for=
           "RTCRtpCodecCapability" class="dictionary-members">
-            <dt><dfn data-idl><code>mimeType</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpReceiver-getCapabilities.html"><dfn data-idl><code>mimeType</code></dfn> of type <span class=
             "idlMemberType">DOMString</span>, required</dt>
             <dd>
               <p>The codec MIME media type/subtype. Valid media types and
               subtypes are listed in [[IANA-RTP-2]].</p>
             </dd>
-            <dt><dfn data-idl><code>clockRate</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpReceiver-getCapabilities.html"><dfn data-idl><code>clockRate</code></dfn> of type <span class=
             "idlMemberType">unsigned long</span>, required</dt>
             <dd>
               <p>The codec clock rate expressed in Hertz.</p>
             </dd>
-            <dt><dfn data-idl><code>channels</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpReceiver-getCapabilities.html"><dfn data-idl><code>channels</code></dfn> of type <span class=
             "idlMemberType">unsigned short</span></dt>
             <dd>
               <p>If present, indicates the maximum number of channels (mono=1, stereo=2).</p>
             </dd>
-            <dt><dfn data-idl><code>sdpFmtpLine</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpReceiver-getCapabilities.html"><dfn data-idl><code>sdpFmtpLine</code></dfn> of type <span class=
             "idlMemberType">DOMString</span></dt>
             <dd>
               <p>The "format specific parameters" field from the "a=fmtp" line
@@ -6992,7 +6992,7 @@ async function updateParameters() {
           <h2>Dictionary <code><a>RTCRtpHeaderExtensionCapability</a></code> Members</h2>
           <dl data-link-for="RTCRtpHeaderExtensionCapability" data-dfn-for=
           "RTCRtpHeaderExtensionCapability" class="dictionary-members">
-            <dt><dfn data-idl><code>uri</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpReceiver-getCapabilities.html"><dfn data-idl><code>uri</code></dfn> of type <span class=
             "idlMemberType">DOMString</span></dt>
             <dd>
               <p>The URI of the RTP header extension, as defined in
@@ -7021,24 +7021,24 @@ async function updateParameters() {
           the <var>track.id</var> is generated by the <a>user agent</a> and does
           not map to any track IDs on the remote side.</p>
         </li>
-        <li>
+        <li data-tests="RTCPeerConnection-addTransceiver.https.html,RTCPeerConnection-transceivers.https.html">
           <p>Initialize <var>track.kind</var> to <var>kind</var>.</p>
         </li>
-        <li>
+        <li data-tests="RTCPeerConnection-addTransceiver.https.html">
           <p>Initialize <var>track.label</var> to the result of concatenating
           the string <code>"remote "</code> with <var>kind</var>.</p>
         </li>
-        <li>
+        <li data-tests="RTCPeerConnection-addTransceiver.https.html">
           <p>Initialize <var>track.readyState</var> to <code>live</code>.</p>
         </li>
-        <li>
+        <li data-tests="RTCPeerConnection-addTransceiver.https.html,RTCPeerConnection-transceivers.https.html">
           <p>Initialize <var>track.muted</var> to <code>true</code>. See the
           <a href="#mediastreamtrack-network-use">MediaStreamTrack</a> section
           about how the <code>muted</code> attribute reflects if a
           <code><a>MediaStreamTrack</a></code> is receiving media data or
           not.</p>
         </li>
-        <li>
+        <li data-tests="RTCPeerConnection-addTransceiver.https.html">
           <p>Let <var>receiver</var> have a <dfn>[[\ReceiverTrack]]</dfn>
           internal slot initialized to <var>track</var>.</p>
         </li>
@@ -7068,7 +7068,7 @@ async function updateParameters() {
         </li>
       </ol>
       <div>
-        <pre class="idl">[Exposed=Window] interface RTCRtpReceiver {
+        <pre class="idl" data-tests="idlharness.https.window.js">[Exposed=Window] interface RTCRtpReceiver {
     readonly        attribute MediaStreamTrack  track;
     readonly        attribute RTCDtlsTransport? transport;
     readonly        attribute RTCDtlsTransport? rtcpTransport;
@@ -7131,9 +7131,9 @@ async function updateParameters() {
           <h2>Methods</h2>
           <dl data-link-for="RTCRtpReceiver" data-dfn-for="RTCRtpReceiver"
           class="methods">
-            <dt><code>getCapabilities</code>, static</dt>
+            <dt data-tests="RTCRtpReceiver-getCapabilities.html"><code>getCapabilities</code>, static</dt>
             <dd>
-              <p>The <dfn data-idl>getCapabilities()</dfn>
+              <p data-tests="RTCRtpReceiver-getCapabilities.html">The <dfn data-idl>getCapabilities()</dfn>
               method returns the most optimistic view of the capabilities of
               the system for receiving media of the given kind. It does not
               reserve any resources, ports, or other state but is meant to
@@ -7149,7 +7149,7 @@ async function updateParameters() {
               privacy-sensitive contexts, browsers can consider mitigations
               such as reporting only a common subset of the capabilities.</p>
             </dd>
-            <dt><code>getParameters</code></dt>
+            <dt data-tests="RTCRtpReceiver-getParameters.html"><code>getParameters</code></dt>
             <dd>
               <p>The <dfn data-idl>getParameters()</dfn> method returns the
               <code>RTCRtpReceiver</code> object's current parameters for how
@@ -7159,17 +7159,17 @@ async function updateParameters() {
               <code><a>RTCRtpReceiveParameters</a></code> dictionary is
               constructed as follows:</p>
               <ul>
-                <li>
+                <li data-tests="RTCRtpReceiver-getParameters.html">
                   <p><code><a data-link-for="RTCRtpReceiveParameters">encodings</a></code>
                   is populated based on the RIDs present in the current remote
                   description.</p>
                 </li>
-                <li>
+                <li data-tests="RTCRtpReceiver-getParameters.html">
                   The <code><a data-link-for="RTCRtpParameters">headerExtensions</a></code>
                   sequence is populated based on the header extensions that the
                   receiver is currently prepared to receive.
                 </li>
-                <li>
+                <li data-tests="RTCRtpReceiver-getParameters.html">
                   <p><code><a data-link-for="RTCRtpParameters">codecs</a></code>
                   is set to the value of the <a>[[\ReceiveCodecs]]</a> internal
                   slot.</p>
@@ -7182,7 +7182,7 @@ async function updateParameters() {
                   by <code>getParameters</code> as the receiver no longer needs
                   to be prepared to receive it.</div>
                 </li>
-                <li>
+                <li data-tests="RTCRtpReceiver-getParameters.html">
                   <code><a data-link-for="RTCRtpParameters">rtcp</a>.reducedSize</code>
                   is set to <code>true</code> if the receiver is currently prepared to
                   receive reduced-size RTCP packets, and <code>false</code> otherwise.
@@ -7191,19 +7191,19 @@ async function updateParameters() {
                 </li>
               </ul>
             </dd>
-            <dt><dfn data-idl><code>getContributingSources</code></dfn></dt>
+            <dt data-tests="RTCRtpReceiver-getContributingSources.https.html"><dfn data-idl><code>getContributingSources</code></dfn></dt>
             <dd>
               <p>Returns an <code><a>RTCRtpContributingSource</a></code> for
               each unique CSRC identifier received by this RTCRtpReceiver in
               the last 10 seconds.</p>
             </dd>
-            <dt><dfn data-idl><code>getSynchronizationSources</code></dfn></dt>
+            <dt data-tests="RTCRtpReceiver-getSynchronizationSources.https.html"><dfn data-idl><code>getSynchronizationSources</code></dfn></dt>
             <dd>
               <p>Returns an <code><a>RTCRtpSynchronizationSource</a></code> for
               each unique SSRC identifier received by this RTCRtpReceiver in
               the last 10 seconds.</p>
             </dd>
-            <dt><code>getStats</code></dt>
+            <dt data-tests="RTCRtpReceiver-getStats.https.html"><code>getStats</code></dt>
             <dd>
               <p>Gathers stats for this receiver only and reports the result
               asynchronously.</p>
@@ -7211,7 +7211,7 @@ async function updateParameters() {
               "widl-RTCRtpReceiver-getStats-Promise-RTCStatsReport">
               <code>getStats()</code></dfn> method is invoked, the user
               agent MUST run the following steps:</p>
-              <ol>
+              <ol data-tests="RTCRtpReceiver-getStats.https.html">
                 <li>
                   <p>Let <var>selector</var> be the
                   <code><a>RTCRtpReceiver</a></code> object on which the method
@@ -7277,7 +7277,7 @@ async function updateParameters() {
           <h2>Dictionary RTCRtpContributingSource Members</h2>
           <dl data-link-for="RTCRtpContributingSource" data-dfn-for=
           "RTCRtpContributingSource" class="dictionary-members">
-            <dt><dfn data-idl><code>timestamp</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpReceiver-getSynchronizationSources.https.html"><dfn data-idl><code>timestamp</code></dfn> of type <span class=
             "idlMemberType">DOMHighResTimeStamp</span>, required</dt>
             <dd>
               <p>The timestamp of type DOMHighResTimeStamp [[!HIGHRES-TIME]],
@@ -7286,13 +7286,13 @@ async function updateParameters() {
               defined as <a>performance.timeOrigin</a> +
               <a>performance.now()</a> at the time of playout.</p>
             </dd>
-            <dt><dfn data-idl><code>source</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpReceiver-getSynchronizationSources.https.html"><dfn data-idl><code>source</code></dfn> of type <span class=
             "idlMemberType">unsigned long</span>, required</dt>
             <dd>
               <p>The CSRC or SSRC identifier of the contributing or
               synchronization source.</p>
             </dd>
-            <dt><dfn data-idl><code>audioLevel</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpReceiver-getSynchronizationSources.https.html"><dfn data-idl><code>audioLevel</code></dfn> of type <span class=
             "idlMemberType">double</span></dt>
             <dd>
               <p>Only present for audio receivers. This is a value between 0..1
@@ -7327,7 +7327,7 @@ async function updateParameters() {
           <h2>Dictionary RTCRtpSynchronizationSource Members</h2>
           <dl data-link-for="RTCRtpSynchronizationSource" data-dfn-for=
           "RTCRtpSynchronizationSource" class="dictionary-members">
-            <dt><dfn data-idl><code>voiceActivityFlag</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpReceiver-getSynchronizationSources.https.html"><dfn data-idl><code>voiceActivityFlag</code></dfn> of type <span class=
             "idlMemberType">boolean</span></dt>
             <dd>
               <p>Only present for audio receivers. Whether the last RTP packet
@@ -7366,19 +7366,19 @@ async function updateParameters() {
           <p>Let <var>transceiver</var> be a new
           <code><a>RTCRtpTransceiver</a></code> object.</p>
         </li>
-        <li>
+        <li data-tests="RTCPeerConnection-addTransceiver.https.html">
           <p>Let <var>transceiver</var> have a <dfn>[[\Sender]]</dfn> internal
           slot, initialized to <var>sender</var>.</p>
         </li>
-        <li>
+        <li data-tests="RTCPeerConnection-addTransceiver.https.html">
           <p>Let <var>transceiver</var> have a <dfn>[[\Receiver]]</dfn> internal
           slot, initialized to <var>receiver</var>.</p>
         </li>
-        <li>
+        <li data-tests="RTCPeerConnection-addTransceiver.https.html,RTCPeerConnection-transceivers.https.html">
           <p>Let <var>transceiver</var> have a <dfn>[[\Stopped]]</dfn> internal
           slot, initialized to <code>false</code>.</p>
         </li>
-        <li>
+        <li data-tests="RTCPeerConnection-addTransceiver.https.html,RTCPeerConnection-transceivers.https.html">
           <p>Let <var>transceiver</var> have a <dfn>[[\Direction]]</dfn> internal slot, initialized to
           <var>direction</var>.</p>
         </li>
@@ -7386,11 +7386,11 @@ async function updateParameters() {
           <p>Let <var>transceiver</var> have a <dfn>[[\Receptive]]</dfn> internal slot,
           initialized to <code>false</code>.</p>
         </li>
-        <li>
+        <li data-tests="RTCPeerConnection-addTransceiver.https.html,RTCPeerConnection-transceivers.https.html">
           <p>Let <var>transceiver</var> have a <dfn>[[\CurrentDirection]]</dfn> internal slot,
           initialized to <code>null</code>.</p>
         </li>
-        <li>
+        <li data-tests="RTCRtpTransceiver-direction.html">
           <p>Let <var>transceiver</var> have a <dfn>[[\FiredDirection]]</dfn> internal slot,
           initialized to <code>null</code>.</p>
         </li>
@@ -7408,7 +7408,7 @@ async function updateParameters() {
       of the process of <a data-lt="set the RTCSessionDescription">setting an
       <code>RTCSessionDescription</code></a>.</div>
       <div>
-        <pre class="idl">[Exposed=Window] interface RTCRtpTransceiver {
+        <pre class="idl" data-tests="idlharness.https.window.js">[Exposed=Window] interface RTCRtpTransceiver {
     readonly        attribute DOMString?                  mid;
     [SameObject]
     readonly        attribute RTCRtpSender                sender;
@@ -7424,7 +7424,7 @@ async function updateParameters() {
           <h2>Attributes</h2>
           <dl data-link-for="RTCRtpTransceiver" data-dfn-for=
           "RTCRtpTransceiver" class="attributes">
-            <dt><code>mid</code> of type <span class=
+            <dt data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html"><code>mid</code> of type <span class=
             "idlAttrType">DOMString</span>, readonly, nullable</dt>
             <dd>
               <p>The <dfn id="dom-rtptransceiver-mid"><code>mid</code></dfn>
@@ -7435,7 +7435,7 @@ async function updateParameters() {
               After rollbacks, the value may change from a non-null value
               to null.</p>
             </dd>
-            <dt><dfn data-idl><code>sender</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html"><dfn data-idl><code>sender</code></dfn> of type <span class=
             "idlAttrType"><a>RTCRtpSender</a></span>, readonly</dt>
             <dd>
               <p>The <code>sender</code> attribute exposes the
@@ -7444,7 +7444,7 @@ async function updateParameters() {
               the attribute MUST return the value of the <a>[[\Sender]]</a>
               slot.</p>
             </dd>
-            <dt><dfn data-idl><code>receiver</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html"><dfn data-idl><code>receiver</code></dfn> of type <span class=
             "idlAttrType"><a>RTCRtpReceiver</a></span>, readonly</dt>
             <dd>
               <p>The <code>receiver</code> attribute is the
@@ -7453,7 +7453,7 @@ async function updateParameters() {
               getting the attribute MUST return the value of the
               <a>[[\Receiver]]</a> slot.</p>
             </dd>
-            <dt><dfn data-idl><code>stopped</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html"><dfn data-idl><code>stopped</code></dfn> of type <span class=
             "idlAttrType">boolean</span>, readonly</dt>
             <dd>
               <p>The <code>stopped</code> attribute indicates that the sender
@@ -7464,7 +7464,7 @@ async function updateParameters() {
               getting, this attribute MUST return the value of the
               <a>[[\Stopped]]</a> slot.</p>
             </dd>
-            <dt><dfn data-idl><code>direction</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html"><dfn data-idl><code>direction</code></dfn> of type <span class=
             "idlAttrType"><a>RTCRtpTransceiverDirection</a></span></dt>
             <dd>
               <p>As defined in <span data-jsep=
@@ -7501,7 +7501,7 @@ async function updateParameters() {
                   <code>true</code>, <a>throw</a> an
                   <code>InvalidStateError</code>.</p>
                 </li>
-                <li>
+                <li data-tests="RTCRtpTransceiver.https.html">
                   <p>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot is
                   <code>true</code>, <a>throw</a> an
                   <code>InvalidStateError</code>.</p>
@@ -7510,7 +7510,7 @@ async function updateParameters() {
                   <p>Let <var>newDirection</var> be the argument to the
                   setter.</p>
                 </li>
-                <li>
+                <li data-tests="RTCRtpTransceiver-direction.html">
                   <p>If <var>newDirection</var> is equal to
                   <var>transceiver</var>'s <a>[[\Direction]]</a> slot, abort these steps.</p>
                 </li>
@@ -7524,7 +7524,7 @@ async function updateParameters() {
                 </li>
               </ol>
             </dd>
-            <dt><dfn data-idl><code>currentDirection</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver-direction.html"><dfn data-idl><code>currentDirection</code></dfn> of type <span class=
             "idlAttrType"><a>RTCRtpTransceiverDirection</a></span>,
             readonly, nullable</dt>
             <dd>
@@ -7546,7 +7546,7 @@ async function updateParameters() {
           <h2>Methods</h2>
           <dl data-link-for="RTCRtpTransceiver" data-dfn-for=
           "RTCRtpTransceiver" class="methods">
-            <dt><code>stop</code></dt>
+            <dt data-tests="RTCRtpTransceiver-stop.html"><code>stop</code></dt>
             <dd>
               <p>Irreversibly stops the <a><code>RTCRtpTransceiver</code></a>.
               The sender of this transceiver will no longer send, the
@@ -7628,7 +7628,7 @@ async function updateParameters() {
                   <p>Let <var>receiver</var> be <var>transceiver</var>'s
                   <a>[[\Receiver]]</a>.</p>
                 </li>
-                <li>
+                <li data-tests="RTCRtpTransceiver-stop.html">
                   <p>Stop sending media with <var>sender</var>.</p>
                 </li>
                 <li>
@@ -7660,7 +7660,7 @@ async function updateParameters() {
                 </li>
               </ol>
             </dd>
-            <dt><dfn data-idl><code>setCodecPreferences</code></dfn></dt>
+            <dt data-tests="RTCRtpTransceiver-setCodecPreferences.html"><dfn data-idl><code>setCodecPreferences</code></dfn></dt>
             <dd>
               <p>The <code>setCodecPreferences</code> method overrides the
               default codec preferences used by the <a>user agent</a>. When
@@ -7708,7 +7708,7 @@ async function updateParameters() {
                 <li>
                   <p>Let <var>codecs</var> be the first argument.</p>
                 </li>
-                <li>
+                <li data-tests="RTCRtpTransceiver-setCodecPreferences.html">
                   <p>If <var>codecs</var> is an empty list, set <var>transceiver</var>'s
                   <a>[[\PreferredCodecs]]</a> slot to <var>codecs</var> and abort these steps.</p>
                 </li>
@@ -7722,7 +7722,7 @@ async function updateParameters() {
                   <p>Let <var>kind</var> be the <var>transceiver</var>'s
                   <a>transceiver kind</a>.</p>
                 </li>
-                <li>
+                <li data-tests="RTCRtpTransceiver-setCodecPreferences.html">
                   <p>If the intersection between <var>codecs</var> and
                   <code>RTCRtpSender.getCapabilities(kind).codecs</code> or the intersection
                   between <var>codecs</var> and
@@ -7743,7 +7743,7 @@ async function updateParameters() {
                     <code>InvalidModificationError</code>.</li>
                   </ol>
                 </li>
-                <li>
+                <li data-tests="RTCRtpTransceiver-setCodecPreferences.html">
                   <p>Set <var>transceiver</var>'s <a>[[\PreferredCodecs]]</a> slot to
                   <var>codecs</var>.</p>
                 </li>
@@ -7921,7 +7921,7 @@ async function onOffHold() {
       data-link-for="RTCDtlsTransport">state</a></code> will be updated accordingly,
       as opposed to being represented by a new object.</div>
 
-      <p>An <code><a>RTCDtlsTransport</a></code> has a
+      <p data-tests="RTCDtlsTransport-getRemoteCertificates.html">An <code><a>RTCDtlsTransport</a></code> has a
       <dfn>[[\DtlsTransportState]]</dfn> internal slot initialized to <code>
       <a data-link-for="RTCDtlsTransportState">new</a></code> and a
       <dfn>[[\RemoteCertificates]]</dfn> slot initialized to an empty list.</p>
@@ -7978,7 +7978,7 @@ async function onOffHold() {
           <p>Set <var>transport</var>'s <a>[[\DtlsTransportState]]</a> slot to
           <var>newState</var>.</p>
         </li>
-        <li>
+        <li data-tests="RTCDtlsTransport-getRemoteCertificates.html">
           <p>If <var>newState</var> is
           <code><a data-link-for="RTCDtlsTransportState">connected</a></code>
           then let <var>newRemoteCertificates</var> be the certificate chain in
@@ -7987,13 +7987,13 @@ async function onOffHold() {
           <var>transport</var>'s <a>[[\RemoteCertificates]]</a> slot to
           <var>newRemoteCertificates</var>.</p>
         </li>
-        <li>
+        <li data-tests="RTCDtlsTransport-state.html">
           <p><a>Fire an event</a> named <code><a data-lt="RTCDtlsTransport state change">statechange</a></code>
           at <var>transport</var>.</p>
         </li>
       </ol>
       <div>
-        <pre class="idl">[Exposed=Window] interface RTCDtlsTransport : EventTarget {
+        <pre class="idl" data-tests="idlharness.https.window.js">[Exposed=Window] interface RTCDtlsTransport : EventTarget {
     [SameObject]
     readonly        attribute RTCIceTransport       iceTransport;
     readonly        attribute RTCDtlsTransportState state;
@@ -8005,7 +8005,8 @@ async function onOffHold() {
           <h2>Attributes</h2>
           <dl data-link-for="RTCDtlsTransport" data-dfn-for="RTCDtlsTransport"
           class="attributes">
-            <dt><dfn data-idl><code>iceTransport</code></dfn> of type <span class=
+            <dt data-tests="RTCIceTransport.html,RTCPeerConnection-connectionState.html"
+                ><dfn data-idl><code>iceTransport</code></dfn> of type <span class=
             "idlAttrType"><a>RTCIceTransport</a></span>, readonly</dt>
             <dd>
               <p>The <code>iceTransport</code> attribute is the underlying
@@ -8013,13 +8014,13 @@ async function onOffHold() {
               underlying transport may not be shared between multiple active
               <code><a>RTCDtlsTransport</a></code> objects.</p>
             </dd>
-            <dt><dfn data-idl><code>state</code></dfn> of type <span class=
+            <dt data-tests="RTCDtlsTransport-state.html,RTCPeerConnection-connectionState.html"><dfn data-idl><code>state</code></dfn> of type <span class=
             "idlAttrType"><a>RTCDtlsTransportState</a></span>, readonly</dt>
             <dd>
               <p>The <code>state</code> attribute MUST, on getting, return the
               value of the <a>[[\DtlsTransportState]]</a> slot.</p>
             </dd>
-            <dt><dfn data-idl><code>onstatechange</code></dfn> of type <span class=
+            <dt data-tests="RTCDtlsTransport-state.html"><dfn data-idl><code>onstatechange</code></dfn> of type <span class=
             "idlAttrType">EventHandler</span></dt>
             <dd>
               The event type of this event handler is <code>
@@ -8035,7 +8036,7 @@ async function onOffHold() {
           <h2>Methods</h2>
           <dl data-link-for="RTCDtlsTransport" data-dfn-for="RTCDtlsTransport"
           class="methods">
-            <dt><dfn data-idl><code>getRemoteCertificates</code></dfn></dt>
+            <dt data-tests="RTCDtlsTransport-getRemoteCertificates.html"><dfn data-idl><code>getRemoteCertificates</code></dfn></dt>
             <dd>
               <p>Returns the value of <a>[[\RemoteCertificates]]</a>.</p>
             </dd>
@@ -8067,12 +8068,12 @@ async function onOffHold() {
               and verifying the remote fingerprint.</td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>connected</code></dfn></td>
+              <td data-tests="RTCDtlsTransport-state.html,RTCPeerConnection-connectionState.html"><dfn data-idl><code>connected</code></dfn></td>
               <td>DTLS has completed negotiation of a secure connection and
               verified the remote fingerprint.</td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>closed</code></dfn></td>
+              <td data-tests="RTCDtlsTransport-state.html"><dfn data-idl><code>closed</code></dfn></td>
               <td>The transport has been closed intentionally as the result of
               receipt of a close_notify alert, or calling <code>close()</code>.</td>
             </tr>
@@ -8086,7 +8087,7 @@ async function onOffHold() {
       </div>
       <section id="rtcdtlsfingerprint">
         <h3><dfn>RTCDtlsFingerprint</dfn> Dictionary</h3>
-        <p>The <code>RTCDtlsFingerprint</code> dictionary includes
+        <p data-tests="RTCCertificate.html">The <code>RTCDtlsFingerprint</code> dictionary includes
         the hash function algorithm and certificate fingerprint as described in
         [[!RFC4572]].</p>
         <div>
@@ -8352,7 +8353,7 @@ async function onOffHold() {
           <code><a>RTCIceCandidatePair</a></code> representing the indicated
           pair if one is selected, and <code>null</code> otherwise.</p>
         </li>
-        <li>
+        <li data-tests="RTCIceTransport.html">
           <p>Set <var>transport</var>'s <a>[[\SelectedCandidatePair]]</a> slot
           to <var>newCandidatePair</var>.</p>
         </li>
@@ -8368,11 +8369,11 @@ async function onOffHold() {
         <a data-link-for="RTCIceTransportState">new</a></code></li>
         <li><dfn>[[\IceGathererState]]</dfn> initialized to <code>
         <a data-link-for="RTCIceGatheringState">new</a></code></li>
-        <li><dfn>[[\SelectedCandidatePair]]</dfn> initialized to
+        <li data-tests="RTCIceTransport.html"><dfn>[[\SelectedCandidatePair]]</dfn> initialized to
         <code>null</code></li>
       </ul>
       <div>
-        <pre class="idl">[Exposed=Window] interface RTCIceTransport : EventTarget {
+        <pre class="idl" data-tests="idlharness.https.window.js">[Exposed=Window] interface RTCIceTransport : EventTarget {
     readonly        attribute RTCIceRole           role;
     readonly        attribute RTCIceComponent      component;
     readonly        attribute RTCIceTransportState state;
@@ -8448,14 +8449,14 @@ async function onOffHold() {
           <h2>Methods</h2>
           <dl data-link-for="RTCIceTransport" data-dfn-for="RTCIceTransport"
           class="methods">
-            <dt><dfn data-idl><code>getLocalCandidates</code></dfn></dt>
+            <dt data-tests="RTCIceTransport.html"><dfn data-idl><code>getLocalCandidates</code></dfn></dt>
             <dd>
               <p>Returns a sequence describing the local ICE candidates
               gathered for this <code><a>RTCIceTransport</a></code> and sent in
               <code><a data-link-for=
               "RTCPeerConnection">onicecandidate</a></code></p>
             </dd>
-            <dt><dfn data-idl><code>getRemoteCandidates</code></dfn></dt>
+            <dt data-tests="RTCIceTransport.html"><dfn data-idl><code>getRemoteCandidates</code></dfn></dt>
             <dd>
               <p>Returns a sequence describing the remote ICE candidates
               received by this <code><a>RTCIceTransport</a></code> via
@@ -8467,13 +8468,13 @@ async function onOffHold() {
                 data-link-for="RTCPeerConnection">addIceCandidate()</a></code>.
               </div>
             </dd>
-            <dt><dfn data-idl><code>getSelectedCandidatePair</code></dfn></dt>
+            <dt data-tests="RTCIceTransport.html"><dfn data-idl><code>getSelectedCandidatePair</code></dfn></dt>
             <dd>
               <p>Returns the selected candidate pair on which packets are sent.
               This method MUST return the value of the
               <a>[[\SelectedCandidatePair]]</a> slot.</p>
             </dd>
-            <dt><dfn data-idl><code>getLocalParameters</code></dfn></dt>
+            <dt data-tests="RTCIceTransport.html"><dfn data-idl><code>getLocalParameters</code></dfn></dt>
             <dd>
               <p>Returns the local ICE parameters received by this
               <code><a>RTCIceTransport</a></code> via <code><a data-link-for=
@@ -8481,7 +8482,7 @@ async function onOffHold() {
               <code>null</code> if the parameters have not yet been
               received.</p>
             </dd>
-            <dt><dfn data-idl><code>getRemoteParameters</code></dfn></dt>
+            <dt data-tests="RTCIceTransport.html"><dfn data-idl><code>getRemoteParameters</code></dfn></dt>
             <dd>
               <p>Returns the remote ICE parameters received by this
               <code><a>RTCIceTransport</a></code> via <code><a data-link-for=
@@ -8564,12 +8565,12 @@ async function onOffHold() {
               has not started gathering candidates yet.</td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>gathering</code></dfn></td>
+              <td data-tests="RTCPeerConnection-iceGatheringState.html"><dfn data-idl><code>gathering</code></dfn></td>
               <td>The <code><a>RTCIceTransport</a></code> is in the process of
               gathering candidates.</td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>complete</code></dfn></td>
+              <td data-tests="RTCPeerConnection-iceGatheringState.html"><dfn data-idl><code>complete</code></dfn></td>
               <td>The <code><a>RTCIceTransport</a></code> has completed
               gathering and the end-of-candidates indication for this transport
               has been sent. It will not gather candidates again until an ICE
@@ -8604,7 +8605,7 @@ async function onOffHold() {
               and has not yet started checking.</td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>checking</code></dfn></td>
+              <td data-tests="RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl><code>checking</code></dfn></td>
               <td>The <code><a>RTCIceTransport</a></code> has received at least
               one remote candidate and is checking candidate pairs and has
               either not yet found a connection or consent checks [[!RFC7675]]
@@ -8612,7 +8613,7 @@ async function onOffHold() {
               addition to checking, it may also still be gathering.</td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>connected</code></dfn></td>
+              <td data-tests="RTCPeerConnection-connectionState.html, RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl><code>connected</code></dfn></td>
               <td>The <code><a>RTCIceTransport</a></code> has found a usable
               connection, but is still checking other candidate pairs to see if
               there is a better connection. It may also still be gathering
@@ -8625,7 +8626,7 @@ async function onOffHold() {
               additional remote candidates).</td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>completed</code></dfn></td>
+              <td data-tests="RTCPeerConnection-connectionState.html,RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl><code>completed</code></dfn></td>
               <td>The <code><a>RTCIceTransport</a></code> has finished
               gathering, received an indication that there are no more remote
               candidates, finished checking all candidate pairs and found a
@@ -8778,7 +8779,7 @@ async function onOffHold() {
       <p>The <code><a>track</a></code> event uses the
       <code><a>RTCTrackEvent</a></code> interface.</p>
       <div>
-        <pre class="idl">
+        <pre class="idl" data-tests="idlharness.https.window.js">
         [ Constructor (DOMString type, RTCTrackEventInit eventInitDict), Exposed=Window]
 interface RTCTrackEvent : Event {
     readonly        attribute RTCRtpReceiver           receiver;
@@ -8791,7 +8792,7 @@ interface RTCTrackEvent : Event {
           <h2>Constructors</h2>
           <dl data-link-for="RTCTrackEvent" data-dfn-for="RTCTrackEvent" class=
           "constructors">
-            <dt><code>RTCTrackEvent</code></dt>
+            <dt data-tests="RTCTrackEvent-constructor.html"><code>RTCTrackEvent</code></dt>
             <dd>
             </dd>
           </dl>
@@ -8800,7 +8801,7 @@ interface RTCTrackEvent : Event {
           <h2>Attributes</h2>
           <dl data-link-for="RTCTrackEvent" data-dfn-for="RTCTrackEvent" class=
           "attributes">
-            <dt><code>receiver</code> of type <span class=
+            <dt data-tests="RTCPeerConnection-ontrack.https.html,RTCTrackEvent-constructor.html"><code>receiver</code> of type <span class=
             "idlAttrType"><a>RTCRtpReceiver</a></span>, readonly</dt>
             <dd>
               <p>The <dfn id=
@@ -8808,7 +8809,7 @@ interface RTCTrackEvent : Event {
               represents the <code><a>RTCRtpReceiver</a></code> object
               associated with the event.</p>
             </dd>
-            <dt><dfn data-idl><code>track</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-ontrack.https.html,RTCTrackEvent-constructor.html"><dfn data-idl><code>track</code></dfn> of type <span class=
             "idlAttrType"><a>MediaStreamTrack</a></span>, readonly</dt>
             <dd>
               <p>The <code>track</code> attribute represents the
@@ -8816,7 +8817,7 @@ interface RTCTrackEvent : Event {
               with the <code><a>RTCRtpReceiver</a></code> identified by
               <code>receiver</code>.</p>
             </dd>
-            <dt><code>streams</code> of type <span class=
+            <dt data-tests="RTCPeerConnection-ontrack.https.html,RTCTrackEvent-constructor.html"><code>streams</code> of type <span class=
             "idlAttrType">FrozenArray&lt;<a>MediaStream</a>&gt;</span>,
             readonly</dt>
             <dd>
@@ -8825,7 +8826,7 @@ interface RTCTrackEvent : Event {
               <code><a>MediaStream</a></code>s that this event's
               <code>track</code> is a part of.</p>
             </dd>
-            <dt><code>transceiver</code> of type <span class=
+            <dt data-tests="RTCPeerConnection-ontrack.https.html,RTCTrackEvent-constructor.html"><code>transceiver</code> of type <span class=
             "idlAttrType"><a>RTCRtpTransceiver</a></span>, readonly</dt>
             <dd>
               <p>The <dfn id=
@@ -8847,14 +8848,14 @@ interface RTCTrackEvent : Event {
           <h2>Dictionary <dfn>RTCTrackEventInit</dfn> Members</h2>
           <dl data-link-for="RTCTrackEventInit" data-dfn-for=
           "RTCTrackEventInit" class="dictionary-members">
-            <dt><dfn data-idl><code>receiver</code></dfn> of type <span class=
+            <dt data-tests="RTCTrackEvent-constructor.html"><dfn data-idl><code>receiver</code></dfn> of type <span class=
             "idlMemberType"><a>RTCRtpReceiver</a></span>, required</dt>
             <dd>
               <p>The <code>receiver</code> attribute represents the
               <code><a>RTCRtpReceiver</a></code> object associated with the
               event.</p>
             </dd>
-            <dt><dfn data-idl><code>track</code></dfn> of type <span class=
+            <dt data-tests="RTCTrackEvent-constructor.html"><dfn data-idl><code>track</code></dfn> of type <span class=
             "idlMemberType"><a>MediaStreamTrack</a></span>, required</dt>
             <dd>
               <p>The <code>track</code> attribute represents the
@@ -8862,7 +8863,7 @@ interface RTCTrackEvent : Event {
               with the <code><a>RTCRtpReceiver</a></code> identified by
               <code>receiver</code>.</p>
             </dd>
-            <dt><dfn data-idl><code>streams</code></dfn> of type <span class=
+            <dt data-tests="RTCTrackEvent-constructor.html"><dfn data-idl><code>streams</code></dfn> of type <span class=
             "idlMemberType">sequence&lt;<a>MediaStream</a>&gt;</span>,
             defaulting to <code>[]</code></dt>
             <dd>
@@ -8871,7 +8872,7 @@ interface RTCTrackEvent : Event {
               <code><a>MediaStream</a></code>s that this event's
               <code>track</code> is a part of.</p>
             </dd>
-            <dt><dfn data-idl><code>transceiver</code></dfn> of type <span class=
+            <dt data-tests="RTCTrackEvent-constructor.html"><dfn data-idl><code>transceiver</code></dfn> of type <span class=
             "idlMemberType"><a>RTCRtpTransceiver</a></span>, required</dt>
             <dd>
               <p>The <code>transceiver</code> attribute represents the
@@ -8893,7 +8894,7 @@ interface RTCTrackEvent : Event {
       <p>The Peer-to-peer data API extends the
       <code><a>RTCPeerConnection</a></code> interface as described below.</p>
       <div>
-        <pre class="idl">partial interface RTCPeerConnection {
+        <pre class="idl" data-tests="idlharness.https.window.js">partial interface RTCPeerConnection {
     readonly        attribute RTCSctpTransport? sctp;
     RTCDataChannel createDataChannel (USVString label, optional RTCDataChannelInit dataChannelDict);
                     attribute EventHandler      ondatachannel;
@@ -8902,7 +8903,7 @@ interface RTCTrackEvent : Event {
           <h2>Attributes</h2>
           <dl data-link-for="RTCPeerConnection" data-dfn-for=
           "RTCPeerConnection" class="attributes">
-            <dt><dfn data-idl><code>sctp</code></dfn> of type <span class=
+            <dt data-tests="RTCIceTransport.html"><dfn data-idl><code>sctp</code></dfn> of type <span class=
             "idlAttrType"><a>RTCSctpTransport</a></span>, readonly,
             nullable</dt>
             <dd>
@@ -8912,7 +8913,7 @@ interface RTCTrackEvent : Event {
               object stored in the <a>[[\SctpTransport]]</a>
               internal slot.</p>
             </dd>
-            <dt><dfn data-idl><code>ondatachannel</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-ondatachannel.html"><dfn data-idl><code>ondatachannel</code></dfn> of type <span class=
             "idlAttrType">EventHandler</span></dt>
             <dd>The event type of this event handler is
             <code><a>datachannel</a></code>.</dd>
@@ -8938,51 +8939,51 @@ interface RTCTrackEvent : Event {
                   <code><a>RTCPeerConnection</a></code> object on which the
                   method is invoked.</p>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-createDataChannel.html">
                   <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
                   <code>true</code>, <a>throw</a> an
                   <code>InvalidStateError</code>.</p>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-createDataChannel.html">
                   <p><a>Create an <code>RTCDataChannel</code></a>,
                   <var>channel</var>.</p>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-createDataChannel.html">
                   <p>Initialize <var>channel</var>'s
                   <a>[[\DataChannelLabel]]</a> slot to the value of the first
                   argument.</p>
                 </li>
-                <li>If <a>[[\DataChannelLabel]]</a>
+                <li data-tests="RTCPeerConnection-createDataChannel.html">If <a>[[\DataChannelLabel]]</a>
                 is longer than 65535 bytes, <a>throw</a> a
                 <code>TypeError</code>.
                 </li>
                 <li>
                   <p>Let <var>options</var> be the second argument.</p>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-createDataChannel.html">
                   <p>Initialize <var>channel</var>'s <a>[[\MaxPacketLifeTime]]</a>
                   slot to <var>option</var>'s
                   <code>maxPacketLifeTime</code> member, if present, otherwise
                   <code>null</code>.</p>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-createDataChannel.html">
                   <p>Initialize <var>channel</var>'s <a>[[\MaxRetransmits]]</a>
                   slot to <var>option</var>'s <code>maxRetransmits</code>
                   member, if present, otherwise <code>null</code>.</p>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-createDataChannel.html">
                   <p>Initialize <var>channel</var>'s <a>[[\Ordered]]</a> slot
                   to <var>option</var>'s <code>ordered</code> member.</p>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-createDataChannel.html">
                   <p>Initialize <var>channel</var>'s
                   <a>[[\DataChannelProtocol]]</a> slot to <var>option</var>'s
                   <code>protocol</code> member.</p>
                 </li>
-                <li>If <a>[[\DataChannelProtocol]]</a> is longer than
+                <li data-tests="RTCPeerConnection-createDataChannel.html">If <a>[[\DataChannelProtocol]]</a> is longer than
                 65535 bytes long, <a>throw</a> a <code>TypeError</code>.
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-createDataChannel.html">
                   <p>Initialize <var>channel</var>'s <a>[[\Negotiated]]</a>
                   slot to <var>option</var>'s <code>negotiated</code> member.</p>
                 </li>
@@ -9010,26 +9011,26 @@ interface RTCTrackEvent : Event {
                   <a>[[\DataChannelPriority]]</a> slot to <var>option</var>'s
                   <code>priority</code> member.</p>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-createDataChannel.html">
                   <p>If both <a>[[\MaxPacketLifeTime]]</a> and
                   <a>[[\MaxRetransmits]]</a>
                   attributes are set (not null), <a>throw</a> a
                   <code>TypeError</code>.</p>
                 </li>
-                <li>
+                <li class=untestable>
                   <p>If a setting, either <a>[[\MaxPacketLifeTime]]</a> or
                   <a>[[\MaxRetransmits]]</a>,
                   has been set to indicate unreliable mode, and that value
                   exceeds the maximum value supported by the user agent, the
                   value MUST be set to the user agents maximum value.</p>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-createDataChannel.html">
                   <p>If <a>[[\DataChannelId]]</a> is
                   equal to 65535, which is greater than the maximum allowed ID
                   of 65534 but still qualifies as an <span class=
                   "idlMemberType">unsigned short</span>, <a>throw</a> a
                   <code>TypeError</code>.</p>
-                <li>
+                <li data-tests="RTCPeerConnection-createDataChannel.html">
                   <p>If the <a>[[\DataChannelId]]</a>
                   slot is <code>null</code> (due to no ID being passed into
                   <code>createDataChannel</code>, or <a>[[\Negotiated]]</a> being false),
@@ -9059,7 +9060,7 @@ interface RTCTrackEvent : Event {
                   <a>[[\MaxChannels]]</a> slot, <a>throw</a> an
                   <code>OperationError</code>.</p>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
                   <p>If <var>channel</var> is the first
                   <code><a>RTCDataChannel</a></code> created on
                   <var>connection</var>, <a>update the
@@ -9090,7 +9091,7 @@ interface RTCTrackEvent : Event {
           optional initial state, <var>initialState</var>, run the following
           steps:</p>
           <ol>
-            <li>
+            <li data-tests="RTCSctpTransport-constructor.html">
               <p>Let <var>transport</var> be a new <code>
               <a>RTCSctpTransport</a></code> object.</p>
             </li>
@@ -9125,7 +9126,7 @@ interface RTCTrackEvent : Event {
               <p>Let <var>transport</var> be the <code><a>RTCSctpTransport</a>
               </code> object to be updated.</p>
             </li>
-            <li>
+            <li data-tests="RTCSctpTransport-maxMessageSize.html">
               <p>Let <var>remoteMaxMessageSize</var> be the value of the
               "max-message-size" SDP attribute read from the remote description,
               as described in [[!SCTP-SDP]] (section 6), or 65536 if the
@@ -9136,17 +9137,17 @@ interface RTCTrackEvent : Event {
               client can send (i.e. the size of the local send buffer) or 0 if
               the implementation can handle messages of any size.</p>
             </li>
-            <li>
+            <li data-tests="RTCSctpTransport-maxMessageSize.html">
               <p>If both <var>remoteMaxMessageSize</var> and
               <var>canSendSize</var> are 0, set <a>[[\MaxMessageSize]]</a> to the
               positive Infinity value.</p>
             </li>
-            <li>
+            <li data-tests="RTCSctpTransport-maxMessageSize.html">
               <p>Else, if either <var>remoteMaxMessageSize</var> or
               <var>canSendSize</var> is 0, set <a>[[\MaxMessageSize]]</a> to the
               larger of the two.</p>
             </li>
-            <li>
+            <li data-tests="RTCSctpTransport-maxMessageSize.html">
               <p>Else, set <a>[[\MaxMessageSize]]</a> to the smaller of
               <var>remoteMaxMessageSize</var> or <var>canSendSize</var>.</p>
             </li>
@@ -9195,7 +9196,7 @@ interface RTCTrackEvent : Event {
           </ol>
         </section>
         <div>
-          <pre class="idl">[Exposed=Window] interface RTCSctpTransport : EventTarget {
+          <pre class="idl" data-tests="idlharness.https.window.js">[Exposed=Window] interface RTCSctpTransport : EventTarget {
     readonly        attribute RTCDtlsTransport transport;
     readonly        attribute RTCSctpTransportState state;
     readonly        attribute unrestricted double maxMessageSize;
@@ -9206,20 +9207,20 @@ interface RTCTrackEvent : Event {
             <h2>Attributes</h2>
             <dl data-link-for="RTCSctpTransport" data-dfn-for=
             "RTCSctpTransport" class="attributes">
-              <dt><dfn data-idl><code>transport</code></dfn> of type <span class=
+              <dt data-tests="RTCIceTransport.html,RTCSctpTransport-constructor.html"><dfn data-idl><code>transport</code></dfn> of type <span class=
               "idlAttrType"><a>RTCDtlsTransport</a></span>, readonly</dt>
               <dd>
                 <p>The transport over which all SCTP packets for data channels
                 will be sent and received.</p>
               </dd>
-              <dt><dfn data-idl><code>state</code></dfn> of type <span class=
+              <dt data-tests="RTCSctpTransport-constructor.html"><dfn data-idl><code>state</code></dfn> of type <span class=
               "idlAttrType"><a>RTCSctpTransportState</a></span>, readonly</dt>
               <dd>
                 <p>The current state of the SCTP transport. On getting, this
                 attribute MUST return the value of the
                 <a>[[\SctpTransportState]]</a> slot.</p>
               </dd>
-              <dt><dfn data-idl><code>maxMessageSize</code></dfn> of type <span class=
+              <dt data-tests="RTCSctpTransport-constructor.html"><dfn data-idl><code>maxMessageSize</code></dfn> of type <span class=
               "idlAttrType">unrestricted double</span>, readonly</dt>
               <dd>
                 <p>The maximum size of data that can be passed to
@@ -9369,7 +9370,7 @@ interface RTCTrackEvent : Event {
           <p>Let <var>channel</var> be a newly created <code>
           <a>RTCDataChannel</a></code> object.</p>
         </li>
-        <li>
+        <li data-tests="RTCPeerConnection-ondatachannel.html">
           <p>Let <var>channel</var> have a <dfn>[[\ReadyState]]</dfn> internal
           slot initialized to <code>"connecting"</code>.</p>
         </li>
@@ -9411,18 +9412,18 @@ interface RTCTrackEvent : Event {
           <p>Set <var>channel</var>'s <a>[[\ReadyState]]</a> slot to
           <code>open</code>.</p>
         </li>
-        <li>
+        <li data-tests="RTCPeerConnection-ondatachannel.html">
           <p><a>Fire an event</a> named <code><a>open</a></code> at
           <var>channel</var>.</p>
         </li>
       </ol>
-      <p>When an <a>underlying data transport</a> is to be announced (the other
+      <p data-tests="RTCPeerConnection-ondatachannel.html">When an <a>underlying data transport</a> is to be announced (the other
       peer created a channel with <code><a data-link-for=
       "RTCDataChannelInit">negotiated</a></code> unset or set to false), the
       user agent of the peer that did not initiate the creation process MUST
       queue a task to run the following steps:</p>
       <ol>
-        <li>
+        <li class="untestable">
           <p>If the associated <code><a>RTCPeerConnection</a></code> object's
           <a>[[\IsClosed]]</a> slot is <code>true</code>, abort these steps.</p>
         </li>
@@ -9430,13 +9431,13 @@ interface RTCTrackEvent : Event {
           <p><a>Create an <code>RTCDataChannel</code></a>,
           <var>channel</var>.</p>
         </li>
-        <li>
+        <li data-tests="RTCPeerConnection-ondatachannel.html">
           <p>Let <var>configuration</var> be an information bundle received
           from the other peer as a part of the process to establish the
           <a>underlying data transport</a> described by the WebRTC DataChannel
           Protocol specification [[!RTCWEB-DATA-PROTOCOL]].</p>
         </li>
-        <li>
+        <li data-tests="RTCPeerConnection-ondatachannel.html">
           <p>Initialize <var>channel</var>'s <a>[[\DataChannelLabel]]</a>,
           <a>[[\Ordered]]</a>, <a>[[\MaxPacketLifeTime]]</a>,
           <a>[[\MaxRetransmits]]</a>, <a>[[\DataChannelProtocol]]</a>,
@@ -9447,7 +9448,7 @@ interface RTCTrackEvent : Event {
           <p>Initialize <var>channel</var>'s <a>[[\Negotiated]]</a> internal
           slot to <code>false</code>.</p>
         </li>
-        <li>
+        <li data-tests="RTCPeerConnection-ondatachannel.html">
           <p>Initialize <var>channel</var>'s <a>[[\DataChannelPriority]]</a>
           internal slot based on the integer priority value in
           <var>configuration</var>, according to the following mapping:
@@ -9483,7 +9484,7 @@ interface RTCTrackEvent : Event {
           <code><a>datachannel</a></code> event handler prior to the
           <code><a>open</a></code> event being fired.</div>
         </li>
-        <li>
+        <li data-tests="RTCPeerConnection-ondatachannel.html">
           <p><a>Fire an event</a> named
           <code><a>datachannel</a></code> using the
           <code><a>RTCDataChannelEvent</a></code> interface with
@@ -9610,11 +9611,11 @@ interface RTCTrackEvent : Event {
           <code>open</code>, abort these steps and discard <var>rawData</var>.
           </p>
         </li>
-        <li>
+        <li data-tests="RTCDataChannel-bufferedAmount.html,RTCDataChannel-send.html">
           <p>Execute the sub step by switching on <var>type</var> and the
           <var>channel</var>'s <code>binaryType</code>:</p>
           <ul>
-            <li>
+            <li data-tests="datachannel-emptystring.html">
               <p>If <var>type</var> indicates that <var>rawData</var> is a
               <code>string</code>:</p>
               <p>Let <var>data</var> be a <span class=
@@ -9635,7 +9636,7 @@ interface RTCTrackEvent : Event {
             </li>
           </ul>
         </li>
-        <li>
+        <li data-tests="RTCDataChannel-send.html,datachannel-emptystring.html">
           <p><a>Fire an event</a> named <code><a>message</a></code> using the
           <code title="event-datachannel-message"><a>MessageEvent</a></code> interface
           with its <code>origin</code> attribute initialized
@@ -9646,7 +9647,7 @@ interface RTCTrackEvent : Event {
         </li>
       </ol>
       <div>
-        <pre class="idl">[Exposed=Window] interface RTCDataChannel : EventTarget {
+        <pre class="idl" data-tests="idlharness.https.window.js">[Exposed=Window] interface RTCDataChannel : EventTarget {
     readonly        attribute USVString           label;
     readonly        attribute boolean             ordered;
     readonly        attribute unsigned short?     maxPacketLifeTime;
@@ -9675,7 +9676,7 @@ interface RTCTrackEvent : Event {
           <h2>Attributes</h2>
           <dl data-link-for="RTCDataChannel" data-dfn-for="RTCDataChannel"
           class="attributes">
-            <dt><code>label</code> of type <span class=
+            <dt data-tests="RTCPeerConnection-createDataChannel.html"><code>label</code> of type <span class=
             "idlAttrType">USVString</span>, readonly</dt>
             <dd>
               <p>The <dfn id="dom-datachannel-label"><code>label</code></dfn>
@@ -9686,7 +9687,7 @@ interface RTCTrackEvent : Event {
               with the same label. On getting, the attribute MUST return the
               value of the <a>[[\DataChannelLabel]]</a> slot.</p>
             </dd>
-            <dt><code>ordered</code> of type <span class=
+            <dt data-tests="RTCPeerConnection-createDataChannel.html"><code>ordered</code> of type <span class=
             "idlAttrType">boolean</span>, readonly</dt>
             <dd>
               <p>The <dfn id=
@@ -9695,7 +9696,7 @@ interface RTCTrackEvent : Event {
               ordered, and false if out of order delivery is allowed. On
               getting, the attribute MUST return the value of the <a>[[\Ordered]]</a> slot.</p>
             </dd>
-            <dt><code>maxPacketLifeTime</code> of type <span class=
+            <dt data-tests="RTCPeerConnection-createDataChannel.html"><code>maxPacketLifeTime</code> of type <span class=
             "idlAttrType">unsigned short</span>, readonly,
             nullable</dt>
             <dd>
@@ -9707,7 +9708,7 @@ interface RTCTrackEvent : Event {
               of the <a>[[\MaxPacketLifeTime]]</a>
               slot.</p>
             </dd>
-            <dt><code>maxRetransmits</code> of type <span class=
+            <dt data-tests="RTCPeerConnection-createDataChannel.html"><code>maxRetransmits</code> of type <span class=
             "idlAttrType">unsigned short</span>, readonly,
             nullable</dt>
             <dd>
@@ -9717,7 +9718,7 @@ interface RTCTrackEvent : Event {
               attempted in unreliable mode. On getting, the attribute MUST
               return the value of the <a>[[\MaxRetransmits]]</a> slot.</p>
             </dd>
-            <dt><code>protocol</code> of type <span class=
+            <dt data-tests="RTCPeerConnection-createDataChannel.html"><code>protocol</code> of type <span class=
             "idlAttrType">USVString</span>, readonly</dt>
             <dd>
               <p>The <dfn id=
@@ -9727,7 +9728,7 @@ interface RTCTrackEvent : Event {
               return the value of the <a>[[\DataChannelProtocol]]</a>
               slot.</p>
             </dd>
-            <dt><code>negotiated</code> of type <span class=
+            <dt data-tests="RTCPeerConnection-createDataChannel.html"><code>negotiated</code> of type <span class=
             "idlAttrType">boolean</span>, readonly</dt>
             <dd>
               <p>The <dfn id=
@@ -9736,7 +9737,7 @@ interface RTCTrackEvent : Event {
               was negotiated by the application, or false otherwise. On getting,
               the attribute MUST return the value of the <a>[[\Negotiated]]</a> slot.</p>
             </dd>
-            <dt><dfn data-idl><code>id</code></dfn> of type <span class=
+            <dt data-tests="RTCDataChannel-id.html, RTCPeerConnection-createDataChannel.html"><dfn data-idl><code>id</code></dfn> of type <span class=
             "idlAttrType">unsigned short</span>, readonly, nullable</dt>
             <dd>
               <p>The <code>id</code> attribute returns the ID for this
@@ -9750,7 +9751,7 @@ interface RTCTrackEvent : Event {
               value, it will not change. On getting, the attribute MUST return
               the value of the <a>[[\DataChannelId]]</a> slot.</p>
             </dd>
-            <dt><dfn data-idl><code>priority</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-createDataChannel.html"><dfn data-idl><code>priority</code></dfn> of type <span class=
             "idlAttrType"><a>RTCPriorityType</a></span>, readonly</dt>
             <dd>
               <p>The <code>priority</code> attribute returns the priority for
@@ -9759,7 +9760,7 @@ interface RTCTrackEvent : Event {
               attribute MUST return the value of the
               <a>[[\DataChannelPriority]]</a> slot.</p>
             </dd>
-            <dt><code>readyState</code> of type <span class=
+            <dt data-tests="RTCDataChannel-send.html, RTCPeerConnection-createDataChannel.html"><code>readyState</code> of type <span class=
             "idlAttrType"><a>RTCDataChannelState</a></span>, readonly</dt>
             <dd>
               <p>The <dfn id=
@@ -9771,7 +9772,7 @@ interface RTCTrackEvent : Event {
             <dt><code>bufferedAmount</code> of type <span class=
             "idlAttrType">unsigned long</span>, readonly</dt>
             <dd>
-              <p>The <dfn id=
+              <p data-tests="RTCDataChannel-bufferedAmount.html">The <dfn id=
               "dom-datachannel-bufferedamount"><code>bufferedAmount</code></dfn>
               attribute MUST, on getting, return the value of the
               <a>[[\BufferedAmount]]</a> slot. The attribute exposes the number
@@ -9793,7 +9794,7 @@ interface RTCTrackEvent : Event {
               <a>[[\BufferedAmount]]</a> with the number of bytes that was
               sent.</p>
             </dd>
-            <dt><code>bufferedAmountLowThreshold</code> of type <span class=
+            <dt data-tests="RTCDataChannel-bufferedAmount.html"><code>bufferedAmountLowThreshold</code> of type <span class=
             "idlAttrType">unsigned long</span></dt>
             <dd>
               <p>The <dfn data-idl><code>bufferedAmountLowThreshold</code></dfn>
@@ -9812,7 +9813,7 @@ interface RTCTrackEvent : Event {
             "idlAttrType">EventHandler</span></dt>
             <dd>The event type of this event handler is
             <code><a>open</a></code>.</dd>
-            <dt><dfn data-idl><code>onbufferedamountlow</code></dfn> of type
+            <dt data-tests="RTCDataChannel-bufferedAmount.html"><dfn data-idl><code>onbufferedamountlow</code></dfn> of type
             <span class="idlAttrType">EventHandler</span></dt>
             <dd>The event type of this event handler is
             <code><a>bufferedamountlow</a></code>.</dd>
@@ -9830,11 +9831,11 @@ interface RTCTrackEvent : Event {
             "idlAttrType">EventHandler</span></dt>
             <dd><p>The event type of this event handler is
             <code><a>close</a></code>.</p></dd>
-            <dt><dfn data-idl><code>onmessage</code></dfn> of type <span class=
+            <dt data-tests="RTCDataChannel-send.html,datachannel-emptystring.html"><dfn data-idl><code>onmessage</code></dfn> of type <span class=
             "idlAttrType">EventHandler</span></dt>
             <dd><p>The event type of this event handler is
             <code><a>message</a></code>.</p></dd>
-            <dt><code>binaryType</code> of type <span class=
+            <dt data-tests="RTCDataChannel-send.html"><code>binaryType</code> of type <span class=
             "idlAttrType">DOMString</span></dt>
             <dd>
               <p>The <dfn id=
@@ -9843,11 +9844,11 @@ interface RTCTrackEvent : Event {
               last set. On setting, if the new value is either the string
               <code>"blob"</code> or the string <code>"arraybuffer"</code>,
               then set the IDL attribute to this new value. Otherwise,
-              <a>throw</a> a <code>SyntaxError</code>. When an
+              <a>throw</a> a <code>SyntaxError</code>. <span  data-tests="RTCPeerConnection-createDataChannel.html">When an
               <code><a>RTCDataChannel</a></code> object is
               created, the <code><a data-link-for=
               "RTCDataChannel">binaryType</a></code> attribute MUST be
-              initialized to the string "<code>blob</code>".</p>
+              initialized to the string "<code>blob</code>".</span></p>
               <p>This attribute controls how binary data is exposed to scripts.
               See the [[WEBSOCKETS-API]] for more information.</p>
             </dd>
@@ -9886,27 +9887,27 @@ interface RTCTrackEvent : Event {
                 </li>
               </ol>
             </dd>
-            <dt><dfn data-idl><code>send</code></dfn></dt>
+            <dt data-tests="RTCDataChannel-send.html"><dfn data-idl><code>send</code></dfn></dt>
             <dd>
               <p>Run the steps described by the <a><code>send()</code>
               algorithm</a> with argument type
               <code>string</code> object.</p>
             </dd>
-            <dt><dfn data-lt="send!overload-1" data-lt-nodefault=
+            <dt data-tests="RTCDataChannel-send.html"><dfn data-lt="send!overload-1" data-lt-nodefault=
             "true"><code>send</code></dfn></dt>
             <dd>
               <p>Run the steps described by the <a><code>send()</code>
               algorithm</a> with argument type
               <code>Blob</code> object.</p>
             </dd>
-            <dt><dfn data-lt="send!overload-2" data-lt-nodefault=
+            <dt data-tests="RTCDataChannel-send.html"><dfn data-lt="send!overload-2" data-lt-nodefault=
             "true"><code>send</code></dfn></dt>
             <dd>
               <p>Run the steps described by the <a><code>
               send()</code> algorithm</a> with argument type
               <code>ArrayBuffer</code> object.</p>
             </dd>
-            <dt><dfn data-lt="send!overload-3" data-lt-nodefault=
+            <dt data-tests="RTCDataChannel-send.html"><dfn data-lt="send!overload-3" data-lt-nodefault=
             "true"><code>send</code></dfn></dt>
             <dd>
               <p>Run the steps described by the <a><code>send()</code>
@@ -9922,7 +9923,7 @@ interface RTCTrackEvent : Event {
           <p>Let <var>channel</var> be the <code><a>RTCDataChannel</a></code>
           object on which data is to be sent.</p>
         </li>
-        <li>
+        <li data-tests="RTCDataChannel-send.html">
           <p>If <var>channel</var>'s <a>[[\ReadyState]]</a> slot is not
           <code>open</code>, <a>throw</a> an
           <code>InvalidStateError</code>.</p>
@@ -9963,7 +9964,7 @@ interface RTCTrackEvent : Event {
           <var>channel</var>'s associated <code>RTCSctpTransport</code>,
           <a>throw</a> a <code>TypeError</code>.</p>
         </li>
-        <li>
+        <li data-tests="RTCDataChannel-send.html">
           <p>Queue <var>data</var> for transmission on <var>channel</var>'s
           <a>underlying data transport</a>. If queuing <var>data</var> is not
           possible because not enough buffer space is available, <a>throw</a>
@@ -9973,7 +9974,7 @@ interface RTCTrackEvent : Event {
           application will be notified asynchronously through <code><a
           data-link-for="RTCDataChannel">onerror</a></code>.</div>
         </li>
-        <li>
+        <li data-tests="RTCDataChannel-bufferedAmount.html">
           <p>Increase the value of the <a>[[\BufferedAmount]]</a> slot by
           the byte size of <var>data</var>.</p>
         </li>
@@ -9998,7 +9999,7 @@ interface RTCTrackEvent : Event {
           <h2>Dictionary <dfn>RTCDataChannelInit</dfn> Members</h2>
           <dl data-link-for="RTCDataChannelInit" data-dfn-for=
           "RTCDataChannelInit" class="dictionary-members">
-            <dt><dfn data-idl><code>ordered</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-createDataChannel.html"><dfn data-idl><code>ordered</code></dfn> of type <span class=
             "idlMemberType">boolean</span>, defaulting to
             <code>true</code></dt>
             <dd>
@@ -10006,27 +10007,27 @@ interface RTCTrackEvent : Event {
               The default value of true, guarantees that data will be delivered
               in order.</p>
             </dd>
-            <dt><dfn data-idl><code>maxPacketLifeTime</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-createDataChannel.html"><dfn data-idl><code>maxPacketLifeTime</code></dfn> of type <span class=
             "idlMemberType">unsigned short</span></dt>
             <dd>
               <p>Limits the time (in milliseconds) during which the channel will
               transmit or retransmit data if not acknowledged. This value may be
               clamped if it exceeds the maximum value supported by the user agent.</p>
             </dd>
-            <dt><dfn data-idl><code>maxRetransmits</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-createDataChannel.html"><dfn data-idl><code>maxRetransmits</code></dfn> of type <span class=
             "idlMemberType">unsigned short</span></dt>
             <dd>
               <p>Limits the number of times a channel will retransmit data if
               not successfully delivered. This value may be clamped if it
               exceeds the maximum value supported by the user agent.</p>
             </dd>
-            <dt><dfn data-idl><code>protocol</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-createDataChannel.html"><dfn data-idl><code>protocol</code></dfn> of type <span class=
             "idlMemberType">USVString</span>, defaulting to
             <code>""</code></dt>
             <dd>
               <p>Subprotocol name used for this channel.</p>
             </dd>
-            <dt><dfn data-idl><code>negotiated</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-createDataChannel.html"><dfn data-idl><code>negotiated</code></dfn> of type <span class=
             "idlMemberType">boolean</span>, defaulting to
             <code>false</code></dt>
             <dd>
@@ -10045,12 +10046,12 @@ interface RTCTrackEvent : Event {
               endpoints create their data channel before the first offer/answer
               exchange is complete.</div>
             </dd>
-            <dt><dfn data-idl><code>id</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-createDataChannel.html"><dfn data-idl><code>id</code></dfn> of type <span class=
             "idlMemberType">unsigned short</span></dt>
             <dd>
               <p>Overrides the default selection of ID for this channel.</p>
             </dd>
-            <dt><dfn data-idl><code>priority</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-createDataChannel.html"><dfn data-idl><code>priority</code></dfn> of type <span class=
             "idlMemberType"><a>RTCPriorityType</a></span>, defaulting to
             <code>low</code></dt>
             <dd>
@@ -10073,7 +10074,7 @@ interface RTCTrackEvent : Event {
               <th colspan="2"><dfn>RTCDataChannelState</dfn> Enumeration description</th>
             </tr>
             <tr>
-              <td><dfn data-idl><code>connecting</code></dfn></td>
+              <td data-tests="RTCPeerConnection-createDataChannel.html"><dfn data-idl><code>connecting</code></dfn></td>
               <td>
                 <p>The user agent is attempting to establish the <a>underlying
                 data transport</a>. This is the initial state of an
@@ -10112,19 +10113,19 @@ interface RTCTrackEvent : Event {
     </section>
     <section>
       <h3><dfn>RTCDataChannelEvent</dfn></h3>
-      <p>The <code><a>datachannel</a></code> event uses the
+      <p data-tests="RTCPeerConnection-ondatachannel.html">The <code><a>datachannel</a></code> event uses the
       <code><a>RTCDataChannelEvent</a></code> interface.</p>
       <div>
-        <pre class="idl">
+        <pre class="idl" data-tests="idlharness.https.window.js">
         [ Constructor (DOMString type, RTCDataChannelEventInit eventInitDict), Exposed=Window]
 interface RTCDataChannelEvent : Event {
     readonly        attribute RTCDataChannel channel;
 };</pre>
-        <section>
+        <section data-tests="RTCDataChannelEvent-constructor.html">
           <h2>Constructors</h2>
           <dl data-link-for="RTCDataChannelEvent" data-dfn-for=
           "RTCDataChannelEvent" class="constructors">
-            <dt><code>RTCDataChannelEvent</code></dt>
+            <dt data-tests="idlharness.https.window.js"><code>RTCDataChannelEvent</code></dt>
             <dd>
             </dd>
           </dl>
@@ -10203,7 +10204,7 @@ interface RTCDataChannelEvent : Event {
       <p>The Peer-to-peer DTMF API extends the <code><a>RTCRtpSender</a></code>
       interface as described below.</p>
       <div>
-        <pre class="idl">partial interface RTCRtpSender {
+        <pre class="idl" data-tests="idlharness.https.window.js">partial interface RTCRtpSender {
     readonly        attribute RTCDTMFSender? dtmf;
 };</pre>
         <section>
@@ -10247,7 +10248,7 @@ interface RTCDataChannelEvent : Event {
           </li>
        </ol>
       <div>
-        <pre class="idl">
+        <pre class="idl" data-tests>
 [Exposed=Window] interface RTCDTMFSender : EventTarget {
     void insertDTMF (DOMString tones, optional unsigned long duration = 100, optional unsigned long interToneGap = 70);
                     attribute EventHandler ontonechange;
@@ -10258,7 +10259,7 @@ interface RTCDataChannelEvent : Event {
           <h2>Attributes</h2>
           <dl data-link-for="RTCDTMFSender" data-dfn-for="RTCDTMFSender" class=
           "attributes">
-            <dt><dfn data-idl><code>ontonechange</code></dfn> of type <span class=
+            <dt data-tests="RTCDTMFSender-ontonechange-long.https.html"><dfn data-idl><code>ontonechange</code></dfn> of type <span class=
             "idlAttrType">EventHandler</span></dt>
             <dd>
               <p>The event type of this event handler is
@@ -10291,7 +10292,7 @@ interface RTCDataChannelEvent : Event {
               <p>An <code><a>RTCDTMFSender</a></code> object's <dfn id=
               "dom-RTCDTMFSender-insertDTMF"><code>insertDTMF</code></dfn>
               method is used to send DTMF tones.</p>
-              <p>The tones parameter is treated as a series of characters. The
+              <p data-tests="RTCDTMFSender-insertDTMF.https.html">The tones parameter is treated as a series of characters. The
               characters 0 through 9, A through D, #, and * generate the
               associated DTMF tones. The characters a to d MUST be normalized
               to uppercase on entry and are equivalent to A to D. As noted in
@@ -10301,7 +10302,7 @@ interface RTCDataChannelEvent : Event {
               the next character in the tones parameter. All other characters
               (and only those other characters) MUST be considered <dfn id=
               "dtmf-unrecognized">unrecognized</dfn>.</p>
-              <p>The duration parameter indicates the duration in ms to use for
+              <p id="clamped-duration" data-tests="RTCDTMFSender-insertDTMF.https.html">The duration parameter indicates the duration in ms to use for
               each character passed in the tones parameters. The duration
               cannot be more than 6000 ms or less than 40 ms. The default
               duration is 100 ms for each tone.</p>
@@ -10322,10 +10323,10 @@ interface RTCDataChannelEvent : Event {
                   <code><a>RTCRtpTransceiver</a></code> object associated with
                   <var>sender</var>.</p>
                 </li>
-                <li>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot is
+                <li data-tests="RTCDTMFSender-insertDTMF.https.html,RTCRtpTransceiver.https.html">If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot is
                 <code>true</code>, <a>throw</a> an
                 <code>InvalidStateError</code>.</li>
-                <li>If <var>transceiver</var>'s <a>[[\CurrentDirection]]</a> slot
+                <li data-tests="RTCDTMFSender-insertDTMF.https.html">If <var>transceiver</var>'s <a>[[\CurrentDirection]]</a> slot
                 is <code>recvonly</code> or <code>inactive</code>,
                 <a>throw</a> an <code>InvalidStateError</code>.</li>
                 <li>Let <var>dtmf</var> be the <code><a>RTCDTMFSender</a></code>
@@ -10333,7 +10334,7 @@ interface RTCDataChannelEvent : Event {
                 <li>If <a>determine if DTMF can be sent</a> for <var>dtmf</var> returns
                 <code>false</code>, <a>throw</a> an <code>InvalidStateError</code>.</li>
                 <li>Let <var>tones</var> be the method's first argument.</li>
-                <li>If <var>tones</var> contains any <a>unrecognized</a>
+                <li data-tests="RTCDTMFSender-insertDTMF.https.html">If <var>tones</var> contains any <a>unrecognized</a>
                 characters, <a>throw</a> an <code>InvalidCharacterError</code>.
                 </li>
                 <li>Set the object's <a>[[\ToneBuffer]]</a> slot to
@@ -10342,17 +10343,17 @@ interface RTCDataChannelEvent : Event {
                 value of the <code>duration</code> parameter.</li>
                 <li>Set <var>dtmf</var>'s <a>[[\InterToneGap]]</a> slot to the
                 value of the <code>interToneGap</code> parameter.</li>
-                <li>If the value of the <code>duration</code> parameter is less than 40 ms,
+                <li data-tests="RTCDTMFSender-ontonechange-long.https.html,RTCDTMFSender-ontonechange.https.html">If the value of the <code>duration</code> parameter is less than 40 ms,
                 set <var>dtmf</var>'s <a>[[\Duration]]</a> slot to 40 ms.</li>
-                <li>If the value of the <code>duration</code> parameter is greater than 6000 ms,
+                <li data-tests="RTCDTMFSender-ontonechange-long.https.html,RTCDTMFSender-ontonechange.https.html">If the value of the <code>duration</code> parameter is greater than 6000 ms,
                 set <var>dtmf</var>'s <a>[[\Duration]]</a> slot to 6000 ms.</li>
-                <li>If the value of the <code>interToneGap</code> parameter is less than 30 ms,
+                <li data-tests="RTCDTMFSender-ontonechange.https.html">If the value of the <code>interToneGap</code> parameter is less than 30 ms,
                 set <var>dtmf</var>'s <a>[[\InterToneGap]]</a> slot to 30 ms.</li>
-                <li>If the value of the <code>interToneGap</code> parameter is greater than 6000 ms,
+                <li data-tests="RTCDTMFSender-ontonechange-long.https.html,RTCDTMFSender-ontonechange.https.html">If the value of the <code>interToneGap</code> parameter is greater than 6000 ms,
                 set <var>dtmf</var>'s <a>[[\InterToneGap]]</a> slot to 6000 ms.</li>
-                <li>If <a>[[\ToneBuffer]]</a> slot is an empty string,
+                <li data-tests="RTCDTMFSender-ontonechange.https.html">If <a>[[\ToneBuffer]]</a> slot is an empty string,
                 abort these steps.</li>
-                <li>If a <em>Playout task</em> is scheduled to be run, abort
+                <li data-tests="RTCDTMFSender-ontonechange.https.html">If a <em>Playout task</em> is scheduled to be run, abort
                 these steps; otherwise queue a task that runs the following
                 steps (<em>Playout task</em>):
                   <ol>
@@ -10433,7 +10434,7 @@ interface RTCDataChannelEvent : Event {
       <p>The <code><a>tonechange</a></code> event uses the
       <code><a>RTCDTMFToneChangeEvent</a></code> interface.</p>
       <div>
-        <pre class="idl">
+        <pre class="idl" data-tests>
         [ Constructor (DOMString type, RTCDTMFToneChangeEventInit eventInitDict), Exposed=Window]
 interface RTCDTMFToneChangeEvent : Event {
     readonly        attribute DOMString tone;
@@ -10536,7 +10537,7 @@ interface RTCDTMFToneChangeEvent : Event {
       <p>The Statistics API extends the <code><a>RTCPeerConnection</a></code>
       interface as described below.</p>
       <div>
-        <pre class="idl">partial interface RTCPeerConnection {
+        <pre class="idl" data-tests="idlharness.https.window.js">partial interface RTCPeerConnection {
     Promise&lt;RTCStatsReport&gt; getStats (optional MediaStreamTrack? selector = null);
     attribute EventHandler onstatsended;
           };</pre>
@@ -10586,7 +10587,7 @@ interface RTCDTMFToneChangeEvent : Event {
           <h2>Methods</h2>
           <dl data-link-for="RTCPeerConnection" data-dfn-for=
           "RTCPeerConnection" class="methods">
-            <dt><code>getStats</code></dt>
+            <dt data-tests="RTCPeerConnection-getStats.https.html,getstats.html"><code>getStats</code></dt>
             <dd>
               <p>Gathers stats for the given <a>selector</a> and reports the
               result asynchronously.</p>
@@ -10604,11 +10605,11 @@ interface RTCDTMFToneChangeEvent : Event {
                   <code><a>RTCPeerConnection</a></code> object on which
                   the method was invoked.</p>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,getstats.html">
                   <p>If <var>selectorArg</var> is <code>null</code>, let
                   <var>selector</var> be <code>null</code>.</p>
                 </li>
-                <li>
+                <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html">
                   <p>If <var>selectorArg</var> is a <a>MediaStreamTrack</a>
                   let <var>selector</var> be an <a>RTCRtpSender</a> or
                   <a>RTCRtpReceiver</a> on <var>connection</var> which
@@ -10629,7 +10630,7 @@ interface RTCDTMFToneChangeEvent : Event {
                       <p>Gather the stats indicated by <var>selector</var>
                       according to the <a>stats selection algorithm</a>.</p>
                     </li>
-                    <li>
+                    <li data-tests="RTCPeerConnection-getStats.https.html,getstats.html">
                       <p><a>Resolve</a> <var>p</var> with the resulting
                       <code><a>RTCStatsReport</a></code> object, containing
                       the gathered stats.</p>
@@ -10665,7 +10666,7 @@ interface RTCDTMFToneChangeEvent : Event {
       <code>RTCStats</code>-derived dictionary per SSRC (which can be
       distinguished by the value of the "ssrc" stats attribute).</p>
       <div>
-        <pre class="idl">[Exposed=Window] interface RTCStatsReport {
+        <pre class="idl" data-tests>[Exposed=Window] interface RTCStatsReport {
     readonly maplike&lt;DOMString, object&gt;;
 };</pre>
         <p>This interface has "entries", "forEach", "get", "has", "keys",
@@ -10721,7 +10722,7 @@ interface RTCDTMFToneChangeEvent : Event {
               <code><a>RTCStats</a></code>-derived dictionary, if
               applicable.</p>
             </dd>
-            <dt><code>type</code> of type <span class=
+            <dt data-tests="getstats.html"><code>type</code> of type <span class=
             "idlMemberType"><a>RTCStatsType</a></span></dt>
             <dd>
               <p>The type of this object.</p>
@@ -10753,7 +10754,7 @@ interface RTCDTMFToneChangeEvent : Event {
       <p>The <code><a>statsended</a></code> event uses
         the <code><a>RTCStatsEvent</a></code>.</p>
       <div>
-        <pre class="idl">[ Constructor (DOMString type, RTCStatsEventInit
+        <pre class="idl" data-tests>[ Constructor (DOMString type, RTCStatsEventInit
           eventInitDict), Exposed=Window]
           interface RTCStatsEvent : Event {
             readonly attribute RTCStatsReport report;
@@ -10812,11 +10813,11 @@ interface RTCDTMFToneChangeEvent : Event {
         <li>
           Let <var>result</var> be an empty RTCStatsReport.
         </li>
-        <li>If <var>selector</var> is <code>null</code>, gather stats for the
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html">If <var>selector</var> is <code>null</code>, gather stats for the
           whole <var>connection</var>, add them to <var>result</var>, return
           <var>result</var>, and abort these steps.
         </li>
-        <li>If <var>selector</var> is an <a>RTCRtpSender</a>, gather stats for
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html">If <var>selector</var> is an <a>RTCRtpSender</a>, gather stats for
           and add the following objects to <var>result</var>:
           <ul>
             <li>
@@ -10829,7 +10830,7 @@ interface RTCDTMFToneChangeEvent : Event {
             </li>
           </ul>
         </li>
-        <li>If <var>selector</var> is an <a>RTCRtpReceiver</a>, gather stats
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html">If <var>selector</var> is an <a>RTCRtpReceiver</a>, gather stats
           for and add the following objects to <var>result</var>:
           <ul>
             <li>
@@ -10856,48 +10857,48 @@ interface RTCDTMFToneChangeEvent : Event {
       types when the corresponding objects exist on a PeerConnection, with the
       attributes that are listed when they are valid for that object:</p>
       <ul>
-        <li>RTCRTPStreamStats, with attributes ssrc, kind,
+        <li data-tests="RTCPeerConnection-getStats.https.html">RTCRTPStreamStats, with attributes ssrc, kind,
         transportId, codecId, nackCount</li>
-        <li>RTCReceivedRTPStreamStats, with all required attributes from its
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCRtpReceiver-getStats.https.html">RTCReceivedRTPStreamStats, with all required attributes from its
         inherited dictionaries, and also attributes packetsReceived,
         packetsLost, jitter, packetsDiscarded</li>
-        <li>RTCInboundRTPStreamStats, with all required attributes from its
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCRtpReceiver-getStats.https.html">RTCInboundRTPStreamStats, with all required attributes from its
         inherited dictionaries, and also attributes bytesReceived, trackId,
         receiverId, remoteId, framesDecoded</li>
-        <li>RTCRemoteInboundRTPStreamStats, with all required attributes from
+        <li data-tests="RTCPeerConnection-getStats.https.html">RTCRemoteInboundRTPStreamStats, with all required attributes from
         its inherited dictionaries, and also attributes localId,
         roundTripTime</li>
-        <li>RTCSentRTPStreamStats, with all required attributes from its
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCRtpSender-getStats.https.html">RTCSentRTPStreamStats, with all required attributes from its
         inherited dictionaries, and also attributes packetsSent, bytesSent</li>
-        <li>RTCOutboundRTPStreamStats, with all required attributes from its
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCRtpSender-getStats.https.html">RTCOutboundRTPStreamStats, with all required attributes from its
         inherited dictionaries, and also attributes trackId, senderId, remoteId, framesEncoded</li>
-        <li>RTCRemoteOutboundRTPStreamStats, with all required attributes from
+        <li data-tests="RTCPeerConnection-getStats.https.html">RTCRemoteOutboundRTPStreamStats, with all required attributes from
         its inherited dictionaries, and also attributes localId, remoteTimestamp
         </li>
-        <li>RTCPeerConnectionStats, with attributes dataChannelsOpened,
+        <li data-tests="RTCPeerConnection-getStats.https.html,getstats.html">RTCPeerConnectionStats, with attributes dataChannelsOpened,
         dataChannelsClosed</li>
-        <li>RTCDataChannelStats, with attributes label, protocol,
+        <li data-tests="RTCPeerConnection-getStats.https.html">RTCDataChannelStats, with attributes label, protocol,
         dataChannelIdentifier, state, messagesSent, bytesSent, messagesReceived,
         bytesReceived</li>
-        <li>RTCMediaStreamStats, with attributes streamIdentifer, trackIds</li>
-        <li>RTCMediaStreamTrackStats, with attribute detached</li>
-        <li>RTCMediaHandlerStats with attributes trackIdentifier, remoteSource, ended</li>
-        <li>RTCAudioHandlerStats with attribute audioLevel</li>
-        <li>RTCVideoHandlerStats with attributes frameWidth, frameHeight, framesPerSecond</li>
-        <li>RTCVideoSenderStats with attribute framesSent</li>
-        <li>RTCVideoReceiverStats with attributes framesReceived, framesDecoded, framesDropped,
+        <li data-tests="RTCPeerConnection-getStats.https.html, RTCPeerConnection-track-stats.https.html">RTCMediaStreamStats, with attributes streamIdentifer, trackIds</li>
+        <li data-tests="RTCPeerConnection-getStats.https.html">RTCMediaStreamTrackStats, with attribute detached</li>
+        <li data-tests="RTCPeerConnection-track-stats.https.html">RTCMediaHandlerStats with attributes trackIdentifier, remoteSource, ended</li>
+        <li data-tests="RTCPeerConnection-track-stats.https.html">RTCAudioHandlerStats with attribute audioLevel</li>
+        <li data-tests="RTCPeerConnection-track-stats.https.html">RTCVideoHandlerStats with attributes frameWidth, frameHeight, framesPerSecond</li>
+        <li data-tests="RTCPeerConnection-track-stats.https.html">RTCVideoSenderStats with attribute framesSent</li>
+        <li data-tests="RTCPeerConnection-track-stats.https.html">RTCVideoReceiverStats with attributes framesReceived, framesDecoded, framesDropped,
         partialFramesLost</li>
-        <li>RTCCodecStats, with attributes payloadType, codec, clockRate,
+        <li data-tests="RTCPeerConnection-getStats.https.html">RTCCodecStats, with attributes payloadType, codec, clockRate,
         channels, sdpFmtpLine</li>
-        <li>RTCTransportStats, with attributes bytesSent, bytesReceived,
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html">RTCTransportStats, with attributes bytesSent, bytesReceived,
         rtcpTransportStatsId, selectedCandidatePairId,
         localCertificateId, remoteCertificateId</li>
-        <li>RTCIceCandidatePairStats, with attributes transportId,
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html">RTCIceCandidatePairStats, with attributes transportId,
         localCandidateId, remoteCandidateId, state, priority, nominated,
         bytesSent, bytesReceived, totalRoundTripTime, currentRoundTripTime</li>
-        <li>RTCIceCandidateStats, with attributes address, port, protocol,
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html">RTCIceCandidateStats, with attributes address, port, protocol,
         candidateType, url</li>
-        <li>RTCCertificateStats, with attributes fingerprint,
+        <li data-tests="RTCPeerConnection-getStats.https.html">RTCCertificateStats, with attributes fingerprint,
         fingerprintAlgorithm, base64Certificate, issuerCertificateId</li>
       </ul>
       <p>An implementation MAY support generating any other statistic defined
@@ -11034,7 +11035,7 @@ async function gatherStats() {
       source, as is the case for each <code>MediaStreamTrack</code>
       associated with
       an <code><a>RTCRtpReceiver</a></code>) is always strong.</p>
-      <p>Whenever an <code><a>RTCRtpReceiver</a></code> receives data on an RTP
+      <p data-tests="RTCPeerConnection-remote-track-mute.https.html">Whenever an <code><a>RTCRtpReceiver</a></code> receives data on an RTP
       source whose corresponding <code><a>MediaStreamTrack</a></code> is muted,
       and the <a>[[\Receptive]]</a> slot of the
       <a><code>RTCRtpTransceiver</code></a> object the
@@ -11615,7 +11616,7 @@ if (sender.dtmf.canInsertDTMF) {
     <section>
       <h3><dfn>RTCError</dfn> Interface</h3>
       <div>
-        <pre class="idl">
+        <pre class="idl" data-tests>
           [
               Exposed=Window,
               Constructor(RTCErrorInit init, optional DOMString message = "")
@@ -11647,7 +11648,7 @@ if (sender.dtmf.canInsertDTMF) {
                 <p>Let <var>e</var> be a new <code><a>RTCError</a></code>
                 object.</p>
               </li>
-              <li>
+              <li data-tests="RTCError.html">
                 <p>Invoke the <code>DOMException</code> constructor of
                 <var>e</var> with the <code>message</code> argument set to
                 <var>message</var> and the <code>name</code> argument set to
@@ -11656,7 +11657,7 @@ if (sender.dtmf.canInsertDTMF) {
                 code so <var>e</var>'s <code>code</code> attribute will return
                 0.</p>
               </li>
-              <li>
+              <li data-tests="RTCError.html">
                 <p>Set all <code>RTCError</code> attributes of <var>e</var> to
                 the value of the corresponding attribute in <var>init</var> if
                 it is present, otherwise set it to <code>null</code>.</p>
@@ -11671,33 +11672,33 @@ if (sender.dtmf.canInsertDTMF) {
       <section>
         <h2>Attributes</h2>
         <dl data-link-for="RTCError" data-dfn-for="RTCError" class="attributes">
-          <dt><dfn data-idl><code>errorDetail</code></dfn> of type <span
+          <dt data-tests="RTCError.html,RTCPeerConnection-setRemoteDescription-offer.html"><dfn data-idl><code>errorDetail</code></dfn> of type <span
           class="idlAttrType">RTCErrorDetailType</span>, readonly</dt>
           <dd>
             <p>The WebRTC-specific error code for the type of error that
             occurred.</p>
           </dd>
-          <dt><dfn data-idl><code>sdpLineNumber</code></dfn> of type <span
+          <dt data-tests="RTCError.html,RTCPeerConnection-setRemoteDescription-offer.html"><dfn data-idl><code>sdpLineNumber</code></dfn> of type <span
           class="idlAttrType">long</span>, readonly, nullable</dt>
           <dd>
             <p>If <code>errorDetail</code> is <code>"sdp-syntax-error"</code>
             this is the line number where the error was detected (the first
             line has line number 1).</p>
           </dd>
-          <dt><dfn data-idl><code>httpRequestStatusCode</code></dfn> of type
+          <dt data-tests="RTCError.html"><dfn data-idl><code>httpRequestStatusCode</code></dfn> of type
           <span class="idlAttrType">long</span>, readonly,
           nullable</dt>
           <dd>
             <p>If <code>errorDetail</code> is <code>"idp-load-failure"</code>
             this is the HTTP status code of the IdP URI response.</p>
           </dd>
-          <dt><dfn data-idl><code>sctpCauseCode</code></dfn> of type <span
+          <dt data-tests="RTCError.html"><dfn data-idl><code>sctpCauseCode</code></dfn> of type <span
           class="idlAttrType">long</span>, readonly, nullable</dt>
           <dd>
             <p>If <code>errorDetail</code> is <code>"sctp-failure"</code> this
             is the SCTP cause code of the failed SCTP negotiation.</p>
           </dd>
-          <dt><dfn data-idl><code>receivedAlert</code></dfn> of type <span
+          <dt data-tests="RTCError.html"><dfn data-idl><code>receivedAlert</code></dfn> of type <span
           class="idlAttrType">unsigned long</span>, readonly,
           nullable</dt>
           <dd>
@@ -11705,7 +11706,7 @@ if (sender.dtmf.canInsertDTMF) {
             a fatal DTLS alert was received, this is the value of the DTLS
             alert received.</p>
           </dd>
-          <dt><dfn data-idl><code>sentAlert</code></dfn> of type <span
+          <dt data-tests="RTCError.html"><dfn data-idl><code>sentAlert</code></dfn> of type <span
           class="idlAttrType">unsigned long</span>, readonly,
           nullable</dt>
           <dd>
@@ -11875,7 +11876,7 @@ if (sender.dtmf.canInsertDTMF) {
               SCTP cause code.</td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>sdp-syntax-error</code></dfn></td>
+              <td data-tests="RTCPeerConnection-setRemoteDescription-offer.html"><dfn data-idl><code>sdp-syntax-error</code></dfn></td>
               <td>The SDP syntax is not valid. The <code>sdpLineNumber</code>
               attribute is set to the line number in the SDP where the syntax
               error was detected.</td>
@@ -11899,7 +11900,7 @@ if (sender.dtmf.canInsertDTMF) {
       <p>The <code>RTCErrorEvent</code> interface is defined for cases when an
       <code><a>RTCError</a></code> is raised as an event:</p>
       <div>
-        <pre class="idl">
+        <pre class="idl" data-tests="idlharness.https.window.js">
         [
             Exposed=Window,
             Constructor (DOMString type, RTCErrorEventInit eventInitDict)
@@ -11911,7 +11912,7 @@ if (sender.dtmf.canInsertDTMF) {
         <h2>Constructors</h2>
         <dl data-link-for="RTCErrorEvent" data-dfn-for=
         "RTCErrorEvent" class="constructors">
-          <dt><dfn data-idl><code>RTCErrorEvent</code></dfn></dt>
+          <dt data-tests="idlharness.https.window.js"><dfn data-idl><code>RTCErrorEvent</code></dfn></dt>
           <dd>
             <p>Constructs a new
             <code><a>RTCErrorEvent</a></code>.</p>
@@ -12153,7 +12154,7 @@ if (sender.dtmf.canInsertDTMF) {
           <td><dfn id=
           "event-RTCDTMFSender-tonechange"><code>tonechange</code></dfn></td>
           <td><code><a>RTCDTMFToneChangeEvent</a></code></td>
-          <td>The <code><a>RTCDTMFSender</a></code> object has either just
+          <td data-tests="RTCDTMFSender-ontonechange-long.https.html">The <code><a>RTCDTMFSender</a></code> object has either just
           begun playout of a tone (returned as the <code><a data-link-for=
           "RTCDTMFToneChangeEvent">tone</a></code> attribute) or just ended
           the playout of tones in the


### PR DESCRIPTION
To help measure and track test suite coverage.

Done during the WebRTC Hackathon in IETF 104.

I'm submitting this as is to avoid rot, and am working separately on additional tools to measure coverage based on that data, and to nudge us toward keeping the data up to date (when new tests are created, or when normative test is added/modified).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dontcallmedom/webrtc-pc/pull/2156.html" title="Last updated on Apr 4, 2019, 2:58 PM UTC (b7d7657)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2156/42b2757...dontcallmedom:b7d7657.html" title="Last updated on Apr 4, 2019, 2:58 PM UTC (b7d7657)">Diff</a>