### PR TITLE
Remove stopped transceivers after negotiation

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1953,7 +1953,7 @@
                         <ol>
                           <li>
                             <p>If <var>transceiver</var> is <a data-link-for="RTCRtpTransceiver">
-                            stopped</a>, it is <a>associated</a> with an m= section, and the
+                            stopped</a>, <a>associated</a> with an m= section and the
                             associated m= section is rejected in
                             <var>connection</var>.<a>[[\CurrentLocalDescription]]</a> or
                             <var>connection</var>.<a>[[\CurrentRemoteDescription]]</a>,
@@ -5161,8 +5161,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
       created. <code><a>RTCRtpSender</a></code>s and
       <code><a>RTCRtpReceiver</a></code>s are always created at the same time
       as an <code><a>RTCRtpTransceiver</a></code>, which they will remain
-      attached until it has been <a data-lt="stop the RTCRtpTransceiver">
-      stopped</a> and the fact that it has been stopped has been negotiated.
+      attached to for their lifetime.
       <code><a>RTCRtpTransceiver</a></code>s are created implicitly when the
       application attaches a <code>MediaStreamTrack</code> to an
       <code><a>RTCPeerConnection</a></code> via the <code>addTrack</code>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1943,6 +1943,28 @@
                     </ol>
                   </li>
                   <li>
+                    <p>If <var>description</var> is of type <code>"answer"</code>, then run
+                    the following steps:</p>
+                    <ol>
+                      <li>
+                        <p>For each <var>transceiver</var> in the <var>connection</var>'s
+                        <a href="#transceivers-set">set of transceivers</a> run the
+                        following steps:</p>
+                        <ol>
+                          <li>
+                            <p>If <var>transceiver</var> is <a data-link-for="RTCRtpTransceiver">
+                            stopped</a>, it is <a>associated</a> with an m= section, and the
+                            associated m= section is rejected in
+                            <var>connection</var>.<a>[[\CurrentLocalDescription]]</a> or
+                            <var>connection</var>.<a>[[\CurrentRemoteDescription]]</a>,
+                            remove the <var>transceiver</var> from the <var>connection</var>'s
+                            <a href="#transceivers-set">set of transceivers</a>.</p>
+                          </li>
+                        </ol>
+                      </li>
+                    </ol>
+                  </li>
+                  <li>
                     <p>If <var>description</var> is of type <code>"rollback"</code>, then run
                     the following steps:</p>
                     <ol>
@@ -5139,7 +5161,9 @@ interface RTCPeerConnectionIceErrorEvent : Event {
       created. <code><a>RTCRtpSender</a></code>s and
       <code><a>RTCRtpReceiver</a></code>s are always created at the same time
       as an <code><a>RTCRtpTransceiver</a></code>, which they will remain
-      attached to for their lifetime.
+      attached until it has been <a data-lt="stop the RTCRtpTransceiver">
+      stopped</a> and the fact that it has been stopped has subsequently been
+      negotiated.
       <code><a>RTCRtpTransceiver</a></code>s are created implicitly when the
       application attaches a <code>MediaStreamTrack</code> to an
       <code><a>RTCPeerConnection</a></code> via the <code>addTrack</code>

--- a/webrtc.html
+++ b/webrtc.html
@@ -5162,8 +5162,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
       <code><a>RTCRtpReceiver</a></code>s are always created at the same time
       as an <code><a>RTCRtpTransceiver</a></code>, which they will remain
       attached until it has been <a data-lt="stop the RTCRtpTransceiver">
-      stopped</a> and the fact that it has been stopped has subsequently been
-      negotiated.
+      stopped</a> and the fact that it has been stopped has been negotiated.
       <code><a>RTCRtpTransceiver</a></code>s are created implicitly when the
       application attaches a <code>MediaStreamTrack</code> to an
       <code><a>RTCPeerConnection</a></code> via the <code>addTrack</code>


### PR DESCRIPTION
Fixes #2092.

This PR replaces #2102. The change also got a lot simpler.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2160.html" title="Last updated on Apr 4, 2019, 1:33 PM UTC (65bcf1c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2160/e38ba0c...henbos:65bcf1c.html" title="Last updated on Apr 4, 2019, 1:33 PM UTC (65bcf1c)">Diff</a>