### PR TITLE
Fix prose indicating reasons why sender may be missing in removeTrack (Editorial)

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5478,9 +5478,9 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 </li>
                 <li>
                   <p>If <var>sender</var> is not in <var>senders</var> (which
-                  indicates that it was removed due to <a href=
-                  "#set-description">setting an RTCSessionDescription</a> of
-                  type "rollback"), then abort these steps.</p>
+                  indicates its transceiver was stopped or removed due to
+                  <a href="#set-description">setting an RTCSessionDescription</a>
+                  of type "rollback"), then abort these steps.</p>
                 </li>
                 <li>
                   <p>If <var>sender</var>'s <a>[[\SenderTrack]]</a> is null,


### PR DESCRIPTION
Nit encountered while fixing a [firefox issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1542021).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2162.html" title="Last updated on Apr 4, 2019, 8:12 PM UTC (d14e657)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2162/9fdc9a8...jan-ivar:d14e657.html" title="Last updated on Apr 4, 2019, 8:12 PM UTC (d14e657)">Diff</a>