### PR TITLE
Restore firing of track event when there are no streams (editorial mistake)

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1859,10 +1859,11 @@
                             <var>removeList</var>.</p>
                           </li>
                           <li data-tests="RTCPeerConnection-ontrack.https.html,RTCPeerConnection-setRemoteDescription-tracks.https.html,RTCPeerConnection-transceivers.https.html">
-                            <p>If the previous step increased the length of
-                            <var>addList</var>, or if <var>transceiver</var>'s
+                            <p>If <var>direction</var> is <code>"sendrecv"</code> or
+                            <code>"recvonly"</code> and <var>transceiver</var>'s
                             <a>[[\FiredDirection]]</a> slot
                             is neither <code>"sendrecv"</code> nor <code>"recvonly"</code>,
+                            or the previous step increased the length of <var>addList</var>,
                             <a>process the addition of a remote track</a> for
                             the <a>media description</a>, given <var>transceiver</var>
                             and <var>trackEventInits</var>.</p>


### PR DESCRIPTION
Fixes mistake I made in https://github.com/w3c/webrtc-pc/pull/1947 ([here](https://github.com/w3c/webrtc-pc/pull/1947/files#diff-25266486aad3fa9244c53420694e037eL1717)).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2163.html" title="Last updated on Apr 5, 2019, 6:30 PM UTC (40bb1e7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2163/230a0b2...jan-ivar:40bb1e7.html" title="Last updated on Apr 5, 2019, 6:30 PM UTC (40bb1e7)">Diff</a>