### PR TITLE
Add rtpTimestamp to RTCRtpContributingSource

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7340,8 +7340,8 @@ async function updateParameters() {
               127 is converted to 0, and all other values are converted using
               the equation: <code>10^(-rfc_level/20)</code>.</p>
             </dd>
-            <dfn data-idl><code>rtpTimestamp</code></dfn> of type <span class=
-            "idlMemberType">unsigned long</span>
+            <dt><dfn data-idl><code>rtpTimestamp</code></dfn> of type
+                <span class="idlMemberType">unsigned long</span></dt>
             <dd>
               <p>The RTP timestamp of the latest played out media that arrived
               in an RTP packet originating from this source.</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -7295,6 +7295,7 @@ async function updateParameters() {
     required DOMHighResTimeStamp timestamp;
     required unsigned long       source;
              double              audioLevel;
+             unsigned long       rtpTimestamp;
 };</pre>
         <section>
           <h2>Dictionary RTCRtpContributingSource Members</h2>
@@ -7338,6 +7339,12 @@ async function updateParameters() {
               <p>To convert these values to the linear 0..1 range, a value of
               127 is converted to 0, and all other values are converted using
               the equation: <code>10^(-rfc_level/20)</code>.</p>
+            </dd>
+            <dfn data-idl><code>rtpTimestamp</code></dfn> of type <span class=
+            "idlMemberType">unsigned long</span>
+            <dd>
+              <p>The RTP timestamp of the latest played out media that arrived
+              in an RTP packet originating from this source.</p>
             </dd>
           </dl>
         </section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -7343,8 +7343,8 @@ async function updateParameters() {
             <dt><dfn data-idl><code>rtpTimestamp</code></dfn> of type
                 <span class="idlMemberType">unsigned long</span></dt>
             <dd>
-              <p>The RTP timestamp of the latest played out media that arrived
-              in an RTP packet originating from this source.</p>
+              <p>The last RTP timestamp, as defined in [[!RFC3559]] Section 5.1,
+              of the media played out at <var>timestamp</var>.</p>
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
Fixes #2177


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/drkron/webrtc-pc/pull/2178.html" title="Last updated on May 9, 2019, 4:09 AM UTC (5a49f49)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2178/0d55754...drkron:5a49f49.html" title="Last updated on May 9, 2019, 4:09 AM UTC (5a49f49)">Diff</a>