### PR TITLE
Clarify "multiple sources of media stitched together"

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5121,8 +5121,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
     <code><a data-link-for="RTCRtpSender">replaceTrack</a></code> changes the
     track sent by an <code><a>RTCRtpSender</a></code> without creating a new
     track on the receiver side; the corresponding
-    <code><a>RTCRtpReceiver</a></code> will only have a single track,
-    potentially representing multiple sources of media stitched together. Both
+    <code><a>RTCRtpReceiver</a></code> will only have a single track. Both
     <code><a data-link-for="RTCPeerConnection">addTransceiver</a></code> and
     <code><a data-link-for="RTCRtpSender">replaceTrack</a></code> can be used to
     cause the same track to be sent multiple times, which will be observed on


### PR DESCRIPTION
When `sender.replaceTrack` is executed, the sender's track is replaced but the `RTCRtpReceiver`still only sees a single RTP stream with a continuous sequence number space.  So in this case, the `RTCRtpReceiver` does not "stitch together" two distinct RTP streams, as would be required when receiving simulcast.  Therefore, the text is wrong and should be removed.

Fix for Issue https://github.com/w3c/webrtc-pc/issues/2171


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2180.html" title="Last updated on Apr 24, 2019, 10:14 PM UTC (6c360cb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2180/0d55754...6c360cb.html" title="Last updated on Apr 24, 2019, 10:14 PM UTC (6c360cb)">Diff</a>