### PR TITLE
Make sure prflx remote candidates do not leak information when exposed by getSelectedCandidatePair

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4250,6 +4250,15 @@ interface RTCIceCandidate {
                 IPv6 addresses, and fully qualified domain names (FQDNs). This
                 corresponds to the <code>connection-address</code> field in
                 <a><code>candidate-attribute</code></a>.</p>
+                <p>Remote candidates may be exposed, for instance
+                via <code><a>[[\SelectedCandidatePair]]</a>.remote</code>.
+                By default, the user agent MUST leave the 'address' member
+                as null for any exposed remote candidate.
+                Once a RTCPeerConnection instance learns on an address
+                by the web application using addIceCandidate, the user agent
+                can expose the 'address' member value in any RTCIceCandidate
+                of the RTCPeerConnection instance representing a remote
+                candidate with that newly learnt address.</p>
                 <div class="note">
                   <p>The addresses exposed in candidates gathered via ICE
                   and made visibile to the application in
@@ -4274,15 +4283,6 @@ interface RTCIceCandidate {
                   itself, browsers can offer their users different policies
                   regarding sharing local addresses, as defined in
                   [[RTCWEB-IP-HANDLING]].</p>
-                  <p>Remote candidates may also be exposed, for instance
-                  via <code><a>[[\SelectedCandidatePair]]</a>.remote</code>.
-                  By default, the user agent must leave the 'address' member
-                  as null for any exposed remote candidate.
-                  Once a RTCPeerConnection instance learns on an
-                  address by the web application using addIceCandidate, the
-                  user agent can expose the 'address' member value in any
-                  RTCIceCandidate representing a remote candidate with that newly
-                  learnt address.</p>
                 </div>
               </dd>
               <dt><dfn data-idl><code>protocol</code></dfn> of type <span class=

--- a/webrtc.html
+++ b/webrtc.html
@@ -4213,8 +4213,8 @@ interface RTCIceCandidate {
               "idlAttrType">DOMString</span>, readonly</dt>
               <dd>This carries the <a><code>candidate-attribute</code></a> as defined
               in section 15.1 of [[!ICE]]. If this <code>RTCIceCandidate</code>
-              represents an end-of-candidates indication,
-              <code>candidate</code> is an empty string.</dd>
+              represents an end-of-candidates indication or a peer reflexive remote
+              candidate, <code>candidate</code> is an empty string.</dd>
               <dt><dfn data-idl><code>sdpMid</code></dfn> of type <span class=
               "idlAttrType">DOMString</span>, readonly, nullable</dt>
               <dd>If not <code>null</code>, this contains the media stream
@@ -4274,6 +4274,15 @@ interface RTCIceCandidate {
                   itself, browsers can offer their users different policies
                   regarding sharing local addresses, as defined in
                   [[RTCWEB-IP-HANDLING]].</p>
+                  <p>Remote candidates may also be exposed, for instance
+                  via <code><a>[[\SelectedCandidatePair]]</a>.remote</code>.
+                  By default, the user agent must leave the 'address' member
+                  as null for any exposed remote candidate.
+                  Once a RTCPeerConnection instance learns on an
+                  address by the web application using addIceCandidate, the
+                  user agent can expose the 'address' member value in any
+                  RTCIceCandidate representing a remote candidate with that newly
+                  learnt address.</p>
                 </div>
               </dd>
               <dt><dfn data-idl><code>protocol</code></dfn> of type <span class=


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-pc/pull/2182.html" title="Last updated on May 22, 2019, 3:34 PM UTC (3bc09cc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2182/0d55754...youennf:3bc09cc.html" title="Last updated on May 22, 2019, 3:34 PM UTC (3bc09cc)">Diff</a>