### PR TITLE
Mark getDefaultIceServers() as feature at risk

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -32,8 +32,9 @@
 
     <p>The following features are marked as at risk:</p>
     <ul>
-      <li>The value <a href="#dom-rtcrtcpmuxpolicy-negotiate"><code>negotiate</code></a> of RTCRtcpMuxPolicy</li>
-      <li>The <code>encodings</code> attribute of <code><a>RTCRtpReceiveParameters</a></code></li>
+      <li>The value <a href="#dom-rtcrtcpmuxpolicy-negotiate"><code>negotiate</code></a> of RTCRtcpMuxPolicy.</li>
+      <li>The <code>encodings</code> attribute of <code><a>RTCRtpReceiveParameters</a></code>.</li>
+      <li>The <code>getDefaultIceServers()</code> method of <code><a>RTCPeerConnection</a></code>.</li>
     </ul>
 
   </section>
@@ -3255,6 +3256,12 @@ interface RTCPeerConnection : EventTarget  {
                 the discretion of application developers, configuring a user
                 agent with these defaults does not per se increase a user's
                 ability to limit the exposure of their IP addresses.</p>
+                <div class="issue atrisk">
+                  <p>Support for the <code>getDefaultIceServers()</code> method
+                  of <code><a>RTCPeerConnection</a></code> is marked as a
+                  feature at risk, since there is no clear commitment from
+                  implementers.</p>
+                </div>
               </dd>
               <dt><dfn data-idl><code>getConfiguration</code></dfn></dt>
               <dd>


### PR DESCRIPTION
Fixes #2185. Per discussions at #2023.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2184.html" title="Last updated on Apr 25, 2019, 10:08 AM UTC (e3ddec1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2184/0d55754...henbos:e3ddec1.html" title="Last updated on Apr 25, 2019, 10:08 AM UTC (e3ddec1)">Diff</a>