### PR TITLE
Adds a note clarifying removeTrack()

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5473,6 +5473,13 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               if the <code><a>MediaStreamTrack</a></code> is not already muted,
               a <code title="event-MediaStreamTrack-muted">muted</code> event is
               fired at the track.</p>
+              <div class="note">The same effect as <code>removeTrack()</code>
+              can be achieved setting the
+              <code>RTCRtpTransceiver.direction</code> attribute of the
+              corresponding transceiver and invoking
+              <code>RTCRtpSender.replaceTrack(null)</code> on the sender. One
+              minor difference is that <code>replaceTrack()</code> is
+              asynchronous and <code>removeTrack()</code> is synchronous.</div>
               <p>When the <dfn data-idl><code>removeTrack</code></dfn> method is
               invoked, the user agent MUST run the following steps:</p>
               <ol>

--- a/webrtc.html
+++ b/webrtc.html
@@ -5474,7 +5474,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               a <code title="event-MediaStreamTrack-muted">muted</code> event is
               fired at the track.</p>
               <div class="note">The same effect as <code>removeTrack()</code>
-              can be achieved setting the
+              can be achieved by setting the
               <code>RTCRtpTransceiver.direction</code> attribute of the
               corresponding transceiver and invoking
               <code>RTCRtpSender.replaceTrack(null)</code> on the sender. One


### PR DESCRIPTION
Fixes #2024.
Clarifies that the effects of removeTrack() can be achieved with transceiver.direction and replaceTrack.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2186.html" title="Last updated on May 2, 2019, 1:37 PM UTC (98cc6c3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2186/0d55754...henbos:98cc6c3.html" title="Last updated on May 2, 2019, 1:37 PM UTC (98cc6c3)">Diff</a>