### PR TITLE
Count datachannel label/protocol length in utf-8.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9020,9 +9020,10 @@ interface RTCTrackEvent : Event {
                   <a>[[\DataChannelLabel]]</a> slot to the value of the first
                   argument.</p>
                 </li>
-                <li data-tests="RTCPeerConnection-createDataChannel.html">If <a>[[\DataChannelLabel]]</a>
-                is longer than 65535 bytes, <a>throw</a> a
-                <code>TypeError</code>.
+                <li data-tests="RTCPeerConnection-createDataChannel.html">
+                  <p>If the UTF-8 representation of <a>[[\DataChannelLabel]]</a>
+                  is longer than 65535 bytes, <a>throw</a> a
+                  <code>TypeError</code>.</p>
                 </li>
                 <li>
                   <p>Let <var>options</var> be the second argument.</p>
@@ -9047,8 +9048,10 @@ interface RTCTrackEvent : Event {
                   <a>[[\DataChannelProtocol]]</a> slot to <var>option</var>'s
                   <code>protocol</code> member.</p>
                 </li>
-                <li data-tests="RTCPeerConnection-createDataChannel.html">If <a>[[\DataChannelProtocol]]</a> is longer than
-                65535 bytes long, <a>throw</a> a <code>TypeError</code>.
+                <li data-tests="RTCPeerConnection-createDataChannel.html">
+                  <p>If the UTF-8 representation of
+                  <a>[[\DataChannelProtocol]]</a> is longer than 65535 bytes,
+                  <a>throw</a> a <code>TypeError</code>.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-createDataChannel.html">
                   <p>Initialize <var>channel</var>'s <a>[[\Negotiated]]</a>


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2191.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2194.html" title="Last updated on May 15, 2019, 5:43 PM UTC (5cff11c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2194/69403dd...jan-ivar:5cff11c.html" title="Last updated on May 15, 2019, 5:43 PM UTC (5cff11c)">Diff</a>