### PR TITLE
getCSRC/SSRC() results in descending timestamp order, no future values.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7254,13 +7254,18 @@ async function updateParameters() {
             <dd>
               <p>Returns an <code><a>RTCRtpContributingSource</a></code> for
               each unique CSRC identifier received by this RTCRtpReceiver in
-              the last 10 seconds.</p>
+              the last 10 seconds, in descending <code>timestamp</code> order,
+              skipping entries for which a <code>timestamp</code> cannot be
+              calculated.
+              </p>
             </dd>
             <dt data-tests="RTCRtpReceiver-getSynchronizationSources.https.html"><dfn data-idl><code>getSynchronizationSources</code></dfn></dt>
             <dd>
               <p>Returns an <code><a>RTCRtpSynchronizationSource</a></code> for
               each unique SSRC identifier received by this RTCRtpReceiver in
-              the last 10 seconds.</p>
+              the last 10 seconds, in descending <code>timestamp</code> order,
+              skipping entries for which a <code>timestamp</code> cannot be
+              calculated.</p>
             </dd>
             <dt data-tests="RTCRtpReceiver-getStats.https.html"><code>getStats</code></dt>
             <dd>
@@ -7345,7 +7350,9 @@ async function updateParameters() {
               delivered to the <code><a>RTCRtpReceiver</a></code>'s
               <code><a>MediaStreamTrack</a></code>. The <code>timestamp</code>
               is defined as <a>performance.timeOrigin</a> +
-              <a>performance.now()</a> at that time.</p>
+              <a>performance.now()</a> at that time. If this hasn't happened
+              yet, then the <code>timestamp</code> cannot be calculated.
+              </p>
             </dd>
             <dt data-tests="RTCRtpReceiver-getSynchronizationSources.https.html"><dfn data-idl><code>source</code></dfn> of type <span class=
             "idlMemberType">unsigned long</span>, required</dt>

--- a/webrtc.html
+++ b/webrtc.html
@@ -7254,18 +7254,15 @@ async function updateParameters() {
             <dd>
               <p>Returns an <code><a>RTCRtpContributingSource</a></code> for
               each unique CSRC identifier received by this RTCRtpReceiver in
-              the last 10 seconds, in descending <code>timestamp</code> order,
-              skipping entries for which a <code>timestamp</code> cannot be
-              calculated.
+              the last 10 seconds, in descending <code>timestamp</code> order.
               </p>
             </dd>
             <dt data-tests="RTCRtpReceiver-getSynchronizationSources.https.html"><dfn data-idl><code>getSynchronizationSources</code></dfn></dt>
             <dd>
               <p>Returns an <code><a>RTCRtpSynchronizationSource</a></code> for
               each unique SSRC identifier received by this RTCRtpReceiver in
-              the last 10 seconds, in descending <code>timestamp</code> order,
-              skipping entries for which a <code>timestamp</code> cannot be
-              calculated.</p>
+              the last 10 seconds, in descending <code>timestamp</code> order.
+              </p>
             </dd>
             <dt data-tests="RTCRtpReceiver-getStats.https.html"><code>getStats</code></dt>
             <dd>
@@ -7350,9 +7347,7 @@ async function updateParameters() {
               delivered to the <code><a>RTCRtpReceiver</a></code>'s
               <code><a>MediaStreamTrack</a></code>. The <code>timestamp</code>
               is defined as <a>performance.timeOrigin</a> +
-              <a>performance.now()</a> at that time. If this hasn't happened
-              yet, then the <code>timestamp</code> cannot be calculated.
-              </p>
+              <a>performance.now()</a> at that time.</p>
             </dd>
             <dt data-tests="RTCRtpReceiver-getSynchronizationSources.https.html"><dfn data-idl><code>source</code></dfn> of type <span class=
             "idlMemberType">unsigned long</span>, required</dt>


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2189.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2195.html" title="Last updated on May 15, 2019, 11:35 PM UTC (1b61dcd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2195/69403dd...jan-ivar:1b61dcd.html" title="Last updated on May 15, 2019, 11:35 PM UTC (1b61dcd)">Diff</a>