### PR TITLE
Silence OperationError in addIceCandidate if stopped.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3167,6 +3167,17 @@ interface RTCPeerConnection : EventTarget  {
                         </ol>
                       </li>
                       <li data-tests="RTCPeerConnection-addIceCandidate.html">
+                        <p>If either <var>candidate.sdpMid</var> or
+                        <var>candidate.sdpMLineIndex</var> indicate a media
+                        description in <code><a data-link-for=
+                          "RTCPeerConnection">remoteDescription</a></code> whose
+                        associated transceiver is
+                        <a data-link-for="RTCRtpTransceiver">
+                          stopped</a>, <a>resolve</a> <var>p</var> with
+                        <code>undefined</code> and abort these steps.
+                        </p>
+                      </li>
+                      <li data-tests="RTCPeerConnection-addIceCandidate.html">
                         <p>If <code><var>candidate</var>.usernameFragment</code>
                         is not <code>null</code>, and is not
                         equal to any username fragment present in the corresponding


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2164.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2196.html" title="Last updated on May 15, 2019, 8:28 PM UTC (1aa5413)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2196/69403dd...jan-ivar:1aa5413.html" title="Last updated on May 15, 2019, 8:28 PM UTC (1aa5413)">Diff</a>