### PR TITLE
Make DOMException references cite [WEBIDL]

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3659,8 +3659,9 @@ interface RTCPeerConnection : EventTarget  {
                   Parameters</h2>
                   <dl data-link-for="RTCPeerConnectionErrorCallback" data-dfn-for=
                   "RTCPeerConnectionErrorCallback" class="callback-members">
-                    <dt><code>error</code> of type <span class=
-                    "idlMemberType">DOMException</span></dt>
+                    <dt><code>error</code> of type
+                    <code><a data-cite="!WEBIDL#idl-DOMException">
+                    DOMException</a></code></dt>
                     <dd>An error object encapsulating information about what went
                     wrong.</dd>
                   </dl>
@@ -4962,11 +4963,12 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   identifies an algorithm that the <a>user agent</a> cannot
                   or will not use to generate a certificate for
                   <code>RTCPeerConnection</code>, return a promise that is
-                  <a>rejected</a> with a <code>DOMException</code> of type
-                  <code>NotSupportedError</code>. In particular,
-                  <var>normalizedKeygenAlgorithm</var> MUST be an asymmetric
-                  algorithm that can be used to produce a signature used to
-                  authenticate DTLS connections.</p>
+                  <a>rejected</a> with a
+                  <code><a data-cite="!WEBIDL#idl-DOMException">
+                  DOMException</a></code> of type <code>NotSupportedError</code>. In
+                  particular, <var>normalizedKeygenAlgorithm</var> MUST be an
+                  asymmetric algorithm that can be used to produce a signature
+                  used to authenticate DTLS connections.</p>
                 </li>
                 <li>
                   <p>Let <var>p</var> be a new promise.</p>
@@ -11703,8 +11705,8 @@ if (sender.dtmf.canInsertDTMF) {
   <section>
     <h2>Error Handling</h2>
     <p>Some operations throw or fire <code>RTCError</code>. This is an extension
-    of <code>DOMException</code> that carries additional WebRTC-specific
-    information.</p>
+    of <code><a data-cite="!WEBIDL#idl-DOMException">DOMException</a></code>
+    that carries additional WebRTC-specific information.</p>
     <section>
       <h3><dfn>RTCError</dfn> Interface</h3>
       <div>
@@ -11712,7 +11714,7 @@ if (sender.dtmf.canInsertDTMF) {
           [
               Exposed=Window,
               Constructor(RTCErrorInit init, optional DOMString message = "")
-          ] interface RTCError /*: DOMException*/ {
+          ] interface RTCError : DOMException {
               readonly attribute RTCErrorDetailType errorDetail;
               readonly attribute long? sdpLineNumber;
               readonly attribute long? httpRequestStatusCode;
@@ -11741,10 +11743,10 @@ if (sender.dtmf.canInsertDTMF) {
                 object.</p>
               </li>
               <li data-tests="RTCError.html">
-                <p>Invoke the <code>DOMException</code> constructor of
-                <var>e</var> with the <code>message</code> argument set to
-                <var>message</var> and the <code>name</code> argument set to
-                <code>"RTCError"</code>.</p>
+                <p>Invoke the <code><a data-cite="!WEBIDL#idl-DOMException">
+                DOMException</a></code> constructor of <var>e</var> with the
+                <code>message</code> argument set to <var>message</var> and the
+                <code>name</code> argument set to <code>"RTCError"</code>.</p>
                 <p class="note">This name does not have a mapping to a legacy
                 code so <var>e</var>'s <code>code</code> attribute will return
                 0.</p>


### PR DESCRIPTION
Fixes #2091.

We (still) have two WebIDL references, [[WEBIDL]](https://heycam.github.io/webidl/) and [[WEBIDL-1]](https://www.w3.org/TR/2016/REC-WebIDL-1-20161215/). These point to different versions.

The first one seem to reference tip-of-tree, the second seem to reference a version from dec 2016, where DOMException is not an interface like it is today.

We should probably cite a recent version and only have one WebIDL source. In the meantime, this PR makes the DOMException references not be broken.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2200.html" title="Last updated on Jun 13, 2019, 1:21 PM UTC (ab24347)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2200/3e20f80...henbos:ab24347.html" title="Last updated on Jun 13, 2019, 1:21 PM UTC (ab24347)">Diff</a>