### PR TITLE
Clarify that setting active to false does not send RTCP BYE

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6719,7 +6719,8 @@ async function updateParameters() {
               <p>Indicates that this
               encoding is actively being sent. Setting it to <code>false</code>
               causes this encoding to no longer be sent. Setting it to <code>true</code>
-              causes this encoding to be sent.
+              causes this encoding to be sent. Since setting the value to <code>false</code>
+              does not cause the SSRC to be removed, an RTCP BYE is not sent.</p>
             </dd>
             <dt data-tests="RTCRtpParameters-encodings.html"><dfn data-idl><code>ptime</code></dfn> of type <span class=
             "idlMemberType">unsigned long</span></dt>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/2202


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2204.html" title="Last updated on Jun 6, 2019, 4:59 AM UTC (021cd4d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2204/44bff1d...021cd4d.html" title="Last updated on Jun 6, 2019, 4:59 AM UTC (021cd4d)">Diff</a>