### PR TITLE
Specify that "id" is ignored when negotiated=false.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -10141,7 +10141,8 @@ interface RTCTrackEvent : Event {
             <dt data-tests="RTCPeerConnection-createDataChannel.html"><dfn data-idl><code>id</code></dfn> of type <span class=
             "idlMemberType">unsigned short</span></dt>
             <dd>
-              <p>Overrides the default selection of ID for this channel.</p>
+              <p>Sets the channel ID when "negotiated" is true.
+                Ignored when "negotiated" is false.</p>
             </dd>
             <dt data-tests="RTCPeerConnection-createDataChannel.html"><dfn data-idl><code>priority</code></dfn> of type <span class=
             "idlMemberType"><a>RTCPriorityType</a></span>, defaulting to


### PR DESCRIPTION
Fixes #2157


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2205.html" title="Last updated on Jun 6, 2019, 1:38 PM UTC (ac788bb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2205/44bff1d...ac788bb.html" title="Last updated on Jun 6, 2019, 1:38 PM UTC (ac788bb)">Diff</a>