### PR TITLE
Fix outdated information in mandatory stats list.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -10950,20 +10950,20 @@ interface RTCDTMFToneChangeEvent : Event {
       attributes that are listed when they are valid for that object:</p>
       <ul>
         <li data-tests="RTCPeerConnection-getStats.https.html">RTCRTPStreamStats, with attributes ssrc, kind,
-        transportId, codecId, nackCount</li>
+        transportId, codecId</li>
         <li data-tests="RTCPeerConnection-getStats.https.html,RTCRtpReceiver-getStats.https.html">RTCReceivedRTPStreamStats, with all required attributes from its
         inherited dictionaries, and also attributes packetsReceived,
         packetsLost, jitter, packetsDiscarded</li>
         <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCRtpReceiver-getStats.https.html">RTCInboundRTPStreamStats, with all required attributes from its
-        inherited dictionaries, and also attributes bytesReceived, trackId,
-        receiverId, remoteId, framesDecoded</li>
+        inherited dictionaries, and also attributes trackId,
+        receiverId, remoteId, framesDecoded, nackCount</li>
         <li data-tests="RTCPeerConnection-getStats.https.html">RTCRemoteInboundRTPStreamStats, with all required attributes from
-        its inherited dictionaries, and also attributes localId,
+        its inherited dictionaries, and also attributes localId, bytesReceived,
         roundTripTime</li>
         <li data-tests="RTCPeerConnection-getStats.https.html,RTCRtpSender-getStats.https.html">RTCSentRTPStreamStats, with all required attributes from its
         inherited dictionaries, and also attributes packetsSent, bytesSent</li>
         <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCRtpSender-getStats.https.html">RTCOutboundRTPStreamStats, with all required attributes from its
-        inherited dictionaries, and also attributes trackId, senderId, remoteId, framesEncoded</li>
+        inherited dictionaries, and also attributes trackId, senderId, remoteId, framesEncoded, nackCount</li>
         <li data-tests="RTCPeerConnection-getStats.https.html">RTCRemoteOutboundRTPStreamStats, with all required attributes from
         its inherited dictionaries, and also attributes localId, remoteTimestamp
         </li>
@@ -10973,14 +10973,15 @@ interface RTCDTMFToneChangeEvent : Event {
         dataChannelIdentifier, state, messagesSent, bytesSent, messagesReceived,
         bytesReceived</li>
         <li data-tests="RTCPeerConnection-getStats.https.html, RTCPeerConnection-track-stats.https.html">RTCMediaStreamStats, with attributes streamIdentifer, trackIds</li>
-        <li data-tests="RTCPeerConnection-getStats.https.html">RTCMediaStreamTrackStats, with attribute detached</li>
-        <li data-tests="RTCPeerConnection-track-stats.https.html">RTCMediaHandlerStats with attributes trackIdentifier, remoteSource, ended</li>
+        <li data-tests="RTCPeerConnection-track-stats.https.html">RTCMediaHandlerStats with attributes trackIdentifier, ended</li>
+        <li data-tests="RTCPeerConnection-track-stats.https.html">RTCSenderVideoTrackAttachmentStats, with all required attributes from its inherited dictionaries</li>
+        <li data-tests="RTCPeerConnection-track-stats.https.html">RTCSenderAudioTrackAttachmentStats, with all required attributes from its inherited dictionaries</li>
         <li data-tests="RTCPeerConnection-track-stats.https.html">RTCAudioHandlerStats with attribute audioLevel</li>
         <li data-tests="RTCPeerConnection-track-stats.https.html">RTCVideoHandlerStats with attributes frameWidth, frameHeight, framesPerSecond</li>
         <li data-tests="RTCPeerConnection-track-stats.https.html">RTCVideoSenderStats with attribute framesSent</li>
         <li data-tests="RTCPeerConnection-track-stats.https.html">RTCVideoReceiverStats with attributes framesReceived, framesDecoded, framesDropped,
         partialFramesLost</li>
-        <li data-tests="RTCPeerConnection-getStats.https.html">RTCCodecStats, with attributes payloadType, codec, clockRate,
+        <li data-tests="RTCPeerConnection-getStats.https.html">RTCCodecStats, with attributes payloadType, codecType, mimeType, clockRate,
         channels, sdpFmtpLine</li>
         <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html">RTCTransportStats, with attributes bytesSent, bytesReceived,
         rtcpTransportStatsId, selectedCandidatePairId,


### PR DESCRIPTION
Mostly editorial. Two discretions taken were:
 1. Adding `codecType`, which seemed like an omission.
 2. Removing `remoteSource` per https://github.com/w3c/webrtc-stats/issues/399.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2206.html" title="Last updated on Jun 6, 2019, 7:14 PM UTC (63d826f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2206/44bff1d...jan-ivar:63d826f.html" title="Last updated on Jun 6, 2019, 7:14 PM UTC (63d826f)">Diff</a>