### PR TITLE
Add implicit rollback to setRemoteDescription(description)

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3113,6 +3113,32 @@ interface RTCPeerConnection : EventTarget  {
                     to <var>connection</var>'s operation queue:</p>
                     <ol>
                       <li>
+                        <p>If the <var>description</var>'s <code><a data-link-for=
+                        "RTCSessionDescription">type</a></code> is
+                        <code>"offer"</code> and is invalid for the
+                        current <a>signaling state</a> of <var>connection</var>
+                        as described in <span data-jsep=
+                        "processing-a-local-desc processing-a-remote-desc">[[!JSEP]]</span>,
+                        then run the following sub-steps:</p>
+                        <ol>
+                          <li>
+                            <p>Let <var>p</var> be the result of <a
+                            href="#set-description">setting the RTCSessionDescription</a>
+                            to a new description with a <code><a
+                            data-link-for="RTCSessionDescription">type</a></code> of
+                            <code>"rollback"</code>.</p>
+                          </li>
+                          <li>
+                            <p>Return the result of <a
+                            href="https://w3ctag.github.io/promises-guide/#transforming-by">
+                            transforming</a> <var>p</var> with a fulfillment handler
+                            that returns the result of
+                            <a href="#set-description">setting the RTCSessionDescription</a>
+                            to <var>description</var>, and abort these steps.</p>
+                          </li>
+                        </ol>
+                      </li>
+                      <li>
                         <p>Return the result of <a
                           href="#set-description">setting the RTCSessionDescription</a>
                         to <var>description</var>.</p>


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2166. For consideration.

Please ignore first commit, as this patch sits on top of https://github.com/w3c/webrtc-pc/pull/2209.

If you got to "Files changed" you'll see both. [This](https://github.com/w3c/webrtc-pc/pull/2212/commits/32c45e9b931e417e4b0e46fb35f7f5100a658dfb) is the patch for review (commit 2).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2212.html" title="Last updated on Jul 11, 2019, 2:37 PM UTC (c639289)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2212/513513b...jan-ivar:c639289.html" title="Last updated on Jul 11, 2019, 2:37 PM UTC (c639289)">Diff</a>