### PR TITLE
Use WHATWG references for HTML

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -74,18 +74,18 @@
   <section>
     <h2>Terminology</h2>
     <p>The <code><a data-cite=
-    "!HTML51/webappapis.html#event-handler">EventHandler</a></code>
+    "!HTML/webappapis.html#eventhandler">EventHandler</a></code>
     interface, representing a callback used for event handlers, and the
-    <code><dfn data-cite="!HTML51/webappapis.html#errorevent-errorevent">
-    ErrorEvent</dfn></code> interface are defined in [[!HTML51]].</p>
-    <p>The concepts <dfn data-cite="!HTML51/webappapis.html#queuing">queue a
-    task</dfn> and <dfn data-cite="!HTML51/webappapis.html#networking-task-source">networking
-    task source</dfn> are defined in [[!HTML51]].</p>
+    <code><dfn data-cite="!HTML/webappapis.html#errorevent">
+    ErrorEvent</dfn></code> interface are defined in [[!HTML]].</p>
+    <p>The concepts <dfn data-cite="!HTML/webappapis.html#queue-a-task">queue a
+    task</dfn> and <dfn data-cite="!HTML/webappapis.html#networking-task-source">networking
+    task source</dfn> are defined in [[!HTML]].</p>
     <p>The concept <dfn data-cite="!DOM#firing-events">fire an
     event</dfn> is defined in [[!DOM]].</p>
-    <p>The terms <dfn>event</dfn>, <dfn data-cite="!HTML51/webappapis.html#events-event-handlers">event
-    handlers</dfn> and <dfn data-cite="!HTML51/webappapis.html#event-handler-event-type">event
-    handler event types</dfn> are defined in [[!HTML51]].</p>
+    <p>The terms <dfn>event</dfn>, <dfn data-cite="!HTML/webappapis.html#events-event-handlers">event
+    handlers</dfn> and <dfn data-cite="!HTML/webappapis.html#event-handler-event-type">event
+    handler event types</dfn> are defined in [[!HTML]].</p>
     <p><code><dfn data-cite="!HIGHRES-TIME#dom-performance-timeorigin">performance.timeOrigin</dfn></code>
     and <code><dfn data-cite="!HIGHRES-TIME#dom-performance-now">performance.now()</dfn></code>
     are defined in [[!HIGHRES-TIME]].</p>

--- a/webrtc.js
+++ b/webrtc.js
@@ -1,9 +1,3 @@
-// Working around  respec using WHATWG HTML links for EventHandler
-// See also https://github.com/w3c/respec/issues/1372
-function cleanHTMLRef() {
-    [...document.querySelectorAll("a[href='https://html.spec.whatwg.org/multipage/#eventhandler']")].forEach(a => a.href = "https://www.w3.org/TR/html52/webappapis.html#event-handler");
-}
-
 // ReSpec no longer handles correctly overloaded methods https://github.com/w3c/respec/issues/1939
 // So we fix duplicate ids manually for now
 function dedupOverload() {
@@ -239,5 +233,5 @@ var respecConfig = {
            "edDraft": "https://w3c.github.io/webrtc-pc/identity.html"
         }
     },
-  postProcess: [cleanHTMLRef, dedupOverload]
+  postProcess: [dedupOverload]
 };


### PR DESCRIPTION
Per http://lists.w3.org/Archives/Public/spec-prod/2019AprJun/0000.html


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2216.html" title="Last updated on Jun 24, 2019, 1:29 PM UTC (fabab3e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2216/ac22ab1...fabab3e.html" title="Last updated on Jun 24, 2019, 1:29 PM UTC (fabab3e)">Diff</a>