### PR TITLE
Don't rely on event.streams in Example 11.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -11326,8 +11326,10 @@ async function warmup(isAnswerer) {
       }
 
       // don't set srcObject again if it is already set.
-      if (remoteView.srcObject) return;
-      remoteView.srcObject = event.streams[0];
+      if (!remoteView.srcObject) {
+        remoteView.srcObject = new MediaStream();
+      }
+      remoteView.srcObject.addTrack(event.track);
     } catch (err) {
       console.error(err);
     }
@@ -11335,7 +11337,8 @@ async function warmup(isAnswerer) {
 
   try {
     // get a local stream, show it in a self-view and add it to be sent
-    const stream = await navigator.mediaDevices.getUserMedia({audio: true, video: true});
+    const stream = await navigator.mediaDevices.getUserMedia({audio: true,
+                                                              video: true});
     selfView.srcObject = stream;
     audioSendTrack = stream.getAudioTracks()[0];
     if (started) {
@@ -11346,7 +11349,7 @@ async function warmup(isAnswerer) {
       await video.sender.replaceTrack(videoSendTrack);
     }
   } catch (err) {
-    console.erro(err);
+    console.error(err);
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2217.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2218.html" title="Last updated on Jun 24, 2019, 8:20 PM UTC (f6e8cbd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2218/ac22ab1...jan-ivar:f6e8cbd.html" title="Last updated on Jun 24, 2019, 8:20 PM UTC (f6e8cbd)">Diff</a>