### PR TITLE
Add the "closing" event to datachannel

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9765,6 +9765,7 @@ interface RTCTrackEvent : Event {
                     attribute EventHandler        onopen;
                     attribute EventHandler        onbufferedamountlow;
                     attribute EventHandler        onerror;
+                    attribute EventHandler        onclosing;
                     attribute EventHandler        onclose;
     void close ();
                     attribute EventHandler        onmessage;
@@ -9929,10 +9930,14 @@ interface RTCTrackEvent : Event {
               Cause Code value, and <code>message</code>
               contains the SCTP Cause-Specific-Information,
               possibly with additional text.</p></dd>
+            <dt><dfn data-idl><code>onclosing</code></dfn> of type <span class=
+            "idlAttrType">EventHandler</span></dt>
+            <dd><p>The event type of this event handler is
+            <code><a>Event</a></code>.</p></dd>
             <dt><dfn data-idl><code>onclose</code></dfn> of type <span class=
             "idlAttrType">EventHandler</span></dt>
             <dd><p>The event type of this event handler is
-            <code><a>close</a></code>.</p></dd>
+            <code><a>Event</a></code>.</p></dd>
             <dt data-tests="RTCDataChannel-send.html,datachannel-emptystring.html"><dfn data-idl><code>onmessage</code></dfn> of type <span class=
             "idlAttrType">EventHandler</span></dt>
             <dd><p>The event type of this event handler is
@@ -12107,6 +12112,14 @@ if (sender.dtmf.canInsertDTMF) {
           <td><dfn><code id="event-datachannel-error">error</code></dfn></td>
           <td><code><a>RTCErrorEvent</a></code></td>
           <td>An error occurred on the data channel.</td>
+        </tr>
+        <tr>
+          <td><dfn><code id="event-datachannel-closing">closing</code></dfn></td>
+          <td><code><a>Event</a></code></td>
+          <td>
+            The <code><a>RTCDataChannel</a></code> object transitions to the
+            "closing" state
+          </td>
         </tr>
         <tr>
           <td><dfn><code id="event-datachannel-close">close</code></dfn></td>


### PR DESCRIPTION
As per October 2018 TPAC decision.
Fixes #1827


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2223.html" title="Last updated on Jul 8, 2019, 8:01 AM UTC (8e9cb19)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2223/dd4a8ec...8e9cb19.html" title="Last updated on Jul 8, 2019, 8:01 AM UTC (8e9cb19)">Diff</a>