### PR TITLE
Add note on allocating bandwidth between simulcast streams

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7875,6 +7875,17 @@ async function updateParameters() {
         attribute to <code>false</code>, or can be reactivated by setting the <code>active</code>
         attribute to <code>true</code>.  Using <code>setParameters</code>, stream characteristics can be
         changed by modifying attributes such as <code>maxBitrate</code> and <code>maxFramerate</code>.</p>
+        <p class="note">
+          Simulcast is frequently used to send multiple encodings to
+          an SFU, which will then forward one of the simulcast streams to the
+          end user. The user agent is therefore expected to allocate bandwidth
+          between encodings in such a way that all simulcast streams are
+          usable on their own; for instance, if two simulcast streams
+          have the same "maxFramerate", one would expect to see a
+          similar framerate on both streams. If bandwidth does not
+          permit all simulcast streams to be sent in an usable form,
+          the user agent is expected to stop sending some of the simulcast streams.
+        </p>
         <p>As defined in <span data-jsep="simulcast">[[!JSEP]]</span>, an offer from a user-agent will
         only contain a "send" description and no "recv" description on the "a=simulcast" line.
         Alternatives and restrictions (described in [[MMUSIC-SIMULCAST]]) are not supported.</p>


### PR DESCRIPTION
Fixes #2141

The note is not normative, so tests are not strictly required.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2225.html" title="Last updated on Jul 8, 2019, 1:29 PM UTC (82b97d1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2225/dd4a8ec...82b97d1.html" title="Last updated on Jul 8, 2019, 1:29 PM UTC (82b97d1)">Diff</a>