### PR TITLE
Replace term "Enqueue an operation" w/"Chain an asynchronous operation" (editorial)

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1149,7 +1149,8 @@
         when all the previous calls have finished executing and their promises
         have <a>settled</a>.</p>
         <p data-tests="RTCPeerConnection-createOffer.html">To <dfn>chain an operation</dfn> to an
-        <a><code>RTCPeerConnection</code></a> object's operations chain, run
+        <a><code>RTCPeerConnection</code></a> object's <a href=
+        "#dfn-operations-chain">operations chain</a>, run
         the following steps:</p>
         <ol>
           <li>
@@ -2618,7 +2619,7 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>Return the result of <a href=
-                    "#chain-an-operation">chaining</a> the following
+                    "#dfn-chain-an-operation">chaining</a> the following
                     steps to <var>connection</var>'s operations chain:</p>
                     <ol>
                       <li>
@@ -2863,7 +2864,7 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>Return the result of <a href=
-                    "#chain-an-operation">chaining</a> the following
+                    "#dfn-chain-an-operation">chaining</a> the following
                     steps to <var>connection</var>'s operations chain:</p>
                     <ol>
                       <li data-tests="RTCPeerConnection-createAnswer.html,RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setLocalDescription-pranswer.html">
@@ -3057,7 +3058,7 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>Return the result of <a href=
-                    "#chain-an-operation">chaining</a> the following steps to
+                    "#dfn-chain-an-operation">chaining</a> the following steps to
                     <var>connection</var>'s operations chain:</p>
                     <ol>
                       <li data-tests="RTCPeerConnection-setLocalDescription-answer.html">
@@ -3109,7 +3110,7 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>Return the result of <a href=
-                    "#chain-an-operation">chaining</a> the following steps
+                    "#dfn-chain-an-operation">chaining</a> the following steps
                     to <var>connection</var>'s operations chain:</p>
                     <ol>
                       <li>
@@ -3178,7 +3179,7 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>Return the result of <a href=
-                    "#chain-an-operation">chaining</a> the following
+                    "#dfn-chain-an-operation">chaining</a> the following
                     steps to <var>connection</var>'s operations chain:</p>
                     <ol>
                       <li data-tests="RTCPeerConnection-addIceCandidate.html">
@@ -6437,7 +6438,7 @@ async function updateParameters() {
                 </li>
                 <li>
                   <p>Return the result of <a href=
-                    "#chain-an-operation">chaining</a> the following
+                    "#dfn-chain-an-operation">chaining</a> the following
                   steps to <var>connection</var>'s operations chain:</p>
                   <ol>
                   <li data-tests="RTCPeerConnection-setRemoteDescription-replaceTrack.https.html,RTCRtpSender-replaceTrack.https.html,RTCRtpTransceiver.https.html">

--- a/webrtc.html
+++ b/webrtc.html
@@ -1082,7 +1082,7 @@
           </li>
           <li>
             <p>Let <var>connection</var> have an <dfn>[[\Operations]]</dfn>
-            internal slot, representing an <a>operations queue</a>, initialized
+            internal slot, representing an <a>operations chain</a>, initialized
             to an empty list.</p>
           </li>
           <li>
@@ -1140,16 +1140,16 @@
         </section>
 
         <section>
-        <h4>Enqueue an operation</h4>
+        <h4>Chain an asynchronous operation</h4>
         <p>An <code><a>RTCPeerConnection</a></code> object has an
-        <dfn>operations queue</dfn>, <a>[[\Operations]]</a>, which ensures that
-        only one asynchronous operation in the queue is executed concurrently.
+        <dfn>operations chain</dfn>, <a>[[\Operations]]</a>, which ensures that
+        only one asynchronous operation in the chain executes concurrently.
         If subsequent calls are made while the returned promise of a previous
-        call is still not <a>settled</a>, they are added to the queue and executed
+        call is still not <a>settled</a>, they are added to the chain and executed
         when all the previous calls have finished executing and their promises
         have <a>settled</a>.</p>
-        <p data-tests="RTCPeerConnection-createOffer.html">To <dfn>enqueue an operation</dfn> to an
-        <a><code>RTCPeerConnection</code></a> object's operation queue, run
+        <p data-tests="RTCPeerConnection-createOffer.html">To <dfn>chain an operation</dfn> to an
+        <a><code>RTCPeerConnection</code></a> object's operations chain, run
         the following steps:</p>
         <ol>
           <li>
@@ -1163,7 +1163,7 @@
             <code>InvalidStateError</code>.</p>
           </li>
           <li>
-            <p>Let <var>operation</var> be the operation to be enqueued.</p>
+            <p>Let <var>operation</var> be the operation to be chained.</p>
           </li>
           <li>
             <p>Let <var>p</var> be a new promise.</p>
@@ -2618,8 +2618,8 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>Return the result of <a href=
-                    "#enqueue-an-operation">enqueuing</a> the following
-                    steps to <var>connection</var>'s operation queue:</p>
+                    "#chain-an-operation">chaining</a> the following
+                    steps to <var>connection</var>'s operations chain:</p>
                     <ol>
                       <li>
                         <p>If <var>connection</var>'s <a>signaling state</a>
@@ -2863,8 +2863,8 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>Return the result of <a href=
-                    "#enqueue-an-operation">enqueuing</a> the following
-                    steps to <var>connection</var>'s operation queue:</p>
+                    "#chain-an-operation">chaining</a> the following
+                    steps to <var>connection</var>'s operations chain:</p>
                     <ol>
                       <li data-tests="RTCPeerConnection-createAnswer.html,RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setLocalDescription-pranswer.html">
                         <p>If <var>connection</var>'s <a>signaling state</a>
@@ -3057,8 +3057,8 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>Return the result of <a href=
-                    "#enqueue-an-operation">enqueuing</a> the following steps to
-                    <var>connection</var>'s operation queue:</p>
+                    "#chain-an-operation">chaining</a> the following steps to
+                    <var>connection</var>'s operations chain:</p>
                     <ol>
                       <li data-tests="RTCPeerConnection-setLocalDescription-answer.html">
                         <p>If <var>description.sdp</var> is the empty string and
@@ -3109,8 +3109,8 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>Return the result of <a href=
-                    "#enqueue-an-operation">enqueuing</a> the following steps
-                    to <var>connection</var>'s operation queue:</p>
+                    "#chain-an-operation">chaining</a> the following steps
+                    to <var>connection</var>'s operations chain:</p>
                     <ol>
                       <li>
                         <p>Return the result of <a
@@ -3178,8 +3178,8 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>Return the result of <a href=
-                    "#enqueue-an-operation">enqueuing</a> the following
-                    steps to <var>connection</var>'s operation queue:</p>
+                    "#chain-an-operation">chaining</a> the following
+                    steps to <var>connection</var>'s operations chain:</p>
                     <ol>
                       <li data-tests="RTCPeerConnection-addIceCandidate.html">
                         <p>If <code><a data-link-for=
@@ -6437,8 +6437,8 @@ async function updateParameters() {
                 </li>
                 <li>
                   <p>Return the result of <a href=
-                    "#enqueue-an-operation">enqueuing</a> the following
-                  steps to <var>connection</var>'s operation queue:</p>
+                    "#chain-an-operation">chaining</a> the following
+                  steps to <var>connection</var>'s operations chain:</p>
                   <ol>
                   <li data-tests="RTCPeerConnection-setRemoteDescription-replaceTrack.https.html,RTCRtpSender-replaceTrack.https.html,RTCRtpTransceiver.https.html">
                     <p>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot is


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2227. @henbos PTAL.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2228.html" title="Last updated on Jul 15, 2019, 3:53 PM UTC (db9858f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2228/513513b...jan-ivar:db9858f.html" title="Last updated on Jul 15, 2019, 3:53 PM UTC (db9858f)">Diff</a>