### PR TITLE
Fix inconsistent WebIDL. Reformat to follow de facto code style of WebIDL,HTML,DOM. (editorial)

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -544,10 +544,11 @@
         the remote endpoint is bundle-aware, all media tracks and data channels
         are bundled onto the same transport.</p>
         <div>
-          <pre id="target-bundle-policy" class="idl">enum RTCBundlePolicy {
-    "balanced",
-    "max-compat",
-    "max-bundle"
+          <pre id="target-bundle-policy" class="idl"
+>enum RTCBundlePolicy {
+  "balanced",
+  "max-compat",
+  "max-bundle"
 };</pre>
           <table data-link-for="RTCBundlePolicy" data-dfn-for="RTCBundlePolicy"
           class="simple">
@@ -584,10 +585,11 @@
         RtcpMuxPolicy affects what ICE candidates are gathered to support
         non-multiplexed RTCP.</p>
         <div>
-          <pre id="target-rtcp-mux-policy" class="idl">enum RTCRtcpMuxPolicy {
-    // At risk due to lack of implementers' interest.
-    "negotiate",
-    "require"
+          <pre id="target-rtcp-mux-policy" class="idl"
+>enum RTCRtcpMuxPolicy {
+  // At risk due to lack of implementers' interest.
+  "negotiate",
+  "require"
 };</pre>
           <table data-link-for="RTCRtcpMuxPolicy" data-dfn-for=
           "RTCRtcpMuxPolicy" class="simple">

--- a/webrtc.html
+++ b/webrtc.html
@@ -8622,8 +8622,8 @@ interface RTCIceTransport : EventTarget {
   readonly attribute RTCIceComponent component;
   readonly attribute RTCIceTransportState state;
   readonly attribute RTCIceGathererState gatheringState;
-  sequence&lt;RTCIceCandidate&gt; getLocalCandidates ();
-  sequence&lt;RTCIceCandidate&gt; getRemoteCandidates ();
+  sequence&lt;RTCIceCandidate&gt; getLocalCandidates();
+  sequence&lt;RTCIceCandidate&gt; getRemoteCandidates();
   RTCIceCandidatePair? getSelectedCandidatePair();
   RTCIceParameters? getLocalParameters();
   RTCIceParameters? getRemoteParameters();

--- a/webrtc.html
+++ b/webrtc.html
@@ -168,15 +168,15 @@
         <code><a>RTCPeerConnection</a></code> is established or
         re-established.</p>
         <div>
-          <pre class="idl">dictionary RTCConfiguration {
-             sequence&lt;RTCIceServer&gt;   iceServers;
-             RTCIceTransportPolicy    iceTransportPolicy;
-             RTCBundlePolicy          bundlePolicy;
-             RTCRtcpMuxPolicy         rtcpMuxPolicy;
-             DOMString                peerIdentity;
-             sequence&lt;RTCCertificate&gt; certificates;
-             [EnforceRange]
-             octet                    iceCandidatePoolSize = 0;
+          <pre class="idl"
+>dictionary RTCConfiguration {
+  sequence&lt;RTCIceServer&gt; iceServers;
+  RTCIceTransportPolicy iceTransportPolicy;
+  RTCBundlePolicy bundlePolicy;
+  RTCRtcpMuxPolicy rtcpMuxPolicy;
+  DOMString peerIdentity;
+  sequence&lt;RTCCertificate&gt; certificates;
+  [EnforceRange] octet iceCandidatePoolSize = 0;
 };</pre>
           <section>
             <h2>Dictionary <a class="idlType">RTCConfiguration</a> Members</h2>
@@ -257,9 +257,10 @@
       <section>
         <h4><dfn>RTCIceCredentialType</dfn> Enum</h4>
         <div>
-          <pre class="idl">enum RTCIceCredentialType {
-    "password",
-    "oauth"
+          <pre class="idl"
+>enum RTCIceCredentialType {
+  "password",
+  "oauth"
 };</pre>
           <table data-link-for="RTCIceCredentialType" data-dfn-for=
           "RTCIceCredentialType" class="simple">
@@ -337,9 +338,10 @@
         <code>RTCIceServer</code>'s <code>username</code> member.
         </p>
         <div>
-          <pre class="idl">dictionary RTCOAuthCredential {
-    required DOMString        macKey;
-    required DOMString        accessToken;
+          <pre class="idl"
+>dictionary RTCOAuthCredential {
+  required DOMString macKey;
+  required DOMString accessToken;
 };</pre>
           <section>
             <h2>Dictionary <a class="idlType">RTCOAuthCredential</a> Members
@@ -393,11 +395,12 @@
         STUN and TURN servers that can be used by the <a>ICE Agent</a> to
         establish a connection with a peer.</p>
         <div>
-          <pre class="idl">dictionary RTCIceServer {
-    required (DOMString or sequence&lt;DOMString&gt;) urls;
-             DOMString                          username;
-             (DOMString or RTCOAuthCredential)     credential;
-             RTCIceCredentialType               credentialType = "password";
+          <pre class="idl"
+>dictionary RTCIceServer {
+  required (DOMString or sequence&lt;DOMString&gt;) urls;
+  DOMString username;
+  (DOMString or RTCOAuthCredential) credential;
+  RTCIceCredentialType credentialType = "password";
 };</pre>
           <section>
             <h2>Dictionary <a class="idlType">RTCIceServer</a> Members</h2>
@@ -486,9 +489,10 @@
         to the application; only these candidates will be used for connectivity
         checks.</p>
         <div>
-          <pre class="idl">enum RTCIceTransportPolicy {
-    "relay",
-    "all"
+          <pre class="idl"
+>enum RTCIceTransportPolicy {
+  "relay",
+  "all"
 };</pre>
           <table data-link-for="RTCIceTransportPolicy" data-dfn-for=
           "RTCIceTransportPolicy" class="simple">
@@ -628,8 +632,9 @@
         <p>These dictionaries describe the options that can be used to control
         the offer/answer creation process.</p>
         <div>
-          <pre class="idl">dictionary RTCOfferAnswerOptions {
-             boolean voiceActivityDetection = true;
+          <pre class="idl"
+>dictionary RTCOfferAnswerOptions {
+  boolean voiceActivityDetection = true;
 };</pre>
           <section>
             <h2>Dictionary <dfn>RTCOfferAnswerOptions</dfn>
@@ -653,8 +658,9 @@
           </section>
         </div>
         <div>
-          <pre class="idl">dictionary RTCOfferOptions : RTCOfferAnswerOptions {
-             boolean iceRestart = false;
+          <pre class="idl"
+>dictionary RTCOfferOptions : RTCOfferAnswerOptions {
+  boolean iceRestart = false;
 };</pre>
           <section>
             <h2>Dictionary <dfn>RTCOfferOptions</dfn> Members</h2>
@@ -698,9 +704,8 @@
         </div>
         <div>
           <p>The <dfn>RTCAnswerOptions</dfn> dictionary describe options specific to session description of type <code>answer</code> (none in this version of the specification).</p>
-          <pre class="idl">
-          dictionary RTCAnswerOptions : RTCOfferAnswerOptions {
-};</pre>
+          <pre class="idl"
+>dictionary RTCAnswerOptions : RTCOfferAnswerOptions {};</pre>
         </div>
       </section>
     </section>
@@ -709,13 +714,14 @@
       <section>
         <h4><dfn>RTCSignalingState</dfn> Enum</h4>
         <div>
-          <pre class="idl">enum RTCSignalingState {
-    "stable",
-    "have-local-offer",
-    "have-remote-offer",
-    "have-local-pranswer",
-    "have-remote-pranswer",
-    "closed"
+          <pre class="idl"
+>enum RTCSignalingState {
+  "stable",
+  "have-local-offer",
+  "have-remote-offer",
+  "have-local-pranswer",
+  "have-remote-pranswer",
+  "closed"
 };</pre>
           <table data-link-for="RTCSignalingState" data-dfn-for=
           "RTCSignalingState" class="simple">
@@ -791,10 +797,11 @@
       <section>
         <h4><dfn>RTCIceGatheringState</dfn> Enum</h4>
         <div>
-          <pre class="idl">enum RTCIceGatheringState {
-    "new",
-    "gathering",
-    "complete"
+          <pre class="idl"
+>enum RTCIceGatheringState {
+  "new",
+  "gathering",
+  "complete"
 };</pre>
           <table data-link-for="RTCIceGatheringState" data-dfn-for=
           "RTCIceGatheringState" class="simple">
@@ -827,13 +834,14 @@
       <section>
         <h4><dfn>RTCPeerConnectionState</dfn> Enum</h4>
         <div>
-          <pre class="idl">enum RTCPeerConnectionState {
-    "closed",
-    "failed",
-    "disconnected",
-    "new",
-    "connecting",
-    "connected"
+          <pre class="idl"
+>enum RTCPeerConnectionState {
+  "closed",
+  "failed",
+  "disconnected",
+  "new",
+  "connecting",
+  "connected"
 };</pre>
           <table data-link-for="RTCPeerConnectionState" data-dfn-for=
           "RTCPeerConnectionState" class="simple">
@@ -892,14 +900,15 @@
       <section>
         <h4><dfn>RTCIceConnectionState</dfn> Enum</h4>
         <div>
-          <pre class="idl">enum RTCIceConnectionState {
-    "closed",
-    "failed",
-    "disconnected",
-    "new",
-    "checking",
-    "completed",
-    "connected"
+          <pre class="idl"
+>enum RTCIceConnectionState {
+  "closed",
+  "failed",
+  "disconnected",
+  "new",
+  "checking",
+  "completed",
+  "connected"
 };</pre>
           <table data-link-for="RTCIceConnectionState" data-dfn-for=
           "RTCIceConnectionState" class="simple">
@@ -2322,37 +2331,37 @@
         the APIs to send and receive <code><a>MediaStreamTrack</a></code>
         objects.</p>
         <div>
-          <pre class="idl" data-tests="idlharness.https.window.js">
-          [ Constructor (optional RTCConfiguration configuration), Exposed=Window]
+          <pre class="idl" data-tests="idlharness.https.window.js"
+>[Exposed=Window, Constructor (optional RTCConfiguration configuration)]
 interface RTCPeerConnection : EventTarget  {
-    Promise&lt;RTCSessionDescriptionInit&gt; createOffer (optional RTCOfferOptions options);
-    Promise&lt;RTCSessionDescriptionInit&gt; createAnswer (optional RTCAnswerOptions options);
-    Promise&lt;void&gt;                      setLocalDescription (RTCSessionDescriptionInit description);
-    readonly        attribute RTCSessionDescription?    localDescription;
-    readonly        attribute RTCSessionDescription?    currentLocalDescription;
-    readonly        attribute RTCSessionDescription?    pendingLocalDescription;
-    Promise&lt;void&gt;                      setRemoteDescription (RTCSessionDescriptionInit description);
-    readonly        attribute RTCSessionDescription?    remoteDescription;
-    readonly        attribute RTCSessionDescription?    currentRemoteDescription;
-    readonly        attribute RTCSessionDescription?    pendingRemoteDescription;
-    Promise&lt;void&gt;                      addIceCandidate (optional RTCIceCandidateInit candidate);
-    readonly        attribute RTCSignalingState         signalingState;
-    readonly        attribute RTCIceGatheringState      iceGatheringState;
-    readonly        attribute RTCIceConnectionState     iceConnectionState;
-    readonly        attribute RTCPeerConnectionState    connectionState;
-    readonly        attribute boolean?                  canTrickleIceCandidates;
-    void                               restartIce ();
-    static sequence&lt;RTCIceServer&gt;      getDefaultIceServers ();
-    RTCConfiguration                   getConfiguration ();
-    void                               setConfiguration (RTCConfiguration configuration);
-    void                               close ();
-                    attribute EventHandler              onnegotiationneeded;
-                    attribute EventHandler              onicecandidate;
-                    attribute EventHandler              onicecandidateerror;
-                    attribute EventHandler              onsignalingstatechange;
-                    attribute EventHandler              oniceconnectionstatechange;
-                    attribute EventHandler              onicegatheringstatechange;
-                    attribute EventHandler              onconnectionstatechange;
+  Promise&lt;RTCSessionDescriptionInit&gt; createOffer(optional RTCOfferOptions options);
+  Promise&lt;RTCSessionDescriptionInit&gt; createAnswer(optional RTCAnswerOptions options);
+  Promise&lt;void&gt; setLocalDescription(RTCSessionDescriptionInit description);
+  readonly attribute RTCSessionDescription? localDescription;
+  readonly attribute RTCSessionDescription? currentLocalDescription;
+  readonly attribute RTCSessionDescription? pendingLocalDescription;
+  Promise&lt;void&gt; setRemoteDescription(RTCSessionDescriptionInit description);
+  readonly attribute RTCSessionDescription? remoteDescription;
+  readonly attribute RTCSessionDescription? currentRemoteDescription;
+  readonly attribute RTCSessionDescription? pendingRemoteDescription;
+  Promise&lt;void&gt; addIceCandidate(optional RTCIceCandidateInit candidate);
+  readonly attribute RTCSignalingState signalingState;
+  readonly attribute RTCIceGatheringState iceGatheringState;
+  readonly attribute RTCIceConnectionState iceConnectionState;
+  readonly attribute RTCPeerConnectionState connectionState;
+  readonly attribute boolean? canTrickleIceCandidates;
+  void restartIce();
+  static sequence&lt;RTCIceServer&gt; getDefaultIceServers();
+  RTCConfiguration getConfiguration();
+  void setConfiguration(RTCConfiguration configuration);
+  void close();
+  attribute EventHandler onnegotiationneeded;
+  attribute EventHandler onicecandidate;
+  attribute EventHandler onicecandidateerror;
+  attribute EventHandler onsignalingstatechange;
+  attribute EventHandler oniceconnectionstatechange;
+  attribute EventHandler onicegatheringstatechange;
+  attribute EventHandler onconnectionstatechange;
 };</pre>
           <section>
             <h2>Constructors</h2>
@@ -3513,12 +3522,22 @@ interface RTCPeerConnection : EventTarget  {
         <section>
           <h4>Method extensions</h4>
         <div>
-          <pre class="idl" data-tests="idlharness.https.window.js">partial interface RTCPeerConnection {
-    Promise&lt;void&gt; createOffer (RTCSessionDescriptionCallback successCallback, RTCPeerConnectionErrorCallback failureCallback, optional RTCOfferOptions options);
-    Promise&lt;void&gt; setLocalDescription (RTCSessionDescriptionInit description, VoidFunction successCallback, RTCPeerConnectionErrorCallback failureCallback);
-    Promise&lt;void&gt; createAnswer (RTCSessionDescriptionCallback successCallback, RTCPeerConnectionErrorCallback failureCallback);
-    Promise&lt;void&gt; setRemoteDescription (RTCSessionDescriptionInit description, VoidFunction successCallback, RTCPeerConnectionErrorCallback failureCallback);
-    Promise&lt;void&gt; addIceCandidate (RTCIceCandidateInit candidate, VoidFunction successCallback, RTCPeerConnectionErrorCallback failureCallback);
+          <pre class="idl" data-tests="idlharness.https.window.js"
+>partial interface RTCPeerConnection {
+  Promise&lt;void&gt; createOffer(RTCSessionDescriptionCallback successCallback,
+                            RTCPeerConnectionErrorCallback failureCallback,
+                            optional RTCOfferOptions options);
+  Promise&lt;void&gt; setLocalDescription(RTCSessionDescriptionInit description,
+                                    VoidFunction successCallback,
+                                    RTCPeerConnectionErrorCallback failureCallback);
+  Promise&lt;void&gt; createAnswer(RTCSessionDescriptionCallback successCallback,
+                             RTCPeerConnectionErrorCallback failureCallback);
+  Promise&lt;void&gt; setRemoteDescription(RTCSessionDescriptionInit description,
+                                     VoidFunction successCallback,
+                                     RTCPeerConnectionErrorCallback failureCallback);
+  Promise&lt;void&gt; addIceCandidate(RTCIceCandidateInit candidate,
+                                VoidFunction successCallback,
+                                RTCPeerConnectionErrorCallback failureCallback);
 };</pre>
           <section>
             <h2>Methods</h2>
@@ -3737,8 +3756,8 @@ interface RTCPeerConnection : EventTarget  {
             <section>
               <h4><dfn>RTCPeerConnectionErrorCallback</dfn></h4>
               <div>
-                <pre class="idl">
-                callback RTCPeerConnectionErrorCallback = void (DOMException error);</pre>
+                <pre class="idl"
+>callback RTCPeerConnectionErrorCallback = void (DOMException error);</pre>
                 <section>
                   <h2>Callback <a class="idlType">RTCPeerConnectionErrorCallback</a>
                   Parameters</h2>
@@ -3756,8 +3775,8 @@ interface RTCPeerConnection : EventTarget  {
             <section>
               <h4><dfn>RTCSessionDescriptionCallback</dfn></h4>
               <div>
-                <pre class="idl">
-                callback RTCSessionDescriptionCallback = void (RTCSessionDescriptionInit description);</pre>
+                <pre class="idl"
+>callback RTCSessionDescriptionCallback = void (RTCSessionDescriptionInit description);</pre>
                 <section>
                   <h2>Callback <a class="idlType">RTCSessionDescriptionCallback</a>
                   Parameters</h2>
@@ -3842,10 +3861,11 @@ interface RTCPeerConnection : EventTarget  {
           </li>
         </ol>
         <div>
-          <pre class="idl">partial dictionary RTCOfferOptions {
-            boolean offerToReceiveAudio;
-            boolean offerToReceiveVideo;
-          };
+          <pre class="idl"
+>partial dictionary RTCOfferOptions {
+  boolean offerToReceiveAudio;
+  boolean offerToReceiveVideo;
+};
           </pre>
           <section>
             <h2>Attributes</h2>
@@ -3899,11 +3919,12 @@ interface RTCPeerConnection : EventTarget  {
         <code><a>RTCSessionDescriptionInit</a></code> or
         <code><a>RTCSessionDescription</a></code> instance.</p>
         <div>
-          <pre class="idl">enum RTCSdpType {
-    "offer",
-    "pranswer",
-    "answer",
-    "rollback"
+          <pre class="idl"
+>enum RTCSdpType {
+  "offer",
+  "pranswer",
+  "answer",
+  "rollback"
 };</pre>
           <table data-link-for="RTCSdpType" data-dfn-for="RTCSdpType" class=
           "simple">
@@ -3961,12 +3982,12 @@ interface RTCPeerConnection : EventTarget  {
         <code><a>RTCPeerConnection</a></code> to expose local and remote
         session descriptions.</p>
         <div>
-          <pre class="idl" data-tests="idlharness.https.window.js">
-          [ Constructor (RTCSessionDescriptionInit descriptionInitDict), Exposed=Window]
+          <pre class="idl" data-tests="idlharness.https.window.js"
+>[Exposed=Window, Constructor(RTCSessionDescriptionInit descriptionInitDict)]
 interface RTCSessionDescription {
-    readonly        attribute RTCSdpType type;
-    readonly        attribute DOMString  sdp;
-    [Default] object toJSON();
+  readonly attribute RTCSdpType type;
+  readonly attribute DOMString sdp;
+  [Default] object toJSON();
 };</pre>
           <section>
             <h2>Constructors</h2>
@@ -4009,9 +4030,10 @@ interface RTCSessionDescription {
           </section>
         </div>
         <div>
-          <pre class="idl">dictionary RTCSessionDescriptionInit {
-    required RTCSdpType type;
-             DOMString  sdp = "";
+          <pre class="idl"
+>dictionary RTCSessionDescriptionInit {
+  required RTCSdpType type;
+  DOMString sdp = "";
 };</pre>
           <section>
             <h2>Dictionary <dfn>RTCSessionDescriptionInit</dfn>
@@ -4232,24 +4254,24 @@ interface RTCSessionDescription {
         if it is well formed.</p>
 
         <div>
-          <pre class="idl" data-tests="idlharness.https.window.js">
-          [ Constructor (optional RTCIceCandidateInit candidateInitDict), Exposed=Window]
+          <pre class="idl" data-tests="idlharness.https.window.js"
+>[Exposed=Window, Constructor(optional RTCIceCandidateInit candidateInitDict)]
 interface RTCIceCandidate {
-    readonly        attribute DOMString               candidate;
-    readonly        attribute DOMString?              sdpMid;
-    readonly        attribute unsigned short?         sdpMLineIndex;
-    readonly        attribute DOMString?              foundation;
-    readonly        attribute RTCIceComponent?        component;
-    readonly        attribute unsigned long?          priority;
-    readonly        attribute DOMString?              address;
-    readonly        attribute RTCIceProtocol?         protocol;
-    readonly        attribute unsigned short?         port;
-    readonly        attribute RTCIceCandidateType?    type;
-    readonly        attribute RTCIceTcpCandidateType? tcpType;
-    readonly        attribute DOMString?              relatedAddress;
-    readonly        attribute unsigned short?         relatedPort;
-    readonly        attribute DOMString?              usernameFragment;
-    RTCIceCandidateInit toJSON();
+  readonly attribute DOMString candidate;
+  readonly attribute DOMString? sdpMid;
+  readonly attribute unsigned short? sdpMLineIndex;
+  readonly attribute DOMString? foundation;
+  readonly attribute RTCIceComponent? component;
+  readonly attribute unsigned long? priority;
+  readonly attribute DOMString? address;
+  readonly attribute RTCIceProtocol? protocol;
+  readonly attribute unsigned short? port;
+  readonly attribute RTCIceCandidateType? type;
+  readonly attribute RTCIceTcpCandidateType? tcpType;
+  readonly attribute DOMString? relatedAddress;
+  readonly attribute unsigned short? relatedPort;
+  readonly attribute DOMString? usernameFragment;
+  RTCIceCandidateInit toJSON();
 };</pre>
           <section>
             <h2>Constructor</h2>
@@ -4471,11 +4493,12 @@ interface RTCIceCandidate {
           </section>
         </div>
         <div>
-          <pre class="idl">dictionary RTCIceCandidateInit {
-             DOMString       candidate = "";
-             DOMString?      sdpMid = null;
-             unsigned short? sdpMLineIndex = null;
-             DOMString?      usernameFragment = null;
+          <pre class="idl"
+>dictionary RTCIceCandidateInit {
+  DOMString candidate = "";
+  DOMString? sdpMid = null;
+  unsigned short? sdpMLineIndex = null;
+  DOMString? usernameFragment = null;
 };</pre>
           <section>
             <h2>Dictionary <dfn>RTCIceCandidateInit</dfn>
@@ -4527,9 +4550,10 @@ interface RTCIceCandidate {
           <p>The <code>RTCIceProtocol</code> represents the protocol of the ICE
           candidate.</p>
           <div>
-            <pre class="idl">enum RTCIceProtocol {
-    "udp",
-    "tcp"
+            <pre class="idl"
+>enum RTCIceProtocol {
+  "udp",
+  "tcp"
 };</pre>
             <table data-link-for="RTCIceProtocol" data-dfn-for="RTCIceProtocol"
             class="simple">
@@ -4554,10 +4578,11 @@ interface RTCIceCandidate {
           <p>The <code>RTCIceTcpCandidateType</code> represents the type of the
           ICE TCP candidate, as defined in [[!RFC6544]].</p>
           <div>
-            <pre class="idl">enum RTCIceTcpCandidateType {
-    "active",
-    "passive",
-    "so"
+            <pre class="idl"
+>enum RTCIceTcpCandidateType {
+  "active",
+  "passive",
+  "so"
 };</pre>
             <table data-link-for="RTCIceTcpCandidateType" data-dfn-for=
             "RTCIceTcpCandidateType" class="simple">
@@ -4594,11 +4619,12 @@ interface RTCIceCandidate {
           <p>The <code>RTCIceCandidateType</code> represents the type of the ICE
           candidate, as defined in [[!ICE]] section 15.1.</p>
           <div>
-            <pre class="idl">enum RTCIceCandidateType {
-    "host",
-    "srflx",
-    "prflx",
-    "relay"
+            <pre class="idl"
+>enum RTCIceCandidateType {
+  "host",
+  "srflx",
+  "prflx",
+  "relay"
 };</pre>
             <table data-link-for="RTCIceCandidateType" data-dfn-for=
             "RTCIceCandidateType" class="simple">
@@ -4686,11 +4712,12 @@ interface RTCIceCandidate {
           </ul>
         </div>
         <div>
-          <pre class="idl" data-tests="idlharness.https.window.js">
-          [ Constructor (DOMString type, optional RTCPeerConnectionIceEventInit eventInitDict), Exposed=Window]
+          <pre class="idl" data-tests="idlharness.https.window.js"
+>[Exposed=Window,
+ Constructor(DOMString type, optional RTCPeerConnectionIceEventInit eventInitDict)]
 interface RTCPeerConnectionIceEvent : Event {
-    readonly        attribute RTCIceCandidate? candidate;
-    readonly        attribute DOMString?       url;
+  readonly attribute RTCIceCandidate? candidate;
+  readonly attribute DOMString? url;
 };</pre>
           <section>
             <h2>Constructors</h2>
@@ -4731,10 +4758,10 @@ interface RTCPeerConnectionIceEvent : Event {
           </section>
         </div>
         <div>
-          <pre class="idl">
-          dictionary RTCPeerConnectionIceEventInit : EventInit {
-             RTCIceCandidate? candidate;
-             DOMString?       url;
+          <pre class="idl"
+>dictionary RTCPeerConnectionIceEventInit : EventInit {
+  RTCIceCandidate? candidate;
+  DOMString? url;
 };</pre>
           <section>
             <h2>Dictionary <dfn>RTCPeerConnectionIceEventInit</dfn>
@@ -4763,13 +4790,14 @@ interface RTCPeerConnectionIceEvent : Event {
         uses the <code><a>RTCPeerConnectionIceErrorEvent</a></code>
         interface.</p>
         <div>
-          <pre class="idl" data-tests="idlharness.https.window.js">
-          [ Constructor (DOMString type, RTCPeerConnectionIceErrorEventInit eventInitDict), Exposed=Window]
+          <pre class="idl" data-tests="idlharness.https.window.js"
+>[Exposed=Window,
+ Constructor(DOMString type, RTCPeerConnectionIceErrorEventInit eventInitDict)]
 interface RTCPeerConnectionIceErrorEvent : Event {
-    readonly        attribute DOMString      hostCandidate;
-    readonly        attribute DOMString      url;
-    readonly        attribute unsigned short errorCode;
-    readonly        attribute USVString      errorText;
+  readonly attribute DOMString hostCandidate;
+  readonly attribute DOMString url;
+  readonly attribute unsigned short errorCode;
+  readonly attribute USVString errorText;
 };</pre>
           <section>
             <h2>Constructors</h2>
@@ -4829,12 +4857,12 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           </section>
         </div>
         <div>
-          <pre class="idl">
-          dictionary RTCPeerConnectionIceErrorEventInit : EventInit {
-             DOMString      hostCandidate;
-             DOMString      url;
-             required unsigned short errorCode;
-             USVString      statusText;
+          <pre class="idl"
+>dictionary RTCPeerConnectionIceErrorEventInit : EventInit {
+  DOMString hostCandidate;
+  DOMString url;
+  required unsigned short errorCode;
+  USVString statusText;
 };</pre>
           <section>
             <h2>Dictionary <dfn>RTCPeerConnectionIceErrorEventInit</dfn>
@@ -4888,11 +4916,12 @@ interface RTCPeerConnectionIceErrorEvent : Event {
       <section>
         <h4><dfn>RTCPriorityType</dfn> Enum</h4>
         <div>
-          <pre class="idl">enum RTCPriorityType {
-    "very-low",
-    "low",
-    "medium",
-    "high"
+          <pre class="idl"
+>enum RTCPriorityType {
+  "very-low",
+  "low",
+  "medium",
+  "high"
 };</pre>
           <table data-link-for="RTCPriorityType" data-dfn-for="RTCPriorityType"
           class="simple">
@@ -4946,8 +4975,10 @@ interface RTCPeerConnectionIceErrorEvent : Event {
       certificate with a private key on the P-256 curve and a signature with a
       SHA-256 hash.</p>
       <div>
-        <pre class="idl" data-tests="idlharness.https.window.js">partial interface RTCPeerConnection {
-    static Promise&lt;RTCCertificate&gt; generateCertificate (AlgorithmIdentifier keygenAlgorithm);
+        <pre class="idl" data-tests="idlharness.https.window.js"
+>partial interface RTCPeerConnection {
+  static Promise&lt;RTCCertificate&gt;
+      generateCertificate(AlgorithmIdentifier keygenAlgorithm);
 };</pre>
         <section>
           <h2>Methods</h2>
@@ -5114,9 +5145,9 @@ interface RTCPeerConnectionIceErrorEvent : Event {
         <p><code><a>RTCCertificateExpiration</a></code> is used to set an
         expiration date on certificates generated by <a data-link-for=
         "RTCPeerConnection"><code>generateCertificate</code></a>.</p>
-        <pre class="idl">dictionary RTCCertificateExpiration {
-    [EnforceRange]
-    DOMTimeStamp expires;
+        <pre class="idl"
+>dictionary RTCCertificateExpiration {
+  [EnforceRange] DOMTimeStamp expires;
 };</pre>
         <dl data-link-for="RTCCertificateExpiration" data-dfn-for=
         "RTCCertificateExpiration" class="methods">
@@ -5141,10 +5172,12 @@ interface RTCPeerConnectionIceErrorEvent : Event {
         uses to authenticate with a peer, and the origin (<dfn>[[\Origin]]</dfn>)
         that created the object.</p>
         <div>
-          <pre class="idl" data-tests="idlharness.https.window.js">[Exposed=Window, Serializable] interface RTCCertificate {
-    readonly        attribute DOMTimeStamp expires;
-    static sequence&lt;AlgorithmIdentifier&gt; getSupportedAlgorithms();
-    sequence&lt;RTCDtlsFingerprint&gt; getFingerprints ();
+          <pre class="idl" data-tests="idlharness.https.window.js"
+>[Exposed=Window, Serializable]
+interface RTCCertificate {
+  readonly attribute DOMTimeStamp expires;
+  static sequence&lt;AlgorithmIdentifier&gt; getSupportedAlgorithms();
+  sequence&lt;RTCDtlsFingerprint&gt; getFingerprints();
 };</pre>
           <section>
             <h2>Attributes</h2>
@@ -5334,14 +5367,16 @@ interface RTCPeerConnectionIceErrorEvent : Event {
       <p>The RTP media API extends the <code><a>RTCPeerConnection</a></code>
       interface as described below.</p>
       <div>
-        <pre class="idl" data-tests="idlharness.https.window.js">partial interface RTCPeerConnection {
-    sequence&lt;RTCRtpSender&gt;      getSenders ();
-    sequence&lt;RTCRtpReceiver&gt;    getReceivers ();
-    sequence&lt;RTCRtpTransceiver&gt; getTransceivers ();
-    RTCRtpSender                addTrack (MediaStreamTrack track, MediaStream... streams);
-    void                        removeTrack (RTCRtpSender sender);
-    RTCRtpTransceiver           addTransceiver ((MediaStreamTrack or DOMString) trackOrKind, optional RTCRtpTransceiverInit init);
-                    attribute EventHandler ontrack;
+        <pre class="idl" data-tests="idlharness.https.window.js"
+>partial interface RTCPeerConnection {
+  sequence&lt;RTCRtpSender&gt; getSenders();
+  sequence&lt;RTCRtpReceiver&gt; getReceivers();
+  sequence&lt;RTCRtpTransceiver&gt; getTransceivers();
+  RTCRtpSender addTrack(MediaStreamTrack track, MediaStream... streams);
+  void removeTrack(RTCRtpSender sender);
+  RTCRtpTransceiver addTransceiver((MediaStreamTrack or DOMString) trackOrKind,
+                                   optional RTCRtpTransceiverInit init);
+  attribute EventHandler ontrack;
 };</pre>
         <section>
           <h2>Attributes</h2>
@@ -5834,10 +5869,11 @@ interface RTCPeerConnectionIceErrorEvent : Event {
         </section>
       </div>
       <div>
-        <pre class="idl">dictionary RTCRtpTransceiverInit {
-             RTCRtpTransceiverDirection         direction = "sendrecv";
-             sequence&lt;MediaStream&gt;              streams = [];
-             sequence&lt;RTCRtpEncodingParameters&gt; sendEncodings = [];
+        <pre class="idl"
+>dictionary RTCRtpTransceiverInit {
+  RTCRtpTransceiverDirection direction = "sendrecv";
+  sequence&lt;MediaStream&gt; streams = [];
+  sequence&lt;RTCRtpEncodingParameters&gt; sendEncodings = [];
 };</pre>
         <section>
           <h2>Dictionary <dfn>RTCRtpTransceiverInit</dfn>
@@ -5865,11 +5901,12 @@ interface RTCPeerConnectionIceErrorEvent : Event {
         </section>
       </div>
       <div>
-        <pre class="idl">enum RTCRtpTransceiverDirection {
-    "sendrecv",
-    "sendonly",
-    "recvonly",
-    "inactive"
+        <pre class="idl"
+>enum RTCRtpTransceiverDirection {
+  "sendrecv",
+  "sendonly",
+  "recvonly",
+  "inactive"
 };</pre>
         <table data-link-for="RTCRtpTransceiverDirection" data-dfn-for=
         "RTCRtpTransceiverDirection" class="simple">
@@ -6113,16 +6150,18 @@ interface RTCPeerConnectionIceErrorEvent : Event {
         </li>
       </ol>
       <div>
-        <pre class="idl" data-tests="idlharness.https.window.js">[Exposed=Window] interface RTCRtpSender {
-    readonly        attribute MediaStreamTrack? track;
-    readonly        attribute RTCDtlsTransport?  transport;
-    readonly        attribute RTCDtlsTransport? rtcpTransport;
-    static RTCRtpCapabilities? getCapabilities (DOMString kind);
-    Promise&lt;void&gt;             setParameters (RTCRtpSendParameters parameters);
-    RTCRtpSendParameters          getParameters ();
-    Promise&lt;void&gt;             replaceTrack (MediaStreamTrack? withTrack);
-    void                            setStreams(MediaStream... streams);
-    Promise&lt;RTCStatsReport&gt;   getStats();
+        <pre class="idl" data-tests="idlharness.https.window.js"
+>[Exposed=Window]
+interface RTCRtpSender {
+  readonly attribute MediaStreamTrack? track;
+  readonly attribute RTCDtlsTransport? transport;
+  readonly attribute RTCDtlsTransport? rtcpTransport;
+  static RTCRtpCapabilities? getCapabilities(DOMString kind);
+  Promise&lt;void&gt; setParameters(RTCRtpSendParameters parameters);
+  RTCRtpSendParameters getParameters();
+  Promise&lt;void&gt; replaceTrack(MediaStreamTrack? withTrack);
+  void setStreams(MediaStream... streams);
+  Promise&lt;RTCStatsReport&gt; getStats();
 };</pre>
         <section>
           <h2>Attributes</h2>
@@ -6613,10 +6652,11 @@ async function updateParameters() {
      <section id="rtcrtpparameters">
      <h3><dfn>RTCRtpParameters</dfn> Dictionary</h3>
       <div>
-        <pre class="idl">dictionary RTCRtpParameters {
-             required sequence&lt;RTCRtpHeaderExtensionParameters&gt; headerExtensions;
-             required RTCRtcpParameters                         rtcp;
-             required sequence&lt;RTCRtpCodecParameters&gt;           codecs;
+        <pre class="idl"
+>dictionary RTCRtpParameters {
+  required sequence&lt;RTCRtpHeaderExtensionParameters&gt; headerExtensions;
+  required RTCRtcpParameters rtcp;
+  required sequence&lt;RTCRtpCodecParameters&gt; codecs;
 };</pre>
         <section>
           <h2>Dictionary <code><a>RTCRtpParameters</a></code> Members</h2>
@@ -6654,11 +6694,12 @@ async function updateParameters() {
      <section id="rtcsendrtpparameters">
      <h3><dfn>RTCRtpSendParameters</dfn> Dictionary</h3>
       <div>
-        <pre class="idl">dictionary RTCRtpSendParameters : RTCRtpParameters {
-             required DOMString             transactionId;
-             required sequence&lt;RTCRtpEncodingParameters&gt;  encodings;
-             RTCDegradationPreference       degradationPreference = "balanced";
-             RTCPriorityType                priority = "low";
+        <pre class="idl"
+>dictionary RTCRtpSendParameters : RTCRtpParameters {
+  required DOMString transactionId;
+  required sequence&lt;RTCRtpEncodingParameters&gt; encodings;
+  RTCDegradationPreference degradationPreference = "balanced";
+  RTCPriorityType priority = "low";
 };</pre>
         <section>
           <h2>Dictionary <code><a>RTCRtpSendParameters</a></code> Members</h2>
@@ -6706,8 +6747,9 @@ async function updateParameters() {
      <section id="rtcreceivertpparameters">
      <h3><dfn>RTCRtpReceiveParameters</dfn> Dictionary</h3>
       <div>
-        <pre class="idl">dictionary RTCRtpReceiveParameters : RTCRtpParameters {
-             required sequence&lt;RTCRtpDecodingParameters&gt;  encodings;
+        <pre class="idl"
+>dictionary RTCRtpReceiveParameters : RTCRtpParameters {
+  required sequence&lt;RTCRtpDecodingParameters&gt; encodings;
 };</pre>
         <section>
           <h2>Dictionary <code><a>RTCRtpReceiveParameters</a></code> Members</h2>
@@ -6733,8 +6775,9 @@ async function updateParameters() {
       <section id="rtcrtpcodingparameters">
       <h3><dfn>RTCRtpCodingParameters</dfn> Dictionary</h3>
       <div>
-        <pre class="idl">dictionary RTCRtpCodingParameters {
-             DOMString           rid;
+        <pre class="idl"
+>dictionary RTCRtpCodingParameters {
+  DOMString rid;
 };</pre>
         <section>
           <h2>Dictionary <code><a>RTCRtpCodingParameters</a></code>
@@ -6758,21 +6801,22 @@ async function updateParameters() {
       <section id="rtcrtpdecodingparameters">
       <h3><dfn>RTCRtpDecodingParameters</dfn> Dictionary</h3>
       <div>
-        <pre class="idl">dictionary RTCRtpDecodingParameters : RTCRtpCodingParameters {
-};</pre>
+        <pre class="idl"
+>dictionary RTCRtpDecodingParameters : RTCRtpCodingParameters {};</pre>
       </div>
       </section>
       <section id="rtcrtpencodingparameters">
       <h3><dfn>RTCRtpEncodingParameters</dfn> Dictionary</h3>
       <div>
-        <pre class="idl">dictionary RTCRtpEncodingParameters : RTCRtpCodingParameters {
-             octet               codecPayloadType;
-             RTCDtxStatus        dtx;
-             boolean             active = true;
-             unsigned long       ptime;
-             unsigned long       maxBitrate;
-             double              maxFramerate;
-             double              scaleResolutionDownBy;
+        <pre class="idl"
+>dictionary RTCRtpEncodingParameters : RTCRtpCodingParameters {
+  octet codecPayloadType;
+  RTCDtxStatus dtx;
+  boolean active = true;
+  unsigned long ptime;
+  unsigned long maxBitrate;
+  double maxFramerate;
+  double scaleResolutionDownBy;
 };</pre>
         <section>
           <h2>Dictionary <code><a>RTCRtpEncodingParameters</a></code>
@@ -6876,10 +6920,11 @@ async function updateParameters() {
       <section id="rtcdtxstatus">
       <h3><dfn>RTCDtxStatus</dfn> Enum</h3>
       <div>
-        <pre class="idl">enum RTCDtxStatus {
-         "disabled",
-         "enabled"
-         };</pre>
+        <pre class="idl"
+>enum RTCDtxStatus {
+  "disabled",
+  "enabled"
+};</pre>
         <table data-link-for="RTCDtxStatus" data-dfn-for="RTCDtxStatus" class=
         "simple">
           <tbody>
@@ -6905,10 +6950,11 @@ async function updateParameters() {
       <section id="rtcdegradationpreference">
       <h3><dfn>RTCDegradationPreference</dfn> Enum</h3>
       <div>
-        <pre class="idl">enum RTCDegradationPreference {
-    "maintain-framerate",
-    "maintain-resolution",
-    "balanced"
+        <pre class="idl"
+>enum RTCDegradationPreference {
+  "maintain-framerate",
+  "maintain-resolution",
+  "balanced"
 };</pre>
         <table data-link-for="RTCDegradationPreference" data-dfn-for=
         "RTCDegradationPreference" class="simple">
@@ -6941,9 +6987,10 @@ async function updateParameters() {
       <section id="rtcrtcpparameters">
       <h3><dfn>RTCRtcpParameters</dfn> Dictionary</h3>
       <div>
-        <pre class="idl">dictionary RTCRtcpParameters {
-             DOMString cname;
-             boolean   reducedSize;
+        <pre class="idl"
+>dictionary RTCRtcpParameters {
+  DOMString cname;
+  boolean reducedSize;
 };</pre>
         <section>
           <h2>Dictionary <code><a>RTCRtcpParameters</a></code> Members</h2>
@@ -6969,10 +7016,11 @@ async function updateParameters() {
       <section id="rtcrtpheaderextensionparameters">
       <h3><dfn>RTCRtpHeaderExtensionParameters</dfn> Dictionary</h3>
       <div>
-        <pre class="idl">dictionary RTCRtpHeaderExtensionParameters {
-             required DOMString      uri;
-             required unsigned short id;
-             boolean                 encrypted = false;
+        <pre class="idl"
+>dictionary RTCRtpHeaderExtensionParameters {
+  required DOMString uri;
+  required unsigned short id;
+  boolean encrypted = false;
 };</pre>
         <section>
           <h2>Dictionary <code><a>RTCRtpHeaderExtensionParameters</a></code>
@@ -7026,12 +7074,13 @@ async function updateParameters() {
       <section id="rtcrtpcodecparameters">
       <h3><dfn>RTCRtpCodecParameters</dfn> Dictionary</h3>
       <div>
-        <pre class="idl">dictionary RTCRtpCodecParameters {
-             required octet          payloadType;
-             required DOMString      mimeType;
-             required unsigned long  clockRate;
-             unsigned short channels;
-             DOMString      sdpFmtpLine;
+        <pre class="idl"
+>dictionary RTCRtpCodecParameters {
+  required octet payloadType;
+  required DOMString mimeType;
+  required unsigned long clockRate;
+  unsigned short channels;
+  DOMString sdpFmtpLine;
 };</pre>
         <section>
           <h2>Dictionary <code><a>RTCRtpCodecParameters</a></code> Members</h2>
@@ -7080,9 +7129,10 @@ async function updateParameters() {
       <section id="rtcrtpcapabilities">
       <h3><dfn>RTCRtpCapabilities</dfn> Dictionary</h3>
       <div>
-        <pre class="idl">dictionary RTCRtpCapabilities {
-             required sequence&lt;RTCRtpCodecCapability&gt;           codecs;
-             required sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensions;
+        <pre class="idl"
+>dictionary RTCRtpCapabilities {
+  required sequence&lt;RTCRtpCodecCapability&gt; codecs;
+  required sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensions;
 };</pre>
         <section>
           <h2>Dictionary <code><a>RTCRtpCapabilities</a></code> Members</h2>
@@ -7108,11 +7158,12 @@ async function updateParameters() {
       <section id="rtcrtpcodeccapability">
       <h3><dfn>RTCRtpCodecCapability</dfn> Dictionary</h3>
       <div>
-        <pre class="idl">dictionary RTCRtpCodecCapability {
-             required DOMString mimeType;
-             required unsigned long  clockRate;
-             unsigned short channels;
-             DOMString      sdpFmtpLine;
+        <pre class="idl"
+>dictionary RTCRtpCodecCapability {
+  required DOMString mimeType;
+  required unsigned long clockRate;
+  unsigned short channels;
+  DOMString sdpFmtpLine;
 };</pre>
         <section>
           <h2>Dictionary <code><a>RTCRtpCodecCapability</a></code> Members </h2>
@@ -7156,8 +7207,9 @@ async function updateParameters() {
       <section id="rtcrtpheaderextensioncapability">
       <h3><dfn>RTCRtpHeaderExtensionCapability</dfn> Dictionary</h3>
       <div>
-        <pre class="idl">dictionary RTCRtpHeaderExtensionCapability {
-             DOMString uri;
+        <pre class="idl"
+>dictionary RTCRtpHeaderExtensionCapability {
+  DOMString uri;
 };</pre>
         <section>
           <h2>Dictionary <code><a>RTCRtpHeaderExtensionCapability</a></code> Members</h2>
@@ -7239,15 +7291,17 @@ async function updateParameters() {
         </li>
       </ol>
       <div>
-        <pre class="idl" data-tests="idlharness.https.window.js">[Exposed=Window] interface RTCRtpReceiver {
-    readonly        attribute MediaStreamTrack  track;
-    readonly        attribute RTCDtlsTransport? transport;
-    readonly        attribute RTCDtlsTransport? rtcpTransport;
-    static RTCRtpCapabilities?         getCapabilities (DOMString kind);
-    RTCRtpReceiveParameters            getParameters ();
-    sequence&lt;RTCRtpContributingSource&gt;    getContributingSources ();
-    sequence&lt;RTCRtpSynchronizationSource&gt; getSynchronizationSources ();
-    Promise&lt;RTCStatsReport&gt;   getStats();
+        <pre class="idl" data-tests="idlharness.https.window.js"
+>[Exposed=Window]
+interface RTCRtpReceiver {
+  readonly attribute MediaStreamTrack track;
+  readonly attribute RTCDtlsTransport? transport;
+  readonly attribute RTCDtlsTransport? rtcpTransport;
+  static RTCRtpCapabilities? getCapabilities(DOMString kind);
+  RTCRtpReceiveParameters getParameters();
+  sequence&lt;RTCRtpContributingSource&gt; getContributingSources();
+  sequence&lt;RTCRtpSynchronizationSource&gt; getSynchronizationSources();
+  Promise&lt;RTCStatsReport&gt; getStats();
 };</pre>
         <section>
           <h2>Attributes</h2>
@@ -7441,11 +7495,12 @@ async function updateParameters() {
       particular <code><a>RTCRtpReceiver</a></code> contain information from a
       single point in the RTP stream.</div>
       <div>
-        <pre class="idl">dictionary RTCRtpContributingSource {
-    required DOMHighResTimeStamp timestamp;
-    required unsigned long       source;
-             double              audioLevel;
-    required unsigned long       rtpTimestamp;
+        <pre class="idl"
+>dictionary RTCRtpContributingSource {
+  required DOMHighResTimeStamp timestamp;
+  required unsigned long source;
+  double audioLevel;
+  required unsigned long rtpTimestamp;
 };</pre>
         <section>
           <h2>Dictionary RTCRtpContributingSource Members</h2>
@@ -7501,8 +7556,9 @@ async function updateParameters() {
         </section>
       </div>
       <div>
-        <pre class="idl">dictionary RTCRtpSynchronizationSource : RTCRtpContributingSource {
-    boolean voiceActivityFlag;
+        <pre class="idl"
+>dictionary RTCRtpSynchronizationSource : RTCRtpContributingSource {
+  boolean voiceActivityFlag;
 };</pre>
         <section>
           <h2>Dictionary RTCRtpSynchronizationSource Members</h2>
@@ -7589,17 +7645,17 @@ async function updateParameters() {
       of the process of <a data-lt="set the RTCSessionDescription">setting an
       <code>RTCSessionDescription</code></a>.</div>
       <div>
-        <pre class="idl" data-tests="idlharness.https.window.js">[Exposed=Window] interface RTCRtpTransceiver {
-    readonly        attribute DOMString?                  mid;
-    [SameObject]
-    readonly        attribute RTCRtpSender                sender;
-    [SameObject]
-    readonly        attribute RTCRtpReceiver              receiver;
-    readonly        attribute boolean                     stopped;
-                    attribute RTCRtpTransceiverDirection  direction;
-    readonly        attribute RTCRtpTransceiverDirection? currentDirection;
-    void stop ();
-    void setCodecPreferences (sequence&lt;RTCRtpCodecCapability&gt; codecs);
+        <pre class="idl" data-tests="idlharness.https.window.js"
+>[Exposed=Window]
+interface RTCRtpTransceiver {
+  readonly attribute DOMString? mid;
+  [SameObject] readonly attribute RTCRtpSender sender;
+  [SameObject] readonly attribute RTCRtpReceiver receiver;
+  readonly attribute boolean stopped;
+  attribute RTCRtpTransceiverDirection direction;
+  readonly attribute RTCRtpTransceiverDirection? currentDirection;
+  void stop();
+  void setCodecPreferences(sequence&lt;RTCRtpCodecCapability&gt; codecs);
 };</pre>
         <section>
           <h2>Attributes</h2>
@@ -8174,13 +8230,14 @@ async function onOffHold() {
         </li>
       </ol>
       <div>
-        <pre class="idl" data-tests="idlharness.https.window.js">[Exposed=Window] interface RTCDtlsTransport : EventTarget {
-    [SameObject]
-    readonly        attribute RTCIceTransport       iceTransport;
-    readonly        attribute RTCDtlsTransportState state;
-    sequence&lt;ArrayBuffer&gt; getRemoteCertificates ();
-                    attribute EventHandler          onstatechange;
-                    attribute EventHandler          onerror;
+        <pre class="idl" data-tests="idlharness.https.window.js"
+>[Exposed=Window]
+interface RTCDtlsTransport : EventTarget {
+  [SameObject] readonly attribute RTCIceTransport iceTransport;
+  readonly attribute RTCDtlsTransportState state;
+  sequence&lt;ArrayBuffer&gt; getRemoteCertificates();
+  attribute EventHandler onstatechange;
+  attribute EventHandler onerror;
 };</pre>
         <section>
           <h2>Attributes</h2>
@@ -8226,12 +8283,13 @@ async function onOffHold() {
       </div>
       <h3><dfn>RTCDtlsTransportState</dfn> Enum</h3>
       <div>
-        <pre class="idl">enum RTCDtlsTransportState {
-    "new",
-    "connecting",
-    "connected",
-    "closed",
-    "failed"
+        <pre class="idl"
+>enum RTCDtlsTransportState {
+  "new",
+  "connecting",
+  "connected",
+  "closed",
+  "failed"
 };</pre>
         <table data-link-for="RTCDtlsTransportState" data-dfn-for=
         "RTCDtlsTransportState" class="simple">
@@ -8272,9 +8330,10 @@ async function onOffHold() {
         the hash function algorithm and certificate fingerprint as described in
         [[!RFC4572]].</p>
         <div>
-          <pre class="idl">dictionary RTCDtlsFingerprint {
-             DOMString algorithm;
-             DOMString value;
+          <pre class="idl"
+>dictionary RTCDtlsFingerprint {
+  DOMString algorithm;
+  DOMString value;
 };</pre>
           <section>
             <h2>Dictionary RTCDtlsFingerprint
@@ -8554,19 +8613,21 @@ async function onOffHold() {
         <code>null</code></li>
       </ul>
       <div>
-        <pre class="idl" data-tests="idlharness.https.window.js">[Exposed=Window] interface RTCIceTransport : EventTarget {
-    readonly        attribute RTCIceRole           role;
-    readonly        attribute RTCIceComponent      component;
-    readonly        attribute RTCIceTransportState state;
-    readonly        attribute RTCIceGathererState gatheringState;
-    sequence&lt;RTCIceCandidate&gt; getLocalCandidates ();
-    sequence&lt;RTCIceCandidate&gt; getRemoteCandidates ();
-    RTCIceCandidatePair?      getSelectedCandidatePair ();
-    RTCIceParameters?         getLocalParameters ();
-    RTCIceParameters?         getRemoteParameters ();
-                    attribute EventHandler         onstatechange;
-                    attribute EventHandler         ongatheringstatechange;
-                    attribute EventHandler         onselectedcandidatepairchange;
+        <pre class="idl" data-tests="idlharness.https.window.js"
+>[Exposed=Window]
+interface RTCIceTransport : EventTarget {
+  readonly attribute RTCIceRole role;
+  readonly attribute RTCIceComponent component;
+  readonly attribute RTCIceTransportState state;
+  readonly attribute RTCIceGathererState gatheringState;
+  sequence&lt;RTCIceCandidate&gt; getLocalCandidates ();
+  sequence&lt;RTCIceCandidate&gt; getRemoteCandidates ();
+  RTCIceCandidatePair? getSelectedCandidatePair();
+  RTCIceParameters? getLocalParameters();
+  RTCIceParameters? getRemoteParameters();
+  attribute EventHandler onstatechange;
+  attribute EventHandler ongatheringstatechange;
+  attribute EventHandler onselectedcandidatepairchange;
 };</pre>
         <section>
           <h2>Attributes</h2>
@@ -8677,9 +8738,10 @@ async function onOffHold() {
       <section id="rtciceparameters">
       <h3><dfn>RTCIceParameters</dfn> Dictionary</h3>
       <div>
-        <pre class="idl">dictionary RTCIceParameters {
-             DOMString usernameFragment;
-             DOMString password;
+        <pre class="idl"
+>dictionary RTCIceParameters {
+  DOMString usernameFragment;
+  DOMString password;
 };</pre>
         <section>
           <h2>Dictionary <code><a>RTCIceParameters</a></code> Members</h2>
@@ -8703,9 +8765,10 @@ async function onOffHold() {
       <section id="rtcicecandidatepair">
       <h3><dfn>RTCIceCandidatePair</dfn> Dictionary</h3>
       <div>
-        <pre class="idl">dictionary RTCIceCandidatePair {
-             RTCIceCandidate local;
-             RTCIceCandidate remote;
+        <pre class="idl"
+>dictionary RTCIceCandidatePair {
+  RTCIceCandidate local;
+  RTCIceCandidate remote;
 };</pre>
         <section>
           <h2>Dictionary <code><a>RTCIceCandidatePair</a></code>
@@ -8729,10 +8792,11 @@ async function onOffHold() {
       <section id="rtcicegathererstate">
       <h4><dfn>RTCIceGathererState</dfn> Enum</h4>
       <div>
-        <pre class="idl">enum RTCIceGathererState {
-    "new",
-    "gathering",
-    "complete"
+        <pre class="idl"
+>enum RTCIceGathererState {
+  "new",
+  "gathering",
+  "complete"
 };</pre>
         <table data-link-for="RTCIceGathererState" data-dfn-for=
         "RTCIceGathererState" class="simple">
@@ -8764,14 +8828,15 @@ async function onOffHold() {
       <section id="rtcicetransportstate">
       <h3><dfn>RTCIceTransportState</dfn> Enum</h3>
       <div>
-        <pre class="idl">enum RTCIceTransportState {
-    "new",
-    "checking",
-    "connected",
-    "completed",
-    "disconnected",
-    "failed",
-    "closed"
+        <pre class="idl"
+>enum RTCIceTransportState {
+  "new",
+  "checking",
+  "connected",
+  "completed",
+  "disconnected",
+  "failed",
+  "closed"
 };</pre>
         <table data-link-for="RTCIceTransportState" data-dfn-for=
         "RTCIceTransportState" class="simple">
@@ -8900,10 +8965,11 @@ async function onOffHold() {
       <section id="rtcicerole">
       <h3><dfn>RTCIceRole</dfn> Enum</h3>
       <div>
-        <pre class="idl">enum RTCIceRole {
-    "unknown",
-    "controlling",
-    "controlled"
+        <pre class="idl"
+>enum RTCIceRole {
+  "unknown",
+  "controlling",
+  "controlled"
 };</pre>
         <table data-link-for="RTCIceRole" data-dfn-for="RTCIceRole" class=
         "simple">
@@ -8932,9 +8998,10 @@ async function onOffHold() {
       <section id="rtcicecomponent">
       <h3><dfn>RTCIceComponent</dfn> Enum</h3>
       <div>
-        <pre class="idl">enum RTCIceComponent {
-    "rtp",
-    "rtcp"
+        <pre class="idl"
+>enum RTCIceComponent {
+  "rtp",
+  "rtcp"
 };</pre>
         <table data-link-for="RTCIceComponent" data-dfn-for="RTCIceComponent"
         class="simple">
@@ -8967,14 +9034,13 @@ async function onOffHold() {
       <p>The <code><a>track</a></code> event uses the
       <code><a>RTCTrackEvent</a></code> interface.</p>
       <div>
-        <pre class="idl" data-tests="idlharness.https.window.js">
-        [ Constructor (DOMString type, RTCTrackEventInit eventInitDict), Exposed=Window]
+        <pre class="idl" data-tests="idlharness.https.window.js"
+>[Exposed=Window, Constructor (DOMString type, RTCTrackEventInit eventInitDict)]
 interface RTCTrackEvent : Event {
-    readonly        attribute RTCRtpReceiver           receiver;
-    readonly        attribute MediaStreamTrack         track;
-    [SameObject]
-    readonly        attribute FrozenArray&lt;MediaStream&gt; streams;
-    readonly        attribute RTCRtpTransceiver        transceiver;
+  readonly attribute RTCRtpReceiver receiver;
+  readonly attribute MediaStreamTrack track;
+  [SameObject] readonly attribute FrozenArray&lt;MediaStream&gt; streams;
+  readonly attribute RTCRtpTransceiver transceiver;
 };</pre>
         <section>
           <h2>Constructors</h2>
@@ -9026,11 +9092,12 @@ interface RTCTrackEvent : Event {
         </section>
       </div>
       <div>
-        <pre class="idl">dictionary RTCTrackEventInit : EventInit {
-    required RTCRtpReceiver        receiver;
-    required MediaStreamTrack      track;
-             sequence&lt;MediaStream&gt; streams = [];
-    required RTCRtpTransceiver     transceiver;
+        <pre class="idl"
+>dictionary RTCTrackEventInit : EventInit {
+  required RTCRtpReceiver receiver;
+  required MediaStreamTrack track;
+  sequence&lt;MediaStream&gt; streams = [];
+  required RTCRtpTransceiver transceiver;
 };</pre>
         <section>
           <h2>Dictionary <dfn>RTCTrackEventInit</dfn> Members</h2>
@@ -9082,10 +9149,12 @@ interface RTCTrackEvent : Event {
       <p>The Peer-to-peer data API extends the
       <code><a>RTCPeerConnection</a></code> interface as described below.</p>
       <div>
-        <pre class="idl" data-tests="idlharness.https.window.js">partial interface RTCPeerConnection {
-    readonly        attribute RTCSctpTransport? sctp;
-    RTCDataChannel createDataChannel (USVString label, optional RTCDataChannelInit dataChannelDict);
-                    attribute EventHandler      ondatachannel;
+        <pre class="idl" data-tests="idlharness.https.window.js"
+>partial interface RTCPeerConnection {
+  readonly attribute RTCSctpTransport? sctp;
+  RTCDataChannel createDataChannel(USVString label,
+                                   optional RTCDataChannelInit dataChannelDict);
+  attribute EventHandler ondatachannel;
 };</pre>
         <section>
           <h2>Attributes</h2>
@@ -9387,12 +9456,14 @@ interface RTCTrackEvent : Event {
           </ol>
         </section>
         <div>
-          <pre class="idl" data-tests="idlharness.https.window.js">[Exposed=Window] interface RTCSctpTransport : EventTarget {
-    readonly        attribute RTCDtlsTransport transport;
-    readonly        attribute RTCSctpTransportState state;
-    readonly        attribute unrestricted double maxMessageSize;
-    readonly        attribute unsigned short? maxChannels;
-                    attribute EventHandler     onstatechange;
+          <pre class="idl" data-tests="idlharness.https.window.js"
+>[Exposed=Window]
+interface RTCSctpTransport : EventTarget {
+  readonly attribute RTCDtlsTransport transport;
+  readonly attribute RTCSctpTransportState state;
+  readonly attribute unrestricted double maxMessageSize;
+  readonly attribute unsigned short? maxChannels;
+  attribute EventHandler onstatechange;
 };</pre>
           <section>
             <h2>Attributes</h2>
@@ -9448,10 +9519,11 @@ interface RTCTrackEvent : Event {
         <p><code>RTCSctpTransportState</code> indicates the state of the SCTP
         transport.</p>
         <div>
-          <pre class="idl">enum RTCSctpTransportState {
-    "connecting",
-    "connected",
-    "closed"
+          <pre class="idl"
+>enum RTCSctpTransportState {
+  "connecting",
+  "connected",
+  "closed"
 };</pre>
           <table data-link-for="RTCSctpTransportState" data-dfn-for=
           "RTCSctpTransportState" class="simple">
@@ -9838,30 +9910,31 @@ interface RTCTrackEvent : Event {
         </li>
       </ol>
       <div>
-        <pre class="idl" data-tests="idlharness.https.window.js">[Exposed=Window] interface RTCDataChannel : EventTarget {
-    readonly        attribute USVString           label;
-    readonly        attribute boolean             ordered;
-    readonly        attribute unsigned short?     maxPacketLifeTime;
-    readonly        attribute unsigned short?     maxRetransmits;
-    readonly        attribute USVString           protocol;
-    readonly        attribute boolean             negotiated;
-    readonly        attribute unsigned short?     id;
-    readonly        attribute RTCPriorityType     priority;
-    readonly        attribute RTCDataChannelState readyState;
-    readonly        attribute unsigned long       bufferedAmount;
-                    [EnforceRange]
-                    attribute unsigned long       bufferedAmountLowThreshold;
-                    attribute EventHandler        onopen;
-                    attribute EventHandler        onbufferedamountlow;
-                    attribute EventHandler        onerror;
-                    attribute EventHandler        onclose;
-    void close ();
-                    attribute EventHandler        onmessage;
-                    attribute DOMString           binaryType;
-    void send (USVString data);
-    void send (Blob data);
-    void send (ArrayBuffer data);
-    void send (ArrayBufferView data);
+        <pre class="idl" data-tests="idlharness.https.window.js"
+>[Exposed=Window]
+interface RTCDataChannel : EventTarget {
+  readonly attribute USVString label;
+  readonly attribute boolean ordered;
+  readonly attribute unsigned short? maxPacketLifeTime;
+  readonly attribute unsigned short? maxRetransmits;
+  readonly attribute USVString protocol;
+  readonly attribute boolean negotiated;
+  readonly attribute unsigned short? id;
+  readonly attribute RTCPriorityType priority;
+  readonly attribute RTCDataChannelState readyState;
+  readonly attribute unsigned long bufferedAmount;
+  [EnforceRange] attribute unsigned long bufferedAmountLowThreshold;
+  attribute EventHandler onopen;
+  attribute EventHandler onbufferedamountlow;
+  attribute EventHandler onerror;
+  attribute EventHandler onclose;
+  void close();
+  attribute EventHandler onmessage;
+  attribute DOMString binaryType;
+  void send(USVString data);
+  void send(Blob data);
+  void send(ArrayBuffer data);
+  void send(ArrayBufferView data);
 };</pre>
         <section>
           <h2>Attributes</h2>
@@ -10174,17 +10247,15 @@ interface RTCTrackEvent : Event {
         </section>
       </div>
       <div>
-        <pre class="idl">dictionary RTCDataChannelInit {
-             boolean         ordered = true;
-             [EnforceRange]
-             unsigned short  maxPacketLifeTime;
-             [EnforceRange]
-             unsigned short  maxRetransmits;
-             USVString       protocol = "";
-             boolean         negotiated = false;
-             [EnforceRange]
-             unsigned short  id;
-             RTCPriorityType priority = "low";
+        <pre class="idl"
+>dictionary RTCDataChannelInit {
+  boolean ordered = true;
+  [EnforceRange] unsigned short maxPacketLifeTime;
+  [EnforceRange] unsigned short maxRetransmits;
+  USVString protocol = "";
+  boolean negotiated = false;
+  [EnforceRange] unsigned short id;
+  RTCPriorityType priority = "low";
 };</pre>
         <section>
           <h2>Dictionary <dfn>RTCDataChannelInit</dfn> Members</h2>
@@ -10253,11 +10324,12 @@ interface RTCTrackEvent : Event {
         </section>
       </div>
       <div>
-        <pre class="idl">enum RTCDataChannelState {
-    "connecting",
-    "open",
-    "closing",
-    "closed"
+        <pre class="idl"
+>enum RTCDataChannelState {
+  "connecting",
+  "open",
+  "closing",
+  "closed"
 };</pre>
         <table data-link-for="RTCDataChannelState" data-dfn-for=
         "RTCDataChannelState" class="simple">
@@ -10308,10 +10380,10 @@ interface RTCTrackEvent : Event {
       <p data-tests="RTCPeerConnection-ondatachannel.html">The <code><a>datachannel</a></code> event uses the
       <code><a>RTCDataChannelEvent</a></code> interface.</p>
       <div>
-        <pre class="idl" data-tests="idlharness.https.window.js">
-        [ Constructor (DOMString type, RTCDataChannelEventInit eventInitDict), Exposed=Window]
+        <pre class="idl" data-tests="idlharness.https.window.js"
+>[Exposed=Window, Constructor (DOMString type, RTCDataChannelEventInit eventInitDict)]
 interface RTCDataChannelEvent : Event {
-    readonly        attribute RTCDataChannel channel;
+  readonly attribute RTCDataChannel channel;
 };</pre>
         <section data-tests="RTCDataChannelEvent-constructor.html">
           <h2>Constructors</h2>
@@ -10338,8 +10410,9 @@ interface RTCDataChannelEvent : Event {
         </section>
       </div>
       <div>
-        <pre class="idl">dictionary RTCDataChannelEventInit : EventInit {
-             required RTCDataChannel channel;
+        <pre class="idl"
+>dictionary RTCDataChannelEventInit : EventInit {
+  required RTCDataChannel channel;
 };</pre>
         <section>
           <h2>Dictionary <dfn>RTCDataChannelEventInit</dfn>
@@ -10396,8 +10469,9 @@ interface RTCDataChannelEvent : Event {
       <p>The Peer-to-peer DTMF API extends the <code><a>RTCRtpSender</a></code>
       interface as described below.</p>
       <div>
-        <pre class="idl" data-tests="idlharness.https.window.js">partial interface RTCRtpSender {
-    readonly        attribute RTCDTMFSender? dtmf;
+        <pre class="idl" data-tests="idlharness.https.window.js"
+>partial interface RTCRtpSender {
+  readonly attribute RTCDTMFSender? dtmf;
 };</pre>
         <section>
           <h2>Attributes</h2>
@@ -10440,12 +10514,13 @@ interface RTCDataChannelEvent : Event {
           </li>
        </ol>
       <div>
-        <pre class="idl" data-tests>
-[Exposed=Window] interface RTCDTMFSender : EventTarget {
-    void insertDTMF (DOMString tones, optional unsigned long duration = 100, optional unsigned long interToneGap = 70);
-                    attribute EventHandler ontonechange;
-    readonly        attribute boolean      canInsertDTMF;
-    readonly        attribute DOMString    toneBuffer;
+        <pre class="idl" data-tests
+>[Exposed=Window]
+interface RTCDTMFSender : EventTarget {
+  void insertDTMF(DOMString tones, optional unsigned long duration = 100, optional unsigned long interToneGap = 70);
+  attribute EventHandler ontonechange;
+  readonly attribute boolean canInsertDTMF;
+  readonly attribute DOMString toneBuffer;
 };</pre>
         <section>
           <h2>Attributes</h2>
@@ -10626,10 +10701,11 @@ interface RTCDataChannelEvent : Event {
       <p>The <code><a>tonechange</a></code> event uses the
       <code><a>RTCDTMFToneChangeEvent</a></code> interface.</p>
       <div>
-        <pre class="idl" data-tests>
-        [ Constructor (DOMString type, RTCDTMFToneChangeEventInit eventInitDict), Exposed=Window]
+        <pre class="idl" data-tests
+>[Exposed=Window,
+ Constructor (DOMString type, RTCDTMFToneChangeEventInit eventInitDict)]
 interface RTCDTMFToneChangeEvent : Event {
-    readonly        attribute DOMString tone;
+  readonly attribute DOMString tone;
 };</pre>
         <section>
           <h2>Constructors</h2>
@@ -10659,8 +10735,9 @@ interface RTCDTMFToneChangeEvent : Event {
         </section>
       </div>
       <div>
-        <pre class="idl">dictionary RTCDTMFToneChangeEventInit : EventInit {
-             required DOMString tone;
+        <pre class="idl"
+>dictionary RTCDTMFToneChangeEventInit : EventInit {
+  required DOMString tone;
 };</pre>
         <section>
           <h2>Dictionary <dfn>RTCDTMFToneChangeEventInit</dfn>
@@ -10729,10 +10806,11 @@ interface RTCDTMFToneChangeEvent : Event {
       <p>The Statistics API extends the <code><a>RTCPeerConnection</a></code>
       interface as described below.</p>
       <div>
-        <pre class="idl" data-tests="idlharness.https.window.js">partial interface RTCPeerConnection {
-    Promise&lt;RTCStatsReport&gt; getStats (optional MediaStreamTrack? selector = null);
-    attribute EventHandler onstatsended;
-          };</pre>
+        <pre class="idl" data-tests="idlharness.https.window.js"
+>partial interface RTCPeerConnection {
+  Promise&lt;RTCStatsReport&gt; getStats(optional MediaStreamTrack? selector = null);
+  attribute EventHandler onstatsended;
+};</pre>
         <section>
           <h2>Attributes</h2>
           <dl data-link-for="RTCPeerConnection"
@@ -10858,8 +10936,10 @@ interface RTCDTMFToneChangeEvent : Event {
       <code>RTCStats</code>-derived dictionary per SSRC (which can be
       distinguished by the value of the "ssrc" stats attribute).</p>
       <div>
-        <pre class="idl" data-tests>[Exposed=Window] interface RTCStatsReport {
-    readonly maplike&lt;DOMString, object&gt;;
+        <pre class="idl" data-tests
+>[Exposed=Window]
+interface RTCStatsReport {
+  readonly maplike&lt;DOMString, object&gt;;
 };</pre>
         <p>This interface has "entries", "forEach", "get", "has", "keys",
         "values", @@iterator methods and a "size" getter brought by
@@ -10892,10 +10972,11 @@ interface RTCDTMFToneChangeEvent : Event {
       implementations MUST return synchronized values for all stats in an
       <code><a>RTCStats</a></code>-derived dictionary.</p>
       <div>
-        <pre class="idl">dictionary RTCStats {
-             required DOMHighResTimeStamp timestamp;
-             required RTCStatsType        type;
-             required DOMString           id;
+        <pre class="idl"
+>dictionary RTCStats {
+  required DOMHighResTimeStamp timestamp;
+  required RTCStatsType type;
+  required DOMString id;
 };</pre>
         <section>
           <h2>Dictionary <a class="idlType">RTCStats</a> Members</h2>
@@ -10946,11 +11027,12 @@ interface RTCDTMFToneChangeEvent : Event {
       <p>The <code><a>statsended</a></code> event uses
         the <code><a>RTCStatsEvent</a></code>.</p>
       <div>
-        <pre class="idl" data-tests>[ Constructor (DOMString type, RTCStatsEventInit
-          eventInitDict), Exposed=Window]
-          interface RTCStatsEvent : Event {
-            readonly attribute RTCStatsReport report;
-          };</pre>
+        <pre class="idl" data-tests
+>[Exposed=Window,
+ Constructor (DOMString type, RTCStatsEventInit eventInitDict)]
+interface RTCStatsEvent : Event {
+  readonly attribute RTCStatsReport report;
+};</pre>
         <section>
           <h2>Constructors</h2>
           <dl data-link-for="RTCStatsEvent"
@@ -10978,9 +11060,10 @@ interface RTCDTMFToneChangeEvent : Event {
         </section>
       </div>
       <div>
-        <pre class="idl">dictionary RTCStatsEventInit : EventInit {
-            required RTCStatsReport report;
-          };</pre>
+        <pre class="idl"
+>dictionary RTCStatsEventInit : EventInit {
+  required RTCStatsReport report;
+};</pre>
         <section>
           <h2>Dictionary <dfn>RTCStatsEventInit</dfn>
             members</h2>
@@ -11812,18 +11895,16 @@ if (sender.dtmf.canInsertDTMF) {
     <section>
       <h3><dfn>RTCError</dfn> Interface</h3>
       <div>
-        <pre class="idl" data-tests>
-          [
-              Exposed=Window,
-              Constructor(RTCErrorInit init, optional DOMString message = "")
-          ] interface RTCError : DOMException {
-              readonly attribute RTCErrorDetailType errorDetail;
-              readonly attribute long? sdpLineNumber;
-              readonly attribute long? httpRequestStatusCode;
-              readonly attribute long? sctpCauseCode;
-              readonly attribute unsigned long? receivedAlert;
-              readonly attribute unsigned long? sentAlert;
-          };</pre>
+        <pre class="idl" data-tests
+>[Exposed=Window, Constructor(RTCErrorInit init, optional DOMString message = "")]
+interface RTCError : DOMException {
+  readonly attribute RTCErrorDetailType errorDetail;
+  readonly attribute long? sdpLineNumber;
+  readonly attribute long? httpRequestStatusCode;
+  readonly attribute long? sctpCauseCode;
+  readonly attribute unsigned long? receivedAlert;
+  readonly attribute unsigned long? sentAlert;
+};</pre>
       </div>
       <section>
         <h2>Constructors</h2>
@@ -11914,15 +11995,15 @@ if (sender.dtmf.canInsertDTMF) {
       </section>
       <h3><dfn>RTCErrorInit</dfn> Dictionary</h3>
       <div>
-        <pre class="idl">
-        dictionary RTCErrorInit {
-            required RTCErrorDetailType errorDetail;
-            long sdpLineNumber;
-            long httpRequestStatusCode;
-            long sctpCauseCode;
-            unsigned long receivedAlert;
-            unsigned long sentAlert;
-        };</pre>
+        <pre class="idl"
+>dictionary RTCErrorInit {
+  required RTCErrorDetailType errorDetail;
+  long sdpLineNumber;
+  long httpRequestStatusCode;
+  long sctpCauseCode;
+  unsigned long receivedAlert;
+  unsigned long sentAlert;
+};</pre>
         <p data-dfn-for="RTCErrorInit">The <dfn data-idl>errorDetail</dfn>, <dfn data-idl>sdpLineNumber</dfn>, <dfn data-idl>httpRequestStatusCode</dfn>, <dfn data-idl>sctpCauseCode</dfn>, <dfn data-idl>receivedAlert</dfn> and <dfn data-idl>sentAlert</dfn> members of <code>RTCErrorInit</code> have the same definitions as the attributes of the same name of <a>RTCError</a>.</p>
       </div>
       <section>
@@ -11971,23 +12052,24 @@ if (sender.dtmf.canInsertDTMF) {
       <section>
         <h3><code><dfn>RTCErrorDetailType</dfn></code> Enum</h3>
         <div>
-          <pre class="idl">enum RTCErrorDetailType {
-              "data-channel-failure",
-              "dtls-failure",
-              "fingerprint-failure",
-              "idp-bad-script-failure",
-              "idp-execution-failure",
-              "idp-load-failure",
-              "idp-need-login",
-              "idp-timeout",
-              "idp-tls-failure",
-              "idp-token-expired",
-              "idp-token-invalid",
-              "sctp-failure",
-              "sdp-syntax-error",
-              "hardware-encoder-not-available",
-              "hardware-encoder-error"
-          };</pre>
+          <pre class="idl"
+>enum RTCErrorDetailType {
+  "data-channel-failure",
+  "dtls-failure",
+  "fingerprint-failure",
+  "idp-bad-script-failure",
+  "idp-execution-failure",
+  "idp-load-failure",
+  "idp-need-login",
+  "idp-timeout",
+  "idp-tls-failure",
+  "idp-token-expired",
+  "idp-token-invalid",
+  "sctp-failure",
+  "sdp-syntax-error",
+  "hardware-encoder-not-available",
+  "hardware-encoder-error"
+};</pre>
         </div>
         <p>
           The error detail types whose names are prefixed with "idp-" are
@@ -12096,13 +12178,12 @@ if (sender.dtmf.canInsertDTMF) {
       <p>The <code>RTCErrorEvent</code> interface is defined for cases when an
       <code><a>RTCError</a></code> is raised as an event:</p>
       <div>
-        <pre class="idl" data-tests="idlharness.https.window.js">
-        [
-            Exposed=Window,
-            Constructor (DOMString type, RTCErrorEventInit eventInitDict)
-        ] interface RTCErrorEvent : Event {
-            [SameObject] readonly attribute RTCError error;
-        };</pre>
+        <pre class="idl" data-tests="idlharness.https.window.js"
+>[Exposed=Window,
+ Constructor (DOMString type, RTCErrorEventInit eventInitDict)]
+interface RTCErrorEvent : Event {
+  [SameObject] readonly attribute RTCError error;
+};</pre>
       </div>
       <section>
         <h2>Constructors</h2>
@@ -12132,10 +12213,10 @@ if (sender.dtmf.canInsertDTMF) {
     <section>
       <h3><dfn>RTCErrorEventInit</dfn> Dictionary</h3>
       <div>
-        <pre class="idl">
-        dictionary RTCErrorEventInit : EventInit {
-             required RTCError error;
-        };</pre>
+        <pre class="idl"
+>dictionary RTCErrorEventInit : EventInit {
+  required RTCError error;
+};</pre>
       </div>
       <section>
         <h2>Dictionary RTCErrorEventInit Members</h2>


### PR DESCRIPTION
We got [feedback](https://phabricator.services.mozilla.com/D30976#1147205) our WebIDL code style is unusual—space before arguments `foo ()`—and when I looked into it I found lots of formatting inconsistencies even within our own doc.

With my editor's hat on, I've reformatted our WebIDL to match that of [WebIDL](https://heycam.github.io/webidl/#example-d7d00072), [HTML](https://html.spec.whatwg.org/#htmlelement) and [DOM](https://dom.spec.whatwg.org/#interface-event).

[Before](https://w3c.github.io/webrtc-pc/#interface-definition) [After](https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2232.html#interface-definition)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2232.html" title="Last updated on Jul 18, 2019, 5:43 PM UTC (9e73947)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2232/7e47ca8...jan-ivar:9e73947.html" title="Last updated on Jul 18, 2019, 5:43 PM UTC (9e73947)">Diff</a>