### PR TITLE
Use SendTrack slot instead of track attribute in replaceTrack algorithm

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6583,9 +6583,7 @@ async function updateParameters() {
                               slot is <code>true</code>, abort these steps.</p>
                             </li>
                             <li data-tests="RTCPeerConnection-setRemoteDescription-replaceTrack.https.html">
-                              <p>Set <var>sender</var>'s <code><a data-link-for=
-                              "RTCRtpSender">track</a></code> attribute to
-                              <var>withTrack</var>.</p>
+                              <p>Set <var>sender</var>'s <a>[[\SenderTrack]]</a> to <var>withTrack</var>.</p>
                             </li>
                             <li>
                               <p><a>Resolve</a> <var>p</var> with


### PR DESCRIPTION
Editorial change


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-pc/pull/2233.html" title="Last updated on Jul 18, 2019, 6:20 PM UTC (3e76c4b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2233/8b172c5...youennf:3e76c4b.html" title="Last updated on Jul 18, 2019, 6:20 PM UTC (3e76c4b)">Diff</a>