### PR TITLE
Infer SLD type from signalingState inside chained steps.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3070,28 +3070,28 @@ interface RTCPeerConnection : EventTarget  {
                     argument.</p>
                   </li>
                   <li>
-                    <p>Let <var>type</var> be
-                    <code><var>description</var>.type</code> if present, or
-                    <code>"offer"</code> if not present and
-                    <var>connection</var>'s <a>signaling state</a> is either
-                    <code>"stable"</code>, <code>"have-local-offer"</code>, or
-                    <code>"have-remote-pranswer"</code>; otherwise
-                    <code>"answer"</code>.</p>
+                    <p>Let <var>connection</var> be the
+                    <code><a>RTCPeerConnection</a></code> object on which the
+                    method was invoked.</p>
                   </li>
                   <li>
                     <p>Let <var>sdp</var> be
                     <code><var>description</var>.sdp</code>.</p>
                   </li>
                   <li>
-                    <p>Let <var>connection</var> be the
-                    <code><a>RTCPeerConnection</a></code> object on which the
-                    method was invoked.</p>
-                  </li>
-                  <li>
                     <p>Return the result of <a href=
                     "#dfn-chain-an-operation">chaining</a> the following steps to
                     <var>connection</var>'s operations chain:</p>
                     <ol>
+                      <li>
+                        <p>Let <var>type</var> be
+                        <code><var>description</var>.type</code> if present, or
+                        <code>"offer"</code> if not present and
+                        <var>connection</var>'s <a>signaling state</a> is either
+                        <code>"stable"</code>, <code>"have-local-offer"</code>,
+                        or <code>"have-remote-pranswer"</code>; otherwise
+                        <code>"answer"</code>.</p>
+                      </li>
                       <li data-tests="RTCPeerConnection-setLocalDescription-offer.html">
                         <p>If <var>type</var> is <code>"offer"</code>, and
                         <var>sdp</var> is not the empty string and not equal to


### PR DESCRIPTION
A fix for a mistake I made in https://github.com/w3c/webrtc-pc/pull/2234. Discovered this while implementing it.

Whenever we read `signalingState` and other negotiation state inside a negotiation methods, we must do so from inside its *chained* steps, to pick up the state at the time of execution (rather than time of invocation).

See https://github.com/w3c/webrtc-pc/issues/2208 for an example of where the two may differ.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2244.html" title="Last updated on Jul 31, 2019, 11:36 PM UTC (ba236b5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2244/3bdf1ec...jan-ivar:ba236b5.html" title="Last updated on Jul 31, 2019, 11:36 PM UTC (ba236b5)">Diff</a>