### PR TITLE
Mark VAD and dtx as "features at risk"

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -655,6 +655,12 @@
                 This option allows the application to provide information about
                 whether it wishes this type of processing enabled or
                 disabled.</p>
+                <div class="issue atrisk">
+                <p>Support for the <code>voiceActivityDetection</code> attribute of
+                <code><a>RTCOfferAnswerOptions</a></code> is marked
+                as a feature at risk, since there is no clear
+                commitment from implementers.</p>
+              </div>
               </dd>
             </dl>
           </section>
@@ -6997,6 +7003,12 @@ async function updateParameters() {
               then discontinuous operation will be turned off regardless of the
               value of <code>dtx</code>, and media will be sent even when silence
               is detected.</p>
+              <div class="issue atrisk">
+                <p>Support for the <code>dtx</code> attribute of
+                <code><a>RTCRtpEncodingParameters</a></code> is marked
+                as a feature at risk, since there is no clear
+                commitment from implementers.</p>
+              </div>
             </dd>
             <dt data-tests="RTCPeerConnection-transceivers.https.html,RTCRtpParameters-encodings.html"><dfn data-idl><code>active</code></dfn> of type <span class=
             "idlMemberType">boolean</span>, defaulting to


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/2236


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2245.html" title="Last updated on Aug 1, 2019, 6:06 PM UTC (eeefe98)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2245/f665b4d...eeefe98.html" title="Last updated on Aug 1, 2019, 6:06 PM UTC (eeefe98)">Diff</a>