### PR TITLE
Clarify SRD() won't reject on identity failure wo/target peer identity.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3270,13 +3270,13 @@ interface RTCPeerConnection : EventTarget  {
                 <p>The <a>target peer identity</a> cannot be changed once set.</p>
                 <p>If a <a>target peer identity</a> is set, then the <a href=
                 "#dfn-validate-the-identity">identity validation</a> MUST be completed before the
-                promise returned <code><a>setRemoteDescription</a></code> is <a>resolved</a>.
-                If <a href="#dfn-validate-the-identity">identity validation</a> fails,
-                then the promise returned by <code><a>setRemoteDescription</a></code>
-                MUST be <a>rejected</a>.</p>
-                <p>If there is no <a>target peer identity</a>, then
-                <code>setRemoteDescription</code> MUST not await the completion
-                of identity validation. Whether
+                promise returned by <code><a>setRemoteDescription</a></code> is <a>resolved</a>,
+                and the promise returned by <code><a>setRemoteDescription</a></code>
+                MUST be <a>rejected</a> if
+                <a href="#dfn-validate-the-identity">identity validation</a> fails.</p>
+                <p>However, if there is no <a>target peer identity</a>, then
+                <code>setRemoteDescription</code> MUST NOT await the completion
+                of identity validation, and whether
                 <a href="#dfn-validate-the-identity">identity validation</a> fails
                 or not MUST NOT influence whether the promise returned by
                 <code><a>setRemoteDescription</a></code> is rejected.</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -3273,10 +3273,13 @@ interface RTCPeerConnection : EventTarget  {
                 promise returned <code><a>setRemoteDescription</a></code> is <a>resolved</a>.
                 If <a href="#dfn-validate-the-identity">identity validation</a> fails,
                 then the promise returned by <code><a>setRemoteDescription</a></code>
-                is <a>rejected</a>.</p>
+                MUST be <a>rejected</a>.</p>
                 <p>If there is no <a>target peer identity</a>, then
-                <code>setRemoteDescription</code> does not await the completion
-                of identity validation.</p>
+                <code>setRemoteDescription</code> MUST not await the completion
+                of identity validation. Whether
+                <a href="#dfn-validate-the-identity">identity validation</a> fails
+                or not MUST NOT influence whether the promise returned by
+                <code><a>setRemoteDescription</a></code> is rejected.</p>
               </dd>
               <dt data-tests="RTCPeerConnection-addIceCandidate.html,promises-call.html"><code>addIceCandidate</code></dt>
               <dd>


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2148.

cc @martinthomson


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2250.html" title="Last updated on Aug 30, 2019, 7:07 PM UTC (c1d194a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2250/f665b4d...jan-ivar:c1d194a.html" title="Last updated on Aug 30, 2019, 7:07 PM UTC (c1d194a)">Diff</a>