### PR TITLE
Don't fire SRD() events until target peer identity has been verified.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1418,6 +1418,17 @@
                 </ol>
               </li>
               <li>
+                <p>If <var>description</var> is set as a remote description and
+                is applied successfully, and a <a>target peer identity</a> is
+                set, then the user agent MUST wait for
+                <a href="#dfn-validate-the-identity">identity validation</a>
+                to complete before proceeding to the next step. If
+                <a href="#dfn-validate-the-identity">identity validation</a>
+                fails, <a>reject</a> <var>p</var> with a newly
+                <a data-link-for="exception" data-lt="create">created</a>
+                <code>OperationError</code>, and abort these steps.</p>
+              </li>
+              <li>
                 <p>If <var>description</var> is applied successfully, the user
                 agent MUST queue a task that runs the following steps:</p>
                 <ol>
@@ -3257,8 +3268,8 @@ interface RTCPeerConnection : EventTarget  {
                 <p>In addition, a remote description is processed to determine
                 and verify the identity of the peer.</p>
                 <p data-tests>If an <code>a=identity</code> attribute is present in the
-                session description, the browser <a data-cite="!WEBRTC-IDENTITY##sec.identity-verify-assertion">validates the identity
-                assertion.</a>.</p>
+                session description, the browser <a data-cite="!WEBRTC-IDENTITY#sec.identity-verify-assertion">validates the identity
+                assertion</a>.</p>
                 <p>If the <a data-link-for="RTCConfiguration">peerIdentity</a> configuration is applied to the
                 <code><a>RTCPeerConnection</a></code>, this establishes a
                 <dfn id="target-peer-identity">target peer identity</dfn> of


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2173.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2251.html" title="Last updated on Aug 3, 2019, 12:47 AM UTC (bdf95fd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2251/f665b4d...jan-ivar:bdf95fd.html" title="Last updated on Aug 3, 2019, 12:47 AM UTC (bdf95fd)">Diff</a>