### PR TITLE
Mark RTCDataChannel/RTCRtpSendParameters.priority as "feature at risk"

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5099,6 +5099,11 @@ interface RTCPeerConnectionIceErrorEvent : Event {
       overall user experience is obtained by lowering the priority of things
       that are not as important rather than raising the priority of the things
       that are.</p>
+      <div class="issue atrisk">
+        <p>Support for the <code>RTCPriorityType</code> enum is marked as a
+        feature at risk, since there is no clear commitment from implementers.
+        </p>
+      </div>
     </section>
     <section>
       <h2 id="sec.cert-mgmt">Certificate Management</h2>
@@ -6890,6 +6895,12 @@ async function updateParameters() {
                 in [[!RTCWEB-TRANSPORT]], Section 4. The user agent is free to sub-allocate bandwidth
                 between the encodings of an <code><a>RTCRtpSender</a></code>.
               </p>
+              <div class="issue atrisk">
+                <p>Support for the <code>priority</code> member of the
+                <code>RTCRtpSendParameters</code> dictionary is marked as a
+                feature at risk, since there is no clear commitment from
+                implementers.</p>
+              </div>
             </dd>
           </dl>
         </section>
@@ -10263,6 +10274,13 @@ interface RTCDataChannel : EventTarget {
               by the user agent at channel creation time. On getting, the
               attribute MUST return the value of the
               <a>[[\DataChannelPriority]]</a> slot.</p>
+              <div class="issue atrisk">
+                <p>Support for the <code>priority</code> attribute of the
+                <code>RTCDataChannel</code> interface and its corresponding
+                <a>[[\DataChannelPriority]]</a> internal slot are marked as a
+                feature at risk, since there is no clear commitment from
+                implementers.</p>
+              </div>
             </dd>
             <dt data-tests="RTCDataChannel-send.html, RTCPeerConnection-createDataChannel.html"><code>readyState</code> of type <span class=
             "idlAttrType"><a>RTCDataChannelState</a></span>, readonly</dt>
@@ -10563,6 +10581,12 @@ interface RTCDataChannel : EventTarget {
             <code>low</code></dt>
             <dd>
               <p>Priority of this channel.</p>
+              <div class="issue atrisk">
+                <p>Support for the <code>priority</code> member of the
+                <code>RTCDataChannelInit</code> dictionary is marked as a
+                feature at risk, since there is no clear commitment from
+                implementers.</p>
+              </div>
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2258.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2259.html" title="Last updated on Aug 8, 2019, 2:38 PM UTC (5c3f143)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2259/f665b4d...jan-ivar:5c3f143.html" title="Last updated on Aug 8, 2019, 2:38 PM UTC (5c3f143)">Diff</a>