### PR TITLE
Mark RTCRtpEncodingParameters.maxFramerate as "feature at risk"

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7059,6 +7059,12 @@ async function updateParameters() {
                 picture is completed; setting the max framerate to zero thus has
                 the effect of freezing the video on the next frame.
               </p>
+              <div class="issue atrisk">
+                <p>Support for the <code>maxFramerate</code> member of the
+                <code><a>RTCRtpEncodingParameters</a></code> is marked
+                as a feature at risk, since there is no clear
+                commitment from implementers.</p>
+              </div>
             </dd>
             <dt data-tests="RTCRtpParameters-encodings.html"><dfn data-idl><code>scaleResolutionDownBy</code></dfn> of type
             <span class="idlMemberType">double</span></dt>


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2260.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2261.html" title="Last updated on Aug 8, 2019, 3:01 PM UTC (71ad9c1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2261/f665b4d...jan-ivar:71ad9c1.html" title="Last updated on Aug 8, 2019, 3:01 PM UTC (71ad9c1)">Diff</a>