### PR TITLE
Add a test-coverage focused view to the spec

### DIFF
--- a/webrtc.css
+++ b/webrtc.css
@@ -49,3 +49,12 @@ p.warning:before { content: '\26A0 Warning! '; }
 .example { display: block; color: #222222; background: #FCFCFC; border-left: double; margin-left: 2em; padding-left: 1em; }
 td > .example:only-child { margin: 0 0 0 0.1em; }
 .rfc2119 { font-variant: small-caps;}
+
+details.respec-tests-details { display: none !important;}
+body.testcoverage details.respec-tests-details { display: inline-block !important; }
+
+body.testcoverage .has-tests { background-color: #cfc !important;}
+body.testcoverage .needs-tests { background-color: #fcc !important;}
+body.testcoverage .untestable { opacity: 0.5;}
+body.testcoverage .issue, body.testcoverage .example, body.testcoverage .note, body.testcoverage .informative, body.testcoverage .appendix { display: none;}
+

--- a/webrtc.js
+++ b/webrtc.js
@@ -19,7 +19,9 @@ function markTestableAssertions() {
             parent = parent.parentNode;
           } while (parent.tagName !== 'SECTION' && parent.matches);
           if (el.tagName === "P" && (el.textContent.match(/MUST/) || el.textContent.match(/SHALL/))) {
-            el.classList.add("needs-tests");
+            if (!((el.parentNode.tagName === "DD" && el.parentNode.previousElementSibling.getAttribute("data-tests") && !el.nextElementSibling) || (el.nextElementSibling && el.nextElementSibling.tagName === "OL"))) {
+              el.classList.add("needs-tests");
+            }
           } else if (el.tagName === "LI" && !el.querySelector('ol')) { // Detect argument assignment cases?
             el.classList.add("needs-tests");
           }

--- a/webrtc.js
+++ b/webrtc.js
@@ -4,6 +4,40 @@ function dedupOverload() {
   [...document.querySelectorAll("#idl-def-rtcdatachannel-send")].forEach((el, i) => el.id += '-' + i);
 }
 
+function markTestableAssertions() {
+  const sectionsToIgnore=["#abstract", "#sotd", "#conformance", ".informative", ".appendix"];
+  const contentToIgnore = [".untestable", ".issue", ".example", ".note", ".informative", ".has-tests", ".needs-tests"];
+  const contentToIgnoreSelector = contentToIgnore.map(sel => `:not(${sel})`).join('');
+
+  [...document.querySelector("body").querySelectorAll(sectionsToIgnore.map(sel => `section:not(${sel})`).join(","))].forEach(
+    section => {
+      [...section.querySelectorAll(`p${contentToIgnoreSelector}, ol > li${contentToIgnoreSelector}`)].forEach(
+        el => {
+          let parent = el.parentNode;
+          do  {
+            if (parent.matches(contentToIgnore.join(','))) return;
+            parent = parent.parentNode;
+          } while (parent.tagName !== 'SECTION' && parent.matches);
+          if (el.tagName === "P" && (el.textContent.match(/MUST/) || el.textContent.match(/SHALL/))) {
+            el.classList.add("needs-tests");
+          } else if (el.tagName === "LI" && !el.querySelector('ol')) { // Detect argument assignment cases?
+            el.classList.add("needs-tests");
+          }
+        })
+    }
+  );
+}
+
+function highlightTests() {
+  [...document.querySelectorAll("[data-tests]")].forEach(el => {
+    if (el.dataset['tests'])
+      el.classList.add("has-tests")
+    else
+      el.classList.add("needs-tests");
+  });
+}
+
+
 var respecConfig = {
   // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
   specStatus:           "ED",
@@ -118,6 +152,8 @@ var respecConfig = {
     }
   ],
   preProcess: [
+    highlightTests,
+    markTestableAssertions,
       function linkToJsep() {
           require(["core/pubsubhub"], function(pubsubhub){
               var xhr = new XMLHttpRequest();
@@ -235,3 +271,6 @@ var respecConfig = {
     },
   postProcess: [dedupOverload]
 };
+respecUI.addCommand("Toggle test annotations", function() {
+  document.querySelector("body").classList.toggle("testcoverage");
+});


### PR DESCRIPTION
* this hides by in-line links to tests (close #2161)
* it adds a command in the respec menu 'toggle test annotations' that:
** show the links to the test cases
** highlights sections of the specs that have / don't have and need tests

