### PR TITLE
Use consistent notation for internal slots

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1174,7 +1174,7 @@
             <code><a>RTCPeerConnection</a></code> object.</p>
           </li>
           <li>
-            <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+            <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
             <code>true</code>, return a promise <a>rejected</a> with a newly
             <a data-link-for="exception" data-lt="create">created</a>
             <code>InvalidStateError</code>.</p>
@@ -1197,7 +1197,7 @@
             <var>operation</var>, run the following steps:</p>
             <ol>
               <li>
-                <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+                <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
                 <code>true</code>, abort these steps.</p>
               </li>
               <li>
@@ -1214,7 +1214,7 @@
                 following steps:</p>
                 <ol>
                   <li>
-                    <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+                    <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
                     <code>true</code>, abort these steps.</p>
                   </li>
                   <li>
@@ -1278,7 +1278,7 @@
         following steps:</p>
         <ol>
           <li>
-            <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+            <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
             <code>true</code>, abort these steps.</p>
           </li>
           <li>
@@ -1321,7 +1321,7 @@
         runs the following steps:</p>
         <ol>
           <li>
-            <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+            <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
             <code>true</code>, abort these steps.</p>
           </li>
           <li>
@@ -1374,7 +1374,7 @@
                 following steps:</p>
                 <ol>
                   <li>
-                    <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+                    <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
                     <code>true</code>, then abort these steps.</p>
                   </li>
                   <li data-tests="RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setLocalDescription-pranswer.html,RTCPeerConnection-setRemoteDescription-answer.html,RTCPeerConnection-setRemoteDescription-offer.html,RTCPeerConnection-setRemoteDescription-pranswer.html">
@@ -1422,7 +1422,7 @@
                 agent MUST queue a task that runs the following steps:</p>
                 <ol>
                   <li>
-                    <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+                    <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
                     <code>true</code>, then abort these steps.</p>
                   </li>
                   <li>
@@ -1536,8 +1536,7 @@
                     <p>If <var>description</var> is of type <code>"answer"</code>, and it
                     initiates the closure of an existing SCTP association, as
                     defined in [[!SCTP-SDP]], Sections 10.3 and 10.4, set the
-                    value of <var>connection</var>'s
-                    <a>[[\SctpTransport]]</a> internal slot to
+                    value of <var>connection</var>.<a>[[\SctpTransport]]</a> to
                     <code>null</code>.</p>
                   </li>
                   <li>
@@ -1554,7 +1553,7 @@
                         association is established,
                         but the "max-message-size" SDP attribute is updated,
                         <a>update the data max message size</a> of
-                        <var>connection</var>'s <a>[[\SctpTransport]]</a>.</p>
+                        <var>connection</var>.<a>[[\SctpTransport]]</a>.</p>
                       </li>
                       <li>
                         <p data-tests="RTCPeerConnection-createDataChannel.html">If <var>description</var> negotiates the DTLS role
@@ -1571,7 +1570,7 @@
                             an ID could not be generated.</p>
                           </li>
                           <li>
-                            <p>Set <var>channel</var>'s <a>[[\ReadyState]]</a> slot
+                            <p>Set <var>channel</var>.<a>[[\ReadyState]]</a>
                             to <code>"closed"</code>.</p>
                           </li>
                           <li>
@@ -1619,7 +1618,7 @@
                                 the <a>media description</a>.</p>
                               </li>
                               <li data-tests="RTCRtpTransceiver-stop.html">
-                                <p>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot
+                                <p>If <var>transceiver</var>.<a>[[\Stopped]]</a>
                                 is <code>true</code>, abort these sub steps.</p>
                               </li>
                               <li>
@@ -1680,7 +1679,7 @@
                             <a>media description</a>.</p>
                           </li>
                           <li data-tests="RTCRtpTransceiver.https.html">
-                            <p>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot
+                            <p>If <var>transceiver</var>.<a>[[\Stopped]]</a>
                             is <code>true</code>, abort these sub steps.</p>
                           </li>
                           <li>
@@ -1692,7 +1691,7 @@
                           <li>
                             <p>If <var>direction</var> is <code>"sendrecv"</code> or
                             <code>"recvonly"</code>,
-                            set <var>transceiver</var>'s <a>[[\Receptive]]</a> slot
+                            set <var>transceiver</var>.<a>[[\Receptive]]</a>
                             to <code>true</code>, otherwise set it to <code>false</code>.</p>
                           </li>
                           <li>
@@ -1717,8 +1716,7 @@
                               <li>
                                 <p>If <var>direction</var> is
                                 <code>"sendonly"</code> or <code>"inactive"</code>,
-                                and <var>transceiver</var>'s
-                                <a>[[\FiredDirection]]</a> slot is either
+                                and <var>transceiver</var>.<a>[[\FiredDirection]]</a> is either
                                 <code>"sendrecv"</code> or <code>"recvonly"</code>,
                                 then run the following steps:</p>
                                 <ol>
@@ -1737,9 +1735,8 @@
                                 </ol>
                               </li>
                               <li data-tests="RTCPeerConnection-transceivers.https.html">
-                                <p>Set <var>transceiver</var>'s
-                                <a>[[\CurrentDirection]]</a> and
-                                <a>[[\FiredDirection]]</a> slots to
+                                <p>Set <var>transceiver</var>.<a>[[\CurrentDirection]]</a> and
+                                <var>transceiver</var>.<a>[[\FiredDirection]]</a> to
                                 <var>direction</var>.</p>
                               </li>
                             </ol>
@@ -1883,8 +1880,7 @@
                           </li>
                           <li data-tests="RTCPeerConnection-ontrack.https.html,RTCPeerConnection-setRemoteDescription-tracks.https.html,RTCPeerConnection-transceivers.https.html">
                             <p>If <var>direction</var> is <code>"sendrecv"</code> or
-                            <code>"recvonly"</code> and <var>transceiver</var>'s
-                            <a>[[\FiredDirection]]</a> slot
+                            <code>"recvonly"</code> and <var>transceiver</var>.<a>[[\FiredDirection]]</a>
                             is neither <code>"sendrecv"</code> nor <code>"recvonly"</code>,
                             or the previous step increased the length of <var>addList</var>,
                             <a>process the addition of a remote track</a> for
@@ -1894,22 +1890,20 @@
                           <li>
                             <p>If <var>direction</var> is <code>"sendonly"</code> or
                             <code>"inactive"</code>,
-                            set <var>transceiver</var>'s <a>[[\Receptive]]</a> slot
+                            set <var>transceiver</var>.<a>[[\Receptive]]</a>
                             to <code>false</code>.</p>
                           </li>
                           <li data-tests="RTCPeerConnection-remote-track-mute.https.html">
                             <p>If <var>direction</var> is
                             <code>"sendonly"</code> or <code>"inactive"</code>, and
-                            <var>transceiver</var>'s
-                            <a>[[\FiredDirection]]</a> slot
+                            <var>transceiver</var>.<a>[[\FiredDirection]]</a>
                             is either <code>"sendrecv"</code> or <code>"recvonly"</code>,
                             <a>process the removal of a remote track</a> for
                             the <a>media description</a>, given <var>transceiver</var>
                             and <var>muteTracks</var>.</p>
                           </li>
                           <li>
-                            <p>Set <var>transceiver</var>'s
-                            <a>[[\FiredDirection]]</a> slot to
+                            <p>Set <var>transceiver</var>.<a>[[\FiredDirection]]</a> to
                             <var>direction</var>.</p>
                           </li>
                           <li>
@@ -1932,9 +1926,8 @@
                                 agent is currently prepared to receive.</p>
                               </li>
                               <li>
-                                <p>Set <var>transceiver</var>'s
-                                <a>[[\CurrentDirection]]</a> and
-                                <a>[[\Direction]]</a> slots to
+                                <p>Set <var>transceiver</var>.<a>[[\CurrentDirection]]</a> and
+                                <var>transceiver</var>.<a>[[\Direction]]</a>s to
                                 <var>direction</var>.</p>
                               </li>
                               <li>
@@ -1974,7 +1967,7 @@
                           </li>
                           <li>
                             <p>If the <a>media description</a> is rejected, and
-                            <var>transceiver</var>'s <a>[[\Stopped]]</a> slot is
+                            <var>transceiver</var>.<a>[[\Stopped]]</a> is
                             <code>false</code>, then
                             <a>stop the RTCRtpTransceiver</a>
                             <var>transceiver</var>.</p>
@@ -2040,8 +2033,7 @@
                         that is being rolled back.</p>
                       </li>
                       <li>
-                        <p>Restore the value of <var>connection</var>'s
-                        <a>[[\SctpTransport]]</a> internal slot to
+                        <p>Restore the value of <var>connection</var>.<a>[[\SctpTransport]]</a> to
                         its value at the last <code>stable</code>
                         <a>signaling state</a>.</p>
                       </li>
@@ -2086,18 +2078,17 @@
                   <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
                     <p>If <var>connection</var>'s <a>signaling state</a> is now
                     <code>"stable"</code>, <a>update the negotiation-needed
-                    flag</a>. If <var>connection</var>'s
-                    <a>[[\NegotiationNeeded]]</a> slot was <code>true</code> both
+                    flag</a>. If <var>connection</var>.<a>[[\NegotiationNeeded]]</a> was <code>true</code> both
                     before and after this update, queue a task that runs the
                     following steps:</p>
                     <ol>
                       <li>
-                        <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot
+                        <p>If <var>connection</var>.<a>[[\IsClosed]]</a>
                         is <code>true</code>, abort these steps.</p>
                       </li>
                       <li>
-                        <p>If <var>connection</var>'s <a>[[\NegotiationNeeded]]</a>
-                        slot is <code>false</code>, abort these steps.</p>
+                        <p>If <var>connection</var>.<a>[[\NegotiationNeeded]]</a>
+                        is <code>false</code>, abort these steps.</p>
                       </li>
                       <li>
                         <p><a>Fire an event</a> named <code><a>negotiationneeded</a></code>
@@ -2606,7 +2597,7 @@ interface RTCPeerConnection : EventTarget  {
                     method was invoked.</p>
                   </li>
                   <li data-tests="RTCPeerConnection-createOffer.html">
-                    <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+                    <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
                     <code>true</code>, return a promise <a>rejected</a> with a newly
                     <a data-link-for="exception" data-lt="create">created</a>
                     <code>InvalidStateError</code>.</p>
@@ -2693,7 +2684,7 @@ interface RTCPeerConnection : EventTarget  {
                 <var>connection</var> and a promise <var>p</var> are as follows:</p>
                 <ol>
                   <li>
-                    <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+                    <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
                     <code>true</code>, then abort these steps.</p>
                   </li>
                   <li data-tests="RTCPeerConnection-createOffer.html">
@@ -2736,8 +2727,7 @@ interface RTCPeerConnection : EventTarget  {
                       <li>
                         <p>The <i>codec preferences</i> of an m= section's
                         associated transceiver is said to be the value of the
-                        <code>RTCRtpTranceiver</code>'s
-                        <a>[[\PreferredCodecs]]</a> slot with the following
+                        <code>RTCRtpTranceiver</code>.<a>[[\PreferredCodecs]]</a> with the following
                         filtering applied (or said not to be set if
                         <a>[[\PreferredCodecs]]</a> is empty):</p>
                         <ol>
@@ -2856,7 +2846,7 @@ interface RTCPeerConnection : EventTarget  {
                     method was invoked.</p>
                   </li>
                   <li data-tests="RTCPeerConnection-createAnswer.html">
-                    <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+                    <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
                     <code>true</code>, return a promise <a>rejected</a> with a newly
                     <a data-link-for="exception" data-lt="create">created</a>
                     <code>InvalidStateError</code>.</p>
@@ -2947,7 +2937,7 @@ interface RTCPeerConnection : EventTarget  {
                 promise <var>p</var> are as follows:</p>
                 <ol>
                   <li>
-                    <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+                    <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
                     <code>true</code>, then abort these steps.</p>
                   </li>
                   <li>
@@ -2980,8 +2970,7 @@ interface RTCPeerConnection : EventTarget  {
                       <li>
                         <p>The <i>codec preferences</i> of an m= section's
                         associated transceiver is said to be the value of the
-                        <code>RTCRtpTranceiver</code>'s
-                        <a>[[\PreferredCodecs]]</a> slot with the following
+                        <code>RTCRtpTranceiver</code>.<a>[[\PreferredCodecs]]</a> with the following
                         filtering applied (or said not to be set if
                         <a>[[\PreferredCodecs]]</a> is empty):</p>
                         <ol>
@@ -3095,8 +3084,8 @@ interface RTCPeerConnection : EventTarget  {
                       <li data-tests="RTCPeerConnection-setLocalDescription-offer.html">
                         <p>If <var>type</var> is <code>"offer"</code>, and
                         <var>sdp</var> is not the empty string and not equal to
-                        <var>connection</var>'s <a>[[\LastCreatedOffer]]</a>
-                        slot, then return a promise <a>rejected</a> with a newly
+                        <var>connection</var>.<a>[[\LastCreatedOffer]]</a>,
+                        then return a promise <a>rejected</a> with a newly
                         <a data-link-for="exception" data-lt="create">created</a>
                         <code>InvalidModificationError</code> and abort these
                         steps.</p>
@@ -3104,8 +3093,7 @@ interface RTCPeerConnection : EventTarget  {
                       <li data-tests="RTCPeerConnection-setLocalDescription-offer.html">
                         <p>If <var>type</var> is <code>"answer"</code> or
                         <code>"pranswer"</code>, and <var>sdp</var> is not the
-                        empty string and not equal to <var>connection</var>'s
-                        <a>[[\LastCreatedAnswer]]</a> slot, then return a
+                        empty string and not equal to <var>connection</var>.<a>[[\LastCreatedAnswer]]</a>, then return a
                         promise <a>rejected</a> with a newly
                         <a data-link-for="exception" data-lt="create">created</a>
                         <code>InvalidModificationError</code> and abort these
@@ -3118,15 +3106,15 @@ interface RTCPeerConnection : EventTarget  {
                         <ol>
                           <li data-tests="RTCPeerConnection-setLocalDescription-offer.html">
                             <p>Set <var>sdp</var> to the value of
-                            <var>connection</var>'s <a>[[\LastCreatedOffer]]</a>
-                            slot.</p>
+                            <var>connection</var>.<a>[[\LastCreatedOffer]]</a>.
+                            </p>
                           </li>
                           <li data-tests="RTCPeerConnection-setLocalDescription-offer.html">
                             <p>If <var>sdp</var> is the empty string, or if it
                             no longer accurately represents the system state of
                             <var>connection</var>, or if <var>connection</var>'s
                             configured identity provider has changed since
-                            <var>connection</var>'s <a>[[\LastCreatedOffer]]</a>
+                            <var>connection</var>.<a>[[\LastCreatedOffer]]</a>
                             was created, then let <var>p</var> be the result of
                             <a href="#dfn-create-an-offer">creating an offer</a>
                             with <var>connection</var>, and return the result of
@@ -3146,15 +3134,15 @@ interface RTCPeerConnection : EventTarget  {
                         <ol>
                           <li data-tests="RTCPeerConnection-setLocalDescription-offer.html">
                             <p>Set <var>sdp</var> to the value of
-                            <var>connection</var>'s <a>[[\LastCreatedAnswer]]</a>
-                            slot.</p>
+                            <var>connection</var>.<a>[[\LastCreatedAnswer]]</a>.
+                            </p>
                           </li>
                           <li data-tests="RTCPeerConnection-setLocalDescription-offer.html">
                             <p>If <var>sdp</var> is the empty string, or if it
                             no longer accurately represents the system state of
                             <var>connection</var>, or if <var>connection</var>'s
                             configured identity provider has changed since
-                            <var>connection</var>'s <a>[[\LastCreatedAnswer]]</a>
+                            <var>connection</var>.<a>[[\LastCreatedAnswer]]</a>
                             was created, then let <var>p</var> be the result of
                             <a href="#dfn-create-an-answer">creating an answer</a>
                             with <var>connection</var>, and return the result of
@@ -3400,8 +3388,7 @@ interface RTCPeerConnection : EventTarget  {
                             that runs the following steps:</p>
                             <ol>
                               <li>
-                                <p>If <var>connection</var>'s
-                                <a>[[\IsClosed]]</a> slot is <code>true</code>,
+                                <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is <code>true</code>,
                                 then abort these steps.</p>
                               </li>
                               <li>
@@ -3418,8 +3405,7 @@ interface RTCPeerConnection : EventTarget  {
                             following steps:</p>
                             <ol>
                               <li>
-                                <p>If <var>connection</var>'s
-                                <a>[[\IsClosed]]</a> slot is <code>true</code>,
+                                <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is <code>true</code>,
                                 then abort these steps.</p>
                               </li>
                               <li>
@@ -3533,7 +3519,7 @@ interface RTCPeerConnection : EventTarget  {
                     was invoked.</p>
                   </li>
                   <li>
-                    <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+                    <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
                     <code>true</code>, <a>throw</a> an
                     <code>InvalidStateError</code>.</p>
                   </li>
@@ -3554,11 +3540,11 @@ interface RTCPeerConnection : EventTarget  {
                     method was invoked.</p>
                   </li>
                   <li>
-                    <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+                    <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
                     <code>true</code>, abort these steps.</p>
                   </li>
                   <li>
-                    <p>Set <var>connection</var>'s <a>[[\IsClosed]]</a> slot to
+                    <p>Set <var>connection</var>.<a>[[\IsClosed]]</a> to
                     <code>true</code>.</p>
                   </li>
                   <li>
@@ -3572,7 +3558,7 @@ interface RTCPeerConnection : EventTarget  {
                     <var>transceivers</var>, run the following steps:</p>
                     <ol>
                       <li>
-                        <p>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot
+                        <p>If <var>transceiver</var>.<a>[[\Stopped]]</a>
                         is <code>true</code>, abort these sub steps.</p>
                       </li>
                       <li>
@@ -3592,7 +3578,7 @@ interface RTCPeerConnection : EventTarget  {
                     will not be invoked.</div>
                   </li>
                   <li>
-                    <p>If the <var>connection</var>'s <a>[[\SctpTransport]]</a>
+                    <p>If the <var>connection</var>.<a>[[\SctpTransport]]</a>
                     is not <code>null</code>, tear down the underlying SCTP
                     association by sending an SCTP ABORT chunk and set the
                     <a>[[\SctpTransportState]]</a> to <code>"<a data-link-for=
@@ -3946,13 +3932,13 @@ interface RTCPeerConnection : EventTarget  {
                   <li data-tests="legacy/RTCPeerConnection-createOffer-offerToReceive.html,legacy/RTCRtpTransceiver-with-OfferToReceive-options.https.html">
                     <p>For each non-stopped "sendrecv" transceiver of
                     <a>transceiver kind</a> <var>kind</var>, set
-                    <var>transceiver</var>'s <a>[[\Direction]]</a> slot to
+                    <var>transceiver</var>.<a>[[\Direction]]</a> to
                     "sendonly".</p>
                   </li>
                   <li data-tests="legacy/RTCPeerConnection-createOffer-offerToReceive.html,legacy/RTCRtpTransceiver-with-OfferToReceive-options.https.html">
                     <p>For each non-stopped "recvonly" transceiver of
                     <a>transceiver kind</a> <var>kind</var>, set
-                    <var>transceiver</var>'s <a>[[\Direction]]</a> slot to
+                    <var>transceiver</var>.<a>[[\Direction]]</a> to
                     "inactive".</p>
                   </li>
                 </ol>
@@ -3975,7 +3961,7 @@ interface RTCPeerConnection : EventTarget  {
                 operation threw an error, abort these steps.</p>
               </li>
               <li>
-                <p>Set <var>transceiver</var>'s <a>[[\Direction]]</a> slot
+                <p>Set <var>transceiver</var>.<a>[[\Direction]]</a>
                 to "recvonly".</p>
               </li>
             </ol>
@@ -4241,7 +4227,7 @@ interface RTCSessionDescription {
         <var>connection</var>, run the following steps:</p>
         <ol>
           <li class=untestable>
-            <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+            <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
             <code>true</code>, abort these steps.</p>
           </li>
           <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
@@ -4257,27 +4243,27 @@ interface RTCSessionDescription {
             <p>If the result of <a data-lt="check if negotiation is needed">
             checking if negotiation is needed</a> is <code>false</code>,
             <dfn>clear the negotiation-needed flag</dfn> by setting
-            <var>connection</var>'s <a>[[\NegotiationNeeded]]</a> slot to
+            <var>connection</var>.<a>[[\NegotiationNeeded]]</a> to
             <code>false</code>, and abort these steps.</p>
           </li>
           <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
-            <p>If <var>connection</var>'s <a>[[\NegotiationNeeded]]</a> slot is
+            <p>If <var>connection</var>.<a>[[\NegotiationNeeded]]</a> is
             already <code>true</code>, abort these steps.</p>
           </li>
           <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
-            <p>Set <var>connection</var>'s <a>[[\NegotiationNeeded]]</a> slot to
+            <p>Set <var>connection</var>.<a>[[\NegotiationNeeded]]</a> to
             <code>true</code>.</p>
           </li>
           <li>
             <p>Queue a task that runs the following steps:</p>
             <ol>
               <li>
-                <p class="untestable">If <var>connection</var>'s <a>[[\IsClosed]]</a> slot
+                <p class="untestable">If <var>connection</var>.<a>[[\IsClosed]]</a>
                 is <code>true</code>, abort these steps.</p>
               </li>
               <li>
-                <p>If <var>connection</var>'s <a>[[\NegotiationNeeded]]</a>
-                slot is <code>false</code>, abort these steps.</p>
+                <p>If <var>connection</var>.<a>[[\NegotiationNeeded]]</a>
+                is <code>false</code>, abort these steps.</p>
               </li>
               <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
                 <p><a>Fire an event</a> named <code><a>negotiationneeded</a></code>
@@ -5388,15 +5374,15 @@ interface RTCCertificate {
 
           <li>Set <var>serialized</var>.[[\Certificate]] to
           a copy of the unstructured binary data in
-          <var>value</var>'s <a>[[\Certificate]]</a> slot.</li>
+          <var>value</var>.<a>[[\Certificate]]</a>.</li>
 
           <li>Set <var>serialized</var>.[[\Origin]] to
           a copy of the unstructured binary data in
-          <var>value</var>'s <a>[[\Origin]]</a> slot.</li>
+          <var>value</var>.<a>[[\Origin]]</a>.</li>
 
           <li>Set <var>serialized</var>.[[\KeyingMaterial]] to a serialization
           of the private keying material represented by
-          <var>value</var>'s <a>[[\KeyingMaterial]]</a> slot.</li>
+          <var>value</var>.<a>[[\KeyingMaterial]]</a>.</li>
         </ol>
 
         <p>Their <a>deserialization steps</a>, given <var>serialized</var> and
@@ -5406,13 +5392,13 @@ interface RTCCertificate {
           <li>Initialize <var>value</var>'s <code>expires</code> attribute to
           contain <var>serialized</var>.[[\Expires]].</li>
 
-          <li>Set <var>value</var>'s <a>[[\Certificate]]</a> slot to a copy of
+          <li>Set <var>value</var>.<a>[[\Certificate]]</a> to a copy of
           <var>serialized</var>.[[\Certificate]].</li>
 
-          <li>Set <var>value</var>'s <a>[[\Origin]]</a> slot to a copy of
+          <li>Set <var>value</var>.<a>[[\Origin]]</a> to a copy of
           <var>serialized</var>.[[\Origin]].</li>
 
-          <li>Set <var>value</var>'s <a>[[\KeyingMaterial]]</a> slot to the private key material
+          <li>Set <var>value</var>.<a>[[\KeyingMaterial]]</a> to the private key material
           resulting from deserializing <var>serialized</var>.[[\KeyingMaterial]]</li>
         </ol>
         <p class="note">Supporting structured cloning in this manner
@@ -5636,7 +5622,7 @@ interface RTCCertificate {
                   was called with a single argument.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-addTrack.https.html">
-                  <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+                  <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
                   <code>true</code>, <a>throw</a> an
                   <code>InvalidStateError</code>.</p>
                 </li>
@@ -5687,12 +5673,11 @@ interface RTCCertificate {
                   following steps to use that sender:</p>
                   <ol>
                     <li>
-                      <p>Set <var>sender</var>'s <a>[[\SenderTrack]]</a> to
+                      <p>Set <var>sender</var>.<a>[[\SenderTrack]]</a> to
                       <var>track</var>.</p>
                     </li>
                     <li>
-                      <p>Set <var>sender</var>'s
-                      <a>[[\AssociatedMediaStreamIds]]</a> to an empty set.
+                      <p>Set <var>sender</var>.<a>[[\AssociatedMediaStreamIds]]</a> to an empty set.
                       </p>
                     </li>
                     <li>
@@ -5708,14 +5693,12 @@ interface RTCCertificate {
                       <var>sender</var>.</p>
                     </li>
                     <li>
-                      <p>If <var>transceiver</var>'s <a>[[\Direction]]</a> slot is
-                      <code>recvonly</code>, set <var>transceiver</var>'s
-                      <a>[[\Direction]]</a> slot to <code>sendrecv</code>.</p>
+                      <p>If <var>transceiver</var>.<a>[[\Direction]]</a> is
+                      <code>recvonly</code>, set <var>transceiver</var>.<a>[[\Direction]]</a> to <code>sendrecv</code>.</p>
                     </li>
                     <li>
-                      <p>If <var>transceiver</var>'s <a>[[\Direction]]</a> slot
-                      is <code>inactive</code>, set <var>transceiver</var>'s
-                      <a>[[\Direction]]</a> slot to <code>sendonly</code>.</p>
+                      <p>If <var>transceiver</var>.<a>[[\Direction]]</a>
+                      is <code>inactive</code>, set <var>transceiver</var>.<a>[[\Direction]]</a> to <code>sendonly</code>.</p>
                     </li>
                   </ol>
                 </li>
@@ -5809,7 +5792,7 @@ interface RTCCertificate {
                   the method was invoked.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-removeTrack.https.html,RTCRtpTransceiver.https.html">
-                  <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+                  <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
                   <code>true</code>, <a>throw</a> an
                   <code>InvalidStateError</code>.</p>
                 </li>
@@ -5829,11 +5812,11 @@ interface RTCCertificate {
                   of type "rollback"), then abort these steps.</p>
                 </li>
                 <li>
-                  <p>If <var>sender</var>'s <a>[[\SenderTrack]]</a> is null,
+                  <p>If <var>sender</var>.<a>[[\SenderTrack]]</a> is null,
                   abort these steps.
                 </li>
                 <li data-tests="RTCPeerConnection-removeTrack.https.html">
-                  <p>Set <var>sender</var>'s <a>[[\SenderTrack]]</a> to null.
+                  <p>Set <var>sender</var>.<a>[[\SenderTrack]]</a> to null.
                 </li>
                 <li>
                   <p>Let <var>transceiver</var> be the
@@ -5841,14 +5824,12 @@ interface RTCCertificate {
                   to <var>sender</var>.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-removeTrack.https.html">
-                  <p>If <var>transceiver</var>'s <a>[[\Direction]]</a> slot is
-                  <code>sendrecv</code>, set <var>transceiver</var>'s
-                  <a>[[\Direction]]</a> slot to <code>recvonly</code>.</p>
+                  <p>If <var>transceiver</var>.<a>[[\Direction]]</a> is
+                  <code>sendrecv</code>, set <var>transceiver</var>.<a>[[\Direction]]</a> to <code>recvonly</code>.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-removeTrack.https.html">
-                  <p>If <var>transceiver</var>'s <a>[[\Direction]]</a> slot
-                  is <code>sendonly</code>, set <var>transceiver</var>'s
-                    <a>[[\Direction]]</a> slot to <code>inactive</code>.</p>
+                  <p>If <var>transceiver</var>.<a>[[\Direction]]</a>
+                  is <code>sendonly</code>, set <var>transceiver</var>.<a>[[\Direction]]</a> to <code>inactive</code>.</p>
                 </li>
                 <li>
                   <p><a data-lt="update the negotiation-needed flag">Update the
@@ -5911,7 +5892,7 @@ interface RTCCertificate {
                   <var>track.kind</var>.</p>
                 </li>
                 <li>
-                  <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+                  <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
                   <code>true</code>, <a>throw</a> an
                   <code>InvalidStateError</code>.</p>
                 </li>
@@ -6122,18 +6103,15 @@ interface RTCCertificate {
         <var>trackEventInits</var>, the user agent MUST run the following steps:</p>
         <ol data-tests="RTCPeerConnection-transceivers.https.html">
           <li>
-            <p>Let <var>receiver</var> be <var>transceiver</var>'s
-            <a>[[\Receiver]]</a>.
+            <p>Let <var>receiver</var> be <var>transceiver</var>.<a>[[\Receiver]]</a>.
             </p>
           </li>
           <li>
-            <p>Let <var>track</var> be <var>receiver</var>'s
-            <a>[[\ReceiverTrack]]</a>.
+            <p>Let <var>track</var> be <var>receiver</var>.<a>[[\ReceiverTrack]]</a>.
             </p>
           </li>
           <li>
-            <p>Let <var>streams</var> be <var>receiver</var>'s
-            <a>[[\AssociatedRemoteMediaStreams]]</a> slot.
+            <p>Let <var>streams</var> be <var>receiver</var>.<a>[[\AssociatedRemoteMediaStreams]]</a>.
             </p>
           </li>
           <li>
@@ -6151,13 +6129,11 @@ interface RTCCertificate {
         <var>muteTracks</var>, the user agent MUST run the following steps:</p>
         <ol data-tests="RTCPeerConnection-remote-track-mute.https.html">
           <li>
-            <p>Let <var>receiver</var> be <var>transceiver</var>'s
-            <a>[[\Receiver]]</a>.
+            <p>Let <var>receiver</var> be <var>transceiver</var>.<a>[[\Receiver]]</a>.
             </p>
           </li>
           <li>
-            <p>Let <var>track</var> be <var>receiver</var>'s
-            <a>[[\ReceiverTrack]]</a>.
+            <p>Let <var>track</var> be <var>receiver</var>.<a>[[\ReceiverTrack]]</a>.
             </p>
           </li>
           <li data-tests="RTCRtpTransceiver.https.html">
@@ -6189,26 +6165,22 @@ interface RTCCertificate {
             <var>msids</var>.</p>
           </li>
           <li>
-            <p>Let <var>track</var> be <var>receiver</var>'s
-            <a>[[\ReceiverTrack]]</a>.
+            <p>Let <var>track</var> be <var>receiver</var>.<a>[[\ReceiverTrack]]</a>.
             </p>
           </li>
           <li>
-            <p>For each <var>stream</var> in <var>receiver</var>'s
-            <a>[[\AssociatedRemoteMediaStreams]]</a> that is not present in
+            <p>For each <var>stream</var> in <var>receiver</var>.<a>[[\AssociatedRemoteMediaStreams]]</a> that is not present in
             <var>streams</var>, add <var>stream</var> and <var>track</var> as a
             pair to <var>removeList</var>.
             </p>
           </li>
           <li data-tests="RTCPeerConnection-ontrack.https.html">
             <p>For each <var>stream</var> in
-            <var>streams</var> that is not present in <var>receiver</var>'s
-            <a>[[\AssociatedRemoteMediaStreams]]</a>, add <var>stream</var> and
+            <var>streams</var> that is not present in <var>receiver</var>.<a>[[\AssociatedRemoteMediaStreams]]</a>, add <var>stream</var> and
             <var>track</var> as a pair to <var>addList</var>.</p>
           </li>
           <li data-tests="RTCPeerConnection-ontrack.https.html">
-            <p>Set <var>receiver</var>'s
-            <a>[[\AssociatedRemoteMediaStreams]]</a> slot to
+            <p>Set <var>receiver</var>.<a>[[\AssociatedRemoteMediaStreams]]</a> to
             <var>streams</var>.
             </p>
           </li>
@@ -6265,7 +6237,7 @@ interface RTCCertificate {
           <span data-jsep="initial-offers">[[!JSEP]]</span>.</p>
         </li>
         <li>
-          <p>Set <var>sender</var>'s <a>[[\AssociatedMediaStreamIds]]</a> to an
+          <p>Set <var>sender</var>.<a>[[\AssociatedMediaStreamIds]]</a> to an
           empty set.</p>
         </li>
         <li>
@@ -6406,13 +6378,13 @@ interface RTCRtpSender {
                 <li>Let <var>transceiver</var> be the
                 <code><a>RTCRtpTransceiver</a></code> object associated
                 with <var>sender</var> (i.e. <var>sender</var> is
-                <var>transceiver</var>'s <a>[[\Sender]]</a>).</li>
-                <li data-tests="RTCRtpSender-setParameters.html,RTCRtpTransceiver.https.html">If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot is
+                <var>transceiver</var>.<a>[[\Sender]]</a>).</li>
+                <li data-tests="RTCRtpSender-setParameters.html,RTCRtpTransceiver.https.html">If <var>transceiver</var>.<a>[[\Stopped]]</a> is
                 <code>true</code>, return a promise <a>rejected</a> with a newly
                 <a data-link-for="exception" data-lt="create">created</a>
                 <code>InvalidStateError</code>.</li>
-                <li data-tests="RTCRtpParameters-transactionId.html">If <var>sender</var>'s <a>[[\LastReturnedParameters]]</a>
-                internal slot is <code>null</code>, return a promise
+                <li data-tests="RTCRtpParameters-transactionId.html">If <var>sender</var>.<a>[[\LastReturnedParameters]]</a>
+                is <code>null</code>, return a promise
                 <a>rejected</a> with a newly
                 <a data-link-for="exception" data-lt="create">created</a>
                 <code>InvalidStateError</code>.</li>
@@ -6427,7 +6399,7 @@ interface RTCRtpSender {
                  <li>
                    Let <var>N</var> be the number of
                    <code><a>RTCRtpEncodingParameters</a></code> stored in
-                   <var>sender</var>'s internal <a>[[\SendEncodings]]</a> slot.
+                   <var>sender</var>.<a>[[\SendEncodings]]</a>.
                  </li>
                  <li>
                    If any of the following conditions are met, return a promise
@@ -6445,8 +6417,8 @@ interface RTCRtpSender {
                        Any parameter in <var>parameters</var> is marked as a
                        <dfn>Read-only parameter</dfn> (such as RID) and has a
                        value that is different from the corresponding parameter
-                       value in <var>sender</var>'s <a>[[\LastReturnedParameters]]</a>
-                       internal slot. Note that this also applies to <var>transactionId</var>.
+                       value in <var>sender</var>.<a>[[\LastReturnedParameters]]</a>.
+                       Note that this also applies to <var>transactionId</var>.
                      </li>
                    </ol>
                  </li>
@@ -6477,11 +6449,9 @@ interface RTCRtpSender {
                     <var>parameters</var>, queue a task to run the following
                     steps:
                       <ol>
-                        <li data-tests="RTCRtpParameters-degradationPreference.html">Set <var>sender</var>'s internal
-                        <a>[[\LastReturnedParameters]]</a> slot to
+                        <li data-tests="RTCRtpParameters-degradationPreference.html">Set <var>sender</var>.<a>[[\LastReturnedParameters]]</a> to
                         <code>null</code>.</li>
-                        <li>Set <var>sender</var>'s internal
-                        <a>[[\SendEncodings]]</a> slot to <code>
+                        <li>Set <var>sender</var>.<a>[[\SendEncodings]]</a> to <code>
                         <var>parameters</var>.encodings</code>.</li>
                         <li><a>Resolve</a> <var>p</var> with <code>undefined</code>.
                       </ol>
@@ -6633,7 +6603,7 @@ async function updateParameters() {
                   steps to <var>connection</var>'s operations chain:</p>
                   <ol>
                   <li data-tests="RTCPeerConnection-setRemoteDescription-replaceTrack.https.html,RTCRtpSender-replaceTrack.https.html,RTCRtpTransceiver.https.html">
-                    <p>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot is
+                    <p>If <var>transceiver</var>.<a>[[\Stopped]]</a> is
                     <code>true</code>, return a promise <a>rejected</a>
                     with a newly <a data-link-for="exception" data-lt="create">
                     created</a> <code>InvalidStateError</code>.</p>
@@ -6643,7 +6613,7 @@ async function updateParameters() {
                     </li>
                     <li>
                       <p>Let <var>sending</var> be <code>true</code> if the
-                      <var>transceiver</var>'s <a>[[\CurrentDirection]]</a>
+                      <var>transceiver</var>.<a>[[\CurrentDirection]]</a>
                       is <code>"sendrecv"</code> or <code>"sendonly"</code>,
                       and <code>false</code> otherwise.</p>
                     </li>
@@ -6677,11 +6647,11 @@ async function updateParameters() {
                           <p data-tests="RTCPeerConnection-setRemoteDescription-replaceTrack.https.html,RTCRtpSender-replaceTrack.https.html">Queue a task that runs the following steps:</p>
                           <ol>
                             <li>
-                              <p>If <var>connection</var>'s <a>[[\IsClosed]]</a>
-                              slot is <code>true</code>, abort these steps.</p>
+                              <p>If <var>connection</var>.<a>[[\IsClosed]]</a>
+                              is <code>true</code>, abort these steps.</p>
                             </li>
                             <li data-tests="RTCPeerConnection-setRemoteDescription-replaceTrack.https.html">
-                              <p>Set <var>sender</var>'s <a>[[\SenderTrack]]</a> to <var>withTrack</var>.</p>
+                              <p>Set <var>sender</var>.<a>[[\SenderTrack]]</a> to <var>withTrack</var>.</p>
                             </li>
                             <li>
                               <p><a>Resolve</a> <var>p</var> with
@@ -6735,7 +6705,7 @@ async function updateParameters() {
                   method was invoked.</p>
                 </li>
                 <li>
-                  <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+                  <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
                   <code>true</code>, <a>throw</a> an
                   <code>InvalidStateError</code>.</p>
                 </li>
@@ -6746,8 +6716,7 @@ async function updateParameters() {
                   without arguments.</p>
                 </li>
                 <li>
-                  <p>Set <var>sender</var>'s
-                  <a>[[\AssociatedMediaStreamIds]]</a> to an empty set.
+                  <p>Set <var>sender</var>.<a>[[\AssociatedMediaStreamIds]]</a> to an empty set.
                   </p>
                 </li>
                 <li>
@@ -7877,7 +7846,7 @@ interface RTCRtpTransceiver {
                   getter is invoked.</p>
                 </li>
                 <li>
-                  <p>If <var>transceiver</var>'s <a>[[\Stopping]]</a> slot is
+                  <p>If <var>transceiver</var>.<a>[[\Stopping]]</a> is
                   <code>true</code>, return <code>"stopped"</code>.</p>
                 </li>
                 <li>
@@ -7900,7 +7869,7 @@ interface RTCRtpTransceiver {
                   associated with <var>transceiver</var>.</p>
                 </li>
                 <li>
-                  <p>If <var>transceiver</var>'s <a>[[\Stopping]]</a> slot is
+                  <p>If <var>transceiver</var>.<a>[[\Stopping]]</a> is
                   <code>true</code>, <a>throw</a> an
                   <code>InvalidStateError</code>.</p>
                 </li>
@@ -7910,7 +7879,7 @@ interface RTCRtpTransceiver {
                 </li>
                 <li data-tests="RTCRtpTransceiver-direction.html">
                   <p>If <var>newDirection</var> is equal to
-                  <var>transceiver</var>'s <a>[[\Direction]]</a> slot, abort these steps.</p>
+                  <var>transceiver</var>.<a>[[\Direction]]</a>, abort these steps.</p>
                 </li>
                 <li data-tests="RTCRtpTransceiver-direction.html">
                   <p>If <var>newDirection</var> is equal to
@@ -7918,7 +7887,7 @@ interface RTCRtpTransceiver {
                   </p>
                 </li>
                 <li>
-                  <p>Set <var>transceiver</var>'s <a>[[\Direction]]</a> slot
+                  <p>Set <var>transceiver</var>.<a>[[\Direction]]</a>
                   to <var>newDirection</var>.</p>
                 </li>
                 <li>
@@ -7951,7 +7920,7 @@ interface RTCRtpTransceiver {
                   getter is invoked.</p>
                 </li>
                 <li>
-                  <p>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot is
+                  <p>If <var>transceiver</var>.<a>[[\Stopped]]</a> is
                   <code>true</code>, return <code>"stopped"</code>.</p>
                 </li>
                 <li>
@@ -8011,12 +7980,12 @@ interface RTCRtpTransceiver {
                   <var>transceiver</var>.</p>
                 </li>
                 <li>
-                  <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+                  <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
                   <code>true</code>, <a>throw</a> an
                   <code>InvalidStateError</code>.</p>
                 </li>
                 <li>
-                  <p>If <var>transceiver</var>'s <a>[[\Stopping]]</a> slot is
+                  <p>If <var>transceiver</var>.<a>[[\Stopping]]</a> is
                   <code>true</code>, abort these steps.</p>
                 </li>
                 <li>
@@ -8032,12 +8001,10 @@ interface RTCRtpTransceiver {
               boolean defaulting to <code>false</code>, is as follows:</p>
               <ol>
                 <li>
-                  <p>Let <var>sender</var> be <var>transceiver</var>'s
-                  <a>[[\Sender]]</a>.</p>
+                  <p>Let <var>sender</var> be <var>transceiver</var>.<a>[[\Sender]]</a>.</p>
                 </li>
                 <li>
-                  <p>Let <var>receiver</var> be <var>transceiver</var>'s
-                  <a>[[\Receiver]]</a>.</p>
+                  <p>Let <var>receiver</var> be <var>transceiver</var>.<a>[[\Receiver]]</a>.</p>
                 </li>
                 <li data-tests="RTCRtpTransceiver-stop.html">
                   <p>Stop sending media with <var>sender</var>.</p>
@@ -8051,19 +8018,17 @@ interface RTCRtpTransceiver {
                 </li>
                 <li>
                   <p>If <var>abruptly</var> is <code>true</code>, set the
-                  <code>readyState</code> of <var>receiver</var>'s
-                  <a>[[\ReceiverTrack]]</a> to <code>"ended"</code>.
-                  Otherwise, execute the steps for <var>receiver</var>'s
-                  <a>[[\ReceiverTrack]]</a> to be
+                  <code>readyState</code> of <var>receiver</var>.<a>[[\ReceiverTrack]]</a> to <code>"ended"</code>.
+                  Otherwise, execute the steps for <var>receiver</var>.<a>[[\ReceiverTrack]]</a> to be
                   <a data-cite="!GETUSERMEDIA#track-ended">ended</a>.</p>
                 </li>
                 <li>
-                  <p>Set <var>transceiver</var>'s <a>[[\Direction]]</a>
-                  slot to <code>inactive</code>.</p>
+                  <p>Set <var>transceiver</var>.<a>[[\Direction]]</a>
+                  to <code>inactive</code>.</p>
                 </li>
                 <li>
-                  <p>Set <var>transceiver</var>'s <a>[[\Stopping]]</a>
-                  slot to <code>true</code>.</p>
+                  <p>Set <var>transceiver</var>.<a>[[\Stopping]]</a>
+                  to <code>true</code>.</p>
                 </li>
               </ol>
               <p>The <dfn>stop the RTCRtpTransceiver</dfn> algorithm given a
@@ -8071,21 +8036,21 @@ interface RTCRtpTransceiver {
               boolean defaulting to <code>false</code>, is as follows:</p>
               <ol>
                 <li>
-                  <p>If <var>transceiver</var>'s <a>[[\Stopping]]</a> slot is
+                  <p>If <var>transceiver</var>.<a>[[\Stopping]]</a> is
                   <code>false</code>, <a>stop sending and receiving</a> given
                   <var>transceiver</var> and <var>abruptly</var>.</p>
                 </li>
                 <li>
-                  <p>Set <var>transceiver</var>'s <a>[[\Stopped]]</a> slot to
+                  <p>Set <var>transceiver</var>.<a>[[\Stopped]]</a> to
                   <code>true</code>.</p>
                 </li>
                 <li>
-                  <p>Set <var>transceiver</var>'s <a>[[\Receptive]]</a>
-                  slot to <code>false</code>.</p>
+                  <p>Set <var>transceiver</var>.<a>[[\Receptive]]</a>
+                  to <code>false</code>.</p>
                 </li>
                 <li>
-                  <p>Set <var>transceiver</var>'s <a>[[\CurrentDirection]]</a>
-                  slot to <code>null</code>.</p>
+                  <p>Set <var>transceiver</var>.<a>[[\CurrentDirection]]</a>
+                  to <code>null</code>.</p>
                 </li>
               </ol>
             </dd>
@@ -8138,8 +8103,7 @@ interface RTCRtpTransceiver {
                   <p>Let <var>codecs</var> be the first argument.</p>
                 </li>
                 <li data-tests="RTCRtpTransceiver-setCodecPreferences.html">
-                  <p>If <var>codecs</var> is an empty list, set <var>transceiver</var>'s
-                  <a>[[\PreferredCodecs]]</a> slot to <var>codecs</var> and abort these steps.</p>
+                  <p>If <var>codecs</var> is an empty list, set <var>transceiver</var>.<a>[[\PreferredCodecs]]</a> to <var>codecs</var> and abort these steps.</p>
                 </li>
                 <li>
                   <p>Remove any duplicate values in <var>codecs</var>. Start at the back of the
@@ -8173,7 +8137,7 @@ interface RTCRtpTransceiver {
                   </ol>
                 </li>
                 <li data-tests="RTCRtpTransceiver-setCodecPreferences.html">
-                  <p>Set <var>transceiver</var>'s <a>[[\PreferredCodecs]]</a> slot to
+                  <p>Set <var>transceiver</var>.<a>[[\PreferredCodecs]]</a> to
                   <var>codecs</var>.</p>
                 </li>
               </ol>
@@ -8382,8 +8346,8 @@ async function onOffHold() {
           </p>
         </li>
         <li>
-          <p>Set <var>transport</var>'s <a>[[\DtlsTransportState]]</a>
-            slot to <code>failed</code>.</p>
+          <p>Set <var>transport</var>.<a>[[\DtlsTransportState]]</a>
+            to <code>failed</code>.</p>
         </li>
         <li>
           <p>
@@ -8415,7 +8379,7 @@ async function onOffHold() {
           <p>Let <var>newState</var> be the new state.</p>
         </li>
         <li>
-          <p>Set <var>transport</var>'s <a>[[\DtlsTransportState]]</a> slot to
+          <p>Set <var>transport</var>.<a>[[\DtlsTransportState]]</a> to
           <var>newState</var>.</p>
         </li>
         <li data-tests="RTCDtlsTransport-getRemoteCertificates.html">
@@ -8424,7 +8388,7 @@ async function onOffHold() {
           then let <var>newRemoteCertificates</var> be the certificate chain in
           use by the remote side, with each certificate encoded in binary
           Distinguished Encoding Rules (DER) [[!X690]], and set
-          <var>transport</var>'s <a>[[\RemoteCertificates]]</a> slot to
+          <var>transport</var>.<a>[[\RemoteCertificates]]</a> to
           <var>newRemoteCertificates</var>.</p>
         </li>
         <li data-tests="RTCDtlsTransport-state.html">
@@ -8595,7 +8559,7 @@ interface RTCDtlsTransport : EventTarget {
           <a>ICE Agent</a>.</p>
         </li>
         <li>
-          <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+          <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
           <code>true</code>, abort these steps.</p>
         </li>
         <li>
@@ -8603,8 +8567,8 @@ interface RTCDtlsTransport : EventTarget {
           for which candidate gathering began.</p>
         </li>
         <li>
-          <p>Set <var>transport</var>'s <a>[[\IceGathererState]]</a>
-          slot to <code><a data-link-for=
+          <p>Set <var>transport</var>.<a>[[\IceGathererState]]</a>
+          to <code><a data-link-for=
           "RTCIceGathererState">gathering</a></code>.</p>
         </li>
         <li>
@@ -8627,7 +8591,7 @@ interface RTCDtlsTransport : EventTarget {
           <a>ICE Agent</a>.</p>
         </li>
         <li>
-          <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+          <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
           <code>true</code>, abort these steps.</p>
         </li>
         <li>
@@ -8663,8 +8627,8 @@ interface RTCDtlsTransport : EventTarget {
           </div>
         </li>
         <li>
-          <p>Set <var>transport</var>'s <a>[[\IceGathererState]]</a>
-          slot to <code><a data-link-for=
+          <p>Set <var>transport</var>.<a>[[\IceGathererState]]</a>
+          to <code><a data-link-for=
           "RTCIceGathererState">complete</a></code>.</p>
         </li>
         <li>
@@ -8691,7 +8655,7 @@ interface RTCDtlsTransport : EventTarget {
           <a>ICE Agent</a>.</p>
         </li>
         <li>
-          <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+          <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
           <code>true</code>, abort these steps.</p>
         </li>
         <li>
@@ -8726,7 +8690,7 @@ interface RTCDtlsTransport : EventTarget {
       <var>connection</var>, run the following steps:</p>
       <ol>
         <li>
-          <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+          <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
           <code>true</code>, abort these steps.</p>
         </li>
         <li>
@@ -8782,7 +8746,7 @@ interface RTCDtlsTransport : EventTarget {
           <a>ICE Agent</a>.</p>
         </li>
         <li>
-          <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+          <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
           <code>true</code>, abort these steps.</p>
         </li>
         <li>
@@ -8794,7 +8758,7 @@ interface RTCDtlsTransport : EventTarget {
           <code><a>RTCIceTransportState</a></code>.
         </li>
         <li>
-          <p>Set <var>transport</var>'s <a>[[\IceTransportState]]</a> slot to
+          <p>Set <var>transport</var>.<a>[[\IceTransportState]]</a> to
           <var>newState</var>.</p>
         </li>
         <li>
@@ -8820,7 +8784,7 @@ interface RTCDtlsTransport : EventTarget {
           <a>ICE Agent</a>.</p>
         </li>
         <li>
-          <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+          <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
           <code>true</code>, abort these steps.</p>
         </li>
         <li>
@@ -8833,7 +8797,7 @@ interface RTCDtlsTransport : EventTarget {
           pair if one is selected, and <code>null</code> otherwise.</p>
         </li>
         <li data-tests="RTCIceTransport.html">
-          <p>Set <var>transport</var>'s <a>[[\SelectedCandidatePair]]</a> slot
+          <p>Set <var>transport</var>.<a>[[\SelectedCandidatePair]]</a>
           to <var>newCandidatePair</var>.</p>
         </li>
         <li>
@@ -9436,7 +9400,7 @@ interface RTCTrackEvent : Event {
                   method is invoked.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-createDataChannel.html">
-                  <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
+                  <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
                   <code>true</code>, <a>throw</a> an
                   <code>InvalidStateError</code>.</p>
                 </li>
@@ -9445,8 +9409,7 @@ interface RTCTrackEvent : Event {
                   <var>channel</var>.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-createDataChannel.html">
-                  <p>Initialize <var>channel</var>'s
-                  <a>[[\DataChannelLabel]]</a> slot to the value of the first
+                  <p>Initialize <var>channel</var>.<a>[[\DataChannelLabel]]</a> to the value of the first
                   argument.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-createDataChannel.html">
@@ -9458,23 +9421,22 @@ interface RTCTrackEvent : Event {
                   <p>Let <var>options</var> be the second argument.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-createDataChannel.html">
-                  <p>Initialize <var>channel</var>'s <a>[[\MaxPacketLifeTime]]</a>
-                  slot to <var>option</var>'s
+                  <p>Initialize <var>channel</var>.<a>[[\MaxPacketLifeTime]]</a>
+                  to <var>option</var>'s
                   <code>maxPacketLifeTime</code> member, if present, otherwise
                   <code>null</code>.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-createDataChannel.html">
-                  <p>Initialize <var>channel</var>'s <a>[[\MaxRetransmits]]</a>
-                  slot to <var>option</var>'s <code>maxRetransmits</code>
+                  <p>Initialize <var>channel</var>.<a>[[\MaxRetransmits]]</a>
+                  to <var>option</var>'s <code>maxRetransmits</code>
                   member, if present, otherwise <code>null</code>.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-createDataChannel.html">
-                  <p>Initialize <var>channel</var>'s <a>[[\Ordered]]</a> slot
+                  <p>Initialize <var>channel</var>.<a>[[\Ordered]]</a>
                   to <var>option</var>'s <code>ordered</code> member.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-createDataChannel.html">
-                  <p>Initialize <var>channel</var>'s
-                  <a>[[\DataChannelProtocol]]</a> slot to <var>option</var>'s
+                  <p>Initialize <var>channel</var>.<a>[[\DataChannelProtocol]]</a> to <var>option</var>'s
                   <code>protocol</code> member.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-createDataChannel.html">
@@ -9483,12 +9445,12 @@ interface RTCTrackEvent : Event {
                   <a>throw</a> a <code>TypeError</code>.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-createDataChannel.html">
-                  <p>Initialize <var>channel</var>'s <a>[[\Negotiated]]</a>
-                  slot to <var>option</var>'s <code>negotiated</code> member.</p>
+                  <p>Initialize <var>channel</var>.<a>[[\Negotiated]]</a>
+                  to <var>option</var>'s <code>negotiated</code> member.</p>
                 </li>
                 <li>
-                  <p>Initialize <var>channel</var>'s <a>[[\DataChannelId]]</a>
-                  slot to the value of <var>option</var>'s
+                  <p>Initialize <var>channel</var>.<a>[[\DataChannelId]]</a>
+                  to the value of <var>option</var>'s
                   <code>id</code> member, if it is present and
                   <a>[[\Negotiated]]</a> is true, otherwise
                   <code>null</code>.</p>
@@ -9506,8 +9468,7 @@ interface RTCTrackEvent : Event {
                   a <code>TypeError</code>.</p>
                 </li>
                 <li>
-                  <p>Initialize <var>channel</var>'s
-                  <a>[[\DataChannelPriority]]</a> slot to <var>option</var>'s
+                  <p>Initialize <var>channel</var>.<a>[[\DataChannelPriority]]</a> to <var>option</var>'s
                   <code>priority</code> member.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-createDataChannel.html">
@@ -9550,13 +9511,11 @@ interface RTCTrackEvent : Event {
                   </div>
                 </li>
                 <li>
-                  <p>Let <var>transport</var> be the <var>connection</var>'s
-                  <a>[[\SctpTransport]]</a> slot.</p>
+                  <p>Let <var>transport</var> be the <var>connection</var>.<a>[[\SctpTransport]]</a>.</p>
                   <p>If the <a>[[\DataChannelId]]</a> slot is not
                   <code>null</code>, <var>transport</var> is in the
                   <code>connected</code> state and <a>[[\DataChannelId]]</a> is
-                  greater or equal to the <var>transport</var>'s
-                  <a>[[\MaxChannels]]</a> slot, <a>throw</a> an
+                  greater or equal to the <var>transport</var>.<a>[[\MaxChannels]]</a>, <a>throw</a> an
                   <code>OperationError</code>.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
@@ -9684,8 +9643,8 @@ interface RTCTrackEvent : Event {
                   <p>Let <var>channel</var> be the <code><a>RTCDataChannel</a></code> object.</p>
                 </li>
                 <li>
-                  <p>If the <var>channel</var>'s <a>[[\DataChannelId]]</a> slot is greater or
-                  equal to <var>transport</var>'s <a>[[\MaxChannels]]</a> slot,
+                  <p>If the <var>channel</var>.<a>[[\DataChannelId]]</a> is greater or
+                  equal to <var>transport</var>.<a>[[\MaxChannels]]</a>,
                   <a data-lt="data-channel-failure"> close the <var>channel</var> due to a failure
                   </a>. Otherwise, <a data-lt="announce the rtcdatachannel as open">announce the
                   <var>channel</var> as open</a>.</p>
@@ -9907,11 +9866,11 @@ interface RTCSctpTransport : EventTarget {
           object to be announced.</p>
         </li>
         <li>
-          <p>If <var>channel</var>'s <a>[[\ReadyState]]</a> is <code>closing</code> or
+          <p>If <var>channel</var>.<a>[[\ReadyState]]</a> is <code>closing</code> or
           <code>closed</code>, abort these steps.</p>
         </li>
         <li>
-          <p>Set <var>channel</var>'s <a>[[\ReadyState]]</a> slot to
+          <p>Set <var>channel</var>.<a>[[\ReadyState]]</a> to
           <code>open</code>.</p>
         </li>
         <li data-tests="RTCPeerConnection-ondatachannel.html">
@@ -9940,19 +9899,17 @@ interface RTCSctpTransport : EventTarget {
           Protocol specification [[!RTCWEB-DATA-PROTOCOL]].</p>
         </li>
         <li data-tests="RTCPeerConnection-ondatachannel.html">
-          <p>Initialize <var>channel</var>'s <a>[[\DataChannelLabel]]</a>,
+          <p>Initialize <var>channel</var>.<a>[[\DataChannelLabel]]</a>,
           <a>[[\Ordered]]</a>, <a>[[\MaxPacketLifeTime]]</a>,
           <a>[[\MaxRetransmits]]</a>, <a>[[\DataChannelProtocol]]</a>,
           and <a>[[\DataChannelId]]</a> internal slots to the corresponding
           values in <var>configuration</var>.</p>
         </li>
         <li>
-          <p>Initialize <var>channel</var>'s <a>[[\Negotiated]]</a> internal
-          slot to <code>false</code>.</p>
+          <p>Initialize <var>channel</var>.<a>[[\Negotiated]]</a> to <code>false</code>.</p>
         </li>
         <li data-tests="RTCPeerConnection-ondatachannel.html">
-          <p>Initialize <var>channel</var>'s <a>[[\DataChannelPriority]]</a>
-          internal slot based on the integer priority value in
+          <p>Initialize <var>channel</var>.<a>[[\DataChannelPriority]]</a> based on the integer priority value in
           <var>configuration</var>, according to the following mapping:
           </p>
           <table class="simple">
@@ -9979,7 +9936,7 @@ interface RTCSctpTransport : EventTarget {
           </table>
         </li>
         <li>
-          <p>Set <var>channel</var>'s <a>[[\ReadyState]]</a> to
+          <p>Set <var>channel</var>.<a>[[\ReadyState]]</a> to
           <code>open</code> (but do not fire the <code><a>open</a></code>
           event, yet).</p>
           <div class="note">This allows to start sending messages inside of the
@@ -10013,7 +9970,7 @@ interface RTCSctpTransport : EventTarget {
         <li>
           <p>Unless the procedure was initiated by the <var>channel</var>'s
           <code><a data-link-for="RTCDataChannel">close</a></code> method, set
-          <var>channel</var>'s <a>[[\ReadyState]]</a> slot to
+          <var>channel</var>.<a>[[\ReadyState]]</a> to
           <code>closing</code>.</p>
         </li>
         <li>
@@ -10049,7 +10006,7 @@ interface RTCSctpTransport : EventTarget {
           closed.</p>
         </li>
         <li>
-          <p>Set <var>channel</var>'s <a>[[\ReadyState]]</a> slot to
+          <p>Set <var>channel</var>.<a>[[\ReadyState]]</a> to
           <code>closed</code>.</p>
         </li>
         <li>
@@ -10082,7 +10039,7 @@ interface RTCSctpTransport : EventTarget {
           data transport</a>.</p>
         </li>
         <li>
-          <p>Set <var>channel</var>'s <a>[[\ReadyState]]</a> slot to
+          <p>Set <var>channel</var>.<a>[[\ReadyState]]</a> to
           <code>closed</code>.</p>
         </li>
         <li>
@@ -10109,7 +10066,7 @@ interface RTCSctpTransport : EventTarget {
           object for which the user agent has received a message.</p>
         </li>
         <li>
-          <p>If <var>channel</var>'s <a>[[\ReadyState]]</a> slot is not
+          <p>If <var>channel</var>.<a>[[\ReadyState]]</a> is not
           <code>open</code>, abort these steps and discard <var>rawData</var>.
           </p>
         </li>
@@ -10381,12 +10338,12 @@ interface RTCDataChannel : EventTarget {
                   be closed.</p>
                 </li>
                 <li>
-                  <p>If <var>channel</var>'s <a>[[\ReadyState]]</a> slot is
+                  <p>If <var>channel</var>.<a>[[\ReadyState]]</a> is
                   <code>closing</code> or <code>closed</code>, then abort these
                   steps.</p>
                 </li>
                 <li>
-                  <p>Set <var>channel</var>'s <a>[[\ReadyState]]</a> slot to
+                  <p>Set <var>channel</var>.<a>[[\ReadyState]]</a> to
                   <code>closing</code>.</p>
                 </li>
                 <li>
@@ -10432,7 +10389,7 @@ interface RTCDataChannel : EventTarget {
           object on which data is to be sent.</p>
         </li>
         <li data-tests="RTCDataChannel-send.html">
-          <p>If <var>channel</var>'s <a>[[\ReadyState]]</a> slot is not
+          <p>If <var>channel</var>.<a>[[\ReadyState]]</a> is not
           <code>open</code>, <a>throw</a> an
           <code>InvalidStateError</code>.</p>
         </li>
@@ -10834,10 +10791,10 @@ interface RTCDTMFSender : EventTarget {
                   <code><a>RTCRtpTransceiver</a></code> object associated with
                   <var>sender</var>.</p>
                 </li>
-                <li data-tests="RTCDTMFSender-insertDTMF.https.html,RTCRtpTransceiver.https.html">If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot is
+                <li data-tests="RTCDTMFSender-insertDTMF.https.html,RTCRtpTransceiver.https.html">If <var>transceiver</var>.<a>[[\Stopped]]</a> is
                 <code>true</code>, <a>throw</a> an
                 <code>InvalidStateError</code>.</li>
-                <li data-tests="RTCDTMFSender-insertDTMF.https.html">If <var>transceiver</var>'s <a>[[\CurrentDirection]]</a> slot
+                <li data-tests="RTCDTMFSender-insertDTMF.https.html">If <var>transceiver</var>.<a>[[\CurrentDirection]]</a>
                 is <code>recvonly</code> or <code>inactive</code>,
                 <a>throw</a> an <code>InvalidStateError</code>.</li>
                 <li>Let <var>dtmf</var> be the <code><a>RTCDTMFSender</a></code>
@@ -10850,28 +10807,28 @@ interface RTCDTMFSender : EventTarget {
                 </li>
                 <li>Set the object's <a>[[\ToneBuffer]]</a> slot to
                 <var>tones</var>.</li>
-                <li>Set <var>dtmf</var>'s <a>[[\Duration]]</a> slot to the
+                <li>Set <var>dtmf</var>.<a>[[\Duration]]</a> to the
                 value of the <code>duration</code> parameter.</li>
-                <li>Set <var>dtmf</var>'s <a>[[\InterToneGap]]</a> slot to the
+                <li>Set <var>dtmf</var>.<a>[[\InterToneGap]]</a> to the
                 value of the <code>interToneGap</code> parameter.</li>
                 <li data-tests="RTCDTMFSender-ontonechange-long.https.html,RTCDTMFSender-ontonechange.https.html">If the value of the <code>duration</code> parameter is less than 40 ms,
-                set <var>dtmf</var>'s <a>[[\Duration]]</a> slot to 40 ms.</li>
+                set <var>dtmf</var>.<a>[[\Duration]]</a> to 40 ms.</li>
                 <li data-tests="RTCDTMFSender-ontonechange-long.https.html,RTCDTMFSender-ontonechange.https.html">If the value of the <code>duration</code> parameter is greater than 6000 ms,
-                set <var>dtmf</var>'s <a>[[\Duration]]</a> slot to 6000 ms.</li>
+                set <var>dtmf</var>.<a>[[\Duration]]</a> to 6000 ms.</li>
                 <li data-tests="RTCDTMFSender-ontonechange.https.html">If the value of the <code>interToneGap</code> parameter is less than 30 ms,
-                set <var>dtmf</var>'s <a>[[\InterToneGap]]</a> slot to 30 ms.</li>
+                set <var>dtmf</var>.<a>[[\InterToneGap]]</a> to 30 ms.</li>
                 <li data-tests="RTCDTMFSender-ontonechange-long.https.html,RTCDTMFSender-ontonechange.https.html">If the value of the <code>interToneGap</code> parameter is greater than 6000 ms,
-                set <var>dtmf</var>'s <a>[[\InterToneGap]]</a> slot to 6000 ms.</li>
+                set <var>dtmf</var>.<a>[[\InterToneGap]]</a> to 6000 ms.</li>
                 <li data-tests="RTCDTMFSender-ontonechange.https.html">If <a>[[\ToneBuffer]]</a> slot is an empty string,
                 abort these steps.</li>
                 <li data-tests="RTCDTMFSender-ontonechange.https.html">If a <em>Playout task</em> is scheduled to be run, abort
                 these steps; otherwise queue a task that runs the following
                 steps (<em>Playout task</em>):
                   <ol>
-                    <li>If <var>transceiver</var>'s <a>[[\Stopped]]</a> slot
+                    <li>If <var>transceiver</var>.<a>[[\Stopped]]</a>
                     is <code>true</code>, abort these steps.</li>
-                    <li>If <var>transceiver</var>'s <a>[[\CurrentDirection]]</a>
-                    slot is <code>recvonly</code> or <code>inactive</code>,
+                    <li>If <var>transceiver</var>.<a>[[\CurrentDirection]]</a>
+                    is <code>recvonly</code> or <code>inactive</code>,
                     abort these steps.</li>
                     <li>If the <a>[[\ToneBuffer]]</a> slot contains the empty
                     string, <a>fire an event</a> named <code><a>tonechange</a></code>
@@ -10929,11 +10886,11 @@ interface RTCDTMFSender : EventTarget {
         <var>transceiver</var>.</li>
         <li>If <var>connection</var>'s <code><a>RTCPeerConnectionState</a></code> is not <code>"connected"</code>
         return <code>false</code>.</li>
-        <li>If <var>sender</var>'s <a>[[\SenderTrack]]</a> is <code>null</code>
+        <li>If <var>sender</var>.<a>[[\SenderTrack]]</a> is <code>null</code>
         return <code>false</code>.</li>
-        <li>If <var>transceiver</var>'s <a>[[\CurrentDirection]]</a> is neither <code>"sendrecv"</code>
+        <li>If <var>transceiver</var>.<a>[[\CurrentDirection]]</a> is neither <code>"sendrecv"</code>
         nor <code>"sendonly"</code> return <code>false</code>.</li>
-        <li>If <var>sender</var>'s <a>[[\SendEncodings]]</a><code>[0].active</code> is
+        <li>If <var>sender</var>.<a>[[\SendEncodings]]</a><code>[0].active</code> is
         <code>false</code> return <code>false</code>.</li>
         <li>If no codec with mimetype <code>"audio/telephone-event"</code> has been
         negotiated for sending with this <var>sender</var>, return <code>false</code>.</li>


### PR DESCRIPTION
Aligning with EcmaScript notation of object.[[InternalSlot]]
See also https://github.com/w3c/payment-request/pull/370
close #2226


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2264.html" title="Last updated on Aug 12, 2019, 8:41 AM UTC (13cad78)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2264/f665b4d...13cad78.html" title="Last updated on Aug 12, 2019, 8:41 AM UTC (13cad78)">Diff</a>