### PR TITLE
Clarify example on example with media before signaling

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -11810,11 +11810,11 @@ signaling.onmessage = async (event) =&gt; {
       </div>
     </section>
     <section>
-      <h3>Peer-to-peer Example with media before signaling</h3>
+      <h3>Peer-to-peer Example with incoming media before signaling</h3>
       <div>
         <p>The answerer may wish to send media in parallel with sending the
         answer, and the offerer may wish to render the media before the answer
-        arrives.</p>
+        arrives. This code shows the receiving side.</p>
         <pre class="example highlight">
 const signaling = new SignalingChannel();
 const configuration = {iceServers: [{urls: 'stuns:stun.example.org'}]};
@@ -11841,9 +11841,6 @@ async function start() {
   };
 
   try {
-    // get a local stream, show it in a self-view and add it to be sent
-    const stream = await navigator.mediaDevices.getUserMedia({audio: true, video: true});
-    selfView.srcObject = stream;
     // Render the media even before ontrack fires.
     remoteView.srcObject = new MediaStream(pc.getReceivers().map((r) =&gt; r.track));
   } catch (err) {


### PR DESCRIPTION
As per discussion in #1708:
* Change the title to 'with incoming media before signaling'
* Change the intro to add 'This code shows the receiving side'
* Remove the 'selfView' code

close #1708


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2266.html" title="Last updated on Aug 14, 2019, 7:37 AM UTC (4c97e90)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2266/f665b4d...4c97e90.html" title="Last updated on Aug 14, 2019, 7:37 AM UTC (4c97e90)">Diff</a>