### PR TITLE
Properly sort simulcast layers in example by size

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8249,16 +8249,16 @@ interface RTCRtpTransceiver {
 
 // Example of 3-layer spatial simulcast with all but the lowest resolution layer disabled
 var encodings = [
-  {rid: 'f', active: false},
-  {rid: 'h', active: false, scaleResolutionDownBy: 2.0},
   {rid: 'q', active: true, scaleResolutionDownBy: 4.0}
+  {rid: 'h', active: false, scaleResolutionDownBy: 2.0},
+  {rid: 'f', active: false},
 ];
 
 // Example of 3-layer framerate simulcast with the middle layer disabled
 var encodings = [
-  {rid: 'f', active: true, maxFramerate: 60},
-  {rid: 'h', active: false, maxFramerate: 30},
   {rid: 'q', active: true, maxFramerate: 15}
+  {rid: 'h', active: false, maxFramerate: 30},
+  {rid: 'f', active: true, maxFramerate: 60},
 ];
         </pre>
         </div>
@@ -11910,9 +11910,9 @@ async function start() {
     pc.addTransceiver(stream.getVideoTracks()[0], {
       direction: 'sendonly',
       sendEncodings: [
-        {rid: 'f'},
-        {rid: 'h', scaleResolutionDownBy: 2.0},
         {rid: 'q', scaleResolutionDownBy: 4.0}
+        {rid: 'h', scaleResolutionDownBy: 2.0},
+        {rid: 'f'},
       ]
     });
   } catch (err) {


### PR DESCRIPTION
Layers should be sorted by size, with the smaller ones first as they usually have a higher priority.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Orphis/webrtc-pc/pull/2267.html" title="Last updated on Aug 12, 2019, 1:25 PM UTC (6aa5c68)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2267/f665b4d...Orphis:6aa5c68.html" title="Last updated on Aug 12, 2019, 1:25 PM UTC (6aa5c68)">Diff</a>