### PR TITLE
Change "stuns" to "stun" in examples

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -11667,7 +11667,7 @@ signaling.onmessage = async ({desc, candidate}) =&gt; {
         both go through these steps.</p>
         <pre class="example highlight">
 const signaling = new SignalingChannel();
-const configuration = {iceServers: [{urls: 'stuns:stun.example.org'}]};
+const configuration = {iceServers: [{urls: 'stun:stun.example.org'}]};
 const audio = null;
 const audioSendTrack = null;
 const video = null;
@@ -11796,7 +11796,7 @@ signaling.onmessage = async (event) =&gt; {
         arrives.</p>
         <pre class="example highlight">
 const signaling = new SignalingChannel();
-const configuration = {iceServers: [{urls: 'stuns:stun.example.org'}]};
+const configuration = {iceServers: [{urls: 'stun:stun.example.org'}]};
 let pc;
 
 // call start() to initiate
@@ -11863,7 +11863,7 @@ signaling.onmessage = async (event) =&gt; {
         server.</p>
         <pre class="example highlight">
 const signaling = new SignalingChannel();
-const configuration = {'iceServers': [{'urls': 'stuns:stun.example.org'}]};
+const configuration = {'iceServers': [{'urls': 'stun:stun.example.org'}]};
 let pc;
 
 // call start() to initiate
@@ -11925,7 +11925,7 @@ signaling.onmessage = async (event) =&gt; {
         is ready, messages are received and when the channel is closed.</p>
         <pre class="example highlight">
 const signaling = new SignalingChannel(); // handles JSON.stringify/parse
-const configuration = {iceServers: [{urls: 'stuns:stun.example.org'}]};
+const configuration = {iceServers: [{urls: 'stun:stun.example.org'}]};
 let pc;
 let channel;
 


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/2270


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2272.html" title="Last updated on Aug 14, 2019, 7:28 PM UTC (8d1bc5c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2272/1a2a324...8d1bc5c.html" title="Last updated on Aug 14, 2019, 7:28 PM UTC (8d1bc5c)">Diff</a>