### PR TITLE
Change "stuns" to "stun" in examples

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -11652,7 +11652,7 @@ async function gatherStats() {
         <pre class="example highlight">
 const signaling = new SignalingChannel(); // handles JSON.stringify/parse
 const constraints = {audio: true, video: true};
-const configuration = {iceServers: [{urls: 'stuns:stun.example.org'}]};
+const configuration = {iceServers: [{urls: 'stun:stun.example.org'}]};
 const pc = new RTCPeerConnection(configuration);
 
 // send any ice candidates to the other peer
@@ -11722,7 +11722,7 @@ signaling.onmessage = async ({desc, candidate}) =&gt; {
         both go through these steps.</p>
         <pre class="example highlight">
 const signaling = new SignalingChannel();
-const configuration = {iceServers: [{urls: 'stuns:stun.example.org'}]};
+const configuration = {iceServers: [{urls: 'stun:stun.example.org'}]};
 const audio = null;
 const audioSendTrack = null;
 const video = null;
@@ -11850,7 +11850,7 @@ signaling.onmessage = async (event) =&gt; {
         server.</p>
         <pre class="example highlight">
 const signaling = new SignalingChannel();
-const configuration = {'iceServers': [{'urls': 'stuns:stun.example.org'}]};
+const configuration = {'iceServers': [{'urls': 'stun:stun.example.org'}]};
 let pc;
 
 // call start() to initiate
@@ -11912,7 +11912,7 @@ signaling.onmessage = async (event) =&gt; {
         is ready, messages are received and when the channel is closed.</p>
         <pre class="example highlight">
 const signaling = new SignalingChannel(); // handles JSON.stringify/parse
-const configuration = {iceServers: [{urls: 'stuns:stun.example.org'}]};
+const configuration = {iceServers: [{urls: 'stun:stun.example.org'}]};
 let pc;
 let channel;
 


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/2270

Rebase of https://github.com/w3c/webrtc-pc/pull/2272


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2274.html" title="Last updated on Aug 15, 2019, 4:02 PM UTC (61746a9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2274/d3da997...61746a9.html" title="Last updated on Aug 15, 2019, 4:02 PM UTC (61746a9)">Diff</a>