### PR TITLE
RTCIceTransport selected candidate pair behavior when changing state

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8796,20 +8796,21 @@ interface RTCDtlsTransport : EventTarget {
           <code><a>RTCIceTransportState</a></code>.</p>
         </li>
         <li>
-          <p>If <var>newState</var> is <code>"new"</code> or <code>"closed"</code>,
-          set <var>transport.<a>[[\SelectedCandidatePair]]</a></var> to
-          <code>null</code>.</p>
+          <p>If <var>newState</var> is <code>"new"</code>,
+          <code>"checking"</code> or <code>"closed"</code>,
+          set <var>transport.<a>[[\SelectedCandidatePair]]</a></var>
+          to <code>null</code>.</p>
         </li>
         <li>
-          <p>If <var>newState</var> is <code>"checking"</code>, set
+          <p>If <var>newState</var> is <code>"connected"</code>, set
           <var>transport.<a>[[\SelectedCandidatePair]]</a></var> to the
-          candidate pair on which media is sent if one exists, otherwise
-          <code>null</code>.</p>
+          candidate pair on which media is sent.</p>
         </li>
         <li>
-          <p>If <var>newState</var> is <code>"disconnected"</code> or <code>"failed"</code>,
-          <var>transport.<a>[[\SelectedCandidatePair]]</a></var> retains its last
-          set value.</p>
+          <p>If <var>newState</var> is <code>"completed"</code>,
+          <code>"disconnected"</code> or <code>"failed"</code>,
+          <var>transport.<a>[[\SelectedCandidatePair]]</a></var> retains
+          its last set value.</p>
         </li>
         <li>
           <p>Set <var>transport</var>.<a>[[\IceTransportState]]</a> to
@@ -8817,6 +8818,12 @@ interface RTCDtlsTransport : EventTarget {
         </li>
         <li>
           <p><a>Fire an event</a> named <code><a>statechange</a></code> at
+          <var>transport</var>.</p>
+        </li>
+        <li>
+          <p>If <var>transport.<a>[[\SelectedCandidatePair]]</a></var>
+          has changed, <a>Fire an event</a> named
+          <code><a>selectedcandidatepairchange</a></code> at
           <var>transport</var>.</p>
         </li>
         <li>
@@ -8828,38 +8835,6 @@ interface RTCDtlsTransport : EventTarget {
         </li>
       </ol>
 
-      <p>When the <a>ICE Agent</a> indicates that the selected candidate pair
-      for an <code><a>RTCIceTransport</a></code> has changed, the user agent
-      MUST queue a task that runs the following steps:</p>
-      <ol>
-        <li>
-          <p>Let <var>connection</var> be the
-          <code><a>RTCPeerConnection</a></code> object associated with this
-          <a>ICE Agent</a>.</p>
-        </li>
-        <li>
-          <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
-          <code>true</code>, abort these steps.</p>
-        </li>
-        <li>
-          <p>Let <var>transport</var> be the <code><a>RTCIceTransport</a></code>
-          whose selected candidate pair is changing.</p>
-        </li>
-        <li>
-          <p>Let <var>newCandidatePair</var> be a newly created
-          <code><a>RTCIceCandidatePair</a></code> representing the indicated
-          pair if one is selected, and <code>null</code> otherwise.</p>
-        </li>
-        <li data-tests="RTCIceTransport.html">
-          <p>Set <var>transport</var>.<a>[[\SelectedCandidatePair]]</a>
-          to <var>newCandidatePair</var>.</p>
-        </li>
-        <li>
-          <p><a>Fire an event</a> named
-          <code><a>selectedcandidatepairchange</a></code> at
-          <var>transport</var>.</p>
-        </li>
-      </ol>
       <p>An <a>RTCIceTransport</a> object has the following internal slots:</p>
       <ul>
         <li><dfn>[[\IceTransportState]]</dfn> initialized to <code>

--- a/webrtc.html
+++ b/webrtc.html
@@ -8804,7 +8804,8 @@ interface RTCDtlsTransport : EventTarget {
         <li>
           <p>If <var>newState</var> is <code>"connected"</code>, set
           <var>transport.<a>[[\SelectedCandidatePair]]</a></var> to the
-          candidate pair on which media is sent.</p>
+          best valid pair (prior to nomination) or the nominated candidate
+          pair.</p>
         </li>
         <li>
           <p>If <var>newState</var> is <code>"completed"</code>,

--- a/webrtc.html
+++ b/webrtc.html
@@ -1268,22 +1268,6 @@
             value as described by the
             <a><code>RTCPeerConnectionState</code></a> enum.</p>
           </li>
-          <li>Let <var>iceTransport</var> be the <code><a>RTCIceTransport</a></code>
-          whose state has changed.
-          </li>
-          <li>Let <var>state</var> be the new state of <var>iceTransport</var>.
-          </li>
-          <li>If <var>state</var> is <code>"new"</code> or <code>"closed"</code>, set
-          <var>iceTransport.<a>[[\SelectedCandidatePair]]</a></var> to <code>null</code>.
-          </li>
-          <li>If <var>state</var> is <code>"checking"</code>, set
-          <var>iceTransport.<a>[[\SelectedCandidatePair]]</a></var> to the candidate
-          pair on which media is sent if one exists, otherwise <code>null</code>.
-          </li>
-          <li>If <var>state</var> is <code>"disconnected"</code> or <code>"failed"</code>,
-          <var>iceTransport.<a>[[\SelectedCandidatePair]]</a></var> retains its last
-          set value.
-          </li>
           <li>
             <p>If <var>connection</var>'s <a>connection state</a> is equal to
             <var>newState</var>, abort these steps.</p>
@@ -8809,12 +8793,28 @@ interface RTCDtlsTransport : EventTarget {
         </li>
         <li>
           <p>Let <var>newState</var> be the new indicated
-          <code><a>RTCIceTransportState</a></code>.
+          <code><a>RTCIceTransportState</a></code>.</p>
+        </li>
+        <li>
+          <p>If <var>newState</var> is <code>"new"</code> or <code>"closed"</code>,
+          set <var>transport.<a>[[\SelectedCandidatePair]]</a></var> to
+          <code>null</code>.</p>
+        </li>
+        <li>
+          <p>If <var>newState</var> is <code>"checking"</code>, set
+          <var>transport.<a>[[\SelectedCandidatePair]]</a></var> to the
+          candidate pair on which media is sent if one exists, otherwise
+          <code>null</code>.</p>
+        </li>
+        <li>
+          <p>If <var>newState</var> is <code>"disconnected"</code> or <code>"failed"</code>,
+          <var>transport.<a>[[\SelectedCandidatePair]]</a></var> retains its last
+          set value.</p>
         </li>
         <li>
           <p>Set <var>transport</var>.<a>[[\IceTransportState]]</a> to
           <var>newState</var>.</p>
-        </li>
+        </li>        
         <li>
           <p><a>Fire an event</a> named <code><a>statechange</a></code> at
           <var>transport</var>.</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -8814,7 +8814,7 @@ interface RTCDtlsTransport : EventTarget {
         <li>
           <p>Set <var>transport</var>.<a>[[\IceTransportState]]</a> to
           <var>newState</var>.</p>
-        </li>        
+        </li>
         <li>
           <p><a>Fire an event</a> named <code><a>statechange</a></code> at
           <var>transport</var>.</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1268,6 +1268,22 @@
             value as described by the
             <a><code>RTCPeerConnectionState</code></a> enum.</p>
           </li>
+          <li>Let <var>iceTransport</var> be the <code><a>RTCIceTransport</a></code>
+          whose state has changed.
+          </li>
+          <li>Let <var>state</var> be the new state of <var>iceTransport</var>.
+          </li>
+          <li>If <var>state</var> is <code>"new"</code> or <code>"closed"</code>, set
+          <var>iceTransport.<a>[[\SelectedCandidatePair]]</a></var> to <code>null</code>.
+          </li>
+          <li>If <var>state</var> is <code>"checking"</code>, set
+          <var>iceTransport.<a>[[\SelectedCandidatePair]]</a></var> to the candidate
+          pair on which media is sent if one exists, otherwise <code>null</code>.
+          </li>
+          <li>If <var>state</var> is <code>"disconnected"</code> or <code>"failed"</code>,
+          <var>iceTransport.<a>[[\SelectedCandidatePair]]</a></var> retains its last
+          set value.
+          </li>
           <li>
             <p>If <var>connection</var>'s <a>connection state</a> is equal to
             <var>newState</var>, abort these steps.</p>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/1981 and https://github.com/w3c/webrtc-pc/issues/2283

Rebase of https://github.com/w3c/webrtc-pc/pull/2269


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2276.html" title="Last updated on Sep 3, 2019, 8:36 PM UTC (dea9be8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2276/90526ef...dea9be8.html" title="Last updated on Sep 3, 2019, 8:36 PM UTC (dea9be8)">Diff</a>