### PR TITLE
Simplify checks in insertDTMF since some of them are redundant

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -10874,12 +10874,6 @@ interface RTCDTMFSender : EventTarget {
                   <code><a>RTCRtpTransceiver</a></code> object associated with
                   <var>sender</var>.</p>
                 </li>
-                <li data-tests="RTCDTMFSender-insertDTMF.https.html,RTCRtpTransceiver.https.html">If <var>transceiver</var>.<a>[[\Stopped]]</a> is
-                <code>true</code>, <a>throw</a> an
-                <code>InvalidStateError</code>.</li>
-                <li data-tests="RTCDTMFSender-insertDTMF.https.html">If <var>transceiver</var>.<a>[[\CurrentDirection]]</a>
-                is <code>recvonly</code> or <code>inactive</code>,
-                <a>throw</a> an <code>InvalidStateError</code>.</li>
                 <li>Let <var>dtmf</var> be the <code><a>RTCDTMFSender</a></code>
                 associated with <var>sender</var>.</li>
                 <li>If <a>determine if DTMF can be sent</a> for <var>dtmf</var> returns
@@ -10908,10 +10902,8 @@ interface RTCDTMFSender : EventTarget {
                 these steps; otherwise queue a task that runs the following
                 steps (<em>Playout task</em>):
                   <ol>
-                    <li>If <var>transceiver</var>.<a>[[\Stopped]]</a>
-                    is <code>true</code>, abort these steps.</li>
                     <li>If <var>transceiver</var>.<a>[[\CurrentDirection]]</a>
-                    is <code>recvonly</code> or <code>inactive</code>,
+                    is neither <code>sendrecv</code> nor <code>sendonly</code>,
                     abort these steps.</li>
                     <li>If the <a>[[\ToneBuffer]]</a> slot contains the empty
                     string, <a>fire an event</a> named <code><a>tonechange</a></code>


### PR DESCRIPTION
PR for https://github.com/w3c/webrtc-pc/issues/2254


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-pc/pull/2285.html" title="Last updated on Aug 30, 2019, 1:28 PM UTC (7ebea0f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2285/c3acf00...youennf:7ebea0f.html" title="Last updated on Aug 30, 2019, 1:28 PM UTC (7ebea0f)">Diff</a>