### PR TITLE
Clarify that blob send order should respect the send call order

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -10483,6 +10483,12 @@ interface RTCDataChannel : EventTarget {
               <p><code>Blob</code> object:</p>
               <p>Let <var>data</var> be the raw data represented by the
               <code>Blob</code> object.</p>
+              <div class="note" data-tests="RTCDataChannel-send-blob-order.html">
+              Although the actual retrieval of <var>data</var> from a <code>Blob</code> object
+              can happen asynchronously, the user agent will make sure to queue the data on
+              the <var>channel</var>'s <a>underlying data transport</a> in the same order
+              as the send method is called. The byte size of <var>data</var> needs to be known
+              synchronously.</div>
             </li>
             <li>
               <p><code>ArrayBuffer</code> object:</p>


### PR DESCRIPTION
PR for https://github.com/w3c/webrtc-pc/issues/2215


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-pc/pull/2286.html" title="Last updated on Aug 30, 2019, 1:30 PM UTC (90a54f2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2286/c3acf00...youennf:90a54f2.html" title="Last updated on Aug 30, 2019, 1:30 PM UTC (90a54f2)">Diff</a>