### PR TITLE
Fix reference to timestamp definition

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7738,7 +7738,7 @@ interface RTCRtpReceiver {
             <dt data-tests="RTCRtpReceiver-getSynchronizationSources.https.html"><dfn data-idl><code>rtpTimestamp</code></dfn> of type
                 <span class="idlMemberType">unsigned long</span>, required</dt>
             <dd>
-              <p>The last RTP timestamp, as defined in [[!RFC3559]] Section 5.1,
+              <p>The last RTP timestamp, as defined in [[!RFC3550]] Section 5.1,
               of the media played out at <var>timestamp</var>.</p>
             </dd>
           </dl>


### PR DESCRIPTION
RFC3550 instead of 3559
close #2281


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2288.html" title="Last updated on Sep 2, 2019, 7:52 AM UTC (cf22c47)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2288/95e0726...cf22c47.html" title="Last updated on Sep 2, 2019, 7:52 AM UTC (cf22c47)">Diff</a>