### PR TITLE
Merge IDL of legacy operations into main IDL definition

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2373,6 +2373,25 @@ interface RTCPeerConnection : EventTarget  {
   attribute EventHandler oniceconnectionstatechange;
   attribute EventHandler onicegatheringstatechange;
   attribute EventHandler onconnectionstatechange;
+
+  // Legacy Interface Extensions
+  // Supporting the methods in this section is optional.
+  // However, if these methods are supported
+  // it is mandatory to implement according to how they are specified .
+  Promise&lt;void&gt; createOffer(RTCSessionDescriptionCallback successCallback,
+                            RTCPeerConnectionErrorCallback failureCallback,
+                            optional RTCOfferOptions options);
+  Promise&lt;void&gt; setLocalDescription(optional RTCSessionDescriptionInit description,
+                                    VoidFunction successCallback,
+                                    RTCPeerConnectionErrorCallback failureCallback);
+  Promise&lt;void&gt; createAnswer(RTCSessionDescriptionCallback successCallback,
+                             RTCPeerConnectionErrorCallback failureCallback);
+  Promise&lt;void&gt; setRemoteDescription(optional RTCSessionDescriptionInit description,
+                                     VoidFunction successCallback,
+                                     RTCPeerConnectionErrorCallback failureCallback);
+  Promise&lt;void&gt; addIceCandidate(RTCIceCandidateInit candidate,
+                                VoidFunction successCallback,
+                                RTCPeerConnectionErrorCallback failureCallback);
 };</pre>
           <section>
             <h2>Constructors</h2>
@@ -3654,9 +3673,6 @@ interface RTCPeerConnection : EventTarget  {
       </section>
       <section>
         <h3>Legacy Interface Extensions</h3>
-          <div class="note">This section is broken out for readability. Consider
-          partial interfaces here to be part of their main counterparts, as they
-          overload existing methods.</div>
           <p>Supporting the methods in this section is optional. However,
           if these methods are supported it is mandatory to implement
           according to what is specified here.</p>
@@ -3670,23 +3686,6 @@ interface RTCPeerConnection : EventTarget  {
         <section>
           <h4>Method extensions</h4>
         <div>
-          <pre class="idl" data-tests="idlharness.https.window.js"
->partial interface RTCPeerConnection {
-  Promise&lt;void&gt; createOffer(RTCSessionDescriptionCallback successCallback,
-                            RTCPeerConnectionErrorCallback failureCallback,
-                            optional RTCOfferOptions options);
-  Promise&lt;void&gt; setLocalDescription(optional RTCSessionDescriptionInit description,
-                                    VoidFunction successCallback,
-                                    RTCPeerConnectionErrorCallback failureCallback);
-  Promise&lt;void&gt; createAnswer(RTCSessionDescriptionCallback successCallback,
-                             RTCPeerConnectionErrorCallback failureCallback);
-  Promise&lt;void&gt; setRemoteDescription(optional RTCSessionDescriptionInit description,
-                                     VoidFunction successCallback,
-                                     RTCPeerConnectionErrorCallback failureCallback);
-  Promise&lt;void&gt; addIceCandidate(RTCIceCandidateInit candidate,
-                                VoidFunction successCallback,
-                                RTCPeerConnectionErrorCallback failureCallback);
-};</pre>
           <section>
             <h2>Methods</h2>
             <dl data-link-for="RTCPeerConnection" data-dfn-for=


### PR DESCRIPTION
As required by WebIDL
close #2289


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2291.html" title="Last updated on Sep 6, 2019, 6:47 AM UTC (37f049c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2291/f189de3...37f049c.html" title="Last updated on Sep 6, 2019, 6:47 AM UTC (37f049c)">Diff</a>