### PR TITLE
Make rollback clear both pending and local description.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1496,7 +1496,8 @@
                       <li data-tests="RTCPeerConnection-setLocalDescription-rollback.html,RTCPeerConnection-setLocalDescription-answer.html">
                         <p>If <var>description</var> is of type <code>"rollback"</code>,
                         then this is a rollback. Set
-                        <var>connection</var>.<a>[[\PendingLocalDescription]]</a>
+                        <var>connection</var>.<a>[[\PendingLocalDescription]]</a> and
+                        <var>connection</var>.<a>[[\PendingRemoteDescription]]</a>
                         to <code>null</code>, and set <a>signaling state</a> to
                         <code>"stable"</code>.</p>
                       </li>
@@ -1551,6 +1552,7 @@
                       <li data-tests="RTCPeerConnection-setRemoteDescription-rollback.html">
                         <p>If <var>description</var> is of type <code>"rollback"</code>,
                         then this is a rollback. Set
+                        <var>connection</var>.<a>[[\PendingLocalDescription]]</a> and
                         <var>connection</var>.<a>[[\PendingRemoteDescription]]</a>
                         to <code>null</code>, and set <a>signaling state</a> to
                         <code>"stable"</code>.</p>


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2294.