### PR TITLE
Fire ended locally on close() (Remove 'abruptly' option in stop algo).

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8060,8 +8060,7 @@ interface RTCRtpTransceiver {
                 </li>
               </ol>
               <p>The <dfn>stop sending and receiving</dfn> algorithm given a
-              <var>transceiver</var> and an optional <var>abruptly</var>
-              boolean defaulting to <code>false</code>, is as follows:</p>
+              <var>transceiver</var>, is as follows:</p>
               <ol>
                 <li>
                   <p>Let <var>sender</var> be <var>transceiver</var>.<a>[[\Sender]]</a>.</p>
@@ -8080,10 +8079,8 @@ interface RTCRtpTransceiver {
                   <p>Stop receiving media with <var>receiver</var>.</p>
                 </li>
                 <li>
-                  <p>If <var>abruptly</var> is <code>true</code>, set the
-                  <code>readyState</code> of <var>receiver</var>.<a>[[\ReceiverTrack]]</a> to <code>"ended"</code>.
-                  Otherwise, execute the steps for <var>receiver</var>.<a>[[\ReceiverTrack]]</a> to be
-                  <a data-cite="!GETUSERMEDIA#track-ended">ended</a>.</p>
+                  <p>Execute the steps for <var>receiver</var>.<a>[[\ReceiverTrack]]</a>
+                  to be <a data-cite="!GETUSERMEDIA#track-ended">ended</a>.</p>
                 </li>
                 <li>
                   <p>Set <var>transceiver</var>.<a>[[\Direction]]</a>
@@ -8095,13 +8092,12 @@ interface RTCRtpTransceiver {
                 </li>
               </ol>
               <p>The <dfn>stop the RTCRtpTransceiver</dfn> algorithm given a
-              <var>transceiver</var> and an optional <var>abruptly</var>
-              boolean defaulting to <code>false</code>, is as follows:</p>
+              <var>transceiver</var>, is as follows:</p>
               <ol>
                 <li>
                   <p>If <var>transceiver</var>.<a>[[\Stopping]]</a> is
                   <code>false</code>, <a>stop sending and receiving</a> given
-                  <var>transceiver</var> and <var>abruptly</var>.</p>
+                  <var>transceiver</var>.</p>
                 </li>
                 <li>
                   <p>Set <var>transceiver</var>.<a>[[\Stopped]]</a> to


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/1575. Chrome, Firefox and Safari already exhibit this [behavior](https://jsfiddle.net/jib1/sbw5t362/).