### PR TITLE
Fixed typo "muted event" => "mute event"

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5807,7 +5807,7 @@ interface RTCCertificate {
               track is removed from any remote <code><a>MediaStream</a></code>s
               that were initially revealed in the <code>track</code> event, and
               if the <code><a>MediaStreamTrack</a></code> is not already muted,
-              a <code title="event-MediaStreamTrack-muted">muted</code> event is
+              a <code title="event-MediaStreamTrack-mute">mute</code> event is
               fired at the track.</p>
               <div class="note">The same effect as <code>removeTrack()</code>
               can be achieved by setting the


### PR DESCRIPTION
I am pretty sure this is a typo. 
`mute` and `unmute` are the event names, `muted` is the read-only property of the `MediaStreamTrack` interface


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/HolgerJeromin/webrtc-pc/pull/2307.html" title="Last updated on Sep 25, 2019, 3:27 PM UTC (8d241f4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2307/39a91c5...HolgerJeromin:8d241f4.html" title="Last updated on Sep 25, 2019, 3:27 PM UTC (8d241f4)">Diff</a>