### PR TITLE
Add adaptivePtime to RTCAdaptivePtime

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -188,6 +188,7 @@
   DOMString peerIdentity;
   sequence&lt;RTCCertificate&gt; certificates;
   [EnforceRange] octet iceCandidatePoolSize = 0;
+  RTCAdaptivePtime adaptivePtime;
 };</pre>
           <section>
             <h2>Dictionary <a class="idlType">RTCConfiguration</a> Members</h2>
@@ -260,6 +261,14 @@
                 <p>Size of the prefetched ICE pool as defined in
                 <span data-jsep=
                 "ice-candidate-pool constructor">[[!JSEP]]</span>.</p>
+              </dd>
+              <!-- TODO: !!! Add data-tests before pushing for full review. -->
+              <dt data-tests="RTCPeerConnection-constructor.html"><dfn data-idl><code>adaptivePtime</code></dfn> of type <span class="idlMemberType"><a>RTCAdaptivePtime</a></span>, defaulting to <code>"default"</code>.</dt>
+              <dd>
+                <p>Indicates whether adaptive audio frame length should be used, should be suppressed, or whether this should be left up to the implementation to decide.</p>
+                <p>When adaptive audio frame length is used, the implementation should dynamically change the audio frame length
+                during the call, so as to adapt to changing network conditions. (Higher frame lengths reduce the bandwidth consumption
+                due to overhead, but do so at the cost of increased latency.)</p>
               </dd>
             </dl>
           </section>
@@ -646,6 +655,39 @@
                 <code><a>RTCRtpSender</a></code> and <code><a>RTCRtpReceiver</a></code>.</li>
             </ol>
           </div>
+        </div>
+      </section>
+      <section>
+        <h4><dfn>RTCAdaptivePtime</dfn> Enum</h4>
+        <div>
+          <pre class="idl">enum RTCAdaptivePtime {
+  "off",
+  "on",
+  "default"
+};</pre>
+          <table data-link-for="RTCAdaptivePtime" data-dfn-for="RTCAdaptivePtime"
+          class="simple">
+            <tbody>
+              <tr>
+                <th colspan="2">Enumeration description</th>
+              </tr>
+              <tr>
+                <!-- TODO: !!! Add data-tests before full review. -->
+                <td data-tests="RTCPeerConnection-constructor.html"><dfn data-idl><code>off</code></dfn></td>
+                <td>The implementation is not allowed to dynamically change the audio frame length during the call.</td>
+              </tr>
+              <tr>
+                <!-- TODO: !!! Add data-tests before full review. -->
+                <td data-tests="RTCPeerConnection-constructor.html"><dfn data-idl><code>on</code></dfn></td>
+                <td>The implementation should dynamically change the audio frame length during the call.</td>
+              </tr>
+              <tr>
+                <!-- TODO: !!! Add data-tests before full review. -->
+                <td data-tests="RTCPeerConnection-constructor.html"><dfn data-idl><code>default</code></dfn></td>
+                <td>It's up to the implementation to decide whether the audio frame length adaptation should be dynamically changed during the call.</td>
+              </tr>
+            </tbody>
+          </table>
         </div>
       </section>
       <section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -262,7 +262,7 @@
                 <span data-jsep=
                 "ice-candidate-pool constructor">[[!JSEP]]</span>.</p>
               </dd>
-              <!-- TODO: !!! Add data-tests before pushing for full review. -->
+              <!-- TODO: !!! Add data-tests before actually pulling. -->
               <dt data-tests="RTCPeerConnection-constructor.html"><dfn data-idl><code>adaptivePtime</code></dfn> of type <span class="idlMemberType"><a>RTCAdaptivePtime</a></span>, defaulting to <code>"default"</code>.</dt>
               <dd>
                 <p>Indicates whether adaptive audio frame length should be used, should be suppressed, or whether this should be left up to the implementation to decide.</p>
@@ -672,17 +672,17 @@
                 <th colspan="2">Enumeration description</th>
               </tr>
               <tr>
-                <!-- TODO: !!! Add data-tests before full review. -->
+                <!-- TODO: !!! Add data-tests before actually pulling. -->
                 <td data-tests="RTCPeerConnection-constructor.html"><dfn data-idl><code>off</code></dfn></td>
                 <td>The implementation is not allowed to dynamically change the audio frame length during the call.</td>
               </tr>
               <tr>
-                <!-- TODO: !!! Add data-tests before full review. -->
+                <!-- TODO: !!! Add data-tests before actually pulling. -->
                 <td data-tests="RTCPeerConnection-constructor.html"><dfn data-idl><code>on</code></dfn></td>
                 <td>The implementation should dynamically change the audio frame length during the call.</td>
               </tr>
               <tr>
-                <!-- TODO: !!! Add data-tests before full review. -->
+                <!-- TODO: !!! Add data-tests before actually pulling. -->
                 <td data-tests="RTCPeerConnection-constructor.html"><dfn data-idl><code>default</code></dfn></td>
                 <td>It's up to the implementation to decide whether the audio frame length adaptation should be dynamically changed during the call.</td>
               </tr>


### PR DESCRIPTION
When adaptivePtime is "on", the browser may dynamically change the audio frame length during the call, either reducing bandwidth consumption at the cost of increased latency, or vice versa.

The full rationale is in [this document](https://docs.google.com/document/d/12sVXRog-Dl9c-hbMInz9obmODk_yft06z7GMgfpdjPw/edit?usp=sharing).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eladalon1983/webrtc-pc/pull/2308.html" title="Last updated on Sep 25, 2019, 9:35 PM UTC (acd5d4b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2308/39a91c5...eladalon1983:acd5d4b.html" title="Last updated on Sep 25, 2019, 9:35 PM UTC (acd5d4b)">Diff</a>