### PR TITLE
Add adaptivePtime to RTCRtpEncodingParameters

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7057,11 +7057,8 @@ async function updateParameters() {
               <p>The value for this configuration option cannot be changed
               from its initial value. If this is attempted,
               <code>InvalidModificationError</code> MUST be thrown.</p>
-              <p><code>adaptivePtime</code> MUST NOT be set to <code>true</code>,
-              if a value was ever set for <code>ptime</code>, even if that value
-              was later cleared. Similarly, if <code>adaptivePtime</code> is set
-              to <code>true</code>, <code>ptime</code> MUST NOT subsequently be
-              set. If either of these is done,
+              <p>If <code>adaptivePtime</code> is set to <code>true</code>,
+              <code>ptime</code> MUST NOT be set; otherwise,
               <code>InvalidModificationError</code> MUST be thrown.</p>
             </dd>
             <dt data-tests="RTCRtpParameters-encodings.html"><dfn data-idl><code>maxBitrate</code></dfn> of type <span class=

--- a/webrtc.html
+++ b/webrtc.html
@@ -188,7 +188,6 @@
   DOMString peerIdentity;
   sequence&lt;RTCCertificate&gt; certificates;
   [EnforceRange] octet iceCandidatePoolSize = 0;
-  boolean adaptivePtime = false;
 };</pre>
           <section>
             <h2>Dictionary <a class="idlType">RTCConfiguration</a> Members</h2>
@@ -261,21 +260,6 @@
                 <p>Size of the prefetched ICE pool as defined in
                 <span data-jsep=
                 "ice-candidate-pool constructor">[[!JSEP]]</span>.</p>
-              </dd>
-              <dt><dfn data-idl><code>adaptivePtime</code></dfn> of type <span class="idlMemberType">boolean</span>, defaulting to <code>false</code>.</dt>
-              <dd>
-                <p>Indicates whether audio RTCRtpSenders MAY dynamically change
-                the frame length. If the value is <code>true</code>,
-                the user agent MAY use any valid frame length for any of its
-                frames, and MAY change this at any time.</p>
-                <p class="note">Using a longer frame length reduces the
-                bandwidth consumption due to overhead, but does so at the cost
-                of increased latency. Allowing the user agent to change the
-                frame length dynamically, allows it to adapt its bandwidth
-                allocation strategy based on the current network conditions.</p>
-                <p>The value for this configuration option cannot be changed
-                from its initial value. If this is attempted,
-                InvalidModificationError MUST be thrown.</p>
               </dd>
             </dl>
           </section>
@@ -6993,6 +6977,7 @@ async function updateParameters() {
   RTCDtxStatus dtx;
   boolean active = true;
   unsigned long ptime;
+  boolean adaptivePtime = false;
   unsigned long maxBitrate;
   double maxFramerate;
   double scaleResolutionDownBy;
@@ -7055,6 +7040,29 @@ async function updateParameters() {
               data-jsep= "applying-a-remote-desc">[[!JSEP]]</span>. Note that
               the user agent MUST still respect the limit imposed by any
               "maxptime" attribute, as defined in [[!RFC4566]], Section 6.</p>
+            </dd>
+            <dt><dfn data-idl><code>adaptivePtime</code></dfn> of type <span class="idlMemberType">boolean</span>, defaulting to <code>false</code>.</dt>
+            <dd>
+              <p>Indicates whether this encoding MAY dynamically change
+              the frame length. If the value is <code>true</code>,
+              the user agent MAY use any valid frame length for any of its
+              frames, and MAY change this at any time. Valid values are positive
+              integers divisible by 10. If the "maxptime" attribute (defined in
+              [[!RFC4566]] Section 6) is specified, that maximum applies.</p>
+              <p class="note">Using a longer frame length reduces the
+              bandwidth consumption due to overhead, but does so at the cost
+              of increased latency. Allowing the user agent to change the
+              frame length dynamically, allows it to adapt its bandwidth
+              allocation strategy based on the current network conditions.</p>
+              <p>The value for this configuration option cannot be changed
+              from its initial value. If this is attempted,
+              <code>InvalidModificationError</code> MUST be thrown.</p>
+              <p><code>adaptivePtime</code> MUST NOT be set to <code>true</code>,
+              if a value was ever set for <code>ptime</code>, even if that value
+              was later cleared. Similarly, if <code>adaptivePtime</code> is set
+              to <code>true</code>, <code>ptime</code> MUST NOT subsequently be
+              set. If either of these is done,
+              <code>InvalidModificationError</code> MUST be thrown.</p>
             </dd>
             <dt data-tests="RTCRtpParameters-encodings.html"><dfn data-idl><code>maxBitrate</code></dfn> of type <span class=
             "idlMemberType">unsigned long</span></dt>

--- a/webrtc.html
+++ b/webrtc.html
@@ -188,6 +188,7 @@
   DOMString peerIdentity;
   sequence&lt;RTCCertificate&gt; certificates;
   [EnforceRange] octet iceCandidatePoolSize = 0;
+  RTCAdaptivePtime adaptivePtime;
 };</pre>
           <section>
             <h2>Dictionary <a class="idlType">RTCConfiguration</a> Members</h2>
@@ -260,6 +261,14 @@
                 <p>Size of the prefetched ICE pool as defined in
                 <span data-jsep=
                 "ice-candidate-pool constructor">[[!JSEP]]</span>.</p>
+              </dd>
+              <!-- TODO: !!! Add data-tests before pushing for full review. -->
+              <dt data-tests="RTCPeerConnection-constructor.html"><dfn data-idl><code>adaptivePtime</code></dfn> of type <span class="idlMemberType"><a>RTCAdaptivePtime</a></span>, defaulting to <code>"default"</code>.</dt>
+              <dd>
+                <p>Indicates whether adaptive audio frame length should be used, should be suppressed, or whether this should be left up to the implementation to decide.</p>
+                <p>When adaptive audio frame length is used, the implementation should dynamically change the audio frame length
+                during the call, so as to adapt to changing network conditions. (Higher frame lengths reduce the bandwidth consumption
+                due to overhead, but do so at the cost of increased latency.)</p>
               </dd>
             </dl>
           </section>
@@ -646,6 +655,39 @@
                 <code><a>RTCRtpSender</a></code> and <code><a>RTCRtpReceiver</a></code>.</li>
             </ol>
           </div>
+        </div>
+      </section>
+      <section>
+        <h4><dfn>RTCAdaptivePtime</dfn> Enum</h4>
+        <div>
+          <pre class="idl">enum RTCAdaptivePtime {
+  "off",
+  "on",
+  "default"
+};</pre>
+          <table data-link-for="RTCAdaptivePtime" data-dfn-for="RTCAdaptivePtime"
+          class="simple">
+            <tbody>
+              <tr>
+                <th colspan="2">Enumeration description</th>
+              </tr>
+              <tr>
+                <!-- TODO: !!! Add data-tests before full review. -->
+                <td data-tests="RTCPeerConnection-constructor.html"><dfn data-idl><code>off</code></dfn></td>
+                <td>The implementation is not allowed to dynamically change the audio frame length during the call.</td>
+              </tr>
+              <tr>
+                <!-- TODO: !!! Add data-tests before full review. -->
+                <td data-tests="RTCPeerConnection-constructor.html"><dfn data-idl><code>on</code></dfn></td>
+                <td>The implementation should dynamically change the audio frame length during the call.</td>
+              </tr>
+              <tr>
+                <!-- TODO: !!! Add data-tests before full review. -->
+                <td data-tests="RTCPeerConnection-constructor.html"><dfn data-idl><code>default</code></dfn></td>
+                <td>It's up to the implementation to decide whether the audio frame length adaptation should be dynamically changed during the call.</td>
+              </tr>
+            </tbody>
+          </table>
         </div>
       </section>
       <section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -264,9 +264,18 @@
               </dd>
               <dt><dfn data-idl><code>adaptivePtime</code></dfn> of type <span class="idlMemberType">boolean</span>, defaulting to <code>false</code>.</dt>
               <dd>
-                <p>Indicates whether audio senders may dynamically change the frame lengths so as to adapt to changing network conditions.
-                (Higher frame lengths reduce the bandwidth consumption due to overhead, but do so at the cost of increased latency.)</p>
-                <p>The value for this configuration option cannot change after its value is initially selected.</p>
+                <p>Indicates whether audio RTCRtpSenders MAY dynamically change
+                the frame length. If the value is <code>true</code>,
+                the user agent MAY use any valid frame length for any of its
+                frames, and MAY change this at any time.</p>
+                <p class="note">Using a longer frame length reduces the
+                bandwidth consumption due to overhead, but does so at the cost
+                of increased latency. Allowing the user agent to change the
+                frame length dynamically, allows it to adapt its bandwidth
+                allocation strategy based on the current network conditions.</p>
+                <p>The value for this configuration option cannot be changed
+                from its initial value. If this is attempted,
+                InvalidModificationError MUST be thrown.</p>
               </dd>
             </dl>
           </section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -266,6 +266,7 @@
               <dd>
                 <p>Indicates whether audio senders may dynamically change the frame lengths so as to adapt to changing network conditions.
                 (Higher frame lengths reduce the bandwidth consumption due to overhead, but do so at the cost of increased latency.)</p>
+                <p>The value for this configuration option cannot change after its value is initially selected.</p>
               </dd>
             </dl>
           </section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -264,7 +264,7 @@
               </dd>
               <dt><dfn data-idl><code>adaptivePtime</code></dfn> of type <span class="idlMemberType">boolean</span>, defaulting to <code>false</code>.</dt>
               <dd>
-                <p>Indicates whether audio senders may dynamically change the frame lengths so as to adapt adapt to changing network conditions.
+                <p>Indicates whether audio senders may dynamically change the frame lengths so as to adapt to changing network conditions.
                 (Higher frame lengths reduce the bandwidth consumption due to overhead, but do so at the cost of increased latency.)</p>
               </dd>
             </dl>

--- a/webrtc.html
+++ b/webrtc.html
@@ -188,7 +188,7 @@
   DOMString peerIdentity;
   sequence&lt;RTCCertificate&gt; certificates;
   [EnforceRange] octet iceCandidatePoolSize = 0;
-  RTCAdaptivePtime adaptivePtime;
+  boolean adaptivePtime = false;
 };</pre>
           <section>
             <h2>Dictionary <a class="idlType">RTCConfiguration</a> Members</h2>
@@ -262,13 +262,10 @@
                 <span data-jsep=
                 "ice-candidate-pool constructor">[[!JSEP]]</span>.</p>
               </dd>
-              <!-- TODO: !!! Add data-tests before actually pulling. -->
-              <dt data-tests="RTCPeerConnection-constructor.html"><dfn data-idl><code>adaptivePtime</code></dfn> of type <span class="idlMemberType"><a>RTCAdaptivePtime</a></span>, defaulting to <code>"default"</code>.</dt>
+              <dt><dfn data-idl><code>adaptivePtime</code></dfn> of type <span class="idlMemberType">boolean</span>, defaulting to <code>false</code>.</dt>
               <dd>
-                <p>Indicates whether adaptive audio frame length should be used, should be suppressed, or whether this should be left up to the implementation to decide.</p>
-                <p>When adaptive audio frame length is used, the implementation should dynamically change the audio frame length
-                during the call, so as to adapt to changing network conditions. (Higher frame lengths reduce the bandwidth consumption
-                due to overhead, but do so at the cost of increased latency.)</p>
+                <p>Indicates whether audio senders may dynamically change the frame lengths so as to adapt adapt to changing network conditions.
+                (Higher frame lengths reduce the bandwidth consumption due to overhead, but do so at the cost of increased latency.)</p>
               </dd>
             </dl>
           </section>
@@ -655,39 +652,6 @@
                 <code><a>RTCRtpSender</a></code> and <code><a>RTCRtpReceiver</a></code>.</li>
             </ol>
           </div>
-        </div>
-      </section>
-      <section>
-        <h4><dfn>RTCAdaptivePtime</dfn> Enum</h4>
-        <div>
-          <pre class="idl">enum RTCAdaptivePtime {
-  "off",
-  "on",
-  "default"
-};</pre>
-          <table data-link-for="RTCAdaptivePtime" data-dfn-for="RTCAdaptivePtime"
-          class="simple">
-            <tbody>
-              <tr>
-                <th colspan="2">Enumeration description</th>
-              </tr>
-              <tr>
-                <!-- TODO: !!! Add data-tests before actually pulling. -->
-                <td data-tests="RTCPeerConnection-constructor.html"><dfn data-idl><code>off</code></dfn></td>
-                <td>The implementation is not allowed to dynamically change the audio frame length during the call.</td>
-              </tr>
-              <tr>
-                <!-- TODO: !!! Add data-tests before actually pulling. -->
-                <td data-tests="RTCPeerConnection-constructor.html"><dfn data-idl><code>on</code></dfn></td>
-                <td>The implementation should dynamically change the audio frame length during the call.</td>
-              </tr>
-              <tr>
-                <!-- TODO: !!! Add data-tests before actually pulling. -->
-                <td data-tests="RTCPeerConnection-constructor.html"><dfn data-idl><code>default</code></dfn></td>
-                <td>It's up to the implementation to decide whether the audio frame length adaptation should be dynamically changed during the call.</td>
-              </tr>
-            </tbody>
-          </table>
         </div>
       </section>
       <section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -262,7 +262,7 @@
                 <span data-jsep=
                 "ice-candidate-pool constructor">[[!JSEP]]</span>.</p>
               </dd>
-              <!-- TODO: !!! Add data-tests before pushing for full review. -->
+              <!-- TODO: !!! Add data-tests before actually pulling. -->
               <dt data-tests="RTCPeerConnection-constructor.html"><dfn data-idl><code>adaptivePtime</code></dfn> of type <span class="idlMemberType"><a>RTCAdaptivePtime</a></span>, defaulting to <code>"default"</code>.</dt>
               <dd>
                 <p>Indicates whether adaptive audio frame length should be used, should be suppressed, or whether this should be left up to the implementation to decide.</p>
@@ -672,17 +672,17 @@
                 <th colspan="2">Enumeration description</th>
               </tr>
               <tr>
-                <!-- TODO: !!! Add data-tests before full review. -->
+                <!-- TODO: !!! Add data-tests before actually pulling. -->
                 <td data-tests="RTCPeerConnection-constructor.html"><dfn data-idl><code>off</code></dfn></td>
                 <td>The implementation is not allowed to dynamically change the audio frame length during the call.</td>
               </tr>
               <tr>
-                <!-- TODO: !!! Add data-tests before full review. -->
+                <!-- TODO: !!! Add data-tests before actually pulling. -->
                 <td data-tests="RTCPeerConnection-constructor.html"><dfn data-idl><code>on</code></dfn></td>
                 <td>The implementation should dynamically change the audio frame length during the call.</td>
               </tr>
               <tr>
-                <!-- TODO: !!! Add data-tests before full review. -->
+                <!-- TODO: !!! Add data-tests before actually pulling. -->
                 <td data-tests="RTCPeerConnection-constructor.html"><dfn data-idl><code>default</code></dfn></td>
                 <td>It's up to the implementation to decide whether the audio frame length adaptation should be dynamically changed during the call.</td>
               </tr>


### PR DESCRIPTION
When adaptivePtime is "on", the browser may dynamically change the audio frame length during the call, either reducing bandwidth consumption at the cost of increased latency, or vice versa.

The full rationale is in [this document](https://docs.google.com/document/d/12sVXRog-Dl9c-hbMInz9obmODk_yft06z7GMgfpdjPw/edit?usp=sharing).

Fixes #2300.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eladalon1983/webrtc-pc/pull/2309.html" title="Last updated on Oct 4, 2019, 3:20 PM UTC (78cc80b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2309/39a91c5...eladalon1983:78cc80b.html" title="Last updated on Oct 4, 2019, 3:20 PM UTC (78cc80b)">Diff</a>