### PR TITLE
Clarify the rules for filtering and split hostCandidate in address and port

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4945,7 +4945,8 @@ interface RTCPeerConnectionIceEvent : Event {
 >[Exposed=Window]
 interface RTCPeerConnectionIceErrorEvent : Event {
   constructor(DOMString type, RTCPeerConnectionIceErrorEventInit eventInitDict);
-  readonly attribute DOMString hostCandidate;
+  readonly attribute DOMString? address;
+  readonly attribute unsigned short? port;
   readonly attribute DOMString url;
   readonly attribute unsigned short errorCode;
   readonly attribute USVString errorText;
@@ -4963,18 +4964,26 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             <h2>Attributes</h2>
             <dl data-link-for="RTCPeerConnectionIceErrorEvent" data-dfn-for=
             "RTCPeerConnectionIceErrorEvent" class="attributes">
-              <dt><dfn data-idl><code>hostCandidate</code></dfn> of type <span class=
+              <dt><dfn data-idl><code>address</code></dfn> of type <span class=
               "idlAttrType">DOMString</span>, readonly</dt>
               <dd>
-                <p>The <code>hostCandidate</code> attribute is the local IP
-                address and port used to communicate with the STUN or TURN
+                <p>The <code>address</code> attribute is the local IP
+                address used to communicate with the STUN or TURN
                 server.</p>
                 <p>On a multihomed system, multiple interfaces may be used to
                 contact the server, and this attribute allows the application
                 to figure out on which one the failure occurred.</p>
-                <p>If use of multiple interfaces has been prohibited for
-                privacy reasons, this attribute will be set to 0.0.0.0:0 or
-                [::]:0, as appropriate.</p>
+                <p>If the local IP address value is not already exposed
+                as part of a local candidate, the <code>address</code>
+                attribute will be set to <code>null</code>.</p>
+              </dd>
+              <dt><dfn data-idl><code>port</code></dfn> of type <span class=
+              "idlAttrType">unsigned short</span>, readonly</dt>
+              <dd>
+                <p>The <code>port</code> attribute is the port used to
+                communicate with the STUN or TURN server.</p>
+                <p>If the <code>address</code> attribute is <code>null</code>,
+                 the <code>port</code> attribute is also set to <code>null</code>.</p>
               </dd>
               <dt><dfn data-idl><code>url</code></dfn> of type <span class=
               "idlAttrType">DOMString</span>, readonly</dt>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-pc/pull/2322.html" title="Last updated on Oct 3, 2019, 2:59 PM UTC (39b9ac3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2322/8917c57...youennf:39b9ac3.html" title="Last updated on Oct 3, 2019, 2:59 PM UTC (39b9ac3)">Diff</a>