### PR TITLE
Update links to promise-guide definitions that moved to webidl.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3201,10 +3201,9 @@ interface RTCPeerConnection : EventTarget  {
                             was created, then let <var>p</var> be the result of
                             <a href="#dfn-create-an-offer">creating an offer</a>
                             with <var>connection</var>, and return the result of
-                            <a href="https://w3ctag.github.io/promises-guide/#transforming-by">
-                            transforming</a> <var>p</var> with a fulfillment
-                            handler that returns the result of
-                            <a href="#set-local-description">setting the local RTCSessionDescription</a>
+                            <a data-cite="!WEBIDL-1#dfn-perform-steps-once-promise-is-settled">
+                            reacting</a> to <var>p</var> with a fulfillment step that
+                            <a href="#set-local-description">sets the local RTCSessionDescription</a>
                             indicated by its first argument.</p>
                           </li>
                         </ol>
@@ -3229,13 +3228,13 @@ interface RTCPeerConnection : EventTarget  {
                             was created, then let <var>p</var> be the result of
                             <a href="#dfn-create-an-answer">creating an answer</a>
                             with <var>connection</var>, and return the result of
-                            <a href="https://w3ctag.github.io/promises-guide/#transforming-by">
-                            transforming</a> <var>p</var> with a fulfillment
-                            handler that runs the following steps:</p>
+                            <a data-cite="!WEBIDL-1#dfn-perform-steps-once-promise-is-settled">
+                            reacting</a> to <var>p</var> with the following
+                            fulfillment steps:</p>
                             <ol>
                               <li>
-                                <p>Let <var>answer</var> be the handler's first
-                                argument.</p>
+                                <p>Let <var>answer</var> be the first argument
+                                to these fulfillment steps.</p>
                               </li>
                               <li>
                                 <p>Return the result of <a
@@ -3303,24 +3302,21 @@ interface RTCPeerConnection : EventTarget  {
                           <li>
                             <p>Let <var>p</var> be the result of <a
                             href="#set-local-description">setting the local RTCSessionDescription</a>
-                            to a new description with a <code><a
-                            data-link-for="RTCSessionDescriptionInit">type</a></code>
-                            of <code>"rollback"</code>.</p>
+                            indicated by <code>{type: "rollback"}</code>.</p>
                           </li>
                           <li>
-                            <p>Return the result of <a
-                            href="https://w3ctag.github.io/promises-guide/#transforming-by">
-                            transforming</a> <var>p</var> with a fulfillment handler
-                            that returns the result of
-                            <a href="#set-remote-description">setting the remote RTCSessionDescription</a>
-                            to <var>description</var>, and abort these steps.</p>
+                            <p>Return the result of
+                            <a data-cite="!WEBIDL-1#dfn-perform-steps-once-promise-is-settled">
+                              reacting</a> to <var>p</var> with a fulfillment step that
+                            <a href="#set-remote-description">sets the remote RTCSessionDescription</a>
+                            <var>description</var>, and abort these steps.</p>
                           </li>
                         </ol>
                       </li>
                       <li>
                         <p>Return the result of <a
-                          href="#set-remote-description">setting the remote RTCSessionDescription</a>
-                        to <var>description</var>.</p>
+                        href="#set-remote-description">setting the remote RTCSessionDescription</a>
+                        <var>description</var>.</p>
                       </li>
                     </ol>
                   </li>


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2337. @annevk PTAL.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2339.html" title="Last updated on Oct 23, 2019, 7:37 PM UTC (20b751f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2339/48c8250...jan-ivar:20b751f.html" title="Last updated on Oct 23, 2019, 7:37 PM UTC (20b751f)">Diff</a>