### PR TITLE
Remove getDefaultIceServers()

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2419,7 +2419,6 @@ interface RTCPeerConnection : EventTarget  {
   readonly attribute RTCPeerConnectionState connectionState;
   readonly attribute boolean? canTrickleIceCandidates;
   void restartIce();
-  static sequence&lt;RTCIceServer&gt; getDefaultIceServers();
   RTCConfiguration getConfiguration();
   void setConfiguration(RTCConfiguration configuration);
   void close();
@@ -3566,29 +3565,6 @@ interface RTCPeerConnection : EventTarget  {
                     negotiation-needed flag</a> for <var>connection</var>.</p>
                   </li>
                 </ol>
-              </dd>
-              <dt data-tests="RTCPeerConnection-getDefaultIceServers.html"><dfn data-idl><code>getDefaultIceServers</code></dfn></dt>
-              <dd>
-                <p>Returns a list of ICE servers that are configured into the
-                browser. A browser might be configured to use local or private
-                STUN or TURN servers. This method allows an application to learn
-                about these servers and optionally use them.</p>
-                <p class="fingerprint">This list is likely to be persistent and
-                is the same across origins. It thus increases the
-                fingerprinting surface of the browser. In privacy-sensitive
-                contexts, browsers can consider mitigations such as only
-                providing this data to whitelisted origins (or not providing it
-                at all.)</p>
-                <p class="note">Since the use of this information is left to
-                the discretion of application developers, configuring a user
-                agent with these defaults does not per se increase a user's
-                ability to limit the exposure of their IP addresses.</p>
-                <div class="issue atrisk">
-                  <p>Support for the <code>getDefaultIceServers()</code> method
-                  of <code><a>RTCPeerConnection</a></code> is marked as a
-                  feature at risk, since there is no clear commitment from
-                  implementers.</p>
-                </div>
               </dd>
               <dt><dfn data-idl><code>getConfiguration</code></dfn></dt>
               <dd>
@@ -12905,11 +12881,6 @@ interface RTCErrorEvent : Event {
       transmitted during <a href="#session-negotiation-model">session
       negotiation</a>. That information is in most cases persistent across time
       and origins, and increases the fingerprint surface of a given device.</p>
-      <p>If set, the configured default ICE servers exposed by <a data-link-for=
-      "RTCPeerConnection">getDefaultIceServers</a> on
-      <code>RTCPeerConnection</code> instances also provides persistent across
-      time and origins information which increases the fingerprinting surface
-      of a given browser.</p>
       <p>When establishing DTLS connections, the WebRTC API can generate
       certificates that can be persisted by the application (e.g. in
       IndexedDB). These certificates are not shared across origins, and get


### PR DESCRIPTION
The webrtc-pc part of #2023. To resolve issue: Also need a webrtc-extensions PR.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2354.html" title="Last updated on Nov 7, 2019, 2:06 PM UTC (7a3a947)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2354/0397769...henbos:7a3a947.html" title="Last updated on Nov 7, 2019, 2:06 PM UTC (7a3a947)">Diff</a>