### PR TITLE
Add hardwareAccelerated field to RTCRtpCodecCapability

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7349,6 +7349,7 @@ async function updateParameters() {
   required unsigned long clockRate;
   unsigned short channels;
   DOMString sdpFmtpLine;
+  boolean hardwareAccelerated;
 };</pre>
         <section>
           <h2>Dictionary <code><a>RTCRtpCodecCapability</a></code> Members </h2>
@@ -7384,6 +7385,12 @@ async function updateParameters() {
             <dd>
               <p>The "format specific parameters" field from the "a=fmtp" line
               in the SDP corresponding to the codec, if one exists.</p>
+            </dd>
+            <dt data-tests="RTCRtpReceiver-getCapabilities.html"><dfn data-idl><code>hardwareAccelerated</code></dfn> of type <span class=
+            "idlMemberType">boolean</span></dt>
+            <dd>
+              <p>If present, indicates whether there is support for hardware
+              acceleration for the specified codec.</p>
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
Fix #2355


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/drkron/webrtc-pc/pull/2356.html" title="Last updated on Nov 8, 2019, 12:33 PM UTC (44266d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2356/9d6b85d...drkron:44266d7.html" title="Last updated on Nov 8, 2019, 12:33 PM UTC (44266d7)">Diff</a>