### PR TITLE
Update Mandatory stats to match refactoring

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -10827,7 +10827,8 @@ interface RTCStatsReport {
         <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCRtpReceiver-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCInboundRtpStreamStats, with all required attributes from its
         inherited dictionaries, and also attributes
         receiverId, remoteId, framesDecoded, nackCount,
-        framesReceived, framesDecoded, framesDropped, partialFramesLost</li>
+        framesReceived, framesDecoded, framesDropped, partialFramesLost,
+        totalAudioEnergy, totalSamplesDuration</li>
         <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCRemoteInboundRTPStreamStats, with all required attributes from
         its inherited dictionaries, and also attributes localId, bytesReceived,
         roundTripTime</li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -10819,22 +10819,24 @@ interface RTCStatsReport {
       types when the corresponding objects exist on a PeerConnection, with the
       attributes that are listed when they are valid for that object:</p>
       <ul>
-        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCRTPStreamStats, with attributes ssrc, kind,
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCRtpStreamStats, with attributes ssrc, kind,
         transportId, codecId</li>
-        <li data-tests="RTCPeerConnection-getStats.https.html,RTCRtpReceiver-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCReceivedRTPStreamStats, with all required attributes from its
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCRtpReceiver-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCReceivedRtpStreamStats, with all required attributes from its
         inherited dictionaries, and also attributes packetsReceived,
         packetsLost, jitter, packetsDiscarded</li>
-        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCRtpReceiver-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCInboundRTPStreamStats, with all required attributes from its
-        inherited dictionaries, and also attributes trackId,
-        receiverId, remoteId, framesDecoded, nackCount</li>
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCRtpReceiver-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCInboundRtpStreamStats, with all required attributes from its
+        inherited dictionaries, and also attributes
+        receiverId, remoteId, framesDecoded, nackCount,
+        framesReceived, framesDecoded, framesDropped, partialFramesLost</li>
         <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCRemoteInboundRTPStreamStats, with all required attributes from
         its inherited dictionaries, and also attributes localId, bytesReceived,
         roundTripTime</li>
-        <li data-tests="RTCPeerConnection-getStats.https.html,RTCRtpSender-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCSentRTPStreamStats, with all required attributes from its
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCRtpSender-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCSentRtpStreamStats, with all required attributes from its
         inherited dictionaries, and also attributes packetsSent, bytesSent</li>
-        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCRtpSender-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCOutboundRTPStreamStats, with all required attributes from its
-        inherited dictionaries, and also attributes trackId, senderId, remoteId, framesEncoded, nackCount</li>
-        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCRemoteOutboundRTPStreamStats, with all required attributes from
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCRtpSender-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCOutboundRtpStreamStats, with all required attributes from its
+        inherited dictionaries, and also attributes senderId, remoteId, framesEncoded, nackCount,
+        framesSent</li>
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCRemoteOutboundRtpStreamStats, with all required attributes from
         its inherited dictionaries, and also attributes localId, remoteTimestamp
         </li>
         <li data-tests="RTCPeerConnection-getStats.https.html,getstats.html,RTCPeerConnection-mandatory-getStats.https.html">RTCPeerConnectionStats, with attributes dataChannelsOpened,
@@ -10842,15 +10844,17 @@ interface RTCStatsReport {
         <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCDataChannelStats, with attributes label, protocol,
         dataChannelIdentifier, state, messagesSent, bytesSent, messagesReceived,
         bytesReceived</li>
-        <li data-tests="RTCPeerConnection-getStats.https.html, RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCMediaStreamStats, with attributes streamIdentifer, trackIds</li>
-        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCMediaHandlerStats with attributes trackIdentifier, ended</li>
-        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCSenderVideoTrackAttachmentStats, with all required attributes from its inherited dictionaries</li>
-        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCSenderAudioTrackAttachmentStats, with all required attributes from its inherited dictionaries</li>
-        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCAudioHandlerStats with attribute audioLevel</li>
-        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCVideoHandlerStats with attributes frameWidth, frameHeight, framesPerSecond</li>
-        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCVideoSenderStats with attribute framesSent</li>
-        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCVideoReceiverStats with attributes framesReceived, framesDecoded, framesDropped,
-        partialFramesLost</li>
+        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCMediaSourceStats with attributes
+        trackIdentifier, kind</li>
+        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCAudioSourceStats, with all required attributes from its inherited dictionaries and
+        totalAudioEnergy, totalSamplesDuration</li>
+        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCVideoSourceStats, with all required attributes from its inherited dictionaries and
+        width, height, framesPerSecond</li>
+        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCMediaHandlerStats with attributes trackIdentifier</li>
+        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCAudioHandlerStats, with all required attributes from its inherited dictionaries</li>
+        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCVideoHandlerStats, with all required attributes from its inherited dictionaries</li>
+        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCVideoSenderStats, with all required attributes from its inherited dictionaries</li>
+        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCVideoReceiverStats, with all required attributes from its inherited dictionaries</li>
         <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCCodecStats, with attributes payloadType, codecType, mimeType, clockRate,
         channels, sdpFmtpLine</li>
         <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCTransportStats, with attributes bytesSent, bytesReceived,


### PR DESCRIPTION
Fixes #2302.

This PR does not intend to change which metrics are or are not mandatory*, only to update itself to match where metrics are placed after the recent restructuring.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2366.html" title="Last updated on Nov 22, 2019, 4:02 PM UTC (9b783f3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2366/00c4a67...henbos:9b783f3.html" title="Last updated on Nov 22, 2019, 4:02 PM UTC (9b783f3)">Diff</a>