### PR TITLE
Construct RTCErrors with name 'OperationError' instead of 'RTCError'

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -11585,7 +11585,7 @@ interface RTCError : DOMException {
                 <p>Invoke the <code><a data-cite="!WEBIDL#idl-DOMException">
                 DOMException</a></code> constructor of <var>e</var> with the
                 <code>message</code> argument set to <var>message</var> and the
-                <code>name</code> argument set to <code>"RTCError"</code>.</p>
+                <code>name</code> argument set to <code>"OperationError"</code>.</p>
                 <p class="note">This name does not have a mapping to a legacy
                 code so <var>e</var>'s <code>code</code> attribute will return
                 0.</p>


### PR DESCRIPTION
Fixes #2330.

Before merging this PR, we need to check if this is in fact consistent with current implementations.
So far, I've noticed that there is one breaking change for Chrome's replaceTrack() which rejects with InvalidModificationError (though I doubt anybody is relying on that operation failing, it only fails on invalid input or when the PC is closed).

I/we need to take a closer look at Chrome and other browsers. (If different names are needed the PR can be updated to allow constructing with different names.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2375.html" title="Last updated on Nov 26, 2019, 5:44 PM UTC (73fd734)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2375/00c4a67...henbos:73fd734.html" title="Last updated on Nov 26, 2019, 5:44 PM UTC (73fd734)">Diff</a>