### PR TITLE
Note that ICE transport state can go to completed

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8707,6 +8707,14 @@ interface RTCIceTransport : EventTarget {
           </tbody>
         </table>
       </div>
+      <p class="note">
+        The most common transitions for a successful call will be new ->
+        checking -> connected -> completed, but under specific circumstances
+        (only the last checked candidate succeeds, and gathering and the
+        no-more candidates indication both occur prior to success), the
+        state can transition directly from "checking" to "completed".
+      </p>
+      </p>
       <p>An ICE restart causes candidate gathering and connectity checks to
       begin anew, causing a transition to <code>connected</code> if begun in the
       <code>completed</code> state. If begun in the transient

--- a/webrtc.html
+++ b/webrtc.html
@@ -8714,7 +8714,6 @@ interface RTCIceTransport : EventTarget {
         no-more candidates indication both occur prior to success), the
         state can transition directly from "checking" to "completed".
       </p>
-      </p>
       <p>An ICE restart causes candidate gathering and connectity checks to
       begin anew, causing a transition to <code>connected</code> if begun in the
       <code>completed</code> state. If begun in the transient


### PR DESCRIPTION
without visiting "connected".

Fixes #2316


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2376.html" title="Last updated on Dec 2, 2019, 2:55 PM UTC (7ad4299)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2376/00c4a67...7ad4299.html" title="Last updated on Dec 2, 2019, 2:55 PM UTC (7ad4299)">Diff</a>