### PR TITLE
Set receiver.[[ReceiveCodecs]] on all descriptions.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1571,6 +1571,18 @@
                             to <code>true</code>, otherwise set it to <code>false</code>.</p>
                           </li>
                           <li>
+                            <p>Set
+                              <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\ReceiveCodecs]]</a>
+                              to the codecs that <var>description</var>
+                              negotiates for receiving, and which the user
+                              agent is currently prepared to receive.</p>
+                            <p class='note'>
+                              If the <var>direction</var> is <code>"sendonly"</code>,
+                              the receiver is not prepared to receive
+                              anything, and the list will be empty.
+                            </p>
+                          </li>
+                          <li>
                             <p>If <var>description</var> is of type
                             <code>"answer"</code> or <code>"pranswer"</code>,
                             then run the following steps:</p>
@@ -1581,13 +1593,6 @@
                                 to the codecs that <var>description</var>
                                 negotiates for sending, and which the user agent
                                 is currently capable of sending.</p>
-                              </li>
-                              <li>
-                                <p>Set
-                                <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\ReceiveCodecs]]</a>
-                                to the codecs that <var>description</var>
-                                negotiates for receiving, and which the user
-                                agent is currently prepared to receive.</p>
                               </li>
                               <li>
                                 <p>If <var>direction</var> is
@@ -1781,6 +1786,13 @@
                             <var>direction</var>.</p>
                           </li>
                           <li>
+                            <p>Set
+                              <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\ReceiveCodecs]]</a>
+                              to the codecs that <var>description</var>
+                              negotiates for receiving, and which the user
+                              agent is currently prepared to receive.</p>
+                          </li>
+                          <li>
                             <p>If <var>description</var> is of type
                             <code>"answer"</code> or <code>"pranswer"</code>, then run
                             the following steps:</p>
@@ -1791,13 +1803,6 @@
                                 to the codecs that <var>description</var>
                                 negotiates for sending, and which the user agent
                                 is currently capable of sending.</p>
-                              </li>
-                              <li>
-                                <p>Set
-                                <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\ReceiveCodecs]]</a>
-                                to the codecs that <var>description</var>
-                                negotiates for receiving, and which the user
-                                agent is currently prepared to receive.</p>
                               </li>
                               <li>
                                 <p>Set <var>transceiver</var>.<a>[[\CurrentDirection]]</a> and

--- a/webrtc.html
+++ b/webrtc.html
@@ -1577,7 +1577,8 @@
                               negotiates for receiving, and which the user
                               agent is currently prepared to receive.</p>
                             <p class='note'>
-                              If the <var>direction</var> is <code>"sendonly"</code>,
+                              If the <var>direction</var> is
+                              <code>"sendonly"</code> or <code>"inactive"</code>,
                               the receiver is not prepared to receive
                               anything, and the list will be empty.
                             </p>


### PR DESCRIPTION
Fixes #2369


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2377.html" title="Last updated on Nov 29, 2019, 6:52 AM UTC (38da743)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2377/00c4a67...38da743.html" title="Last updated on Nov 29, 2019, 6:52 AM UTC (38da743)">Diff</a>