### PR TITLE
Remove getDefaultIceServers reference from "at risk" section

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -32,7 +32,6 @@
 
     <p>The following features are marked as at risk:</p>
     <ul>
-      <li>The <code>getDefaultIceServers</code> method of <code><a>RTCPeerConnection</a></code>.</li>
       <li>The <code>encodings</code> member of the <code><a>RTCRtpReceiveParameters</a></code> dictonary.</li>
     </ul>
 


### PR DESCRIPTION
I missed this one in PR #2354.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2381.html" title="Last updated on Nov 28, 2019, 11:47 AM UTC (c5431e8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2381/00c4a67...henbos:c5431e8.html" title="Last updated on Nov 28, 2019, 11:47 AM UTC (c5431e8)">Diff</a>