### PR TITLE
Remove RTCRtpReceiveParameters.encodings

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -33,7 +33,6 @@
     <p>The following features are marked as at risk:</p>
     <ul>
       <li>The <code>getDefaultIceServers</code> method of <code><a>RTCPeerConnection</a></code>.</li>
-      <li>The <code>encodings</code> member of the <code><a>RTCRtpReceiveParameters</a></code> dictonary.</li>
     </ul>
 
   </section>
@@ -6558,27 +6557,7 @@ async function updateParameters() {
       <div>
         <pre class="idl"
 >dictionary RTCRtpReceiveParameters : RTCRtpParameters {
-  required sequence&lt;RTCRtpDecodingParameters&gt; encodings;
 };</pre>
-        <section>
-          <h2>Dictionary <code><a>RTCRtpReceiveParameters</a></code> Members</h2>
-          <dl data-link-for="RTCRtpReceiveParameters" data-dfn-for="RTCRtpReceiveParameters"
-          class="dictionary-members">
-            <dt><dfn data-idl><code>encodings</code></dfn> of type <span class=
-            "idlMemberType">sequence&lt;<a>RTCRtpDecodingParameters</a>&gt;</span>,
-            required</dt>
-            <dd>
-              <p>A sequence containing information about incoming RTP encodings
-              of media.</p>
-              <div class="issue atrisk">
-                <p>Support for the <code>encodings</code> attribute of
-                <code><a>RTCRtpReceiveParameters</a></code> is marked
-                as a feature at risk, since there is no clear
-                commitment from implementers.</p>
-              </div>
-            </dd>
-          </dl>
-        </section>
       </div>
       </section>
       <section id="rtcrtpcodingparameters">
@@ -7096,11 +7075,6 @@ interface RTCRtpReceiver {
               <code><a>RTCRtpReceiveParameters</a></code> dictionary is
               constructed as follows:</p>
               <ul>
-                <li data-tests="RTCRtpReceiver-getParameters.html">
-                  <p><code><a data-link-for="RTCRtpReceiveParameters">encodings</a></code>
-                  is populated based on the RIDs present in the current remote
-                  description.</p>
-                </li>
                 <li data-tests="RTCRtpReceiver-getParameters.html">
                   The <code><a data-link-for="RTCRtpParameters">headerExtensions</a></code>
                   sequence is populated based on the header extensions that the


### PR DESCRIPTION
Fixes #2382


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2383.html" title="Last updated on Nov 28, 2019, 11:56 AM UTC (dfb3f25)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2383/00c4a67...henbos:dfb3f25.html" title="Last updated on Nov 28, 2019, 11:56 AM UTC (dfb3f25)">Diff</a>