### PR TITLE
Note that getSynchronizationSources works without sinks

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7197,6 +7197,10 @@ interface RTCRtpReceiver {
       in order of ascending RTP timestamps. The user agent MUST keep information
       from RTP packets delivered to the <code><a>RTCRtpReceiver</a></code>'s
       <code><a>MediaStreamTrack</a></code> in the previous 10 seconds.</p>
+      <div class="note">Even if the <a>MediaStreamTrack</a> is not attached to
+      any sink for playout, <code>getSynchronizationSources</code> and
+      <code>getContributingSources</code> returns up-to-date information; sinks
+      are not a prerequisite for decoding RTP packets.</div>
       <div class="note">As stated in the <a href="#conformance">conformance
       section</a>, requirements phrased as algorithms may be implemented in
       any manner so long as the end result is equivalent. So, an

--- a/webrtc.html
+++ b/webrtc.html
@@ -7199,8 +7199,9 @@ interface RTCRtpReceiver {
       <code><a>MediaStreamTrack</a></code> in the previous 10 seconds.</p>
       <div class="note">Even if the <a>MediaStreamTrack</a> is not attached to
       any sink for playout, <code>getSynchronizationSources</code> and
-      <code>getContributingSources</code> returns up-to-date information; sinks
-      are not a prerequisite for decoding RTP packets.</div>
+      <code>getContributingSources</code> returns up-to-date information as long
+      as the track is not ended; sinks are not a prerequisite for decoding RTP
+      packets.</div>
       <div class="note">As stated in the <a href="#conformance">conformance
       section</a>, requirements phrased as algorithms may be implemented in
       any manner so long as the end result is equivalent. So, an


### PR DESCRIPTION
Fixes #2240


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2385.html" title="Last updated on Nov 28, 2019, 2:50 PM UTC (dbf600e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2385/00c4a67...henbos:dbf600e.html" title="Last updated on Nov 28, 2019, 2:50 PM UTC (dbf600e)">Diff</a>