### PR TITLE
Do not send audio when track is disabled

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6089,9 +6089,9 @@ interface RTCRtpSender {
               associated with this <code><a>RTCRtpSender</a></code> object. If
               <code>track</code> is ended, or if the track's output is disabled,
               i.e. the track is disabled and/or muted, the <code>
-              <a>RTCRtpSender</a></code> MUST send silence (audio), black
-              frames (video) or a zero-information-content equivalent. In the
-              case of video, the <code><a>RTCRtpSender</a></code> SHOULD send one
+              <a>RTCRtpSender</a></code> MUST send black frames (video) or
+              MUST NOT send (audio).  In the case of video,
+              the <code><a>RTCRtpSender</a></code> SHOULD send one
               black frame per second. If <code>track</code> is null then
               the <code>RTCRtpSender</code> does not send. On getting, the
               attribute MUST return the value of the <a>[[\SenderTrack]]</a>

--- a/webrtc.html
+++ b/webrtc.html
@@ -6089,7 +6089,7 @@ interface RTCRtpSender {
               associated with this <code><a>RTCRtpSender</a></code> object. If
               <code>track</code> is ended, or if the track's output is disabled,
               i.e. the track is disabled and/or muted, the <code>
-              <a>RTCRtpSender</a></code> MUST send black frames (video) or
+              <a>RTCRtpSender</a></code> MUST send black frames (video) and
               MUST NOT send (audio).  In the case of video,
               the <code><a>RTCRtpSender</a></code> SHOULD send one
               black frame per second. If <code>track</code> is null then


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/1764


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2395.html" title="Last updated on Dec 5, 2019, 3:45 PM UTC (22c3fe1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2395/5cbd3ed...22c3fe1.html" title="Last updated on Dec 5, 2019, 3:45 PM UTC (22c3fe1)">Diff</a>