### PR TITLE
Specify that SCTP transport goes to "closed" on DTLS close

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9272,11 +9272,22 @@ interface RTCSctpTransport : EventTarget {
                 "idl-def-RTCSctpTransportState.closed">closed</code></dfn></td>
                 <td>
                   <p>A task is queued to update the [[\SctpTransportState]]
-                  slot to <code>"closed"</code> when a SHUTDOWN or ABORT chunk
-                  is received or when the SCTP association has been closed
-                  intentionally, such as by closing the peer connection
-                  or applying a remote description that rejects data or
-                  changes the SCTP port.</p>
+                    slot to <code>"closed"</code> when:
+                    <ul>
+                      <li>a SHUTDOWN or ABORT chunk
+                        is received.</li>
+                      <li>the SCTP association has been closed
+                        intentionally, such as by closing the peer connection
+                        or applying a remote description that rejects data or
+                        changes the SCTP port.</li>
+                      <li>the underlying DTLS association has transitioned
+                        to "closed" state.</li>
+                    </ul>
+                    Note that the last transition is logical due to the
+                    fact that [[RFC8261]] section 6.1 specifies that
+                    SCTP over DTLS is single-homed, so no possibility
+                    of switching to an alternate transport exist.
+                  </p>
                 </td>
               </tr>
             </tbody>

--- a/webrtc.html
+++ b/webrtc.html
@@ -9273,16 +9273,18 @@ interface RTCSctpTransport : EventTarget {
                 <td>
                   <p>A task is queued to update the [[\SctpTransportState]]
                     slot to <code>"closed"</code> when:
-                    <ul>
-                      <li>a SHUTDOWN or ABORT chunk
-                        is received.</li>
-                      <li>the SCTP association has been closed
-                        intentionally, such as by closing the peer connection
-                        or applying a remote description that rejects data or
-                        changes the SCTP port.</li>
-                      <li>the underlying DTLS association has transitioned
-                        to "closed" state.</li>
-                    </ul>
+                    </p>
+                  <ul>
+                    <li>a SHUTDOWN or ABORT chunk
+                      is received.</li>
+                    <li>the SCTP association has been closed
+                      intentionally, such as by closing the peer connection
+                      or applying a remote description that rejects data or
+                      changes the SCTP port.</li>
+                    <li>the underlying DTLS association has transitioned
+                      to "closed" state.</li>
+                  </ul>
+                  <p>
                     Note that the last transition is logical due to the
                     fact that [[RFC8261]] section 6.1 specifies that
                     SCTP over DTLS is single-homed, so no possibility

--- a/webrtc.html
+++ b/webrtc.html
@@ -9286,9 +9286,11 @@ interface RTCSctpTransport : EventTarget {
                   </ul>
                   <p>
                     Note that the last transition is logical due to the
-                    fact that [[RFC8261]] section 6.1 specifies that
-                    SCTP over DTLS is single-homed, so no possibility
-                    of switching to an alternate transport exist.
+                    fact that an SCTP association requires an established
+                    DTLS connection - [[RFC8261]] section 6.1 specifies that
+                    SCTP over DTLS is single-homed - and that no way of
+                    of switching to an alternate transport is defined in this
+                    API.
                   </p>
                 </td>
               </tr>


### PR DESCRIPTION
Fixes #2360


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2401.html" title="Last updated on Dec 12, 2019, 5:15 PM UTC (7ccc008)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2401/7fdd9b4...7ccc008.html" title="Last updated on Dec 12, 2019, 5:15 PM UTC (7ccc008)">Diff</a>