### PR TITLE
Reject RID renegotiation

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1593,6 +1593,15 @@
                             description</a>.</p>
                           </li>
                           <li>
+                            <p>If a suitable transceiver was found, and
+                              <var>transceiver</var>.<a>[[\Sender]]</a>.<a>[[\SendEncodings]]</a>
+                              is non-empty, and not equal to <var>sendEncodings</var>, we reject the
+                              <a>media description</a>. Reject <var>p</var> with a newly
+                              <a data-link-for="exception" data-lt="create">created</a>
+                              <code>InvalidAccessError</code> and abort these steps.
+                              This specification does not allow remotely initiated RID renegotiation.
+                            </p>
+                          <li>
                             <p>If a suitable transceiver was found (<var>transceiver</var>
                             is set) and <var>sendEncodings</var> is non-empty, set
                             <var>transceiver</var>.<a>[[\Sender]]</a>.<a>[[\SendEncodings]]</a>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1192,8 +1192,17 @@
           </li>
           <li>
             <p>In parallel, start the process to apply <var>description</var>
-            as described in <span data-jsep=
-            "processing-a-local-desc processing-a-remote-desc">[[!JSEP]]</span>.</p>
+              as described in <span data-jsep=
+                                  "processing-a-local-desc processing-a-remote-desc">[[!JSEP]]</span>,
+              with the additional restriction that if applying <var>description</var>
+              leads to modifying a transceiver <var>transceiver</var>, and
+              <var>transceiver</var>.<a>[[\Sender]]</a>.<a>[[\SendEncodings]]</a>
+              is non-empty, and not equal to the encodings that would result from
+              processing <var>description</var>, the process of applying <var>description</var>
+              fails.
+              This specification does not allow remotely initiated RID renegotiation.
+            </p>
+
             <ol>
               <li>
                 <p>If the process to apply <var>description</var> fails for any
@@ -1231,6 +1240,12 @@
                     data-lt="create">created</a>
                     <code>InvalidAccessError</code> and abort these steps.</p>
                   </li>
+                  <li>
+                    <p>If the description attempted to renegotiate RIDs, as described
+                      above, then <a>reject</a> <var>p</var> with a newly
+                      <a data-link-for="exception" data-lt="create">created</a>
+                      <code>InvalidAccessError</code> and abort these steps.
+                    </p>
                   <li>
                     <p>If the content of <var>description</var> is invalid,
                     then <a>reject</a> <var>p</var> with a newly
@@ -1592,15 +1607,6 @@
                             object, <var>transceiver</var>, to represent the <a>media
                             description</a>.</p>
                           </li>
-                          <li>
-                            <p>If a suitable transceiver was found, and
-                              <var>transceiver</var>.<a>[[\Sender]]</a>.<a>[[\SendEncodings]]</a>
-                              is non-empty, and not equal to <var>sendEncodings</var>, we reject the
-                              <a>media description</a>. Reject <var>p</var> with a newly
-                              <a data-link-for="exception" data-lt="create">created</a>
-                              <code>InvalidAccessError</code> and abort these steps.
-                              This specification does not allow remotely initiated RID renegotiation.
-                            </p>
                           <li>
                             <p>If a suitable transceiver was found (<var>transceiver</var>
                             is set) and <var>sendEncodings</var> is non-empty, set


### PR DESCRIPTION
Fixes #2314 

Note: This is the first time we reject a SRD in the text section that comes after applying it successfully in JSEP. I'm not sure this is the right way to specify that, but doing it before JSEP gets weird too (repeated "look up this transceiver" steps). Suggestions welcome.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2402.html" title="Last updated on Dec 12, 2019, 2:20 PM UTC (213fa33)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2402/7fdd9b4...213fa33.html" title="Last updated on Dec 12, 2019, 2:20 PM UTC (213fa33)">Diff</a>