### PR TITLE
Use proper WHATWG references for webmessaging, xhr, web sockets

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -51,8 +51,7 @@
     specification developed by the <a href=
     "https://datatracker.ietf.org/wg/rtcweb/">IETF RTCWEB group</a> and an API
     specification to get access to local media devices [[GETUSERMEDIA]]
-    developed by the <a href="https://www.w3.org/wiki/Media_Capture">Media
-    Capture Task Force</a>. An overview of the system can be found in
+    developed by the WebRTC Working Group. An overview of the system can be found in
     [[RTCWEB-OVERVIEW]] and [[RTCWEB-SECURITY]].</p>
   </section>
   <section id="conformance">

--- a/webrtc.html
+++ b/webrtc.html
@@ -80,7 +80,7 @@
     task source</dfn> are defined in [[!HTML]].</p>
     <p>The concept <dfn data-cite="!DOM#firing-events">fire an
         event</dfn> is defined in [[!DOM]].</p>
-    <p>The terms <dfn>event</dfn>, <dfn data-cite="!HTML/webappapis.html#events-event-handlers">event
+    <p>The terms <dfn>event</dfn>, <dfn data-cite="!HTML/webappapis.html#event-handlers">event
     handlers</dfn> and <dfn data-cite="!HTML/webappapis.html#event-handler-event-type">event
     handler event types</dfn> are defined in [[!HTML]].</p>
     <p><code><dfn data-cite="!hr-time#dom-performance-timeorigin">performance.timeOrigin</dfn></code>
@@ -148,8 +148,7 @@
       exchange of control messages (called a signaling protocol) over a
       signaling channel which is provided by unspecified means, but generally
       by a script in the page via the server, e.g. using
-      <code>XMLHttpRequest</code> [[?XMLHttpRequest]] or Web Sockets
-      [[?WEBSOCKETS-API]].</p>
+      <code>XMLHttpRequest</code> [[?xhr]] or <a data-cite="html">Web Sockets</a>.</p>
     </section>
     <section>
       <h3>Configuration</h3>
@@ -5095,7 +5094,7 @@ interface RTCCertificate {
         <p class="note">Supporting structured cloning in this manner
         allows <a>RTCCertificate</a> instances to be persisted to stores.  It
         also allows instances to be passed to other origins using APIs
-        like <code>postMessage</code> [[webmessaging]].  However, the object cannot
+        like {{MessagePort/postMessage()}} [[html]].  However, the object cannot
         be used by any other origin than the one that originally created it.</p>
       </section>
     </section>
@@ -6343,7 +6342,7 @@ async function updateParameters() {
                 <ol>
                   <li>Changing a resolution to a value outside of the
                   negotiated imageattr bounds, as described in
-                  [[!RFC6236]].</li>
+                  [[RFC6236]].</li>
                   <li>Changing a frame rate to a value that causes the block
                   rate for the codec to be exceeded.</li>
                   <li>A video track differing in raw vs. pre-encoded
@@ -8857,7 +8856,7 @@ interface RTCTrackEvent : Event {
     <h2>Peer-to-peer Data API</h2>
     <p>The Peer-to-peer Data API lets a web application send and receive
     generic application data peer-to-peer. The API for sending and receiving
-    data models the behavior of WebSockets [[?WEBSOCKETS-API]].</p>
+    data models the behavior of <a data-cite="html">Web Sockets</a>.</p>
     <section>
       <h3>RTCPeerConnection Interface Extensions</h3>
       <p>The Peer-to-peer data API extends the
@@ -9814,7 +9813,7 @@ interface RTCDataChannel : EventTarget {
             <code><a>message</a></code>.</p></dd>
             <dt data-tests="RTCDataChannel-send.html"><code>binaryType</code> of type <span class=
             "idlAttrType">DOMString</span></dt>
-            <dd>
+            <dd data-cite="html">
               <p>The <dfn id=
               "dom-datachannel-binarytype"><code>binaryType</code></dfn>
               attribute MUST, on getting, return the value to which it was
@@ -9827,7 +9826,7 @@ interface RTCDataChannel : EventTarget {
               "RTCDataChannel">binaryType</a></code> attribute MUST be
               initialized to the string "<code>blob</code>".</span></p>
               <p>This attribute controls how binary data is exposed to scripts.
-              See the [[WEBSOCKETS-API]] for more information.</p>
+              See Web Socket's {{WebSocket/binaryType}}.</p>
             </dd>
           </dl>
         </section>
@@ -11866,9 +11865,7 @@ interface RTCErrorEvent : Event {
         <tr>
           <td><dfn id=
           "event-datachannel-message"><code>message</code></dfn></td>
-          <td><dfn id=the-messageevent-interfaces><code><a data-cite=
-          "!webmessaging#the-messageevent-interfaces">MessageEvent</a></code>
-          </dfn>[[webmessaging]]</td>
+          <td><dfn id=the-messageevent-interfaces>{{MessageEvent}}</dfn> [[html]]</td>
           <td>A message was successfully received.</td>
         </tr>
         <tr>


### PR DESCRIPTION
as requested in transition approval https://github.com/w3c/transitions/issues/199#issuecomment-563393930


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2403.html" title="Last updated on Dec 9, 2019, 8:56 PM UTC (f79262c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2403/7fdd9b4...f79262c.html" title="Last updated on Dec 9, 2019, 8:56 PM UTC (f79262c)">Diff</a>