### PR TITLE
Make configuration argument optional in setConfiguration

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2203,7 +2203,7 @@ interface RTCPeerConnection : EventTarget  {
   readonly attribute boolean? canTrickleIceCandidates;
   void restartIce();
   RTCConfiguration getConfiguration();
-  void setConfiguration(RTCConfiguration configuration);
+  void setConfiguration(optional RTCConfiguration configuration = {});
   void close();
   attribute EventHandler onnegotiationneeded;
   attribute EventHandler onicecandidate;


### PR DESCRIPTION
As required by WebIDL
close #2410


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2411.html" title="Last updated on Dec 11, 2019, 8:51 PM UTC (4ef9f3e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2411/7fdd9b4...4ef9f3e.html" title="Last updated on Dec 11, 2019, 8:51 PM UTC (4ef9f3e)">Diff</a>