### PR TITLE
Make tone optional and constructor dictionary parameter optional

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -10425,7 +10425,7 @@ interface RTCDTMFSender : EventTarget {
         <pre class="idl" data-tests
 >[Exposed=Window]
 interface RTCDTMFToneChangeEvent : Event {
-  constructor(DOMString type, RTCDTMFToneChangeEventInit eventInitDict);
+  constructor(DOMString type, optional RTCDTMFToneChangeEventInit eventInitDict = {});
   readonly attribute DOMString tone;
 };</pre>
         <section>
@@ -10458,7 +10458,7 @@ interface RTCDTMFToneChangeEvent : Event {
       <div>
         <pre class="idl" data-cite="DOM"
 >dictionary RTCDTMFToneChangeEventInit : EventInit {
-  required DOMString tone;
+  DOMString tone = "";
 };</pre>
         <section>
           <h2>Dictionary <dfn>RTCDTMFToneChangeEventInit</dfn>
@@ -10466,7 +10466,8 @@ interface RTCDTMFToneChangeEvent : Event {
           <dl data-link-for="RTCDTMFToneChangeEventInit" data-dfn-for=
           "RTCDTMFToneChangeEventInit" class="dictionary-members">
             <dt><dfn data-idl><code>tone</code></dfn> of type <span class=
-            "idlMemberType">DOMString</span></dt>
+            "idlMemberType">DOMString</span>, defaulting to
+              <code>""</code></dt>
             <dd>
               <p>The <code>tone</code> attribute contains the
               character for the tone (including ",") that has just


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-pc/pull/2413.html" title="Last updated on Dec 13, 2019, 9:52 AM UTC (bdd6349)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2413/affeeb2...youennf:bdd6349.html" title="Last updated on Dec 13, 2019, 9:52 AM UTC (bdd6349)">Diff</a>