### PR TITLE
Make [[ReadyState]] value a string everywhere

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9435,12 +9435,12 @@ interface RTCSctpTransport : EventTarget {
           object to be announced.</p>
         </li>
         <li>
-          <p>If <var>channel</var>.<a>[[\ReadyState]]</a> is <code>closing</code> or
-          <code>closed</code>, abort these steps.</p>
+          <p>If <var>channel</var>.<a>[[\ReadyState]]</a> is <code>"closing"</code> or
+          <code>"closed"</code>, abort these steps.</p>
         </li>
         <li>
           <p>Set <var>channel</var>.<a>[[\ReadyState]]</a> to
-          <code>open</code>.</p>
+          <code>"open"</code>.</p>
         </li>
         <li data-tests="RTCPeerConnection-ondatachannel.html">
           <p><a>Fire an event</a> named <code><a>open</a></code> at
@@ -9487,7 +9487,7 @@ interface RTCSctpTransport : EventTarget {
         </li>
         <li data-tests="RTCPeerConnection-ondatachannel.html">
           <p>Set <var>channel</var>.<a>[[\ReadyState]]</a> to
-          <code>open</code> (but do not fire the <code><a>open</a></code>
+          <code>"open"</code> (but do not fire the <code><a>open</a></code>
           event, yet).</p>
           <div class="note">This allows to start sending messages inside of the
           <code><a>datachannel</a></code> event handler prior to the
@@ -9523,7 +9523,7 @@ interface RTCSctpTransport : EventTarget {
           <p>Unless the procedure was initiated by the <var>channel</var>'s
           <code><a data-link-for="RTCDataChannel">close</a></code> method, set
           <var>channel</var>.<a>[[\ReadyState]]</a> to
-          <code>closing</code>.</p>
+          <code>"closing"</code>.</p>
         </li>
         <li>
           <p>Run the following steps in parallel:</p>
@@ -9562,7 +9562,7 @@ interface RTCSctpTransport : EventTarget {
         </li>
         <li>
           <p>Set <var>channel</var>.<a>[[\ReadyState]]</a> to
-          <code>closed</code>.</p>
+          <code>"closed"</code>.</p>
         </li>
         <li>
           <p>If the <a data-lt="data transport">transport</a> was closed
@@ -9598,7 +9598,7 @@ interface RTCSctpTransport : EventTarget {
         </li>
         <li>
           <p>Set <var>channel</var>.<a>[[\ReadyState]]</a> to
-          <code>closed</code>.</p>
+          <code>"closed"</code>.</p>
         </li>
         <li>
           <p><a>Fire an event</a> named <code><a data-link-for=
@@ -9633,7 +9633,7 @@ interface RTCSctpTransport : EventTarget {
         </li>
         <li>
           <p>If <var>channel</var>.<a>[[\ReadyState]]</a> is not
-          <code>open</code>, abort these steps and discard <var>rawData</var>.
+          <code>"open"</code>, abort these steps and discard <var>rawData</var>.
           </p>
         </li>
         <li data-tests="RTCDataChannel-bufferedAmount.html,RTCDataChannel-send.html">
@@ -9805,7 +9805,7 @@ interface RTCDataChannel : EventTarget {
               hardware. The value of the <a>[[\BufferedAmount]]</a> slot will
               only increase with each call to the <code><a data-link-for=
               "RTCDataChannel">send()</a></code> method as long as the <a>
-              [[\ReadyState]]</a> slot is <code>open</code>; however, the
+              [[\ReadyState]]</a> slot is <code>"open"</code>; however, the
               slot does not reset to zero once the channel closes. When the
               <a>underlying data transport</a> sends data from its queue, the
               user agent MUST queue a task that reduces
@@ -9896,12 +9896,12 @@ interface RTCDataChannel : EventTarget {
                 </li>
                 <li>
                   <p>If <var>channel</var>.<a>[[\ReadyState]]</a> is
-                  <code>closing</code> or <code>closed</code>, then abort these
+                  <code>"closing"</code> or <code>"closed"</code>, then abort these
                   steps.</p>
                 </li>
                 <li>
                   <p>Set <var>channel</var>.<a>[[\ReadyState]]</a> to
-                  <code>closing</code>.</p>
+                  <code>"closing"</code>.</p>
                 </li>
                 <li>
                   <p>If the <code><a>closing procedure</a></code> has not
@@ -9947,7 +9947,7 @@ interface RTCDataChannel : EventTarget {
         </li>
         <li data-tests="RTCDataChannel-send.html">
           <p>If <var>channel</var>.<a>[[\ReadyState]]</a> is not
-          <code>open</code>, <a>throw</a> an
+          <code>"open"</code>, <a>throw</a> an
           <code>InvalidStateError</code>.</p>
         </li>
         <li>
@@ -10194,19 +10194,19 @@ interface RTCDataChannelEvent : Event {
       <ul>
         <li>
           <p><a>[[\ReadyState]]</a> slot is
-          <code>connecting</code> and at least one event listener is registered
+          <code>"connecting"</code> and at least one event listener is registered
           for <code>open</code> events, <code>message</code> events,
           <code>error</code> events, or <code>close</code> events.</p>
         </li>
         <li>
           <p><a>[[\ReadyState]]</a> slot is
-          <code>open</code> and at least one event listener is registered for
+          <code>"open"</code> and at least one event listener is registered for
           <code>message</code> events, <code>error</code> events, or
           <code>close</code> events.</p>
         </li>
         <li>
           <p><a>[[\ReadyState]]</a> slot is
-          <code>closing</code> and at least one event listener is registered
+          <code>"closing"</code> and at least one event listener is registered
           for <code>error</code> events, or <code>close</code> events.</p>
         </li>
         <li>


### PR DESCRIPTION
Currently values of `[[ReadyState]]` are surrounded by double quotes in some places and not surrounded in other places. It's value is a string value so it should be consistently surrounded be double quotes everywhere


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chicoxyzzy/webrtc-pc/pull/2414.html" title="Last updated on Dec 14, 2019, 10:54 PM UTC (e01bb3b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2414/5690992...chicoxyzzy:e01bb3b.html" title="Last updated on Dec 14, 2019, 10:54 PM UTC (e01bb3b)">Diff</a>