### PR TITLE
Reinstate credential attribute in RTCIceServer

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -282,6 +282,7 @@
 >dictionary RTCIceServer {
   required (DOMString or sequence&lt;DOMString&gt;) urls;
   DOMString username;
+  DOMString credential;
   RTCIceCredentialType credentialType = "password";
 };</pre>
           <section>
@@ -302,6 +303,16 @@
                 TURN server, and {{credentialType}} is
                 {{RTCIceCredentialType/"password"}}, then this attribute specifies the
                 username to use with that TURN server.</p>
+              </dd>
+              <dt><dfn data-idl>credential</dfn> of type DOMString</dt>
+              <dd>
+                <p>If this {{RTCIceServer}} object represents a
+                TURN server, then this attribute specifies the credential to
+                use with that TURN server.</p>
+                <p>If {{credentialType}} is {{RTCIceCredentialType/"password"}},
+                {{credential}} is a DOMString, and represents a
+                long-term authentication password, as described in
+                [[!RFC5389]], Section 10.2.</p>
               </dd>
               <dt><dfn data-idl>credentialType</dfn> of type <span class=
               "idlMemberType">{{RTCIceCredentialType}}</span>, defaulting to
@@ -2040,7 +2051,7 @@
                       <p>If <var>scheme name</var> is <code class=scheme>turn</code> or
                       <code class=scheme>turns</code>, and either of
                       <var>server</var>.{{RTCIceServer/username}} or
-                      <var>server</var>.<code class=fixme>credential</code> are omitted,
+                      <var>server</var>.{{RTCIceServer/credential}} are omitted,
                       then [= exception/throw =] an {{InvalidAccessError}}.</p>
                     </li>
                     <li>
@@ -2048,7 +2059,7 @@
                       <code class=scheme>turns</code>, and
                       <var>server</var>.{{RTCIceServer/credentialType}} is
                       {{RTCIceCredentialType/"password"}}, and
-                      <var>server</var>.<code class=fixme>credential</code> is not a
+                      <var>server</var>.{{RTCIceServer/credential}} is not a
                       <span class="idlMemberType">DOMString</span>, then
                       [= exception/throw =] an {{InvalidAccessError}}.</p>
                     </li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -313,6 +313,9 @@
                 {{credential}} is a DOMString, and represents a
                 long-term authentication password, as described in
                 [[!RFC5389]], Section 10.2.</p>
+                <p class="note">To support additional values of
+                {{credentialType}} in future, {{credential}} may need to be
+                re-defined as a union.</p>
               </dd>
               <dt><dfn data-idl>credentialType</dfn> of type <span class=
               "idlMemberType">{{RTCIceCredentialType}}</span>, defaulting to

--- a/webrtc.html
+++ b/webrtc.html
@@ -314,8 +314,8 @@
                 long-term authentication password, as described in
                 [[!RFC5389]], Section 10.2.</p>
                 <p class="note">To support additional values of
-                {{credentialType}} in future, {{credential}} may need to be
-                re-defined as a union.</p>
+                {{credentialType}}, {{credential}} may evolve in
+                future as a union.</p>
               </dd>
               <dt><dfn data-idl>credentialType</dfn> of type <span class=
               "idlMemberType">{{RTCIceCredentialType}}</span>, defaulting to


### PR DESCRIPTION
needed to authenticate to a TURN server
close #2415


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2416.html" title="Last updated on Jan 7, 2020, 5:29 PM UTC (5587263)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2416/e9065b3...5587263.html" title="Last updated on Jan 7, 2020, 5:29 PM UTC (5587263)">Diff</a>