### PR TITLE
Use ReSpec shortcut for internal and external references

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -61,7 +61,7 @@
 
     <p>The following features are marked as at risk:</p>
     <ul>
-      <li>All attributes defined in <code><a>RTCError</a></code>: <code>errorDetail</code>, <code>sdpLineNumber</code>, <code>httpRequestStatusCode</code>, <code>sctpCauseCode</code>, <code>receivedAlert</code> and <code>sentAlert</code>.</li>
+      <li>All attributes defined in {{RTCError}}: <code>errorDetail</code>, <code>sdpLineNumber</code>, <code>httpRequestStatusCode</code>, <code>sctpCauseCode</code>, <code>receivedAlert</code> and <code>sentAlert</code>.</li>
     </ul>
   </section>
   <section class="informative" id="intro">
@@ -98,46 +98,32 @@
   </section>
   <section>
     <h2>Terminology</h2>
-    <p>The <code><a data-cite=
-    "!HTML/webappapis.html#eventhandler">EventHandler</a></code>
-    interface, representing a callback used for event handlers, and the
-    <code><dfn data-cite="!HTML/webappapis.html#errorevent">
-    ErrorEvent</dfn></code> interface are defined in [[!HTML]].</p>
-    <p>The concepts <dfn data-cite="!HTML/webappapis.html#queue-a-task">queue a
-    task</dfn> and <dfn data-cite="!HTML/webappapis.html#networking-task-source">networking
-    task source</dfn> are defined in [[!HTML]].</p>
-    <p>The concept <dfn data-cite="!DOM#firing-events">fire an
-        event</dfn> is defined in [[!DOM]].</p>
-    <p>The terms <dfn>event</dfn>, <dfn data-cite="!HTML/webappapis.html#event-handlers">event
-    handlers</dfn> and <dfn data-cite="!HTML/webappapis.html#event-handler-event-type">event
-    handler event types</dfn> are defined in [[!HTML]].</p>
-    <p><code><dfn data-cite="!hr-time#dom-performance-timeorigin">performance.timeOrigin</dfn></code>
-    and <code><dfn data-cite="!hr-time#dom-performance-now">performance.now()</dfn></code>
-    are defined in [[!hr-time]].</p>
-    <p>The terms <dfn><a href=
-    "https://html.spec.whatwg.org/multipage/infrastructure.html#serializable-objects">
-    serializable objects</a></dfn>, <dfn><a href=
-    "https://html.spec.whatwg.org/multipage/infrastructure.html#serialization-steps">
-    serialization steps</a></dfn>, and <dfn><a href=
-    "https://html.spec.whatwg.org/multipage/infrastructure.html#deserialization-steps">
-    deserialization steps</a></dfn> are defined in [[!HTML]].</p>
-    <p>The terms <dfn>MediaStream</dfn>, <dfn>MediaStreamTrack</dfn>, and
-    <dfn>MediaStreamConstraints</dfn> are defined in [[!GETUSERMEDIA]].
-    Note that <code><a>MediaStream</a></code> is extended in <code><a href="#mediastream-network-use">
-    the MediaStream section</a></code> in this document while <code><a>MediaStreamTrack</a></code>
-    is extended in <code><a href="#mediastreamtrack-network-use">
-    the MediaStreamTrack section</a></code> in this document.</p>
-    <p>The term <dfn>Blob</dfn> is defined in [[!FILEAPI]].</p>
+    <p>The {{EventHandler}}
+    interface, representing a callback used for event handlers, is defined in [[!HTML]].</p>
+    <p>The concepts [= queue a
+    task =] and [= networking
+    task source =] are defined in [[!HTML]].</p>
+    <p>The concept [= fire an event =] is defined in [[!DOM]].</p>
+    <p>The terms [= event =], [= event handlers =] and [= event
+    handler event types =] are defined in [[!HTML]].</p>
+    <p>{{Performance.timeOrigin}} and {{Performance.now()}} are defined in [[!hr-time]].</p>
+    <p>The terms [= serializable objects =], [=
+    serialization steps =], and [=
+    deserialization steps =] are defined in [[!HTML]].</p>
+    <p>The terms {{MediaStream}}, {{MediaStreamTrack}}, and
+    {{MediaStreamConstraints}} are defined in [[!GETUSERMEDIA]].
+    Note that {{MediaStream}} is extended in <a href="#mediastream-network-use"></a> in this document while {{MediaStreamTrack}}
+    is extended in <a href="#mediastreamtrack-network-use"></a>
+     in this document.</p>
+    <p>The term {{Blob}} is defined in [[!FILEAPI]].</p>
     <p>The term <dfn>media description</dfn> is defined in [[!RFC4566]].</p>
     <p>The term <dfn>media transport</dfn> is defined in [[!RFC7656]].</p>
     <p>The term <dfn>generation</dfn> is defined in [[!TRICKLE-ICE]] Section 2.</p>
-    <p>The terms <dfn data-cite="!WEBRTC-STATS#dom-rtcstatstype">RTCStatsType</dfn>, <dfn data-cite="!WEBRTC-STATS#dfn-stats-object">stats object</dfn> and <dfn data-cite="!WEBRTC-STATS#dfn-monitored-object">monitored object</dfn> are defined in [[!WEBRTC-STATS]].
-    <p>When referring to exceptions, the terms <dfn
-    data-cite="!WEBIDL#dfn-throw">throw</dfn> and
-    <dfn data-dfn-for="exception" data-cite=
-    "!WEBIDL#dfn-create-exception">create</dfn> are
+    <p>The terms <dfn data-cite="!WEBRTC-STATS#dfn-stats-object">stats object</dfn> and <dfn data-cite="!WEBRTC-STATS#dfn-monitored-object">monitored object</dfn>, the dictionaries <dfn data-cite="!WEBRTC-STATS#dom-rtcstatstype">RTCStatsType</dfn>, <dfn data-cite="WEBRTC-STATS#dom-rtcinboundrtpstreamstats">RTCInboundRtpStreamStats</dfn>, <dfn data-cite="WEBRTC-STATS#dom-rtcoutboundrtpstreamstats">RTCOutboundRtpStreamStats</dfn> are defined in [[!WEBRTC-STATS]].</p>
+    <p>When referring to exceptions, the terms [= exception/throw =] and
+    [= exception/create =] are
     defined in [[!WEBIDL]].</p>
-    <p>The callback <dfn data-cite="!WEBIDL#VoidFunction">VoidFunction</dfn> is defined in [[!WEBIDL]].</p>
+    <p>The callback {{VoidFunction}} is defined in [[!WEBIDL]].</p>
     <p>The term "throw" is used as specified in [[!INFRA]]: it terminates
       the current processing steps.
     </p>
@@ -169,9 +155,9 @@
     <h2>Peer-to-peer connections</h2>
     <section>
       <h3>Introduction</h3>
-      <p>An <code><a>RTCPeerConnection</a></code> instance allows an
+      <p>An {{RTCPeerConnection}} instance allows an
       application to establish peer-to-peer communications with another
-      <code><a>RTCPeerConnection</a></code> instance in another browser, or to
+      {{RTCPeerConnection}} instance in another browser, or to
       another endpoint implementing the required protocols. Communications are coordinated by the
       exchange of control messages (called a signaling protocol) over a
       signaling channel which is provided by unspecified means, but generally
@@ -182,9 +168,9 @@
       <h3>Configuration</h3>
       <section>
         <h4><dfn>RTCConfiguration</dfn> Dictionary</h4>
-        <p>The <code>RTCConfiguration</code> defines a set of parameters to
+        <p>The {{RTCConfiguration}} defines a set of parameters to
         configure how the peer-to-peer communication established via
-        <code><a>RTCPeerConnection</a></code> is established or
+        {{RTCPeerConnection}} is established or
         re-established.</p>
         <div>
           <pre class="idl"
@@ -197,62 +183,61 @@
   [EnforceRange] octet iceCandidatePoolSize = 0;
 };</pre>
           <section>
-            <h2>Dictionary <a class="idlType">RTCConfiguration</a> Members</h2>
+            <h2>Dictionary {{RTCConfiguration}} Members</h2>
             <dl data-link-for="RTCConfiguration" data-dfn-for=
             "RTCConfiguration" class="dictionary-members">
-              <dt data-tests="RTCConfiguration-iceServers.html"><dfn data-idl><code>iceServers</code></dfn> of type <span class=
-              "idlMemberType">sequence&lt;<a>RTCIceServer</a>&gt;</span></dt>
+              <dt data-tests="RTCConfiguration-iceServers.html"><dfn data-idl>iceServers</dfn> of type <span class=
+              "idlMemberType">sequence&lt;{{RTCIceServer}}&gt;</span></dt>
               <dd>
                 <p>An array of objects describing servers available to be used
                 by ICE, such as STUN and TURN servers.</p>
               </dd>
-              <dt data-tests="RTCConfiguration-iceTransportPolicy.html"><dfn data-idl><code>iceTransportPolicy</code></dfn> of type
-              <span class="idlMemberType"><a>RTCIceTransportPolicy</a></span>.</dt>
+              <dt data-tests="RTCConfiguration-iceTransportPolicy.html"><dfn data-idl>iceTransportPolicy</dfn> of type
+              <span class="idlMemberType">{{RTCIceTransportPolicy}}</span>.</dt>
               <dd>
-                <p>Indicates which candidates the <a>ICE Agent</a> is allowed
+                <p>Indicates which candidates the [= ICE Agent =] is allowed
                 to use.</p>
               </dd>
-              <dt data-tests="RTCConfiguration-bundlePolicy.html,RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl><code>bundlePolicy</code></dfn> of type <span class=
-              "idlMemberType"><a>RTCBundlePolicy</a></span>.</dt>
+              <dt data-tests="RTCConfiguration-bundlePolicy.html,RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl>bundlePolicy</dfn> of type <span class=
+              "idlMemberType">{{RTCBundlePolicy}}</span>.</dt>
               <dd>
                 <p>Indicates which <a data-lt=RTCBundlePolicy>media-bundling policy</a> to use when
                 gathering ICE candidates.</p>
               </dd>
-              <dt><dfn data-idl><code>rtcpMuxPolicy</code></dfn> of type <span class=
-              "idlMemberType"><a>RTCRtcpMuxPolicy</a></span>.</dt>
+              <dt><dfn data-idl>rtcpMuxPolicy</dfn> of type <span class=
+              "idlMemberType">{{RTCRtcpMuxPolicy}}</span>.</dt>
               <dd>
                 <p>Indicates which <a data-lt=RTCRtcpMuxPolicy>rtcp-mux policy</a> to use when gathering
                 ICE candidates.</p>
               </dd>
-              <dt data-tests="RTCPeerConnection-constructor.html"><dfn data-idl><code>certificates</code></dfn> of type <span class=
-              "idlMemberType">sequence&lt;<a>RTCCertificate</a>&gt;</span></dt>
+              <dt data-tests="RTCPeerConnection-constructor.html"><dfn data-idl>certificates</dfn> of type <span class=
+              "idlMemberType">sequence&lt;{{RTCCertificate}}&gt;</span></dt>
               <dd>
                 <p>A set of certificates that the
-                <a>RTCPeerConnection</a> uses to authenticate.</p>
+                {{RTCPeerConnection}} uses to authenticate.</p>
                 <p>Valid values for this parameter are created through calls to
-                the <a data-link-for=
-                "RTCPeerConnection">generateCertificate</a>
+                the {{RTCPeerConnection/generateCertificate()}}
                 function.</p>
                 <p>Although any given DTLS connection will use only one
                 certificate, this attribute allows the caller to provide
                 multiple certificates that support different algorithms. The
                 final certificate will be selected based on the DTLS handshake,
                 which establishes which certificates are allowed. The
-                <code>RTCPeerConnection</code> implementation selects which of
+                {{RTCPeerConnection}} implementation selects which of
                 the certificates is used for a given connection; how
                 certificates are selected is outside the scope of this
                 specification.</p>
                 <p>If this value is absent, then a default set of certificates
-                is generated for each <a>RTCPeerConnection</a>
+                is generated for each {{RTCPeerConnection}}
                 instance.</p>
                 <p>This option allows applications to establish key continuity.
-                An <code>RTCCertificate</code> can be persisted in
+                An {{RTCCertificate}} can be persisted in
                 [[?INDEXEDDB]] and reused. Persistence and reuse also avoids the
                 cost of key generation.</p>
                 <p>The value for this configuration option cannot change after
                 its value is initially selected.</p>
               </dd>
-              <dt data-tests="RTCPeerConnection-constructor.html"><dfn data-idl><code>iceCandidatePoolSize</code></dfn> of type
+              <dt data-tests="RTCPeerConnection-constructor.html"><dfn data-idl>iceCandidatePoolSize</dfn> of type
               <span class="idlMemberType">octet</span>, defaulting to
               <code>0</code></dt>
               <dd>
@@ -278,7 +263,7 @@
                 <th colspan="2">Enumeration description</th>
               </tr>
               <tr>
-                <td data-tests="RTCConfiguration-iceServers.html"><dfn data-idl><code>password</code></dfn></td>
+                <td data-tests="RTCConfiguration-iceServers.html"><dfn data-idl>password</dfn></td>
                 <td>The credential is a long-term authentication username and
                 password, as described in [[!RFC5389]], Section 10.2.
                 </td>
@@ -289,8 +274,8 @@
       </section>
       <section>
          <h4><dfn>RTCIceServer</dfn> Dictionary</h4>
-        <p>The <code>RTCIceServer</code> dictionary is used to describe the
-        STUN and TURN servers that can be used by the <a>ICE Agent</a> to
+        <p>The {{RTCIceServer}} dictionary is used to describe the
+        STUN and TURN servers that can be used by the [= ICE Agent =] to
         establish a connection with a peer.</p>
         <div>
           <pre class="idl"
@@ -300,29 +285,29 @@
   RTCIceCredentialType credentialType = "password";
 };</pre>
           <section>
-            <h2>Dictionary <a class="idlType">RTCIceServer</a> Members</h2>
+            <h2>Dictionary {{RTCIceServer}} Members</h2>
             <dl data-link-for="RTCIceServer" data-dfn-for="RTCIceServer" class=
             "dictionary-members">
-              <dt><dfn data-idl><code>urls</code></dfn> of type <span class=
+              <dt><dfn data-idl>urls</dfn> of type <span class=
               "idlMemberType">(DOMString or
               sequence&lt;DOMString&gt;)</span>, required</dt>
               <dd>
                 <p>STUN or TURN URI(s) as defined in [[!RFC7064]] and
                 [[!RFC7065]] or other URI types.</p>
               </dd>
-              <dt><dfn data-idl><code>username</code></dfn> of type <span class=
+              <dt><dfn data-idl>username</dfn> of type <span class=
               "idlMemberType">DOMString</span></dt>
               <dd>
-                <p>If this <code><a>RTCIceServer</a></code> object represents a
+                <p>If this {{RTCIceServer}} object represents a
                 TURN server, and <code>credentialType</code> is
                 <code>"password"</code>, then this attribute specifies the
                 username to use with that TURN server.</p>
               </dd>
-              <dt><dfn data-idl><code>credentialType</code></dfn> of type <span class=
-              "idlMemberType"><a>RTCIceCredentialType</a></span>, defaulting to
+              <dt><dfn data-idl>credentialType</dfn> of type <span class=
+              "idlMemberType">{{RTCIceCredentialType}}</span>, defaulting to
               <code>"password"</code></dt>
               <dd>
-                <p>If this <code><a>RTCIceServer</a></code> object represents a
+                <p>If this {{RTCIceServer}} object represents a
                 TURN server, then this attribute specifies how
                 <var>credential</var> should be used when that TURN server
                 requests authorization.</p>
@@ -344,8 +329,8 @@
       <section data-tests="RTCConfiguration-iceTransportPolicy.html">
         <h4><dfn>RTCIceTransportPolicy</dfn> Enum</h4>
         <p>As described in <span data-jsep="constructor">[[!JSEP]]</span>, if the
-        <a data-link-for='RTCConfiguration'>iceTransportPolicy</a> member of
-        the <code>RTCConfiguration</code> is specified, it defines the
+        {{RTCConfiguration/iceTransportPolicy}} member of
+        the {{RTCConfiguration}} is specified, it defines the
         <span data-jsep="ice-candidate-policy">ICE candidate policy
         [[!JSEP]]</span> the browser uses to surface the permitted candidates
         to the application; only these candidates will be used for connectivity
@@ -363,10 +348,10 @@
                 <th colspan="2">Enumeration description (non-normative)</th>
               </tr>
               <tr>
-                <td><dfn data-idl><code>relay</code></dfn></td>
+                <td><dfn data-idl>relay</dfn></td>
                 <td>
                   <p>
-                    The <a>ICE Agent</a> uses only media relay candidates
+                    The [= ICE Agent =] uses only media relay candidates
                     such as candidates passing through a TURN server.
                   </p>
                   <div class="note">
@@ -380,17 +365,17 @@
                 </td>
               </tr>
               <tr>
-                <td><dfn data-idl><code>all</code></dfn></td>
+                <td><dfn data-idl>all</dfn></td>
                 <td>
                   <p>
-                    The <a>ICE Agent</a> can use any type of candidate when
+                    The [= ICE Agent =] can use any type of candidate when
                     this value is specified.
                   </p>
                   <div class="note">
                     The implementation can still use its own candidate
                     filtering policy in order to limit the IP addresses exposed
                     to the application, as noted in the description of
-                    <code>RTCIceCandidate.<a data-link-for="RTCIceCandidate">address</a></code>.
+                    {{RTCIceCandidate}}.{{RTCIceCandidate/address}}.
                   </div>
                 </td>
               </tr>
@@ -419,20 +404,20 @@
                 <th colspan="2">Enumeration description (non-normative)</th>
               </tr>
               <tr>
-                <td data-tests="RTCRtpSender-transport.https.html,RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl><code>balanced</code></dfn></td>
+                <td data-tests="RTCRtpSender-transport.https.html,RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl>balanced</dfn></td>
                 <td>Gather ICE candidates for each media type in use (audio,
                 video, and data). If the remote endpoint is not bundle-aware,
                 negotiate only one audio and video track on separate
                 transports.</td>
               </tr>
               <tr>
-                <td data-tests="RTCRtpSender-transport.https.html,RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl><code>max-compat</code></dfn></td>
+                <td data-tests="RTCRtpSender-transport.https.html,RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl>max-compat</dfn></td>
                 <td>Gather ICE candidates for each track. If the remote
                 endpoint is not bundle-aware, negotiate all media tracks on
                 separate transports.</td>
               </tr>
               <tr>
-                <td data-tests="RTCRtpSender-transport.https.html,RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl><code>max-bundle</code></dfn></td>
+                <td data-tests="RTCRtpSender-transport.https.html,RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl>max-bundle</dfn></td>
                 <td>Gather ICE candidates for only one track. If the remote
                 endpoint is not bundle-aware, negotiate only one media
                 track.</td>
@@ -459,7 +444,7 @@
                 <th colspan="2">Enumeration description (non-normative)</th>
               </tr>
               <tr>
-                <td><dfn data-idl><code>require</code></dfn></td>
+                <td><dfn data-idl>require</dfn></td>
                 <td>Gather ICE candidates only for RTP and multiplex RTCP on
                 the RTP candidates. If the remote endpoint is not capable of
                 rtcp-mux, session negotiation will fail.</td>
@@ -492,36 +477,33 @@
             <h2>Dictionary <dfn>RTCOfferOptions</dfn> Members</h2>
             <dl data-link-for="RTCOfferOptions" data-dfn-for="RTCOfferOptions"
             class="dictionary-members">
-              <dt><dfn data-idl><code>iceRestart</code></dfn> of type <span class=
+              <dt><dfn data-idl>iceRestart</dfn> of type <span class=
                 "idlMemberType">boolean</span>, defaulting to
               <code>false</code></dt>
               <dd>
                 <p>When the value of this dictionary member is <code>true</code>,
-                or the relevant <code><a>RTCPeerConnection</a></code> object's
+                or the relevant {{RTCPeerConnection}} object's
                 <a>[[\LocalIceCredentialsToReplace]]</a> slot is not empty, then
                 the generated description will have ICE credentials that are
                 different from the current credentials (as visible in the
-                <code><a data-link-for=
-                "RTCPeerConnection">currentLocalDescription</a></code> attribute's
+                {{RTCPeerConnection/currentLocalDescription}} attribute's
                 SDP). Applying the generated description will restart ICE, as
                 described in section 9.1.1.1 of [[!ICE]].</p>
                 <p>When the value of this dictionary member is <code>false</code>,
-                and the relevant <code><a>RTCPeerConnection</a></code> object's
+                and the relevant {{RTCPeerConnection}} object's
                 <a>[[\LocalIceCredentialsToReplace]]</a> slot is empty,
-                and the <code><a data-link-for=
-                "RTCPeerConnection">currentLocalDescription</a></code> attribute has
+                and the {{RTCPeerConnection/currentLocalDescription}} attribute has
                 valid ICE credentials, then the generated description will have the
                 same ICE credentials as the current value from the
-                <code><a data-link-for=
-                "RTCPeerConnection">currentLocalDescription</a></code> attribute.</p>
+                {{RTCPeerConnection/currentLocalDescription}} attribute.</p>
                 <p class="note">Performing an ICE restart is recommended when
-                <code><a data-link-for="RTCPeerConnection">iceConnectionState</a></code> transitions to
-                <code>"<a data-link-for="RTCIceConnectionState">failed</a>"</code>.
+                {{RTCPeerConnection/iceConnectionState}} transitions to
+                "{{RTCIceConnectionState/failed}}".
                 An application may additionally choose to listen for the
-                <code><a data-link-for="RTCPeerConnection">iceConnectionState</a></code> transition to
-                <code>"<a data-link-for="RTCIceConnectionState">disconnected</a>"</code>
+                {{RTCPeerConnection/iceConnectionState}} transition to
+                "{{RTCIceConnectionState/disconnected}}"
                 and then use other sources of information (such as using
-                <code><a data-link-for="RTCPeerConnection">getStats</a></code> to measure if the number of bytes sent
+                {{RTCPeerConnection/getStats}} to measure if the number of bytes sent
                 or received over the next couple of seconds increases) to determine
                 whether an ICE restart is advisable.</p>
               </dd>
@@ -556,37 +538,37 @@
                 <th colspan="2">Enumeration description</th>
               </tr>
               <tr>
-                <td data-tests="RTCPeerConnection-onsignalingstatechanged.https.html,RTCPeerConnection-setRemoteDescription.html"><dfn data-idl><code>stable</code></dfn></td>
+                <td data-tests="RTCPeerConnection-onsignalingstatechanged.https.html,RTCPeerConnection-setRemoteDescription.html"><dfn data-idl>stable</dfn></td>
                 <td>There is no offer/answer exchange in progress. This is
                 also the initial state, in which case the local and remote
                 descriptions are empty.</td>
               </tr>
               <tr>
-                <td data-tests="RTCPeerConnection-createOffer.html, RTCPeerConnection-setLocalDescription-offer.html,RTCPeerConnection-setLocalDescription.html,RTCPeerConnection-setRemoteDescription.html"><dfn data-idl><code>have-local-offer</code></dfn></td>
+                <td data-tests="RTCPeerConnection-createOffer.html, RTCPeerConnection-setLocalDescription-offer.html,RTCPeerConnection-setLocalDescription.html,RTCPeerConnection-setRemoteDescription.html"><dfn data-idl>have-local-offer</dfn></td>
                 <td>A local description, of type <code>"offer"</code>, has been successfully
                 applied.</td>
               </tr>
               <tr>
-                <td data-tests="RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setRemoteDescription-offer.html,RTCPeerConnection-setRemoteDescription-rollback.html,RTCPeerConnection-setRemoteDescription.html"><dfn data-idl><code>have-remote-offer</code></dfn></td>
+                <td data-tests="RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setRemoteDescription-offer.html,RTCPeerConnection-setRemoteDescription-rollback.html,RTCPeerConnection-setRemoteDescription.html"><dfn data-idl>have-remote-offer</dfn></td>
                 <td>A remote description, of type <code>"offer"</code>, has been
                 successfully applied.</td>
               </tr>
               <tr>
-                <td><dfn data-idl><code>have-local-pranswer</code></dfn></td>
+                <td><dfn data-idl>have-local-pranswer</dfn></td>
                 <td>A remote description of type <code>"offer"</code> has been successfully
                 applied and a local description of type <code>"pranswer"</code> has been
                 successfully applied.</td>
               </tr>
               <tr>
-                <td data-tests="RTCPeerConnection-setRemoteDescription-pranswer.html,RTCPeerConnection-setRemoteDescription.html"><dfn data-idl><code>have-remote-pranswer</code></dfn></td>
+                <td data-tests="RTCPeerConnection-setRemoteDescription-pranswer.html,RTCPeerConnection-setRemoteDescription.html"><dfn data-idl>have-remote-pranswer</dfn></td>
                 <td>A local description of type <code>"offer"</code> has been successfully
                 applied and a remote description of type <code>"pranswer"</code> has been
                 successfully applied.</td>
               </tr>
               <tr>
-                <td><dfn data-idl><code>closed</code></dfn></td>
-                <td>The <code><a>RTCPeerConnection</a></code> has been closed;
-                its <a>[[\IsClosed]]</a> slot is <code>true</code>.</td>
+                <td><dfn data-idl>closed</dfn></td>
+                <td>The {{RTCPeerConnection}} has been closed;
+                  its <a>[[\IsClosed]]</a> slot is <code>true</code>.</td>
               </tr>
             </tbody>
           </table>
@@ -636,21 +618,21 @@
                 <th colspan="2">Enumeration description</th>
               </tr>
               <tr>
-                <td data-tests="RTCPeerConnection-iceGatheringState.html"><dfn data-idl><code>new</code></dfn></td>
-                <td>Any of the <code><a>RTCIceTransport</a></code>s are in the
+                <td data-tests="RTCPeerConnection-iceGatheringState.html"><dfn data-idl>new</dfn></td>
+                <td>Any of the {{RTCIceTransport}}s are in the
                 <code>"new"</code> gathering state and none of the transports are
                 in the <code>"gathering"</code> state, or there are no
                 transports.</td>
               </tr>
               <tr>
-                <td data-tests="RTCPeerConnection-iceGatheringState.html"><dfn data-idl><code>gathering</code></dfn></td>
-                <td>Any of the <code><a>RTCIceTransport</a></code>s are in the
+                <td data-tests="RTCPeerConnection-iceGatheringState.html"><dfn data-idl>gathering</dfn></td>
+                <td>Any of the {{RTCIceTransport}}s are in the
                 <code>"gathering"</code> state.</td>
               </tr>
               <tr>
-                <td data-tests="RTCPeerConnection-iceGatheringState.html,protocol/candidate-exchange.https.html "><dfn data-idl><code>complete</code></dfn></td>
-                <td>At least one <code><a>RTCIceTransport</a></code> exists,
-                and all <code><a>RTCIceTransport</a></code>s are in the
+                <td data-tests="RTCPeerConnection-iceGatheringState.html,protocol/candidate-exchange.https.html "><dfn data-idl>complete</dfn></td>
+                <td>At least one {{RTCIceTransport}} exists,
+                and all {{RTCIceTransport}}s are in the
                 <code>"completed"</code> gathering state.</td>
               </tr>
             </tbody>
@@ -676,46 +658,46 @@
                 <th colspan="2">Enumeration description</th>
               </tr>
               <tr>
-                <td><dfn data-idl><code>closed</code></dfn></td>
+                <td><dfn data-idl>closed</dfn></td>
                 <td>
-                  The <code><a>RTCPeerConnection</a></code> object's
+                  The {{RTCPeerConnection}} object's
                   <a>[[\IsClosed]]</a> slot is <code>true</code>.
                 </td>
               </tr>
               <tr>
-                <td data-tests="protocol/dtls-fingerprint-validation.html"><dfn data-idl><code>failed</code></dfn></td>
+                <td data-tests="protocol/dtls-fingerprint-validation.html"><dfn data-idl>failed</dfn></td>
                 <td>The previous state doesn't apply and any
-                <code><a>RTCIceTransport</a></code>s or
-                <code><a>RTCDtlsTransport</a></code>s are in the
+                {{RTCIceTransport}}s or
+                {{RTCDtlsTransport}}s are in the
                 <code>"failed"</code> state.</td>
               </tr>
               <tr>
-                <td><dfn data-idl><code>disconnected</code></dfn></td>
+                <td><dfn data-idl>disconnected</dfn></td>
                 <td>None of the previous states apply and any
-                <code><a>RTCIceTransport</a></code>s or
-                <code><a>RTCDtlsTransport</a></code>s are in the
+                {{RTCIceTransport}}s or
+                {{RTCDtlsTransport}}s are in the
                 <code>"disconnected"</code> state.</td>
               </tr>
               <tr>
-                <td><dfn data-idl><code>new</code></dfn></td>
+                <td><dfn data-idl>new</dfn></td>
                 <td>None of the previous states apply and all
-                <code><a>RTCIceTransport</a></code>s and
-                <code><a>RTCDtlsTransport</a></code>s are in the
+                {{RTCIceTransport}}s and
+                {{RTCDtlsTransport}}s are in the
                 <code>"new"</code> or <code>"closed"</code> state, or there are
                 no transports.</td>
               </tr>
               <tr>
-                <td data-tests="RTCPeerConnection-connectionState.https.html"><dfn data-idl><code>connecting</code></dfn></td>
+                <td data-tests="RTCPeerConnection-connectionState.https.html"><dfn data-idl>connecting</dfn></td>
                 <td>None of the previous states apply and all
-                <code><a>RTCIceTransport</a></code>s or
-                <code><a>RTCDtlsTransport</a></code>s are in the
+                {{RTCIceTransport}}s or
+                {{RTCDtlsTransport}}s are in the
                 <code>"new"</code>, <code>"connecting"</code> or <code>"checking"</code> state.</td>
               </tr>
               <tr>
-                <td data-tests="RTCPeerConnection-connectionState.https.html"><dfn data-idl><code>connected</code></dfn></td>
+                <td data-tests="RTCPeerConnection-connectionState.https.html"><dfn data-idl>connected</dfn></td>
                 <td>None of the previous states apply and all
-                <code><a>RTCIceTransport</a></code>s and
-                <code><a>RTCDtlsTransport</a></code>s are in the
+                {{RTCIceTransport}}s and
+                {{RTCDtlsTransport}}s are in the
                 <code>"connected"</code>, <code>"completed"</code> or
                 <code>"closed"</code> state.</td>
               </tr>
@@ -743,104 +725,104 @@
                 <th colspan="2">Enumeration description</th>
               </tr>
               <tr>
-                <td data-tests="RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl><code>closed</code></dfn></td>
+                <td data-tests="RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl>closed</dfn></td>
                 <td>
-                  The <code><a>RTCPeerConnection</a></code> object's
+                  The {{RTCPeerConnection}} object's
                   <a>[[\IsClosed]]</a> slot is <code>true</code>.
                 </td>
               </tr>
               <tr>
-                <td data-tests="RTCPeerConnection-iceConnectionState-disconnected.https.html,protocol/ice-state.https.html"><dfn data-idl><code>failed</code></dfn></td>
+                <td data-tests="RTCPeerConnection-iceConnectionState-disconnected.https.html,protocol/ice-state.https.html"><dfn data-idl>failed</dfn></td>
                 <td>The previous state doesn't apply and any
-                <code><a>RTCIceTransport</a></code>s are in the
+                {{RTCIceTransport}}s are in the
                 <code>"failed"</code> state.</td>
               </tr>
               <tr>
-                <td data-tests="RTCPeerConnection-iceConnectionState-disconnected.https.html,protocol/ice-state.https.html"><dfn data-idl><code>disconnected</code></dfn></td>
+                <td data-tests="RTCPeerConnection-iceConnectionState-disconnected.https.html,protocol/ice-state.https.html"><dfn data-idl>disconnected</dfn></td>
                 <td>None of the previous states apply and any
-                <code><a>RTCIceTransport</a></code>s are in the
+                {{RTCIceTransport}}s are in the
                 <code>"disconnected"</code> state.</td>
               </tr>
               <tr>
-                <td data-tests="RTCPeerConnection-iceConnectionState.https.html,no-media-call.html"><dfn data-idl><code>new</code></dfn></td>
+                <td data-tests="RTCPeerConnection-iceConnectionState.https.html,no-media-call.html"><dfn data-idl>new</dfn></td>
                 <td>None of the previous states apply and all
-                <code><a>RTCIceTransport</a></code>s are in the
+                {{RTCIceTransport}}s are in the
                 <code>"new"</code> or <code>"closed"</code> state,
                 or there are no transports.</td>
               </tr>
               <tr>
-                <td data-tests="RTCPeerConnection-iceConnectionState.https.html,no-media-call.html"><dfn data-idl><code>checking</code></dfn></td>
+                <td data-tests="RTCPeerConnection-iceConnectionState.https.html,no-media-call.html"><dfn data-idl>checking</dfn></td>
                 <td>None of the previous states apply and any
-                <code><a>RTCIceTransport</a></code>s are in the
+                {{RTCIceTransport}}s are in the
                 <code>"new"</code> or <code>"checking"</code> state.</td>
               </tr>
               <tr>
-                <td data-tests="RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl><code>completed</code></dfn></td>
+                <td data-tests="RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl>completed</dfn></td>
                 <td>None of the previous states apply and all
-                <code><a>RTCIceTransport</a></code>s are in the
+                {{RTCIceTransport}}s are in the
                 <code>"completed"</code> or <code>"closed"</code> state.</td>
               </tr>
               <tr>
-                <td data-tests="RTCPeerConnection-iceConnectionState.https.html,protocol/ice-state.https.html,RTCIceConnectionState-candidate-pair.https.html"><dfn data-idl><code>connected</code></dfn></td>
+                <td data-tests="RTCPeerConnection-iceConnectionState.https.html,protocol/ice-state.https.html,RTCIceConnectionState-candidate-pair.https.html"><dfn data-idl>connected</dfn></td>
                 <td>None of the previous states apply and all
-                <code><a>RTCIceTransport</a></code>s are in the
+                {{RTCIceTransport}}s are in the
                 <code>"connected"</code>, <code>"completed"</code> or
                 <code>"closed"</code> state.</td>
               </tr>
             </tbody>
           </table>
         </div>
-        <p>Note that if an <code><a>RTCIceTransport</a></code> is discarded as
+        <p>Note that if an {{RTCIceTransport}} is discarded as
         a result of signaling (e.g. RTCP mux or bundling), or created as a
-        result of signaling (e.g. adding a new <a>media description</a>), the
+        result of signaling (e.g. adding a new [= media description =]), the
         state may advance directly from one state to another.</p>
       </section>
     </section>
     <section>
       <h3>RTCPeerConnection Interface</h3>
       <p>The [[!JSEP]] specification, as a whole, describes the details of how
-      the <code><a>RTCPeerConnection</a></code> operates. References to
+      the {{RTCPeerConnection}} operates. References to
       specific subsections of [[!JSEP]] are provided as appropriate.</p>
       <section>
         <h4>Operation</h4>
-        <p>Calling <code>new <a>RTCPeerConnection</a>(<var>configuration</var>)
-        </code> creates an <code><a>RTCPeerConnection</a></code> object.</p>
+        <p>Calling <code>new {{RTCPeerConnection}}(<var>configuration</var>)
+        </code> creates an {{RTCPeerConnection}} object.</p>
         <p><code><var>configuration</var>.servers</code> contains information
         used to find and access the servers used by ICE. The application can
         supply multiple servers of each type, and any TURN server MAY also be
         used as a STUN server for the purposes of gathering server reflexive
         candidates.</p>
-        <p>An <code><a>RTCPeerConnection</a></code> object has a <dfn>signaling
+        <p>An {{RTCPeerConnection}} object has a <dfn>signaling
         state</dfn>, a <dfn>connection state</dfn>, an <dfn>ICE gathering
         state</dfn>, and an <dfn>ICE connection state</dfn>. These are
         initialized when the object is created.</p>
 
         <p data-link-for="RTCPeerConnection">The ICE protocol implementation of
-        an <code><a>RTCPeerConnection</a></code> is represented by an <dfn>ICE
-        agent</dfn> [[!ICE]]. Certain <code><a>RTCPeerConnection</a></code>
-        methods involve interactions with the <a>ICE Agent</a>, namely
-        <code><a>addIceCandidate</a></code>, <code><a>setConfiguration</a></code>,
-        <code><a>setLocalDescription</a></code>,
-        <code><a>setRemoteDescription</a></code> and <code><a>close</a></code>.
+        an {{RTCPeerConnection}} is represented by an <dfn>ICE
+        agent</dfn> [[!ICE]]. Certain {{RTCPeerConnection}}
+        methods involve interactions with the [= ICE Agent =], namely
+        {{addIceCandidate}}, {{setConfiguration}},
+        {{setLocalDescription}},
+        {{setRemoteDescription}} and {{close}}.
         These interactions are described in the relevant sections in this
-        document and in [[!JSEP]]. The <a>ICE Agent</a> also provides
+        document and in [[!JSEP]]. The [= ICE Agent =] also provides
         indications to the user agent when the state of its internal
-        representation of an <code><a>RTCIceTransport</a></code> changes, as
+        representation of an {{RTCIceTransport}} changes, as
         described in <a href= "#rtcicetransport"></a>.</p>
 
         <p>The task source for the tasks listed in this section is the
-        <a>networking task source</a>.</p>
+        [= networking task source =].</p>
 
         <p class="note" data-link-for="RTCPeerConnection">The state of the SDP
           negotiation is represented by
-        the <a>connection state</a> and the internal
+        the [= connection state =] and the internal
         variables <a>[[\CurrentLocalDescription]]</a>,
         <a>[[\CurrentRemoteDescription]]</a>, <a>[[\PendingLocalDescription]]</a>
         and <a>[[\PendingRemoteDescription]]</a>. These are only set
-        inside the <code><a>setLocalDescription</a></code>
-        and <code><a>setRemoteDescription</a></code> operations, and
-        modified by the <code><a>addIceCandidate</a></code> operation and
-        the <a>surface a candidate</a> procedure. In each case, all
+        inside the {{setLocalDescription}}
+        and {{setRemoteDescription}} operations, and
+        modified by the {{addIceCandidate}} operation and
+        the [= surface a candidate =] procedure. In each case, all
         the modifications to all the five variables are completed
         before the procedures fire any events or invoke any callbacks,
         so the modifications are made visible at a single point in time.</p>
@@ -853,20 +835,17 @@
         <ol>
           <li>
             <p>If any of the steps enumerated below fails for a reason not
-              specified here, <a>throw</a> an <code>UnknownError</code>
+              specified here, [= exception/throw =] an {{UnknownError}}
               with the "message" field set to an appropriate description.
             </p>
           </li>
           <li>
             <p>Let <var>connection</var> be a newly created
-            <code><a>RTCPeerConnection</a></code> object.</p>
+            {{RTCPeerConnection}} object.</p>
           </li>
           <li>
             <p>Let <var>connection</var> have a <dfn>[[\DocumentOrigin]]</dfn>
-            internal slot, initialized to the <a
-            href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">
-            current settings object</a>'s <a
-            href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">
+            internal slot, initialized to the <a data-cite="html">current settings object</a>'s <a data-cite="html#concept-settings-object-origin">
             origin</a>.</p>
           </li>
           <li data-tests="RTCCertificate.html">
@@ -876,13 +855,12 @@
             <ol>
               <li>
                 <p>If the value of <var>certificate</var>.<code>expires</code>
-                is less than the current time, <a>throw</a> an
-                <code>InvalidAccessError</code>.</p> </li>
+                is less than the current time, [= exception/throw =] an
+                {{InvalidAccessError}}.</p> </li>
               <li>
-                <p>If <var>certificate</var>.<a>[[\Origin]]</a> is not <a
-                href="https://html.spec.whatwg.org/multipage/origin.html#same-origin">same
+                <p>If <var>certificate</var>.<a>[[\Origin]]</a> is not <a data-cite="html">same
                 origin</a> with <var>connection</var>.<a>[[\DocumentOrigin]]</a>,
-                <a>throw</a> an <code>InvalidAccessError</code>.</p>
+                [= exception/throw =] an {{InvalidAccessError}}.</p>
               </li>
               <li>
                 <p>Store <var>certificate</var>.</p>
@@ -890,8 +868,8 @@
             </ol>
           </li>
           <li>
-            <p>Else, generate one or more new <code>RTCCertificate</code> instances
-            with this <code>RTCPeerConnection</code> instance and store them. This MAY happen
+            <p>Else, generate one or more new {{RTCCertificate}} instances
+            with this {{RTCPeerConnection}} instance and store them. This MAY happen
             asynchronously and the value of <code>certificates</code> remains
             <code>undefined</code> for the subsequent steps. As noted in Section 4.3.2.3 of
             [[RTCWEB-SECURITY]], WebRTC utilizes self-signed rather than
@@ -900,26 +878,23 @@
             certificate checks are unnecessary.</p>
           </li>
           <li>
-            <p>Initialize <var>connection</var>'s <a>ICE Agent</a>.</p>
+            <p>Initialize <var>connection</var>'s [= ICE Agent =].</p>
           </li>
           <li>
-            <p>If the value of <code><var>configuration</var>.<a data-link-for=
-            "RTCConfiguration">iceTransportPolicy</a></code> is
+            <p>If the value of <code><var>configuration</var>.{{RTCConfiguration/iceTransportPolicy}}</code> is
             <code>undefined</code>, set it to <code>"all"</code>.</p>
           </li>
           <li>
-            <p>If the value of <code><var>configuration</var>.<a data-link-for=
-            "RTCConfiguration">bundlePolicy</a></code> is
+            <p>If the value of <code><var>configuration</var>.{{RTCConfiguration/bundlePolicy}}</code> is
             <code>undefined</code>, set it to <code>"balanced"</code>.</p>
           </li>
           <li>
-            <p>If the value of <code><var>configuration</var>.<a data-link-for=
-            "RTCConfiguration">rtcpMuxPolicy</a></code> is
+            <p>If the value of <code><var>configuration</var>.{{RTCConfiguration/rtcpMuxPolicy}}</code> is
             <code>undefined</code>, set it to <code>"require"</code>.</p>
           </li>
           <li>
             <p>Let <var>connection</var> have a <dfn>[[\Configuration]]</dfn>
-            internal slot. <a>Set the configuration</a> specified by
+            internal slot. [= Set the configuration =] specified by
             <var>configuration</var>.</p>
           </li>
           <li>
@@ -936,7 +911,7 @@
           </li>
           <li>
             <p>Let <var>connection</var> have an <dfn>[[\Operations]]</dfn>
-            internal slot, representing an <a>operations chain</a>, initialized
+            internal slot, representing an [= operations chain =], initialized
             to an empty list.</p>
           </li>
           <li>
@@ -952,19 +927,19 @@
               internal slot, initialized to an empty list.</p>
           </li>
           <li data-tests="RTCPeerConnection-constructor.html">
-            <p>Set <var>connection</var>'s <a>signaling state</a> to
+            <p>Set <var>connection</var>'s [= signaling state =] to
             <code>"stable"</code>.</p>
           </li>
           <li data-tests="RTCPeerConnection-constructor.html">
-            <p>Set <var>connection</var>'s <a>ICE connection state</a> to
+            <p>Set <var>connection</var>'s [= ICE connection state =] to
             <code>"new"</code>.</p>
           </li>
           <li data-tests="RTCPeerConnection-constructor.html">
-            <p>Set <var>connection</var>'s <a>ICE gathering state</a> to
+            <p>Set <var>connection</var>'s [= ICE gathering state =] to
             <code>"new"</code>.</p>
           </li>
           <li data-tests="RTCPeerConnection-constructor.html">
-            <p>Set <var>connection</var>'s <a>connection state</a> to
+            <p>Set <var>connection</var>'s [= connection state =] to
             <code>"new"</code>.</p>
           </li>
           <li data-tests="RTCPeerConnection-constructor.html">
@@ -1000,27 +975,26 @@
 
         <section>
         <h4>Chain an asynchronous operation</h4>
-        <p>An <code><a>RTCPeerConnection</a></code> object has an
+        <p>An {{RTCPeerConnection}} object has an
         <dfn>operations chain</dfn>, <a>[[\Operations]]</a>, which ensures that
         only one asynchronous operation in the chain executes concurrently.
         If subsequent calls are made while the returned promise of a previous
-        call is still not <a>settled</a>, they are added to the chain and executed
+        call is still not [= settled =], they are added to the chain and executed
         when all the previous calls have finished executing and their promises
-        have <a>settled</a>.</p>
-        <p data-tests="RTCPeerConnection-createOffer.html">To <dfn>chain an operation</dfn> to an
-        <a>RTCPeerConnection</a> object's <a href=
-        "#dfn-operations-chain">operations chain</a>, run
+        have [= settled =].</p>
+        <p data-tests="RTCPeerConnection-createOffer.html">To <dfn data-lt="chain|chaining">chain an operation</dfn> to an
+        {{RTCPeerConnection}} object's [= operations chain =], run
         the following steps:</p>
         <ol>
           <li>
             <p>Let <var>connection</var> be the
-            <code><a>RTCPeerConnection</a></code> object.</p>
+            {{RTCPeerConnection}} object.</p>
           </li>
           <li>
             <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
-            <code>true</code>, return a promise <a>rejected</a> with a newly
-            <a data-link-for="exception" data-lt="create">created</a>
-            <code>InvalidStateError</code>.</p>
+            <code>true</code>, return a promise [= rejected =] with a newly
+            [= exception/create | created =]
+            {{InvalidStateError}}.</p>
           </li>
           <li>
             <p>Let <var>operation</var> be the operation to be chained.</p>
@@ -1036,7 +1010,7 @@
             <var>operation</var>.</p>
           </li>
           <li>
-            <p>Upon <a>fulfillment</a> or <a>rejection</a> of the promise returned by the
+            <p>Upon [= fulfillment =] or [= rejection =] of the promise returned by the
             <var>operation</var>, run the following steps:</p>
             <ol>
               <li>
@@ -1045,15 +1019,15 @@
               </li>
               <li>
                 <p>If the promise returned by <var>operation</var> was
-                <a>fulfilled</a> with a value, <a>fulfill</a> <var>p</var> with that
+                [= fulfilled =] with a value, [= fulfill =] <var>p</var> with that
                 value.</p>
               </li>
               <li>
-                <p>If the promise returned by <var>operation</var> was <a>rejected</a>
-                with a value, <a>reject</a> <var>p</var> with that value.</p>
+                <p>If the promise returned by <var>operation</var> was [= rejected =]
+                with a value, [= reject =] <var>p</var> with that value.</p>
               </li>
               <li>
-                <p>Upon <a>fulfillment</a> or <a>rejection</a> of <var>p</var>, execute the
+                <p>Upon [= fulfillment =] or [= rejection =] of <var>p</var>, execute the
                 following steps:</p>
                 <ol>
                   <li>
@@ -1080,33 +1054,33 @@
 
         <section>
         <h4>Update the connection state</h4>
-        <p>An <code><a>RTCPeerConnection</a></code> object has an aggregated
-        <a>connection state</a>. Whenever the state of an
-        <code><a>RTCDtlsTransport</a></code> changes or when the
+        <p>An {{RTCPeerConnection}} object has an aggregated
+        [= connection state =]. Whenever the state of an
+        {{RTCDtlsTransport}} changes or when the
         <a>[[\IsClosed]]</a> slot turns <code>true</code>, the user agent MUST
         update the connection state by queueing a task that runs the
         following steps:</p>
         <ol data-tests="RTCPeerConnection-connectionState.https.html">
           <li>
             <p>Let <var>connection</var> be this
-            <code><a>RTCPeerConnection</a></code> object.</p>
+            {{RTCPeerConnection}} object.</p>
           </li>
           <li>
             <p>Let <var>newState</var> be the value of deriving a new state
             value as described by the
-            <a>RTCPeerConnectionState</a> enum.</p>
+            {{RTCPeerConnectionState}} enum.</p>
           </li>
           <li>
-            <p>If <var>connection</var>'s <a>connection state</a> is equal to
+            <p>If <var>connection</var>'s [= connection state =] is equal to
             <var>newState</var>, abort these steps.</p>
           </li>
           <li>
-            <p>Let <var>connection</var>'s <a>connection state</a> be
+            <p>Let <var>connection</var>'s [= connection state =] be
             <var>newState</var>.</p>
           </li>
           <li>
-            <p><a>Fire an event</a> named
-            <code><a>connectionstatechange</a></code> at
+            <p>[= Fire an event =] named
+            {{connectionstatechange}} at
             <var>connection</var>.</p>
           </li>
         </ol>
@@ -1114,8 +1088,8 @@
 
         <section>
         <h4>Update the ICE gathering state</h4>
-        <p>To <dfn id="update-ice-gathering-state">update the <a>ICE gathering
-        state</a></dfn> of an <code><a>RTCPeerConnection</a></code> instance
+        <p>To <dfn id="update-ice-gathering-state">update the [= ICE gathering
+        state =]</dfn> of an {{RTCPeerConnection}} instance
         <var>connection</var>, the user agent MUST queue a task that runs the
         following steps:</p>
         <ol>
@@ -1125,32 +1099,32 @@
           </li>
           <li>
             <p>Let <var>newState</var> be the value of deriving a new state
-            value as described by the <a>RTCIceGatheringState</a>
+            value as described by the {{RTCIceGatheringState}}
             enum.</p>
           </li>
           <li>
-            <p>If <var>connection</var>'s <a>ICE gathering state</a> is equal to
+            <p>If <var>connection</var>'s [= ICE gathering state =] is equal to
             <var>newState</var>, abort these steps.</p>
           </li>
           <li>
-            <p>Set <var>connection</var>'s <a>ice gathering state</a> to
+            <p>Set <var>connection</var>'s [= ICE gathering state =] to
             <var>newState</var>.</p>
           </li>
           <li data-tests="protocol/candidate-exchange.https.html">
-            <p><a>Fire an event</a> named
-            <code><a>icegatheringstatechange</a></code> at
+            <p>[= Fire an event =] named
+            {{icegatheringstatechange}} at
             <var>connection</var>.</p>
           </li>
           <li>
             <p>If <var>newState</var> is <code>"completed"</code>,
-            <a>fire an event</a> named <code><a>icecandidate</a></code>
-            using the <code><a>RTCPeerConnectionIceEvent</a></code>
+            [= fire an event =] named {{icecandidate}}
+            using the {{RTCPeerConnectionIceEvent}}
             interface with the candidate attribute set to
             <code>null</code> at <var>connection</var>.</p>
             <div class="note">The null candidate event is fired to ensure
             legacy compatibility. New code should monitor the gathering state
-            of <code><a>RTCIceTransport</a></code> and/or <code>
-            <a>RTCPeerConnection</a></code>.</div>
+            of {{RTCIceTransport}} and/or <code>
+            {{RTCPeerConnection}}</code>.</div>
           </li>
         </ol>
         </section>
@@ -1158,28 +1132,28 @@
         <section>
         <h4>Set the RTCSessionDescription</h4>
         <p>To <dfn id="set-local-description" data-lt=
-          "set local RTCSessionDescription">set a local RTCSessionDescription</dfn>
-        <var>description</var> on an <code><a>RTCPeerConnection</a></code>
-        object <var>connection</var>, run the <a>set an RTCSessionDescription</a>
+          "set local RTCSessionDescription|setting the local RTCSessionDescription">set a local RTCSessionDescription</dfn>
+        <var>description</var> on an {{RTCPeerConnection}}
+        object <var>connection</var>, run the [= set an RTCSessionDescription =]
         algorithm with <var>remote</var> set to <code>false</code>.</p>
         <p>To <dfn id="set-remote-description" data-lt=
-          "set remote RTCSessionDescription">set a remote RTCSessionDescription</dfn>
-        <var>description</var> on an <code><a>RTCPeerConnection</a></code>
-        object <var>connection</var>, run the <a>set an RTCSessionDescription</a>
+          "set remote RTCSessionDescription|setting the remote RTCSessionDescription">set a remote RTCSessionDescription</dfn>
+        <var>description</var> on an {{RTCPeerConnection}}
+        object <var>connection</var>, run the [= set an RTCSessionDescription =]
         algorithm with <var>remote</var> set to <code>true</code>.</p>
         <p>To <dfn id="set-description" data-lt=
-        "set the RTCSessionDescription">set an RTCSessionDescription</dfn>
-        <var>description</var> on an <code><a>RTCPeerConnection</a></code>
+        "set the RTCSessionDescription|setting an RTCSessionDescription">set an RTCSessionDescription</dfn>
+        <var>description</var> on an {{RTCPeerConnection}}
         object <var>connection</var>, given a <var>remote</var> boolean, run the
         following steps:</p>
         <ol>
           <li data-tests="RTCPeerConnection-setLocalDescription-rollback.html,RTCPeerConnection-setRemoteDescription-rollback.html">
             <p>If <code><var>description</var>.type</code> is
-            <code>"rollback"</code> and <var>connection</var>'s <a>signaling state</a> is either
+            <code>"rollback"</code> and <var>connection</var>'s [= signaling state =] is either
             <code>"stable"</code>, <code>"have-local-pranswer"</code>, or
-            <code>"have-remote-pranswer"</code>, then <a>reject</a> <var>p</var>
-            with a newly <a data-link-for="exception" data-lt="create">created</a>
-            <code>InvalidStateError</code> and abort these steps.</p>
+            <code>"have-remote-pranswer"</code>, then [= reject =] <var>p</var>
+            with a newly [= exception/create | created =]
+            {{InvalidStateError}} and abort these steps.</p>
           </li>
           <li>
             <p>Let <var>p</var> be a new promise.</p>
@@ -1208,48 +1182,46 @@
                     <code>true</code>, then abort these steps.</p>
                   </li>
                   <li data-tests="RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setLocalDescription-pranswer.html,RTCPeerConnection-setRemoteDescription-answer.html,RTCPeerConnection-setRemoteDescription-offer.html,RTCPeerConnection-setRemoteDescription-pranswer.html">
-                    <p>If the <var>description</var>'s <code><a data-link-for=
-                    "RTCSessionDescription">type</a></code> is invalid for the
-                    current <a>signaling state</a> of <var>connection</var>
+                    <p>If the <var>description</var>'s {{RTCSessionDescription/type}} is invalid for the
+                    current [= signaling state =] of <var>connection</var>
                     as described in <span data-jsep=
                     "processing-a-local-desc processing-a-remote-desc">[[!JSEP]]</span>,
-                    then <a>reject</a> <var>p</var> with a newly
-                    <a data-link-for="exception" data-lt="create">created</a>
-                    <code>InvalidStateError</code> and abort these steps.</p>
+                    then [= reject =] <var>p</var> with a newly
+                    [= exception/create | created =]
+                    {{InvalidStateError}} and abort these steps.</p>
                   </li>
                   <li data-tests="RTCPeerConnection-setRemoteDescription-offer.html,RTCPeerConnection-setRemoteDescription.html,protocol/missing-fields.html">
                     <p>If the content of <var>description</var> is not
-                    valid SDP syntax, then <a>reject</a> <var>p</var> with an
-                    <code><a>RTCError</a></code> (with <code>errorDetail</code>
+                    valid SDP syntax, then [= reject =] <var>p</var> with an
+                    {{RTCError}} (with <code>errorDetail</code>
                     set to "sdp-syntax-error" and the <code>sdpLineNumber</code>
                     attribute set to the line number in the SDP where
                     the syntax error was detected) and abort these steps.</p>
                   </li>
                   <li>
                     <p>If <var>remote</var> is <code>true</code>,
-                    the <var>connection</var>'s <code><a>RTCRtcpMuxPolicy</a></code>
-                    is <code><a data-link-for="RTCRtcpMuxPolicy">require</a></code>
+                    the <var>connection</var>'s {{RTCRtcpMuxPolicy}}
+                    is {{RTCRtcpMuxPolicy/require}}
                     and the description does not use RTCP mux,
-                    then <a>reject</a> <var>p</var> with a newly <a data-link-for="exception"
-                    data-lt="create">created</a>
-                    <code>InvalidAccessError</code> and abort these steps.</p>
+                    then [= reject =] <var>p</var> with a newly [= exception/create | created =]
+                    {{InvalidAccessError}} and abort these steps.</p>
                   </li>
                   <li>
                     <p>If the description attempted to renegotiate RIDs, as described
-                      above, then <a>reject</a> <var>p</var> with a newly
-                      <a data-link-for="exception" data-lt="create">created</a>
-                      <code>InvalidAccessError</code> and abort these steps.
+                      above, then [= reject =] <var>p</var> with a newly
+                      [= exception/create | created =]
+                      {{InvalidAccessError}} and abort these steps.
                     </p>
                   <li>
                     <p>If the content of <var>description</var> is invalid,
-                    then <a>reject</a> <var>p</var> with a newly
-                    <a data-link-for="exception" data-lt="create">created</a>
-                    <code>InvalidAccessError</code> and abort these steps.</p>
+                    then [= reject =] <var>p</var> with a newly
+                    [= exception/create | created =]
+                    {{InvalidAccessError}} and abort these steps.</p>
                   </li>
                   <li>
-                    <p>For all other errors, <a>reject</a> <var>p</var> with a newly
-                    <a data-link-for="exception" data-lt="create">created</a>
-                    <code>OperationError</code>.</p>
+                    <p>For all other errors, [= reject =] <var>p</var> with a newly
+                    [= exception/create | created =]
+                    {{OperationError}}.</p>
                   </li>
                 </ol>
               </li>
@@ -1263,10 +1235,10 @@
                   </li>
                   <li>
                     <p>If <var>description</var> is of type <code>"offer"</code>
-                    and the <a>signaling state</a> of <var>connection</var> is
+                    and the [= signaling state =] of <var>connection</var> is
                     <code>"stable"</code> then for each <var>transceiver</var>
-                    in <var>connection</var>'s <a href="#transceivers-set">set
-                    of transceivers</a>, run the following steps:</p>
+                    in <var>connection</var>'s [= set
+                    of transceivers =], run the following steps:</p>
                     <ol>
                       <li>
                         <p>Set <var>transceiver</var>.<a>[[\Sender]]</a>.<a>[[\LastStableStateSenderTransport]]</a>
@@ -1294,10 +1266,10 @@
                       <li data-tests="RTCPeerConnection-setLocalDescription-offer.html,RTCPeerConnection-setLocalDescription.html">
                         <p>If <var>description</var> is of type <code>"offer"</code>, set
                         <var>connection</var>.<a>[[\PendingLocalDescription]]</a>
-                        to a new <code><a>RTCSessionDescription</a></code> object
+                        to a new {{RTCSessionDescription}} object
                         constructed from <var>description</var>, set
-                        <var>connection</var>'s <a>signaling state</a> to <code>"have-local-offer"</code>,
-                        and <a>release early candidates</a>.</p>
+                        <var>connection</var>'s [= signaling state =] to <code>"have-local-offer"</code>,
+                        and [= release early candidates =].</p>
                       </li>
                       <!-- C) transition haveRemoteOffer or haveLocalProvAnswer to
                       stable -->
@@ -1305,7 +1277,7 @@
                         <p>If <var>description</var> is of type <code>"answer"</code>, then
                         this completes an offer answer negotiation. Set
                         <var>connection</var>.<a>[[\CurrentLocalDescription]]</a>
-                        to a new <code><a>RTCSessionDescription</a></code> object
+                        to a new {{RTCSessionDescription}} object
                         constructed from <var>description</var>, and set
                         <var>connection</var>.<a>[[\CurrentRemoteDescription]]</a>
                         to <var>connection</var>.<a>[[\PendingRemoteDescription]]</a>.
@@ -1315,8 +1287,8 @@
                         <var>connection</var>.<a>[[\LastCreatedOffer]]</a> and
                         <var>connection</var>.<a>[[\LastCreatedAnswer]]</a> to
                         <code>""</code>, set <var>connection</var>'s
-                        <a>signaling state</a> to <code>"stable"</code>, and
-                        <a>release early candidates</a>. Finally, if none of the
+                        [= signaling state =] to <code>"stable"</code>, and
+                        [= release early candidates =]. Finally, if none of the
                         ICE credentials in
                         <var>connection</var>.[[\LocalIceCredentialsToReplace]] are
                         present in <var>description</var>, then set
@@ -1327,10 +1299,10 @@
                       <li data-tests="RTCPeerConnection-setLocalDescription-pranswer.html">
                         <p>If <var>description</var> is of type <code>"pranswer"</code>,
                         then set <var>connection</var>.<a>[[\PendingLocalDescription]]</a>
-                        to a new <code><a>RTCSessionDescription</a></code> object
+                        to a new {{RTCSessionDescription}} object
                         constructed from <var>description</var>, set <var>connection</var>'s
-                        <a>signaling state</a> to <code>"have-local-pranswer"</code>,
-                        and <a>release early candidates</a>.</p>
+                        [= signaling state =] to <code>"have-local-pranswer"</code>,
+                        and [= release early candidates =].</p>
                       </li>
                     </ol>
                   </li>
@@ -1342,9 +1314,9 @@
                       <li data-tests="RTCPeerConnection-setRemoteDescription-offer.html">
                         <p>If <var>description</var> is of type <code>"offer"</code>, set
                         <var>connection</var>.<a>[[\PendingRemoteDescription]]</a>
-                        attribute to a new <code><a>RTCSessionDescription</a></code>
+                        attribute to a new {{RTCSessionDescription}}
                         object constructed from <var>description</var>, and set <var>connection</var>'s
-                        <a>signaling state</a> to <code>"have-remote-offer"</code>.</p>
+                        [= signaling state =] to <code>"have-remote-offer"</code>.</p>
                       </li>
                       <!-- F) transition haveRemoteOffer or haveLocalProvAnswer to
                       stable -->
@@ -1352,7 +1324,7 @@
                         <p>If <var>description</var> is of type <code>"answer"</code>, then
                         this completes an offer answer negotiation. Set
                         <var>connection</var>.<a>[[\CurrentRemoteDescription]]</a>
-                        to a new <code><a>RTCSessionDescription</a></code> object
+                        to a new {{RTCSessionDescription}} object
                         constructed from <var>description</var>, and set
                         <var>connection</var>.<a>[[\CurrentLocalDescription]]</a>
                         to <var>connection</var>.<a>[[\PendingLocalDescription]]</a>.
@@ -1362,7 +1334,7 @@
                         <var>connection</var>.<a>[[\LastCreatedOffer]]</a> and
                         <var>connection</var>.<a>[[\LastCreatedAnswer]]</a> to
                         <code>""</code>, and set <var>connection</var>'s
-                        <a>signaling state</a> to <code>"stable"</code>.
+                        [= signaling state =] to <code>"stable"</code>.
                         Finally, if none of the ICE credentials in
                         <var>connection</var>.[[\LocalIceCredentialsToReplace]]
                         are present in the newly set
@@ -1374,9 +1346,9 @@
                       <li data-tests="RTCPeerConnection-setRemoteDescription-pranswer.html">
                         <p>If <var>description</var> is of type <code>"pranswer"</code>,
                         then set <var>connection</var>.<a>[[\PendingRemoteDescription]]</a>
-                        to a new <code><a>RTCSessionDescription</a></code> object
+                        to a new {{RTCSessionDescription}} object
                         constructed from <var>description</var> and set <var>connection</var>'s
-                        <a>signaling state</a> to <code>"have-remote-pranswer"</code>.</p>
+                        [= signaling state =] to <code>"have-remote-pranswer"</code>.</p>
                       </li>
                     </ol>
                   </li>
@@ -1399,22 +1371,22 @@
                       <li data-tests="RTCPeerConnection-createDataChannel.html,RTCSctpTransport-constructor.html">
                         <p>If <var>description</var> initiates the
                         establishment of a new SCTP association, as defined in
-                        [[!SCTP-SDP]], Sections 10.3 and 10.4, <a>create an
-                        RTCSctpTransport</a> with an initial state of
+                        [[!SCTP-SDP]], Sections 10.3 and 10.4, [= create an
+                        RTCSctpTransport =] with an initial state of
                         <code>"connecting"</code> and assign the result to the
                         <a>[[\SctpTransport]]</a> slot. Otherwise, if an SCTP
                         association is established,
                         but the "max-message-size" SDP attribute is updated,
-                        <a>update the data max message size</a> of
+                        [= update the data max message size =] of
                         <var>connection</var>.<a>[[\SctpTransport]]</a>.</p>
                       </li>
                       <li>
                         <p data-tests="RTCPeerConnection-createDataChannel.html">
                         If <var>description</var> negotiates the DTLS role of
                         the SCTP transport, then for each
-                        <code><a>RTCDataChannel</a></code>, <var>channel</var>,
+                        {{RTCDataChannel}}, <var>channel</var>,
                         with a <code>null</code>
-                        <code><a data-link-for="RTCDataChannel">id</a></code>,
+                        {{RTCDataChannel/id}},
                         run the following step:</p>
                         <ol>
                           <li>Give <var>channel</var> a new ID generated
@@ -1439,23 +1411,22 @@
                     <ol>
                       <li>
                         <p>If <var>remote</var> is <code>false</code>, then run
-                        the following steps for each <a>media description</a> in
+                        the following steps for each [= media description =] in
                         <var>description</var>:</p>
                         <ol>
                           <li>
-                            <p>If the <a>media description</a> is not yet <a>associated</a>
-                            with an <code><a>RTCRtpTransceiver</a></code> object then run
+                            <p>If the [= media description =] is not yet {{associated}}
+                            with an {{RTCRtpTransceiver}} object then run
                             the following steps:</p>
                             <ol>
                               <li data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-transceivers.https.html">
                                 <p>Let <var>transceiver</var> be the <code>
-                                <a>RTCRtpTransceiver</a></code> used to create the
-                                <a>media description</a>.</p>
+                                {{RTCRtpTransceiver}}</code> used to create the
+                                [= media description =].</p>
                               </li>
                               <li data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html">
-                                <p>Set <var>transceiver</var>'s <code><a data-link-for=
-                                "RTCRtpTransceiver">mid</a></code> value to the mid of
-                                the <a>media description</a>.</p>
+                                <p>Set <var>transceiver</var>'s {{RTCRtpTransceiver/mid}} value to the mid of
+                                the [= media description =].</p>
                               </li>
                               <li data-tests="RTCRtpTransceiver-stop.html">
                                 <p>If <var>transceiver</var>.<a>[[\Stopped]]</a>
@@ -1463,10 +1434,10 @@
                               </li>
                               <li data-tests="RTCRtpSender-transport.https.html">
                                 <p>
-                                  If the <a>media description</a> is indicated as using
-                                  an existing <a>media transport</a> according to
+                                  If the [= media description =] is indicated as using
+                                  an existing [= media transport =] according to
                                   [[!BUNDLE]], let <var>transport</var> be the
-                                  <code><a>RTCDtlsTransport</a></code> object
+                                  {{RTCDtlsTransport}} object
                                   representing the RTP/RTCP component of that
                                   transport.
                                 </p>
@@ -1475,9 +1446,9 @@
                                 <p>
                                   Otherwise, let <var>transport</var>
                                   be a newly created
-                                  <code><a>RTCDtlsTransport</a></code> object
+                                  {{RTCDtlsTransport}} object
                                   with a new underlying
-                                  <code><a>RTCIceTransport</a></code>.
+                                  {{RTCIceTransport}}.
                                 </p>
                               </li>
                               <li data-tests="RTCRtpSender-transport.https.html">
@@ -1496,8 +1467,8 @@
                           </li>
                           <li>
                             <p>Let <var>transceiver</var> be the <code>
-                            <a>RTCRtpTransceiver</a></code> <a>associated</a> with the
-                            <a>media description</a>.</p>
+                            {{RTCRtpTransceiver}}</code> {{associated}} with the
+                            [= media description =].</p>
                           </li>
                           <li data-tests="RTCRtpTransceiver.https.html">
                             <p>If <var>transceiver</var>.<a>[[\Stopped]]</a>
@@ -1505,9 +1476,9 @@
                           </li>
                           <li>
                             <p>Let <var>direction</var> be an <code>
-                            <a>RTCRtpTransceiverDirection</a></code> value
-                            representing the direction from the <a>media
-                            description</a>.</p>
+                            {{RTCRtpTransceiverDirection}}</code> value
+                            representing the direction from the [= media
+                            description =].</p>
                           </li>
                           <li>
                             <p>If <var>direction</var> is <code>"sendrecv"</code> or
@@ -1550,14 +1521,14 @@
                                 then run the following steps:</p>
                                 <ol>
                                   <li>
-                                    <p><a>Set the associated remote streams</a> given
+                                    <p>[= Set the associated remote streams =] given
                                     <var>transceiver</var>.<a>[[\Receiver]]</a>,
                                     an empty list, another empty list, and
                                     <var>removeList</var>.</p>
                                   </li>
                                   <li data-tests="RTCRtpTransceiver.https.html">
-                                    <p><a>process the removal of a remote track</a>
-                                    for the <a>media description</a>, given
+                                    <p>[= process the removal of a remote track =]
+                                    for the [= media description =], given
                                     <var>transceiver</var> and
                                     <var>muteTracks</var>.</p>
                                   </li>
@@ -1574,14 +1545,14 @@
                       </li>
                       <li>
                         <p>Otherwise, (if <var>remote</var> is <code>true</code>)
-                        run the following steps for each <a>media description</a>
+                        run the following steps for each [= media description =]
                         in <var>description</var>:</p>
                         <ol>
                           <li>
                             <p>If the <var>description</var> is of type <code>"offer"</code>
                             and contains a request to receive simulcast, use the order
                             of the rid values specified in the simulcast attribute to create
-                            an <code><a>RTCRtpEncodingParameters</a></code> dictionary for
+                            an {{RTCRtpEncodingParameters}} dictionary for
                             each of the simulcast layers, populating the <code>rid</code> member
                             according to the corresponding rid value, and let <var>sendEncodings</var>
                             be the list containing the created dictionaries. Otherwise,
@@ -1597,9 +1568,9 @@
                           <li>
                             <p>As described by <span data-jsep=
                             "applying-a-remote-desc">[[!JSEP]]</span>, attempt to
-                            find an existing <code><a>RTCRtpTransceiver</a></code>
-                            object, <var>transceiver</var>, to represent the <a>media
-                            description</a>.</p>
+                            find an existing {{RTCRtpTransceiver}}
+                            object, <var>transceiver</var>, to represent the [= media
+                            description =].</p>
                           </li>
                           <li>
                             <p>If a suitable transceiver was found (<var>transceiver</var>
@@ -1615,25 +1586,25 @@
                             steps:</p>
                             <ol>
                               <li data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-transceivers.https.html,RTCRtpParameters-encodings.html">
-                                <p><a>Create an RTCRtpSender</a>, <var>sender</var>,
-                                from the <a>media description</a> using <var>sendEncodings</var>.</p>
+                                <p>[= Create an RTCRtpSender =], <var>sender</var>,
+                                from the [= media description =] using <var>sendEncodings</var>.</p>
                               </li>
                               <li data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-transceivers.https.html">
-                                <p><a>Create an RTCRtpReceiver</a>,
-                                <var>receiver</var>, from the <a>media description</a>.</p>
+                                <p>[= Create an RTCRtpReceiver =],
+                                <var>receiver</var>, from the [= media description =].</p>
                               </li>
                               <li data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-transceivers.https.html">
-                                <p><a>Create an RTCRtpTransceiver</a> with
+                                <p>[= Create an RTCRtpTransceiver =] with
                                 <var>sender</var>, <var>receiver</var> and
-                                an <code><a>RTCRtpTransceiverDirection</a></code>
+                                an {{RTCRtpTransceiverDirection}}
                                 value of <code>"recvonly"</code>, and let
                                 <var>transceiver</var> be the result.</p>
                               </li>
                               <li data-tests="RTCPeerConnection-setDescription-transceiver.html">
                                 <p>Add <var>transceiver</var> to the
                                 <var>connection</var>'s
-                                <a href="#transceivers-set">
-                                set of transceivers</a>.</p>
+                                [=
+                                set of transceivers =].</p>
                               </li>
                             </ol>
                           </li>
@@ -1657,7 +1628,7 @@
                               <li>
                                 <p>Update the paused status as indicated by [[MMUSIC-SIMULCAST]] of
                                 each simulcast layer by setting the
-                                <code><a data-link-for="RTCRtpEncodingParameters">active</a></code>
+                                {{RTCRtpEncodingParameters/active}}
                                 member on the corresponding dictionaries in
                                 <var>transceiver</var>.<a>[[\Sender]]</a>.<a>[[\SendEncodings]]</a>
                                 to <code>true</code> for unpaused or to <code>false</code> for paused.</p>
@@ -1665,21 +1636,20 @@
                             </ol>
                           </li>
                           <li data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCRtpTransceiver.https.html">
-                            <p>Set <var>transceiver</var>'s <code><a data-link-for=
-                            "RTCRtpTransceiver">mid</a></code> value to the mid of
-                            the corresponding <a>media description</a>. If the <a>media
-                            description</a> has no MID, and <var>transceiver</var>'s
-                            <code><a data-link-for="RTCRtpTransceiver">mid</a></code>
+                            <p>Set <var>transceiver</var>'s {{RTCRtpTransceiver/mid}} value to the mid of
+                            the corresponding [= media description =]. If the [=media
+                            description =] has no MID, and <var>transceiver</var>'s
+                            {{RTCRtpTransceiver/mid}}
                             is unset then generate a random value as described in
                             <span data-jsep="applying-a-remote-desc">[[!JSEP]]</span>.</p>
                           </li>
                           <li>
                             <p>Let <var>direction</var> be an <code>
-                            <a>RTCRtpTransceiverDirection</a></code> value
-                            representing the direction from the <a>media
-                            description</a>, but with the send and receive
+                            {{RTCRtpTransceiverDirection}}</code> value
+                            representing the direction from the [= media
+                            description =], but with the send and receive
                             directions reversed to represent this peer's point
-                            of view. If the <a>media description</a> is rejected,
+                            of view. If the [= media description =] is rejected,
                             set <var>direction</var> to <code>"inactive"</code>.
                             </p>
                           </li>
@@ -1692,11 +1662,11 @@
                             <var>msids</var> be an empty list.</p>
                             <div class="note">
                             <var>msids</var> will be an empty list here if
-                            <a>media description</a> is rejected.
+                            [= media description =] is rejected.
                             </div>
                           </li>
                           <li data-tests="RTCPeerConnection-ontrack.https.html,RTCPeerConnection-setRemoteDescription-tracks.https.html,RTCTrackEvent-fire.html">
-                            <p><a>Process remote tracks</a> with <var>transceiver</var>,
+                            <p>[= Process remote tracks =] with <var>transceiver</var>,
                             <var>direction</var>, <var>msids</var>, <var>addList</var>,
                             <var>removeList</var>, and <var>trackEventInits</var>.</p>
                           </li>
@@ -1727,9 +1697,9 @@
                               <li>
                                 <p>
                                   Let <var>transport</var> be the
-                                  <code><a>RTCDtlsTransport</a></code> object representing the RTP/RTCP
-                                  component of the <a>media transport</a> used by
-                                  <var>transceiver</var>'s <a>associated</a> <a>media description</a>,
+                                  {{RTCDtlsTransport}} object representing the RTP/RTCP
+                                  component of the [= media transport =] used by
+                                  <var>transceiver</var>'s {{associated}} [= media description =],
                                   according to [[!BUNDLE]].
                                 </p>
                               </li>
@@ -1752,21 +1722,21 @@
                                 <div class='note'>The rules of [[RFC8445]] that
                                   apply here are:
                                   <ul>
-                                    <li>If <a>[[\IceRole]]</a> is not <a data-link-for="RTCIceRole">unknown</a>, do not modify <a>[[\IceRole]]</a>.
+                                    <li>If <a>[[\IceRole]]</a> is not {{RTCIceRole/unknown}}, do not modify <a>[[\IceRole]]</a>.
                                     <li>If <var>description</var> is a local offer,
-                                      set it to <code><a data-link-for="RTCIceRole">controlling</a></code>.</li>
-                                    <li>If <var>description</var> is a remote offer, and contains "a=ice-lite", set <a>[[\IceRole]]</a> to <code><a data-link-for="RTCIceRole">controlling</a></code>.</li>
-                                    <li>If <var>description</var> is a remote offer, and does not contain "a=ice-lite", set <a>[[\IceRole]]</a> to <code><a data-link-for="RTCIceRole">controlled</a></code>.</li>
+                                      set it to {{RTCIceRole/controlling}}.</li>
+                                    <li>If <var>description</var> is a remote offer, and contains "a=ice-lite", set <a>[[\IceRole]]</a> to {{RTCIceRole/controlling}}.</li>
+                                    <li>If <var>description</var> is a remote offer, and does not contain "a=ice-lite", set <a>[[\IceRole]]</a> to {{RTCIceRole/controlled}}.</li>
                                   </ul>
                                   This ensures that <a>[[\IceRole]]</a> always has a value after the first offer is processed.
                                 </div>
                             </ol>
                           </li>
                           <li>
-                            <p>If the <a>media description</a> is rejected, and
+                            <p>If the [= media description =] is rejected, and
                             <var>transceiver</var>.<a>[[\Stopped]]</a> is
                             <code>false</code>, then
-                            <a>stop the RTCRtpTransceiver</a>
+                            [= stop the RTCRtpTransceiver =]
                             <var>transceiver</var>.</p>
                           </li>
                         </ol>
@@ -1779,15 +1749,15 @@
                     <ol>
                       <li>
                         <p>For each <var>transceiver</var> in the <var>connection</var>'s
-                        <a href="#transceivers-set">set of transceivers</a> run the
+                        [= set of transceivers =] run the
                         following steps:</p>
                         <ol>
                           <li>
-                            <p>If the <var>transceiver</var> was not <a>associated</a> with
-                            a <a>media description</a> prior to applying the
-                            <code><a>RTCSessionDescription</a></code> that is being rolled
+                            <p>If the <var>transceiver</var> was not {{associated}} with
+                            a [= media description =] prior to applying the
+                            {{RTCSessionDescription}} that is being rolled
                             back, disassociate it and set <var>transceiver</var>'s
-                            <code><a data-link-for="RTCRtpTransceiver">mid</a></code> value
+                            {{RTCRtpTransceiver/mid}} value
                             to <code>null</code>.</p>
                           </li>
                           <li>
@@ -1809,7 +1779,7 @@
                             <ol>
                               <li>
                                 <p>Let <var>msids</var> be a list of the <code>id</code>s
-                                of all <code><a>MediaStream</a></code> objects in
+                                of all {{MediaStream}} objects in
                                 <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\LastStableStateAssociatedRemoteMediaStreams]]</a>,
                                 or an empty list if there are none.</p>
                               </li>
@@ -1825,9 +1795,9 @@
                             <p>If the <var>transceiver</var> was created by applying the
                             <code><a>RTCSessionDescription</a></code> that is
                             being rolled back, and a track has never been attached to
-                            it via <code>addTrack</code>, then <a>stop the RTCRtpTransceiver</a>
+                            it via {{RTCPeerConnection/addTrack()}}, then <a>stop the RTCRtpTransceiver</a>
                             <var>transceiver</var>, and remove it from <var>connection</var>'s
-                            <a href="#transceivers-set">set of transceivers</a>.</p>
+                            [= set of transceivers =].</p>
                           </li>
                         </ol>
                       </li>
@@ -1835,7 +1805,7 @@
                         <p>Set <var>connection</var>.<a>[[\PendingLocalDescription]]</a>
                         and <var>connection</var>.<a>[[\PendingRemoteDescription]]</a>
                         to <code>null</code>, and set <var>connection</var>'s
-                        <a>signaling state</a> to <code>"stable"</code>.</p>
+                        [= signaling state =] to <code>"stable"</code>.</p>
                       </li>
                     </ol>
                   </li>
@@ -1845,28 +1815,27 @@
                     <ol>
                       <li>
                         <p>For each <var>transceiver</var> in the <var>connection</var>'s
-                        <a href="#transceivers-set">set of transceivers</a> run the
+                        [= set of transceivers =] run the
                         following steps:</p>
                         <ol>
                           <li>
-                            <p>If <var>transceiver</var> is <a data-link-for="RTCRtpTransceiver">
-                            stopped</a>, <a>associated</a> with an m= section and the
+                            <p>If <var>transceiver</var> is {{RTCRtpTransceiver/stopped}}, [= associated =] with an m= section and the
                             associated m= section is rejected in
                             <var>connection</var>.<a>[[\CurrentLocalDescription]]</a> or
                             <var>connection</var>.<a>[[\CurrentRemoteDescription]]</a>,
                             remove the <var>transceiver</var> from the <var>connection</var>'s
-                            <a href="#transceivers-set">set of transceivers</a>.</p>
+                            [= set of transceivers =].</p>
                           </li>
                         </ol>
                       </li>
                     </ol>
                   </li>
                   <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
-                    <p>If <var>connection</var>'s <a>signaling state</a> is now
-                    <code>"stable"</code>, <a>update the negotiation-needed
-                    flag</a>. If <var>connection</var>.<a>[[\NegotiationNeeded]]</a>
+                    <p>If <var>connection</var>'s [= signaling state =] is now
+                    <code>"stable"</code>, [= update the negotiation-needed
+                    flag =]. If <var>connection</var>.<a>[[\NegotiationNeeded]]</a>
                     was <code>true</code> both before and after this update,
-                    <p><a href="#dfn-chain-an-operation">Chain</a> a step to
+                    <p>[= Chain =] a step to
                     queue a task that runs the following steps, to
                     <var>connection</var>'s operations chain:</p>
                     <ol>
@@ -1879,45 +1848,44 @@
                         is <code>false</code>, abort these steps.</p>
                       </li>
                       <li>
-                        <p><a>Fire an event</a> named <code><a>negotiationneeded</a></code>
+                        <p>[= Fire an event =] named {{negotiationneeded}}
                         at <var>connection</var>.</p>
                       </li>
                     </ol>
                   </li>
                   <li>
-                    <p>If <var>connection</var>'s <a>signaling state</a>
-                    changed above, <a>fire an event</a> named
-                    <code><a>signalingstatechange</a></code> at
+                    <p>If <var>connection</var>'s [= signaling state =]
+                    changed above, [= fire an event =] named
+                    {{signalingstatechange}} at
                     <var>connection</var>.</p>
                   </li>
                   <li>
                     <p>For each <var>channel</var> in <var>errorList</var>,
-                    <a>fire an event</a> named <code><a data-link-for=
-                      "RTCDataChannel">error</a></code> using the
-                    <code><a>RTCErrorEvent</a></code> interface with the
+                    [= fire an event =] named {{RTCDataChannel/error}} using the
+                    {{RTCErrorEvent}} interface with the
                     <code>errorDetail</code> attribute set to
                     "data-channel-failure" at <var>channel</var>.</p>
                   </li>
                   <li id="remote-mute" data-tests="RTCPeerConnection-remote-track-mute.https.html">
                     <p>For each <var>track</var> in <var>muteTracks</var>,
-                    <a>set the muted state</a> of <var>track</var> to the
+                    [= set the muted state =] of <var>track</var> to the
                     value <code>true</code>.</p>
                   </li>
                   <li data-tests="RTCPeerConnection-setRemoteDescription-tracks.https.html">
                     <p>For each <var>stream</var> and <var>track</var> pair
-                    in <var>removeList</var>, <a>remove the track</a>
+                    in <var>removeList</var>, [= remove the track =]
                     <var>track</var> from <var>stream</var>.</p>
                   </li>
                   <li>
                     <p>For each <var>stream</var> and <var>track</var> pair
-                    in <var>addList</var>, <a>add the track</a>
+                    in <var>addList</var>, [= add the track =]
                     <var>track</var> to <var>stream</var>.</p>
                   </li>
                   <li data-tests="RTCPeerConnection-ontrack.https.html,RTCPeerConnection-setRemoteDescription-tracks.https.html,RTCTrackEvent-fire.html">
                     <p>For each entry <var>entry</var> in <var>trackEventInits</var>,
-                    <a>fire an event</a> named <code title=
-                    "event-track"><a>track</a></code> using the
-                    <code><a>RTCTrackEvent</a></code> interface with its
+                    [= fire an event =] named <code title=
+                    "event-track">{{track}}</code> using the
+                    {{RTCTrackEvent}} interface with its
                     <code>receiver</code> attribute initialized to
                     <var>entry</var>.<code>receiver</code>, its
                     <code>track</code> attribute initialized to
@@ -1929,7 +1897,7 @@
                     at the <var>connection</var> object.</p>
                   </li>
                   <li data-tests="RTCPeerConnection-setLocalDescription.html">
-                    <p><a>Resolve</a> <var>p</var> with <code>undefined</code>.</p>
+                    <p>[= Resolve =] <var>p</var> with <code>undefined</code>.</p>
                   </li>
                 </ol>
               </li>
@@ -1947,10 +1915,10 @@
           following steps:</p>
           <ol>
             <li><p>Let <var>configuration</var> be the
-            <code><a>RTCConfiguration</a></code> dictionary to be
+            {{RTCConfiguration}} dictionary to be
             processed.</p></li>
             <li><p>Let <var>connection</var> be the target
-            <code><a>RTCPeerConnection</a></code> object.</p></li>
+            {{RTCPeerConnection}} object.</p></li>
             <li data-tests="RTCCertificate.html">
               <p id="setconfig-certificate">If <code><var>configuration</var>.certificates</code> is
               set, run the following steps:</p>
@@ -1959,7 +1927,7 @@
                   <p>If the length of <code><var>configuration</var>.certificates</code>
                   is different from the length of
                   <code><var>connection</var>.[[\Configuration]].certificates</code>,
-                  <a>throw</a> an <code>InvalidModificationError</code>.</p>
+                  [= exception/throw =] an {{InvalidModificationError}}.</p>
                 </li>
                 <li>
                   <p>Let <var>index</var> be initialized to 0.</p>
@@ -1978,8 +1946,8 @@
                       <var>index</var> is not the same as the ECMAScript
                       object represented by the value of
                       <code><var>connection</var>.[[\Configuration]].certificates</code>
-                      at <var>index</var>, <a>throw</a> an
-                      <code>InvalidModificationError</code>.</p>
+                      at <var>index</var>, [= exception/throw =] an
+                      {{InvalidModificationError}}.</p>
                     </li>
                     <li>
                       <p>Increment <var>index</var> by 1.</p>
@@ -1988,39 +1956,33 @@
                 </li>
               </ol>
             </li>
-            <li><p id="config-bundle" data-tests="RTCConfiguration-bundlePolicy.html">If the value of <code><var>configuration</var>.<a data-link-for=
-            "RTCConfiguration">bundlePolicy</a></code> is set and its value
-            differs from the <var>connection</var>'s bundle policy, <a>throw</a>
-            an <code>InvalidModificationError</code>.</p></li>
-            <li><p id="config-rtcpmux" data-tests="RTCConfiguration-rtcpMuxPolicy.html">If the value of <code><var>configuration</var>.<a data-link-for=
-            "RTCConfiguration">rtcpMuxPolicy</a></code> is set and its value
-            differs from the <var>connection</var>'s rtcpMux policy, <a>throw</a> an
-            <code>InvalidModificationError</code>.</p></li>
-            <li><p  id="config-icepool" data-tests="RTCConfiguration-iceCandidatePoolSize.html">If the value of <code><var>configuration</var>.<a data-link-for=
-            "RTCConfiguration">iceCandidatePoolSize</a></code> is set and its
+            <li><p id="config-bundle" data-tests="RTCConfiguration-bundlePolicy.html">If the value of <code><var>configuration</var>.{{RTCConfiguration/bundlePolicy}}</code> is set and its value
+            differs from the <var>connection</var>'s bundle policy, [= exception/throw =]
+            an {{InvalidModificationError}}.</p></li>
+            <li><p id="config-rtcpmux" data-tests="RTCConfiguration-rtcpMuxPolicy.html">If the value of <code><var>configuration</var>.{{RTCConfiguration/rtcpMuxPolicy}}</code> is set and its value
+            differs from the <var>connection</var>'s rtcpMux policy, [= exception/throw =] an
+            {{InvalidModificationError}}.</p></li>
+            <li><p  id="config-icepool" data-tests="RTCConfiguration-iceCandidatePoolSize.html">If the value of <code><var>configuration</var>.{{RTCConfiguration/iceCandidatePoolSize}}</code> is set and its
             value differs from the <var>connection</var>'s previously set
-            <code>iceCandidatePoolSize</code>, and <code><a data-link-for=
-            "RTCPeerConnection">setLocalDescription</a></code> has
-            already been called, <a>throw</a> an
-            <code>InvalidModificationError</code>.</p></li>
+            <code>iceCandidatePoolSize</code>, and {{RTCPeerConnection/setLocalDescription}} has
+            already been called, [= exception/throw =] an
+            {{InvalidModificationError}}.</p></li>
             <li data-tests="RTCConfiguration-iceTransportPolicy.html">
-              <p id="config-icetransportpolicy" >Set the <a>ICE Agent</a>'s <dfn id=
+              <p id="config-icetransportpolicy" >Set the [= ICE Agent =]'s <dfn id=
               "ice-transports-setting">ICE transports setting</dfn> to
-              the value of <code><var>configuration</var>.<a data-link-for=
-              "RTCConfiguration">iceTransportPolicy</a></code>. As defined
+              the value of <code><var>configuration</var>.{{RTCConfiguration/iceTransportPolicy}}</code>. As defined
               in <span data-jsep="setconfiguration">[[!JSEP]]</span>, if
-              the new <a>ICE transports setting</a> changes the existing
+              the new [= ICE transports setting =] changes the existing
               setting, no action will be taken until the next gathering
               phase. If a script wants this to happen immediately, it
               should do an ICE restart.</p>
             </li>
             <li>
-              <p>Set the <a>ICE Agent</a>'s prefetched <dfn>ICE candidate
+              <p>Set the [= ICE Agent =]'s prefetched <dfn>ICE candidate
               pool size</dfn> as defined in <span data-jsep=
               "ice-candidate-pool constructor">[[!JSEP]]</span> to the
-              value of <code><var>configuration</var>.<a data-link-for=
-              "RTCConfiguration">iceCandidatePoolSize</a></code>. If the
-              new <a>ICE candidate pool size</a> changes the existing
+              value of <code><var>configuration</var>.{{RTCConfiguration/iceCandidatePoolSize}}</code>. If the
+              new [= ICE candidate pool size =] changes the existing
               setting, this may result in immediate gathering of new
               pooled candidates, or discarding of existing pooled
               candidates, as defined in <span data-jsep=
@@ -2030,8 +1992,7 @@
               <p>Let <var>validatedServers</var> be an empty list.</p>
             </li>
             <li data-tests="RTCConfiguration-iceServers.html">
-              <p id="config-iceservers">If <code><var>configuration</var>.<a data-link-for=
-              "RTCConfiguration">iceServers</a></code> is defined, then
+              <p id="config-iceservers">If <code><var>configuration</var>.{{RTCConfiguration/iceServers}}</code> is defined, then
               run the following steps for each element:</p>
               <ol>
                 <li>
@@ -2046,8 +2007,8 @@
                   list consisting of just that string.</p>
                 </li>
                 <li>
-                  <p>If <var>urls</var> is empty, <a>throw</a> a
-                  <code>SyntaxError</code>.</p>
+                  <p>If <var>urls</var> is empty, [= exception/throw =] a
+                  {{SyntaxError}}.</p>
                 </li>
                 <li>
                   <p>For each <var>url</var> in <var>urls</var> run the
@@ -2059,27 +2020,27 @@
                       defined in [[!RFC3986]] and obtain the
                       <var>scheme name</var>. If the parsing based
                       on the syntax defined in [[!RFC3986]] fails,
-                      <a>throw</a> a <code>SyntaxError</code>.  If
+                      [= exception/throw =] a {{SyntaxError}}.  If
                       the <var>scheme name</var> is not implemented
-                      by the browser <a>throw</a> a
-                      <code>NotSupportedError</code>. If
+                      by the browser [= exception/throw =] a
+                      {{NotSupportedError}}. If
                       <var>scheme name</var> is <code>turn</code> or
                       <code>turns</code>, and parsing the
                       <var>url</var> using the syntax defined in
-                      [[!RFC7064]] fails, <a>throw</a> a
-                      <code>SyntaxError</code>. If <var>scheme
+                      [[!RFC7064]] fails, [= exception/throw =] a
+                      {{SyntaxError}}. If <var>scheme
                       name</var> is <code>stun</code> or
                       <code>stuns</code>, and parsing the
                       <var>url</var> using the syntax defined in
-                      [[!RFC7065]] fails, <a>throw</a> a
-                      <code>SyntaxError</code>. </p>
+                      [[!RFC7065]] fails, [= exception/throw =] a
+                      {{SyntaxError}}. </p>
                     </li>
                     <li>
                       <p>If <var>scheme name</var> is <code>turn</code> or
                       <code>turns</code>, and either of
                       <code><var>server</var>.username</code> or
                       <code><var>server</var>.credential</code> are omitted,
-                      then <a>throw</a> an <code>InvalidAccessError</code>.</p>
+                      then [= exception/throw =] an {{InvalidAccessError}}.</p>
                     </li>
                     <li>
                       <p>If <var>scheme name</var> is <code>turn</code> or
@@ -2088,7 +2049,7 @@
                       <code>"password"</code>, and
                       <code><var>server</var>.credential</code> is not a
                       <span class="idlMemberType">DOMString</span>, then
-                      <a>throw</a> an <code>InvalidAccessError</code>.</p>
+                      [= exception/throw =] an {{InvalidAccessError}}.</p>
                     </li>
                   </ol>
                 </li>
@@ -2097,16 +2058,16 @@
                   <var>validatedServers</var>.</p>
                 </li>
               </ol>
-              <p>Let <var>validatedServers</var> be the <a>ICE
-              Agent</a>'s <dfn id="ice-servers-list">ICE servers
+              <p>Let <var>validatedServers</var> be the [= ICE
+              Agent =]'s <dfn id="ice-servers-list">ICE servers
               list</dfn>.</p>
               <p>As defined in <span
               data-jsep="setconfiguration">[[!JSEP]]</span>, if a new list
-              of servers replaces the <a>ICE Agent</a>'s existing ICE
+              of servers replaces the [= ICE Agent =]'s existing ICE
               servers list, no action will be taken until the next
               gathering phase. If a script wants this to happen
               immediately, it should do an ICE restart. However, if the
-              <a data-lt="ICE candidate pool size">ICE candidate pool</a>
+              [= ICE candidate pool size | ICE candidate pool =]
               has a nonzero size, any existing pooled candidates will be
               discarded, and new candidates will be gathered from the new
               servers.</p>
@@ -2120,10 +2081,10 @@
       </section>
       <section>
         <h3>Interface Definition</h3>
-        <p>The <code><a>RTCPeerConnection</a></code> interface presented in
+        <p>The {{RTCPeerConnection}} interface presented in
         this section is extended by several partial interfaces throughout this
-        specification. Notably, the <a>RTP Media API</a> section, which adds
-        the APIs to send and receive <code><a>MediaStreamTrack</a></code>
+        specification. Notably, the [= RTP Media API =] section, which adds
+        the APIs to send and receive {{MediaStreamTrack}}
         objects.</p>
         <div>
           <pre class="idl" data-tests="idlharness.https.window.js" data-cite="DOM HTML"
@@ -2183,7 +2144,7 @@ interface RTCPeerConnection : EventTarget  {
             <dl data-link-for="RTCPeerConnection" data-dfn-for=
             "RTCPeerConnection" class="attributes">
               <dt><code>localDescription</code> of type <span class=
-              "idlAttrType"><a>RTCSessionDescription</a></span>, readonly,
+              "idlAttrType">{{RTCSessionDescription}}</span>, readonly,
               nullable</dt>
               <dd>
                 <p>The <dfn id=
@@ -2192,28 +2153,28 @@ interface RTCPeerConnection : EventTarget  {
                 not null and otherwise it MUST return
                 <a>[[\CurrentLocalDescription]]</a>.</p>
 
-                <p>Note that <a>[[\CurrentLocalDescription]]</a>.<a data-link-for="RTCSessionDescription">sdp</a> and
-                <a>[[\PendingLocalDescription]]</a>.<a data-link-for="RTCSessionDescription">sdp</a> need not be
+                <p>Note that <a>[[\CurrentLocalDescription]]</a>.{{RTCSessionDescription/sdp}} and
+                <a>[[\PendingLocalDescription]]</a>.{{RTCSessionDescription/sdp}} need not be
                 string-wise identical to the SDP value passed to the corresponding
-                <a>setLocalDescription</a> call (i.e. SDP
+                {{setLocalDescription}} call (i.e. SDP
                 may be parsed and reformatted, and ICE candidates may be
                 added).</p>
               </dd>
               <dt><code>currentLocalDescription</code> of type <span class=
-              "idlAttrType"><a>RTCSessionDescription</a></span>, readonly,
+              "idlAttrType">{{RTCSessionDescription}}</span>, readonly,
               nullable</dt>
               <dd>
                 <p>The <dfn id=
                 "dom-peerconnection-currentlocaldesc"><code>currentLocalDescription</code></dfn>
                 attribute MUST return <a>[[\CurrentLocalDescription]]</a>.</p>
                 <p>It represents the local description that was successfully
-                negotiated the last time the <code>RTCPeerConnection</code>
+                negotiated the last time the {{RTCPeerConnection}}
                 transitioned into the stable state plus any local candidates
-                that have been generated by the <a>ICE Agent</a> since the offer
+                that have been generated by the [= ICE Agent =] since the offer
                 or answer was created.</p>
               </dd>
               <dt><code>pendingLocalDescription</code> of type <span class=
-              "idlAttrType"><a>RTCSessionDescription</a></span>, readonly,
+              "idlAttrType">{{RTCSessionDescription}}</span>, readonly,
               nullable</dt>
               <dd>
                 <p>The <dfn id=
@@ -2221,12 +2182,12 @@ interface RTCPeerConnection : EventTarget  {
                 attribute MUST return <a>[[\PendingLocalDescription]]</a>.</p>
                 <p>It represents a local description that is in the
                 process of being negotiated plus any local candidates that have
-                been generated by the <a>ICE Agent</a> since the offer or
-                answer was created. If the <code>RTCPeerConnection</code> is in
+                been generated by the [= ICE Agent =] since the offer or
+                answer was created. If the {{RTCPeerConnection}} is in
                 the stable state, the value is <code>null</code>.</p>
               </dd>
               <dt data-tests="RTCPeerConnection-setRemoteDescription-answer.html,RTCPeerConnection-setRemoteDescription-offer.html"><code>remoteDescription</code> of type <span class=
-              "idlAttrType"><a>RTCSessionDescription</a></span>, readonly,
+              "idlAttrType">{{RTCSessionDescription}}</span>, readonly,
               nullable</dt>
               <dd>
                 <p>The <dfn id=
@@ -2235,29 +2196,28 @@ interface RTCPeerConnection : EventTarget  {
                 is not <code>null</code> and otherwise it MUST return
                 <a>[[\CurrentRemoteDescription]]</a>.</p>
 
-                <p>Note that <a>[[\CurrentRemoteDescription]]</a>.<a data-link-for="RTCSessionDescription">sdp</a> and
-                <a>[[\PendingRemoteDescription]]</a>.<a data-link-for="RTCSessionDescription">sdp</a> need not be
+                <p>Note that <a>[[\CurrentRemoteDescription]]</a>.{{RTCSessionDescription/sdp}} and
+                <a>[[\PendingRemoteDescription]]</a>.{{RTCSessionDescription/sdp}} need not be
                 string-wise identical to the SDP value passed to the corresponding
-                <a>setRemoteDescription</a> call (i.e. SDP
+                {{setRemoteDescription}} call (i.e. SDP
                 may be parsed and reformatted, and ICE candidates may be
                 added).</p>
               </dd>
               <dt data-tests="RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setRemoteDescription-answer.html,RTCPeerConnection-setRemoteDescription-offer.html"><code>currentRemoteDescription</code> of type <span class=
-              "idlAttrType"><a>RTCSessionDescription</a></span>, readonly,
+              "idlAttrType">{{RTCSessionDescription}}</span>, readonly,
               nullable</dt>
               <dd>
                 <p>The <dfn id=
                 "dom-peerconnection-currentremotedesc"><code>currentRemoteDescription</code></dfn>
                 attribute MUST return <a>[[\CurrentRemoteDescription]]</a>.</p>
                 <p>It represents the last remote description that was successfully
-                negotiated the last time the <code>RTCPeerConnection</code>
+                negotiated the last time the {{RTCPeerConnection}}
                 transitioned into the stable state plus any remote candidates
-                that have been supplied via <code><a data-link-for=
-                "RTCPeerConnection">addIceCandidate()</a></code> since the
+                that have been supplied via {{RTCPeerConnection/addIceCandidate()}} since the
                 offer or answer was created.</p>
               </dd>
               <dt data-tests="RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setRemoteDescription-answer.html,RTCPeerConnection-setRemoteDescription-offer.html"><code>pendingRemoteDescription</code> of type <span class=
-              "idlAttrType"><a>RTCSessionDescription</a></span>, readonly,
+              "idlAttrType">{{RTCSessionDescription}}</span>, readonly,
               nullable</dt>
               <dd>
                 <p>The <dfn id=
@@ -2265,101 +2225,98 @@ interface RTCPeerConnection : EventTarget  {
                 attribute MUST return <a>[[\PendingRemoteDescription]]</a>.</p>
                 <p>It  represents a remote description that is in the
                 process of being negotiated, complete with any remote
-                candidates that have been supplied via <code><a data-link-for=
-                "RTCPeerConnection">addIceCandidate()</a></code> since the
+                candidates that have been supplied via {{RTCPeerConnection/addIceCandidate()}} since the
                 offer or answer was created. If the
-                <code>RTCPeerConnection</code> is in the stable state, the
+                {{RTCPeerConnection}} is in the stable state, the
                 value is <code>null</code>.</p>
               </dd>
               <dt><code>signalingState</code> of type <span class=
-              "idlAttrType"><a>RTCSignalingState</a></span>, readonly</dt>
+              "idlAttrType">{{RTCSignalingState}}</span>, readonly</dt>
               <dd>
                 <p>The <dfn id=
                 "dom-peerconnection-signaling-state"><code>signalingState</code></dfn>
-                attribute MUST return the <code><a data-link-for=
-                "RTCPeerConnection">RTCPeerConnection</a></code> object's
-                <a>signaling state</a>.</p>
+                attribute MUST return the {{RTCPeerConnection/RTCPeerConnection}} object's
+                [= signaling state =].</p>
               </dd>
               <dt data-tests="RTCPeerConnection-iceGatheringState.html,protocol/candidate-exchange.https.html"><code>iceGatheringState</code> of type <span class=
-              "idlAttrType"><a>RTCIceGatheringState</a></span>, readonly</dt>
+              "idlAttrType">{{RTCIceGatheringState}}</span>, readonly</dt>
               <dd>
                 <p>The <dfn id=
                 "dom-peerconnection-ice-gathering-state"><code>iceGatheringState</code></dfn>
-                attribute MUST return the <a>ICE gathering state</a> of the
-                <code>RTCPeerConnection</code> instance.</p>
+                attribute MUST return the [= ICE gathering state =] of the
+                {{RTCPeerConnection}} instance.</p>
               </dd>
               <dt data-tests="RTCPeerConnection-iceConnectionState.https.html,no-media-call.html,RTCPeerConnection-iceConnectionState-disconnected.https.html,protocol/ice-state.https.html"><code>iceConnectionState</code> of type <span class=
-              "idlAttrType"><a>RTCIceConnectionState</a></span>, readonly</dt>
+              "idlAttrType">{{RTCIceConnectionState}}</span>, readonly</dt>
               <dd>
                 <p>The <dfn id=
                 "dom-peerconnection-ice-connection-state"><code>iceConnectionState</code></dfn>
-                attribute MUST return the <a>ICE connection state</a> of the
-                <code>RTCPeerConnection</code> instance.</p>
+                attribute MUST return the [= ICE connection state =] of the
+                {{RTCPeerConnection}} instance.</p>
               </dd>
               <dt data-tests="RTCPeerConnection-connectionState.https.html"><code>connectionState</code> of type <span class=
-              "idlAttrType"><a>RTCPeerConnectionState</a></span>, readonly</dt>
+              "idlAttrType">{{RTCPeerConnectionState}}</span>, readonly</dt>
               <dd>
                 <p>The <dfn id=
                 "dom-peerconnection-connection-state"><code>connectionState</code></dfn>
-                attribute MUST return the <a>connection state</a> of the
-                <code><a>RTCPeerConnection</a></code> instance.</p>
+                attribute MUST return the [= connection state =] of the
+                {{RTCPeerConnection}} instance.</p>
               </dd>
               <dt data-tests="RTCPeerConnection-canTrickleIceCandidates.html, RTCPeerConnection-constructor.html"><code>canTrickleIceCandidates</code> of type <span class=
               "idlAttrType">boolean</span>, readonly, nullable</dt>
               <dd>
-                <p>The <dfn data-idl><code>canTrickleIceCandidates</code></dfn>
+                <p>The <dfn data-idl>canTrickleIceCandidates</dfn>
                 attribute indicates whether the remote peer is able to accept
                 trickled ICE candidates [[TRICKLE-ICE]]. The value is
                 determined based on whether a remote description indicates
                 support for trickle ICE, as defined in <span data-jsep=
                 "cantrickle">[[!JSEP]]</span>. Prior to the completion of
-                <a data-link-for=
-                "RTCPeerConnection">setRemoteDescription</a>, this
+                {{RTCPeerConnection/setRemoteDescription}}, this
                 value is <code>null</code>.</p>
               </dd>
-              <dt data-tests="RTCPeerConnection-onnegotiationneeded.html"><dfn data-idl><code>onnegotiationneeded</code></dfn> of type
+              <dt data-tests="RTCPeerConnection-onnegotiationneeded.html"><dfn data-idl>onnegotiationneeded</dfn> of type
               <span class="idlAttrType">EventHandler</span></dt>
               <dd>The event type of this event handler is
-              <code><a>negotiationneeded</a></code>.</dd>
-              <dt data-tests="promises-call.html"><dfn data-idl><code>onicecandidate</code></dfn> of type <span class=
+              {{negotiationneeded}}.</dd>
+              <dt data-tests="promises-call.html"><dfn data-idl>onicecandidate</dfn> of type <span class=
               "idlAttrType">EventHandler</span></dt>
               <dd>The event type of this event handler is
-              <code><a>icecandidate</a></code>.</dd>
-              <dt data-tests="RTCPeerConnection-onicecandidateerror.https.html"><dfn data-idl><code>onicecandidateerror</code></dfn> of type
+              {{icecandidate}}.</dd>
+              <dt data-tests="RTCPeerConnection-onicecandidateerror.https.html"><dfn data-idl>onicecandidateerror</dfn> of type
               <span class="idlAttrType">EventHandler</span></dt>
               <dd>The event type of this event handler is
-              <code><a>icecandidateerror</a></code>.</dd>
-              <dt data-tests="RTCPeerConnection-createOffer.html,RTCPeerConnection-onsignalingstatechanged.https.html"><dfn data-idl><code>onsignalingstatechange</code></dfn> of type
+              {{icecandidateerror}}.</dd>
+              <dt data-tests="RTCPeerConnection-createOffer.html,RTCPeerConnection-onsignalingstatechanged.https.html"><dfn data-idl>onsignalingstatechange</dfn> of type
               <span class="idlAttrType">EventHandler</span></dt>
               <dd>The event type of this event handler is
-                <code><a>signalingstatechange</a></code>.</dd>
-              <dt data-tests="RTCPeerConnection-connectionState.https.html,RTCPeerConnection-iceConnectionState.https.html,no-media-call.html,RTCPeerConnection-iceConnectionState-disconnected.https.html,protocol/ice-state.https.html"><dfn data-idl><code>oniceconnectionstatechange</code></dfn> of type
+                {{signalingstatechange}}.</dd>
+              <dt data-tests="RTCPeerConnection-connectionState.https.html,RTCPeerConnection-iceConnectionState.https.html,no-media-call.html,RTCPeerConnection-iceConnectionState-disconnected.https.html,protocol/ice-state.https.html"><dfn data-idl>oniceconnectionstatechange</dfn> of type
               <span class="idlAttrType">EventHandler</span></dt>
               <dd>The event type of this event handler is
-              <code><a>iceconnectionstatechange</a></code></dd>
-              <dt data-tests="RTCPeerConnection-iceGatheringState.html,protocol/candidate-exchange.https.html"><dfn data-idl><code>onicegatheringstatechange</code></dfn> of type
+              {{iceconnectionstatechange}}</dd>
+              <dt data-tests="RTCPeerConnection-iceGatheringState.html,protocol/candidate-exchange.https.html"><dfn data-idl>onicegatheringstatechange</dfn> of type
               <span class="idlAttrType">EventHandler</span></dt>
               <dd>The event type of this event handler is
-              <code><a>icegatheringstatechange</a></code>.</dd>
-              <dt><dfn data-idl><code>onconnectionstatechange</code></dfn> of type
+              {{icegatheringstatechange}}.</dd>
+              <dt><dfn data-idl>onconnectionstatechange</dfn> of type
               <span class="idlAttrType">EventHandler</span></dt>
               <dd>The event type of this event handler is
-              <code><a>connectionstatechange</a></code>.</dd>
+              {{connectionstatechange}}.</dd>
             </dl>
           </section>
           <section>
             <h2>Methods</h2>
             <dl data-link-for="RTCPeerConnection" data-dfn-for=
             "RTCPeerConnection" class="methods">
-              <dt data-tests="RTCPeerConnection-createOffer.html,promises-call.html"><dfn data-idl><code>createOffer</code></dfn></dt>
+              <dt data-tests="RTCPeerConnection-createOffer.html,promises-call.html"><dfn data-idl>createOffer</dfn></dt>
               <dd>
                 <p>The <code>createOffer</code> method generates a blob of SDP that contains
                 an RFC 3264 offer with the supported configurations for the
                 session, including descriptions of the local
-                <code>MediaStreamTrack</code>s attached to this
-                <code>RTCPeerConnection</code>, the codec/RTP/RTCP capabilities
-                supported by this implementation, and parameters of the <a>ICE
-                agent</a> and the DTLS connection. The <code>options</code>
+                {{MediaStreamTrack}}s attached to this
+                {{RTCPeerConnection}}, the codec/RTP/RTCP capabilities
+                supported by this implementation, and parameters of the [= ICE
+                agent =] and the DTLS connection. The <code>options</code>
                 parameter may be supplied to provide additional control over
                 the offer generated.</p>
                 <p>If a system has limited resources (e.g. a finite number of
@@ -2368,13 +2325,13 @@ interface RTCPeerConnection : EventTarget  {
                 <code>setLocalDescription</code> will succeed when it attempts
                 to acquire those resources. The session descriptions MUST
                 remain usable by <code>setLocalDescription</code> without
-                causing an error until at least the end of the <a>fulfillment</a>
+                causing an error until at least the end of the [= fulfillment =]
                 callback of the returned promise.</p>
                 <p data-tests="RTCRtpTransceiver-stop.html,protocol/jsep-initial-offer.https.html">Creating the SDP
                 MUST follow the appropriate process for generating an offer
                 described in [[!JSEP]], except the user agent MUST treat a
-                <a data-link-for="RTCRtpTransceiver">stopping</a> transceiver as
-                <a data-link-for="RTCRtpTransceiver">stopped</a> for the
+                {{RTCRtpTransceiver/stopping}} transceiver as
+                {{RTCRtpTransceiver/stopped}} for the
                 purposes of JSEP in this case.</p>
                 <p>
                 As an offer, the generated SDP will contain the full set of
@@ -2390,15 +2347,15 @@ interface RTCPeerConnection : EventTarget  {
                 the capabilities of the current local description as well as
                 any additional capabilities that could be negotiated in an
                 updated offer.</p>
-                <p>The generated SDP will also contain the <a>ICE agent</a>'s
-                <a data-link-for="RTCIceParameters">usernameFragment</a>,
-                <a data-link-for="RTCIceParameters">password</a> and
+                <p>The generated SDP will also contain the [= ICE agent =]'s
+                {{RTCIceParameters/usernameFragment}},
+                {{RTCIceParameters/password}} and
                 ICE options (as defined in [[!ICE]], Section 14) and may also contain
                 any local candidates that have been gathered by the agent.</p>
                 <p>The <code>certificates</code> value in <var>configuration</var>
-                for the <code>RTCPeerConnection</code> provides the
+                for the {{RTCPeerConnection}} provides the
                 certificates configured by the application for the
-                <code>RTCPeerConnection</code>.  These certificates,
+                {{RTCPeerConnection}}.  These certificates,
                 along with any default certificates are used to produce a set of
                 certificate fingerprints. These certificate fingerprints are
                 used in the construction of SDP.</p>
@@ -2414,40 +2371,38 @@ interface RTCPeerConnection : EventTarget  {
                 <ol>
                   <li>
                     <p>Let <var>connection</var> be the
-                    <code><a>RTCPeerConnection</a></code> object on which the
+                    {{RTCPeerConnection}} object on which the
                     method was invoked.</p>
                   </li>
                   <li data-tests="RTCPeerConnection-createOffer.html">
                     <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
-                    <code>true</code>, return a promise <a>rejected</a> with a newly
-                    <a data-link-for="exception" data-lt="create">created</a>
-                    <code>InvalidStateError</code>.</p>
+                    <code>true</code>, return a promise [= rejected =] with a newly
+                    [= exception/create | created =]
+                    {{InvalidStateError}}.</p>
                   </li>
                   <li>
-                    <p>Return the result of <a href=
-                    "#dfn-chain-an-operation">chaining</a> the result of
-                    <a href="#dfn-create-an-offer">creating an offer</a> with
+                    <p>Return the result of [= chaining =] the result of
+                    [= creating an offer =] with
                     <var>connection</var> to <var>connection</var>'s operations
                     chain.</p>
                   </li>
                 </ol>
-                <p>To <dfn>create an offer</dfn> given <var>connection</var>
+                <p>To <dfn data-lt="creating an offer">create an offer</dfn> given <var>connection</var>
                 run the following steps:</p>
                 <ol>
                   <li data-tests="RTCPeerConnection-setRemoteDescription-offer.html">
-                    <p>If <var>connection</var>'s <a>signaling state</a> is
+                    <p>If <var>connection</var>'s [= signaling state =] is
                     neither <code>"stable"</code> nor
                     <code>"have-local-offer"</code>, return a promise
-                    <a>rejected</a> with a newly <a data-link-for="exception"
-                      data-lt="create">created</a>
-                    <code>InvalidStateError</code>.</p>
+                    [= rejected =] with a newly [= exception/create | created =]
+                    {{InvalidStateError}}.</p>
                   </li>
                   <li>
                     <p>Let <var>p</var> be a new promise.</p>
                   </li>
                   <li>
-                    <p>In parallel, begin the <a>in-parallel steps to create an
-                      offer</a> given <var>connection</var> and <var>p</var>.</p>
+                    <p>In parallel, begin the [= in-parallel steps to create an
+                      offer =] given <var>connection</var> and <var>p</var>.</p>
                   </li>
                   <li>
                     <p>Return <var>p</var>.</p>
@@ -2468,14 +2423,14 @@ interface RTCPeerConnection : EventTarget  {
                     "createoffer">[[!JSEP]]</span>.</p>
                   </li>
                   <li class=untestable>
-                    <p>If this inspection failed for any reason, <a>reject</a>
+                    <p>If this inspection failed for any reason, [= reject =]
                     <var>p</var> with a newly
-                    <a data-link-for="exception" data-lt="create">created</a>
-                    <code>OperationError</code> and abort these steps.</p>
+                    [= exception/create | created =]
+                    {{OperationError}} and abort these steps.</p>
                   </li>
                   <li>
-                    <p>Queue a task that runs the <a>final steps to create an
-                    offer</a> given <var>connection</var> and <var>p</var>.</p>
+                    <p>Queue a task that runs the [= final steps to create an
+                    offer =] given <var>connection</var> and <var>p</var>.</p>
                   </li>
                 </ol>
                 <p>The <dfn>final steps to create an offer</dfn> given
@@ -2487,35 +2442,35 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li data-tests="RTCPeerConnection-createOffer.html">
                     <p>If <var>connection</var> was modified in such a way that
-                    additional inspection of the <a>offerer's system state</a>
+                    additional inspection of the [= offerer's system state =]
                     is necessary, then in parallel begin the
-                    <a>in-parallel steps to create an offer</a> again, given
+                    [= in-parallel steps to create an offer =] again, given
                     <var>connection</var> and <var>p</var>, and abort these
                     steps.</p>
                     <div class="note">
                       This may be necessary if, for example,
                       <code>createOffer</code> was called when only an audio
-                      <code><a>RTCRtpTransceiver</a></code> was added to
+                      {{RTCRtpTransceiver}} was added to
                       <var>connection</var>, but while performing the
-                      <a>in-parallel steps to create an offer</a>, a video
-                      <code><a>RTCRtpTransceiver</a></code> was added, requiring
+                      [= in-parallel steps to create an offer =], a video
+                      {{RTCRtpTransceiver}} was added, requiring
                       additional inspection of video system resources.
                     </div>
                   </li>
                   <li>
                     <p class=untestable>Given the information that was obtained from previous
                     inspection, the current state of <var>connection</var>
-                    and its <code><a>RTCRtpTransceiver</a></code>s,
+                    and its {{RTCRtpTransceiver}}s,
                     generate an SDP offer, <var>sdpString</var>, as described
                     in <span data-jsep="create-offer">[[!JSEP]]</span>.</p>
                     <ol>
                       <li data-tests="RTCRtpSender-transport.https.html">
                         <p>As described in [[!BUNDLE]] (Section 7), if bundling
-                        is used (see <a>RTCBundlePolicy</a>) an offerer tagged
+                        is used (see {{RTCBundlePolicy}}) an offerer tagged
                         m= section must be selected in order to negotiate a
                         BUNDLE group. The user agent MUST choose the m= section
                         that corresponds to the first non-stopped transceiver in
-                        the <a>set of transceivers</a> as the offerer tagged m=
+                        the [= set of transceivers =] as the offerer tagged m=
                         section. This allows the remote endpoint to predict
                         which transceiver is the offerer tagged m= section
                         without having to parse the SDP.</p>
@@ -2523,25 +2478,25 @@ interface RTCPeerConnection : EventTarget  {
                       <li>
                         <p>The <i>codec preferences</i> of an m= section's
                         associated transceiver is said to be the value of the
-                        <code>RTCRtpTranceiver</code>.<a>[[\PreferredCodecs]]</a> with the following
+                        {{RTCRtpTransceiver}}.<a>[[\PreferredCodecs]]</a> with the following
                         filtering applied (or said not to be set if
                         <a>[[\PreferredCodecs]]</a> is empty):</p>
                         <ol>
                           <li>
-                            <p>If the <a data-link-for="RTCRtpTransceiver">direction</a> is
+                            <p>If the {{RTCRtpTransceiver/direction}} is
                             <code>"sendrecv"</code>, exclude any codecs not
                             included in the intersection of
                             <code>RTCRtpSender.getCapabilities(kind).codecs</code>
                             and <code>RTCRtpReceiver.getCapabilities(kind).codecs</code>.
                           </li>
                           <li>
-                            <p>If the <a data-link-for="RTCRtpTransceiver">direction</a> is
+                            <p>If the {{RTCRtpTransceiver/direction}} is
                             <code>"sendonly"</code>, exclude any codecs not
                             included in
                             <code>RTCRtpSender.getCapabilities(kind).codecs</code>.
                           </li>
                           <li>
-                            <p>If the <a data-link-for="RTCRtpTransceiver">direction</a> is
+                            <p>If the {{RTCRtpTransceiver/direction}} is
                             <code>"recvonly"</code>, exclude any codecs not
                             included in
                             <code>RTCRtpReceiver.getCapabilities(kind).codecs</code>.
@@ -2575,7 +2530,7 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li data-tests="RTCPeerConnection-createOffer.html">
                     <p>Let <var>offer</var> be a newly created
-                    <code><a>RTCSessionDescriptionInit</a></code> dictionary
+                    {{RTCSessionDescriptionInit}} dictionary
                     with its <code>type</code> member initialized to the string
                     <code>"offer"</code> and its <code>sdp</code> member
                     initialized to <var>sdpString</var>.</p>
@@ -2584,91 +2539,88 @@ interface RTCPeerConnection : EventTarget  {
                     <var>sdpString</var>.</p>
                   </li>
                   <li>
-                    <p><a>Resolve</a> <var>p</var> with <var>offer</var>.</p>
+                    <p>[= Resolve =] <var>p</var> with <var>offer</var>.</p>
                   </li>
                 </ol>
               </dd>
-              <dt data-tests="RTCPeerConnection-createAnswer.html,promises-call.html"><dfn data-idl><code>createAnswer</code></dfn></dt>
+              <dt data-tests="RTCPeerConnection-createAnswer.html,promises-call.html"><dfn data-idl>createAnswer</dfn></dt>
               <dd>
                 <p>The <code>createAnswer</code> method generates an [[!SDP]]
                 answer with the supported configuration for the session that is
                 compatible with the parameters in the remote configuration.
                 Like <code>createOffer</code>, the returned blob of SDP contains
-                descriptions of the local <code>MediaStreamTrack</code>s
-                attached to this <code>RTCPeerConnection</code>, the
+                descriptions of the local {{MediaStreamTrack}}s
+                attached to this {{RTCPeerConnection}}, the
                 codec/RTP/RTCP options negotiated for this session, and any
-                candidates that have been gathered by the <a>ICE Agent</a>. The
+                candidates that have been gathered by the [= ICE Agent =]. The
                 <code>options</code> parameter may be supplied to provide
                 additional control over the generated answer.</p>
                 <p>Like <code>createOffer</code>, the
                 returned description SHOULD reflect the current state of the
                 system. The session descriptions MUST remain usable by
                 <code>setLocalDescription</code> without causing an error until
-                at least the end of the <a>fulfillment</a> callback of the returned
+                at least the end of the [= fulfillment =] callback of the returned
                 promise.</p>
                 <p>As an answer, the generated SDP will contain a specific
                 codec/RTP/RTCP configuration that, along with the corresponding offer,
                 specifies how the media plane should be established. The
                 generation of the SDP MUST follow the appropriate process for
                 generating an answer described in [[!JSEP]].</p>
-                <p>The generated SDP will also contain the <a>ICE agent</a>'s
-                <a data-link-for="RTCIceParameters">usernameFragment</a>,
-                <a data-link-for="RTCIceParameters">password</a> and
+                <p>The generated SDP will also contain the [= ICE agent =]'s
+                {{RTCIceParameters/usernameFragment}},
+                {{RTCIceParameters/password}} and
                 ICE options (as defined in [[!ICE]], Section 14) and may also contain
                 any local candidates that have been gathered by the agent.</p>
                 <p>The <code>certificates</code> value in <var>configuration</var>
-                for the <code>RTCPeerConnection</code> provides the
+                for the {{RTCPeerConnection}} provides the
                 certificates configured by the application for the
-                <code>RTCPeerConnection</code>.  These certificates,
+                {{RTCPeerConnection}}.  These certificates,
                 along with any default certificates are used to produce a set of
                 certificate fingerprints. These certificate fingerprints are
                 used in the construction of SDP.</p>
                 <p>An answer can be marked as provisional, as described in
                 <span data-jsep="use-of-provisional-answer">[[!JSEP]]</span>,
-                by setting the <code><a data-link-for=
-                "RTCSessionDescription">type</a></code> to
+                by setting the {{RTCSessionDescription/type}} to
                 <code>"pranswer"</code>.</p>
                 <p>When the method is called, the user agent MUST run the
                 following steps:</p>
                 <ol>
                   <li>
                     <p>Let <var>connection</var> be the
-                    <code><a>RTCPeerConnection</a></code> object on which the
+                    {{RTCPeerConnection}} object on which the
                     method was invoked.</p>
                   </li>
                   <li data-tests="RTCPeerConnection-createAnswer.html">
                     <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
-                    <code>true</code>, return a promise <a>rejected</a> with a newly
-                    <a data-link-for="exception" data-lt="create">created</a>
-                    <code>InvalidStateError</code>.</p>
+                    <code>true</code>, return a promise [= rejected =] with a newly
+                    [= exception/create | created =]
+                    {{InvalidStateError}}.</p>
                   </li>
                   <li>
-                    <p>Return the result of <a href=
-                    "#dfn-chain-an-operation">chaining</a> the result of
-                    <a href="#dfn-create-an-answer">creating an answer</a> with
+                    <p>Return the result of [= chaining =] the result of
+                    [= creating an answer =] with
                     <var>connection</var> to <var>connection</var>'s operations
                     chain.</p>
                   </li>
                 </ol>
-                <p>To <dfn>create an answer</dfn> given <var>connection</var>
+                <p>To <dfn data-lt="creating an answer">create an answer</dfn> given <var>connection</var>
                 run the following steps:</p>
                 <ol>
                   <li data-tests="RTCPeerConnection-createAnswer.html,
                   RTCPeerConnection-setLocalDescription-answer.html,
                   RTCPeerConnection-setLocalDescription-pranswer.html">
-                    <p>If <var>connection</var>'s <a>signaling state</a>
+                    <p>If <var>connection</var>'s [= signaling state =]
                     is neither <code>"have-remote-offer"</code> nor
                     <code>"have-local-pranswer"</code>, return a promise
-                    <a>rejected</a> with a newly <a data-link-for="exception"
-                      data-lt="create">created</a>
-                    <code>InvalidStateError</code>.</p>
+                    [= rejected =] with a newly [= exception/create | created =]
+                    {{InvalidStateError}}.</p>
                   </li>
                   <li>
                     <p>Let <var>p</var> be a new promise.</p>
                   </li>
                   <li>
-                    <p>In parallel, begin the <a>in-parallel steps to create
-                      an answer</a> given <var>connection</var> and
+                    <p>In parallel, begin the [= in-parallel steps to create
+                      an answer =] given <var>connection</var> and
                     <var>p</var>.</p>
                   </li>
                   <li>
@@ -2691,14 +2643,14 @@ interface RTCPeerConnection : EventTarget  {
                     "createanswer">[[!JSEP]]</span>.</p>
                   </li>
                   <li class=untestable>
-                    <p>If this inspection failed for any reason, <a>reject</a>
+                    <p>If this inspection failed for any reason, [= reject =]
                     <var>p</var> with a newly
-                    <a data-link-for="exception" data-lt="create">created</a>
-                    <code>OperationError</code> and abort these steps.</p>
+                    [= exception/create | created =]
+                    {{OperationError}} and abort these steps.</p>
                   </li>
                   <li>
-                    <p>Queue a task that runs the <a>final steps to create an
-                    answer</a> given <var>p</var>.</p>
+                    <p>Queue a task that runs the [= final steps to create an
+                    answer =] given <var>p</var>.</p>
                   </li>
                 </ol>
                 <p>The <dfn>final steps to create an answer</dfn> given a
@@ -2710,17 +2662,17 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>If <var>connection</var> was modified in such a way that
-                    additional inspection of the <a>answerer's system state</a>
+                    additional inspection of the [= answerer's system state =]
                     is necessary, then in parallel begin the
-                    <a>in-parallel steps to create an answer</a> again given
+                    [= in-parallel steps to create an answer =] again given
                     <var>connection</var> and <var>p</var>, and abort these
                     steps.</p>
                     <div class="note">
                       This may be necessary if, for example,
                       <code>createAnswer</code> was called when an
-                      <code><a>RTCRtpTransceiver</a></code>'s direction was
+                      {{RTCRtpTransceiver}}'s direction was
                       <code>"recvonly"</code>, but while performing the
-                      <a>in-parallel steps to create an answer</a>, the
+                      [= in-parallel steps to create an answer =], the
                       direction was changed to <code>"sendrecv"</code>,
                       requiring additional inspection of video encoding
                       resources.
@@ -2729,32 +2681,32 @@ interface RTCPeerConnection : EventTarget  {
                   <li>
                     <p>Given the information that was obtained from previous
                     inspection and the current state of <var>connection</var>
-                    and its <code><a>RTCRtpTransceiver</a></code>s,
+                    and its {{RTCRtpTransceiver}}s,
                     generate an SDP answer, <var>sdpString</var>, as described
                     in <span data-jsep="generating-an-answer">[[!JSEP]]</span>.</p>
                     <ol>
                       <li>
                         <p>The <i>codec preferences</i> of an m= section's
                         associated transceiver is said to be the value of the
-                        <code>RTCRtpTranceiver</code>.<a>[[\PreferredCodecs]]</a> with the following
+                        {{RTCRtpTransceiver}}.<a>[[\PreferredCodecs]]</a> with the following
                         filtering applied (or said not to be set if
                         <a>[[\PreferredCodecs]]</a> is empty):</p>
                         <ol>
                           <li>
-                            <p>If the <a data-link-for="RTCRtpTransceiver">direction</a> is
+                            <p>If the {{RTCRtpTransceiver/direction}} is
                             <code>"sendrecv"</code>, exclude any codecs not
                             included in the intersection of
                             <code>RTCRtpSender.getCapabilities(kind).codecs</code>
                             and <code>RTCRtpReceiver.getCapabilities(kind).codecs</code>.
                           </li>
                           <li>
-                            <p>If the <a data-link-for="RTCRtpTransceiver">direction</a> is
+                            <p>If the {{RTCRtpTransceiver/direction}} is
                             <code>"sendonly"</code>, exclude any codecs not
                             included in
                             <code>RTCRtpSender.getCapabilities(kind).codecs</code>.
                           </li>
                           <li>
-                            <p>If the <a data-link-for="RTCRtpTransceiver">direction</a> is
+                            <p>If the {{RTCRtpTransceiver/direction}} is
                             <code>"recvonly"</code>, exclude any codecs not
                             included in
                             <code>RTCRtpReceiver.getCapabilities(kind).codecs</code>.
@@ -2780,7 +2732,7 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li data-tests="RTCPeerConnection-createAnswer.html">
                     <p>Let <var>answer</var> be a newly created
-                    <code><a>RTCSessionDescriptionInit</a></code> dictionary
+                    {{RTCSessionDescriptionInit}} dictionary
                     with its <code>type</code> member initialized to the string
                     <code>"answer"</code> and its <code>sdp</code> member
                     initialized to <var>sdpString</var>.</p>
@@ -2789,7 +2741,7 @@ interface RTCPeerConnection : EventTarget  {
                     <var>sdpString</var>.</p>
                   </li>
                   <li>
-                    <p><a>Resolve</a> <var>p</var> with <var>answer</var>.</p>
+                    <p>[= Resolve =] <var>p</var> with <var>answer</var>.</p>
                   </li>
                 </ol>
               </dd>
@@ -2797,22 +2749,22 @@ interface RTCPeerConnection : EventTarget  {
               <dd>
                 <p>The <dfn id=
                 "dom-peerconnection-setlocaldescription"><code>setLocalDescription</code></dfn>
-                method instructs the <code><a>RTCPeerConnection</a></code> to
-                apply the supplied <code><a>RTCSessionDescriptionInit</a></code>
+                method instructs the {{RTCPeerConnection}} to
+                apply the supplied {{RTCSessionDescriptionInit}}
                 as the local description.</p>
                 <p>This API changes the local media state. In order to
                 successfully handle scenarios where the application wants to
                 offer to change from one media format to a different,
-                incompatible format, the <code><a>RTCPeerConnection</a></code>
+                incompatible format, the {{RTCPeerConnection}}
                 MUST be able to simultaneously support use of both the current
                 and pending local descriptions (e.g. support codecs that exist
                 in both descriptions) until a final answer is received, at
-                which point the <code><a>RTCPeerConnection</a></code> can fully
+                which point the {{RTCPeerConnection}} can fully
                 adopt the pending local description, or rollback to the current
                 description if the remote side rejected the change.</p>
                 <p>Passing in a description is optional. If left out, then
                 <code>setLocalDescription</code> will implicitly
-                <a>create an offer</a> or <a>create an answer</a>, as needed.
+                [= create an offer =] or [= create an answer =], as needed.
                 As noted in <span data-jsep="modifying-sdp">[[!JSEP]]</span>,
                 if a description with SDP is passed in, that SDP is not allowed
                 to have changed from when it was returned from either
@@ -2826,7 +2778,7 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>Let <var>connection</var> be the
-                    <code><a>RTCPeerConnection</a></code> object on which the
+                    {{RTCPeerConnection}} object on which the
                     method was invoked.</p>
                   </li>
                   <li>
@@ -2834,15 +2786,14 @@ interface RTCPeerConnection : EventTarget  {
                     <code><var>description</var>.sdp</code>.</p>
                   </li>
                   <li>
-                    <p>Return the result of <a href=
-                    "#dfn-chain-an-operation">chaining</a> the following steps to
+                    <p>Return the result of [= chaining =] the following steps to
                     <var>connection</var>'s operations chain:</p>
                     <ol>
                       <li>
                         <p>Let <var>type</var> be
                         <code><var>description</var>.type</code> if present, or
                         <code>"offer"</code> if not present and
-                        <var>connection</var>'s <a>signaling state</a> is either
+                        <var>connection</var>'s [= signaling state =] is either
                         <code>"stable"</code>, <code>"have-local-offer"</code>,
                         or <code>"have-remote-pranswer"</code>; otherwise
                         <code>"answer"</code>.</p>
@@ -2851,18 +2802,18 @@ interface RTCPeerConnection : EventTarget  {
                         <p>If <var>type</var> is <code>"offer"</code>, and
                         <var>sdp</var> is not the empty string and not equal to
                         <var>connection</var>.<a>[[\LastCreatedOffer]]</a>,
-                        then return a promise <a>rejected</a> with a newly
-                        <a data-link-for="exception" data-lt="create">created</a>
-                        <code>InvalidModificationError</code> and abort these
+                        then return a promise [= rejected =] with a newly
+                        [= exception/create | created =]
+                        {{InvalidModificationError}} and abort these
                         steps.</p>
                       </li>
                       <li data-tests="RTCPeerConnection-setLocalDescription-offer.html">
                         <p>If <var>type</var> is <code>"answer"</code> or
                         <code>"pranswer"</code>, and <var>sdp</var> is not the
                         empty string and not equal to <var>connection</var>.<a>[[\LastCreatedAnswer]]</a>, then return a
-                        promise <a>rejected</a> with a newly
-                        <a data-link-for="exception" data-lt="create">created</a>
-                        <code>InvalidModificationError</code> and abort these
+                        promise [= rejected =] with a newly
+                        [= exception/create | created =]
+                        {{InvalidModificationError}} and abort these
                         steps.</p>
                       </li>
                       <li>
@@ -2877,13 +2828,13 @@ interface RTCPeerConnection : EventTarget  {
                           </li>
                           <li data-tests="RTCPeerConnection-setLocalDescription-offer.html">
                             <p>If <var>sdp</var> is the empty string, or if it
-                            no longer accurately represents the <a>offerer's system state</a> of
+                            no longer accurately represents the [= offerer's system state =] of
                             <var>connection</var>, then let <var>p</var> be the result of
-                            <a href="#dfn-create-an-offer">creating an offer</a>
+                            [= creating an offer =]
                             with <var>connection</var>, and return the result of
-                            <a data-cite="!WEBIDL#dfn-perform-steps-once-promise-is-settled">
-                            reacting</a> to <var>p</var> with a fulfillment step that
-                            <a href="#set-local-description">sets the local RTCSessionDescription</a>
+                            [= promise/reacting =]
+                            to <var>p</var> with a fulfillment step that
+                            [= set a local RTCSessionDescription | sets the local RTCSessionDescription =]
                             indicated by its first argument.</p>
                           </li>
                         </ol>
@@ -2901,12 +2852,12 @@ interface RTCPeerConnection : EventTarget  {
                           </li>
                           <li data-tests="RTCPeerConnection-setLocalDescription-offer.html">
                             <p>If <var>sdp</var> is the empty string, or if it
-                            no longer accurately represents the <a>answerer's system state</a> of
+                            no longer accurately represents the [= answerer's system state =] of
                             <var>connection</var>, then let <var>p</var> be the result of
-                            <a href="#dfn-create-an-answer">creating an answer</a>
+                            [= creating an answer =]
                             with <var>connection</var>, and return the result of
-                            <a data-cite="!WEBIDL#dfn-perform-steps-once-promise-is-settled">
-                            reacting</a> to <var>p</var> with the following
+                            [= promise/reacting =]
+                            to <var>p</var> with the following
                             fulfillment steps:</p>
                             <ol>
                               <li>
@@ -2914,8 +2865,7 @@ interface RTCPeerConnection : EventTarget  {
                                 to these fulfillment steps.</p>
                               </li>
                               <li>
-                                <p>Return the result of <a
-                                href="#set-local-description">setting the local RTCSessionDescription</a>
+                                <p>Return the result of [= setting the local RTCSessionDescription =]
                                 indicated by
                                 <code>{<var>type</var>, <var>answer</var>.sdp}</code>.
                                 </p>
@@ -2925,8 +2875,7 @@ interface RTCPeerConnection : EventTarget  {
                         </ol>
                       </li>
                       <li>
-                        <p>Return the result of <a
-                        href="#set-local-description">setting the local RTCSessionDescription</a>
+                        <p>Return the result of [= setting the local RTCSessionDescription =]
                         indicated by
                         <code>{<var>type</var>, <var>sdp</var>}</code>.</p>
                       </li>
@@ -2936,16 +2885,16 @@ interface RTCPeerConnection : EventTarget  {
                 <div class="note">
                   <p>As noted in <span data-jsep="applying-a-local-desc">[[!JSEP]]</span>,
                   calling this method may trigger the ICE candidate gathering process
-                  by the <a>ICE Agent</a>.</p>
+                  by the [= ICE Agent =].</p>
                 </div>
               </dd>
               <dt data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-setLocalDescription-answer.html,promises-call.html,simplecall-no-ssrcs.https.html,simplecall.https.html"><code>setRemoteDescription</code></dt>
               <dd>
                 <p>The <dfn id=
                 "dom-peerconnection-setremotedescription"><code>setRemoteDescription</code></dfn>
-                method instructs the <code><a>RTCPeerConnection</a></code> to
+                method instructs the {{RTCPeerConnection}} to
                 apply the supplied
-                <code><a>RTCSessionDescriptionInit</a></code> as the remote
+                {{RTCSessionDescriptionInit}} as the remote
                 offer or answer. This API changes the local media state.</p>
                 <p>When the method is invoked, the user agent MUST run the following steps:</p>
                 <ol>
@@ -2954,45 +2903,40 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>Let <var>connection</var> be the
-                    <code><a>RTCPeerConnection</a></code> object on which the
+                    {{RTCPeerConnection}} object on which the
                     method was invoked.</p>
                   </li>
                   <li data-tests="RTCPeerConnection-setRemoteDescription-offer.html">
-                    <p>If <var>description</var>'s <code><a data-link-for=
-                    "RTCSessionDescriptionInit">type</a></code> is not present,
-                    <a>throw</a> a <code>TypeError</code>.</p>
+                    <p>If <var>description</var>'s {{RTCSessionDescriptionInit/type}} is not present,
+                    [= exception/throw =] a {{TypeError}}.</p>
                   </li>
                   <li>
-                    <p>Return the result of <a href=
-                    "#dfn-chain-an-operation">chaining</a> the following steps
+                    <p>Return the result of [= chaining =] the following steps
                     to <var>connection</var>'s operations chain:</p>
                     <ol>
                       <li>
-                        <p>If the <var>description</var>'s <code><a data-link-for=
-                        "RTCSessionDescriptionInit">type</a></code> is
+                        <p>If the <var>description</var>'s {{RTCSessionDescriptionInit/type}} is
                         <code>"offer"</code> and is invalid for the
-                        current <a>signaling state</a> of <var>connection</var>
+                        current [= signaling state =] of <var>connection</var>
                         as described in <span data-jsep=
                         "processing-a-local-desc processing-a-remote-desc">[[!JSEP]]</span>,
                         then run the following sub steps:</p>
                         <ol>
                           <li>
-                            <p>Let <var>p</var> be the result of <a
-                            href="#set-local-description">setting the local RTCSessionDescription</a>
+                            <p>Let <var>p</var> be the result of [= setting the local RTCSessionDescription =]
                             indicated by <code>{type: "rollback"}</code>.</p>
                           </li>
                           <li>
                             <p>Return the result of
-                            <a data-cite="!WEBIDL#dfn-perform-steps-once-promise-is-settled">
-                              reacting</a> to <var>p</var> with a fulfillment step that
-                            <a href="#set-remote-description">sets the remote RTCSessionDescription</a>
+                            [= promise/reacting =]
+                            to <var>p</var> with a fulfillment step that
+                            [= set a remote RTCSessionDescription | sets the remote RTCSessionDescription =]
                             <var>description</var>, and abort these steps.</p>
                           </li>
                         </ol>
                       </li>
                       <li>
-                        <p>Return the result of <a
-                        href="#set-remote-description">setting the remote RTCSessionDescription</a>
+                        <p>Return the result of [= setting the remote RTCSessionDescription =]
                         <var>description</var>.</p>
                       </li>
                     </ol>
@@ -3003,15 +2947,11 @@ interface RTCPeerConnection : EventTarget  {
               <dd>
                 <p>The <dfn id=
                 "dom-peerconnection-addicecandidate"><code>addIceCandidate</code></dfn>
-                method provides a remote candidate to the <a>ICE Agent</a>.
+                method provides a remote candidate to the [= ICE Agent =].
                 This method can also be used to indicate the end of remote
-                candidates when called with an empty string for the <code><a
-                data-link-for="RTCIceCandidate">candidate</a></code> member. The only
-                members of the argument used by this method are <code><a data-link-for=
-                "RTCIceCandidate">candidate</a></code>, <code><a data-link-for=
-                "RTCIceCandidate">sdpMid</a></code>, <code><a data-link-for=
-                "RTCIceCandidate">sdpMLineIndex</a></code>, and
-                <code><a data-link-for="RTCIceCandidate">usernameFragment</a></code>; the rest
+                candidates when called with an empty string for the {{RTCIceCandidate/candidate}} member. The only
+                members of the argument used by this method are {{RTCIceCandidate/candidate}}, {{RTCIceCandidate/sdpMid}}, {{RTCIceCandidate/sdpMLineIndex}}, and
+                {{RTCIceCandidate/usernameFragment}}; the rest
                 are ignored. When the method is invoked, the user agent MUST
                 run the following steps:</p>
                 <ol>
@@ -3020,28 +2960,26 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>Let <var>connection</var> be the
-                    <code><a>RTCPeerConnection</a></code> object on which the
+                    {{RTCPeerConnection}} object on which the
                     method was invoked.</p>
                   </li>
                   <li>
                     <p>If <var>candidate.candidate</var> is not an empty string
                     and both <var>candidate.sdpMid</var> and
                     <var>candidate.sdpMLineIndex</var> are
-                    <code>null</code>, return a promise <a>rejected</a> with a newly
-                    <a data-link-for="exception" data-lt="create">created</a>
-                    <code>TypeError</code>.</p>
+                    <code>null</code>, return a promise [= rejected =] with a newly
+                    [= exception/create | created =]
+                    {{TypeError}}.</p>
                   </li>
                   <li>
-                    <p>Return the result of <a href=
-                    "#dfn-chain-an-operation">chaining</a> the following
+                    <p>Return the result of [= chaining =] the following
                     steps to <var>connection</var>'s operations chain:</p>
                     <ol>
                       <li data-tests="RTCPeerConnection-addIceCandidate.html">
-                        <p>If <code><a data-link-for=
-                        "RTCPeerConnection">remoteDescription</a></code> is
-                        <code>null</code> return a promise <a>rejected</a> with a newly
-                        <a data-link-for="exception" data-lt="create">created
-                        </a> <code>InvalidStateError</code>.</p>
+                        <p>If {{RTCPeerConnection/remoteDescription}} is
+                        <code>null</code> return a promise [= rejected =] with a newly
+                        [= exception/create | created =]
+                        {{InvalidStateError}}.</p>
                       </li>
                       <li>
                         <p>Let <var>p</var> be a new promise.</p>
@@ -3053,11 +2991,10 @@ interface RTCPeerConnection : EventTarget  {
                           <li data-tests="RTCPeerConnection-addIceCandidate.html">
                             <p>If <var>candidate.sdpMid</var> is not equal to
                             the mid of any media description in
-                            <code><a data-link-for=
-                            "RTCPeerConnection">remoteDescription</a></code>,
-                            <a>reject</a> <var>p</var> with a newly
-                            <a data-link-for="exception" data-lt="create">
-                            created</a> <code>OperationError</code> and abort
+                            {{RTCPeerConnection/remoteDescription}},
+                            [= reject =] <var>p</var> with a newly
+                            [= exception/create | created =]
+                            {{OperationError}} and abort
                             these steps.</p>
                           </li>
                         </ol>
@@ -3069,11 +3006,10 @@ interface RTCPeerConnection : EventTarget  {
                           <li>
                             <p>If <var>candidate.sdpMLineIndex</var> is equal
                             to or larger than the number of media descriptions
-                            in <code><a data-link-for=
-                            "RTCPeerConnection">remoteDescription</a></code>,
-                            <a>reject</a> <var>p</var> with a newly
-                            <a data-link-for="exception" data-lt="create">
-                            created</a> <code>OperationError</code> and abort
+                            in {{RTCPeerConnection/remoteDescription}},
+                            [= reject =] <var>p</var> with a newly
+                            [= exception/create | created =]
+                            {{OperationError}} and abort
                             these steps.</p>
                           </li>
                         </ol>
@@ -3081,11 +3017,10 @@ interface RTCPeerConnection : EventTarget  {
                       <li data-tests="RTCPeerConnection-addIceCandidate.html">
                         <p>If either <var>candidate.sdpMid</var> or
                         <var>candidate.sdpMLineIndex</var> indicate a media
-                        description in <code><a data-link-for=
-                          "RTCPeerConnection">remoteDescription</a></code> whose
+                        description in {{RTCPeerConnection/remoteDescription}} whose
                         associated transceiver is
-                        <a data-link-for="RTCRtpTransceiver">
-                          stopped</a>, <a>resolve</a> <var>p</var> with
+                        {{RTCRtpTransceiver/
+                          stopped}}, [= resolve =] <var>p</var> with
                         <code>undefined</code> and abort these steps.
                         </p>
                       </li>
@@ -3093,10 +3028,10 @@ interface RTCPeerConnection : EventTarget  {
                         <p>If <code><var>candidate</var>.usernameFragment</code>
                         is not <code>null</code>, and is not
                         equal to any username fragment present in the corresponding
-                        <a>media description</a> of an applied remote
-                        description, <a>reject</a> <var>p</var> with a newly
-                        <a data-link-for="exception" data-lt="create">created
-                        </a> <code>OperationError</code> and abort these steps.
+                        [= media description =] of an applied remote
+                        description, [= reject =] <var>p</var> with a newly
+                        [= exception/create | created =]
+                        {{OperationError}} and abort these steps.
                         </p>
                       </li>
                       <li>
@@ -3104,16 +3039,16 @@ interface RTCPeerConnection : EventTarget  {
                         <var>candidate</var> as described in <span data-jsep=
                         "addicecandidate">[[!JSEP]]</span>. Use
                         <code><var>candidate</var>.usernameFragment</code> to identify the
-                        ICE <a>generation</a>; if <code>usernameFragment</code> is null, process the
+                        ICE [= generation =]; if <code>usernameFragment</code> is null, process the
                         <var>candidate</var> for the most recent ICE
-                        <a>generation</a>. If
+                        [= generation =]. If
                         <code><var>candidate</var>.candidate</code> is an empty
                         string, process <var>candidate</var> as an
                         end-of-candidates indication for the corresponding
-                        <a>media description</a> and ICE candidate
-                        <a>generation</a>. If both <var>candidate.sdpMid</var> and
+                        [= media description =] and ICE candidate
+                        [= generation =]. If both <var>candidate.sdpMid</var> and
                         <var>candidate.sdpMLineIndex</var> are <code>null</code>, then
-                        this applies to all <a>media description</a>s.</p>
+                        this applies to all [= media description =]s.</p>
                         <ol>
                           <li>
                             <p>If <var>candidate</var> could not be
@@ -3125,9 +3060,9 @@ interface RTCPeerConnection : EventTarget  {
                                 then abort these steps.</p>
                               </li>
                               <li>
-                                <p><a>Reject</a> <var>p</var> with a newly
-                                <a data-link-for="exception" data-lt="create">
-                                created</a> <code>OperationError</code> and abort
+                                <p>[= Reject =] <var>p</var> with a newly
+                                [= exception/create | created =]
+                                {{OperationError}} and abort
                                 these steps.</p>
                               </li>
                             </ol>
@@ -3143,18 +3078,18 @@ interface RTCPeerConnection : EventTarget  {
                               </li>
                               <li>
                                 <p>If <var>connection</var>.<a>[[\PendingRemoteDescription]]</a>
-                                is not <code>null</code>, and represents the ICE <a>generation</a>
+                                is not <code>null</code>, and represents the ICE [= generation =]
                                 for which <var>candidate</var> was processed, add <var>candidate</var>
                                 to the <var>connection</var>.<a>[[\PendingRemoteDescription]]</a>.sdp.</p>
                               </li>
                               <li>
                                 <p>If <var>connection</var>.<a>[[\CurrentRemoteDescription]]</a>
-                                is not <code>null</code>, and represents the ICE <a>generation</a>
+                                is not <code>null</code>, and represents the ICE [= generation =]
                                 for which <var>candidate</var> was processed, add <var>candidate</var>
                                 to the <var>connection</var>.<a>[[\CurrentRemoteDescription]]</a>.sdp.</p>
                               </li>
                               <li>
-                                <p><a>Resolve</a> <var>p</var> with
+                                <p>[= Resolve =] <var>p</var> with
                                 <code>undefined</code>.</p>
                               </li>
                             </ol>
@@ -3173,10 +3108,10 @@ interface RTCPeerConnection : EventTarget  {
                 descriptions and ICE candidate generation. This is by design for
                 legacy reasons.</p>
               </dd>
-              <dt data-tests="RTCPeerConnection-restartIce.https.html"><dfn data-idl><code>restartIce</code></dfn></dt>
+              <dt data-tests="RTCPeerConnection-restartIce.https.html"><dfn data-idl>restartIce</dfn></dt>
               <dd>
                 <p>The <code>restartIce</code> method tells the
-                <code><a>RTCPeerConnection</a></code> that ICE should be
+                {{RTCPeerConnection}} that ICE should be
                 restarted. Subsequent calls to <code>createOffer</code> will
                 create descriptions that will restart ICE, as described in
                 section 9.1.1.1 of [[!ICE]].</p>
@@ -3185,7 +3120,7 @@ interface RTCPeerConnection : EventTarget  {
                 <ol>
                   <li>
                     <p>Let <var>connection</var> be the
-                    <code><a>RTCPeerConnection</a></code> on which the method
+                    {{RTCPeerConnection}} on which the method
                     was invoked.</p>
                   </li>
                   <li data-tests="RTCPeerConnection-restartIce.https.html">
@@ -3197,56 +3132,56 @@ interface RTCPeerConnection : EventTarget  {
                     <var>connection</var>.<a>[[\PendingLocalDescription]]</a>.</p>
                   </li>
                   <li data-tests="RTCPeerConnection-restartIce.https.html,RTCPeerConnection-restartIce-onnegotiationneeded.https.html">
-                    <p><a data-lt="update the negotiation-needed flag">Update the
-                    negotiation-needed flag</a> for <var>connection</var>.</p>
+                    <p>[= Update the
+                    negotiation-needed flag =] for <var>connection</var>.</p>
                   </li>
                 </ol>
               </dd>
-              <dt><dfn data-idl><code>getConfiguration</code></dfn></dt>
+              <dt><dfn data-idl>getConfiguration</dfn></dt>
               <dd>
-                <p>Returns an <code><a>RTCConfiguration</a></code> object
+                <p>Returns an {{RTCConfiguration}} object
                 representing the current configuration of this
-                <code><a>RTCPeerConnection</a></code> object.</p>
+                {{RTCPeerConnection}} object.</p>
                 <p>When this method is called, the user agent MUST return the
-                <code><a>RTCConfiguration</a></code> object stored in the
+                {{RTCConfiguration}} object stored in the
                 <a>[[\Configuration]]</a> internal slot.</p>
               </dd>
               <dt><code>setConfiguration</code></dt>
               <dd>
                 <p>The <code>setConfiguration</code> method updates the
-                configuration of this <code><a>RTCPeerConnection</a></code>
-                object. This includes changing the configuration of the <a>ICE
-                Agent</a>. As noted in <span data-jsep=
+                configuration of this {{RTCPeerConnection}}
+                object. This includes changing the configuration of the [= ICE
+                Agent =]. As noted in <span data-jsep=
                 "ice-gather-overview">[[!JSEP]]</span>, when the ICE
                 configuration changes in a way that requires a new gathering
                 phase, an ICE restart is required.</p>
-                <p>When the <dfn data-idl><code>setConfiguration</code></dfn> method is
+                <p>When the <dfn data-idl>setConfiguration</dfn> method is
                 invoked, the user agent MUST run the following steps:</p>
                 <ol>
                   <li>
                     <p>Let <var>connection</var> be the
-                    <code><a>RTCPeerConnection</a></code> on which the method
+                    {{RTCPeerConnection}} on which the method
                     was invoked.</p>
                   </li>
                   <li>
                     <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
-                    <code>true</code>, <a>throw</a> an
-                    <code>InvalidStateError</code>.</p>
+                    <code>true</code>, [= exception/throw =] an
+                    {{InvalidStateError}}.</p>
                   </li>
                   <li>
-                    <p><a>Set the configuration</a> specified by
+                    <p>[= Set the configuration =] specified by
                     <var>configuration</var>.</p>
                   </li>
                 </ol>
               </dd>
               <dt data-tests="RTCPeerConnection-transceivers.https.html"><code>close</code></dt>
               <dd>
-                <p>When the <dfn data-idl><code>close</code></dfn> method is invoked,
+                <p>When the <dfn data-idl>close</dfn> method is invoked,
                 the user agent MUST run the following steps:</p>
                 <ol>
                   <li>
                     <p>Let <var>connection</var> be the
-                    <code><a>RTCPeerConnection</a></code> object on which the
+                    {{RTCPeerConnection}} object on which the
                     method was invoked.</p>
                   </li>
                   <li>
@@ -3258,13 +3193,13 @@ interface RTCPeerConnection : EventTarget  {
                     <code>true</code>.</p>
                   </li>
                   <li>
-                    <p>Set <var>connection</var>'s <a>signaling state</a> to
+                    <p>Set <var>connection</var>'s [= signaling state =] to
                     <code>"closed"</code>.</p>
                   </li>
                   <li data-tests="RTCPeerConnection-transceivers.https.html">
                     <p>Let <var>transceivers</var> be the result of executing the
-                    <code><a>CollectTransceivers</a></code> algorithm. For every
-                    <code><a>RTCRtpTransceiver</a></code> <var>transceiver</var> in
+                    {{CollectTransceivers}} algorithm. For every
+                    {{RTCRtpTransceiver}} <var>transceiver</var> in
                     <var>transceivers</var>, run the following steps:</p>
                     <ol>
                       <li>
@@ -3272,18 +3207,16 @@ interface RTCPeerConnection : EventTarget  {
                         is <code>true</code>, abort these sub steps.</p>
                       </li>
                       <li>
-                        <p><a data-lt="stop the RTCRtpTransceiver">
-                        Stop the RTCRtpTransceiver</a> with <var>transceiver</var>
+                        <p>[= Stop the RTCRtpTransceiver =] with <var>transceiver</var>
                         and the value <code>true</code>.</p>
                       </li>
                     </ol>
                   </li>
                   <li>
                     <p>Set the <a>[[\ReadyState]]</a> slot of each of
-                    <var>connection</var>'s <code><a>RTCDataChannel</a></code>s
-                    to <code>"<a data-link-for=
-                    "RTCDataChannelState">closed</a>"</code></p>
-                    <div class="note">The <code><a>RTCDataChannel</a></code>s
+                    <var>connection</var>'s {{RTCDataChannel}}s
+                    to <code>"{{RTCDataChannelState/closed}}"</code></p>
+                    <div class="note">The {{RTCDataChannel}}s
                     will be closed abruptly and the closing procedure
                     will not be invoked.</div>
                   </li>
@@ -3291,34 +3224,31 @@ interface RTCPeerConnection : EventTarget  {
                     <p>If the <var>connection</var>.<a>[[\SctpTransport]]</a>
                     is not <code>null</code>, tear down the underlying SCTP
                     association by sending an SCTP ABORT chunk and set the
-                    <a>[[\SctpTransportState]]</a> to <code>"<a data-link-for=
-                    "RTCSctpTransportState">closed</a>"</code>.</p>
+                    <a>[[\SctpTransportState]]</a> to <code>"{{RTCSctpTransportState/closed}}"</code>.</p>
                   </li>
                   <li>
                     <p>Set the <a>[[\DtlsTransportState]]</a> slot of each of
-                    <var>connection</var>'s <code><a>RTCDtlsTransport</a></code>s
-                    to <code>"<a data-link-for=
-                    "RTCDtlsTransportState">closed</a>"</code>.</p>
+                    <var>connection</var>'s {{RTCDtlsTransport}}s
+                    to <code>"{{RTCDtlsTransportState/closed}}"</code>.</p>
                   </li>
                   <li>
-                    <p>Destroy <var>connection</var>'s <a>ICE Agent</a>,
+                    <p>Destroy <var>connection</var>'s [= ICE Agent =],
                     abruptly ending any active ICE processing and
                     releasing any relevant resources (e.g. TURN
                     permissions).</p>
                   </li>
                   <li>
                     <p>Set the <a>[[\IceTransportState]]</a> slot of each of
-                    <var>connection</var>'s <code><a>RTCIceTransport</a></code>s
-                    to <code>"<a data-link-for=
-                    "RTCIceTransportState">closed</a>"</code>.</p>
+                    <var>connection</var>'s {{RTCIceTransport}}s
+                    to <code>"{{RTCIceTransportState/closed}}"</code>.</p>
                   </li>
                   <li>
-                    <p>Set <var>connection</var>'s <a>ICE connection state</a> to
+                    <p>Set <var>connection</var>'s [= ICE connection state =] to
                       <code>"closed"</code>. This does not fire any event.
                     </p>
                   </li>
                   <li>
-                    <p>Set <var>connection</var>'s <a>connection state</a> to
+                    <p>Set <var>connection</var>'s [= connection state =] to
                     <code>"closed"</code>.</p>
                   </li>
                 </ol>
@@ -3335,7 +3265,7 @@ interface RTCPeerConnection : EventTarget  {
           according to what is specified here.</p>
         <div class="note">
           The addStream method that used to exist on
-          <code><a>RTCPeerConnection</a></code> is easy to polyfill as:
+          {{RTCPeerConnection}} is easy to polyfill as:
           <pre>RTCPeerConnection.prototype.addStream = function(stream) {
   stream.getTracks().forEach((track) =&gt; this.addTrack(track, stream));
 };</pre>
@@ -3367,23 +3297,22 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li data-tests="legacy/RTCPeerConnection-createOffer-offerToReceive.html">
                     <p>Run the steps specified by
-                    <code><a>RTCPeerConnection</a></code>'s <a data-link-for=
-                    "RTCPeerConnection">createOffer()</a> method with
+                    {{RTCPeerConnection}}'s {{RTCPeerConnection/createOffer()}} method with
                     <var>options</var> as the sole argument, and let
                     <var>p</var> be the resulting promise.</p>
                   </li>
                   <li data-tests="legacy/RTCPeerConnection-createOffer-offerToReceive.html">
-                    <p>Upon <a>fulfillment</a> of <var>p</var> with value
+                    <p>Upon [= fulfillment =] of <var>p</var> with value
                     <var>offer</var>, invoke <var>successCallback</var> with
                     <var>offer</var> as the argument.</p>
                   </li>
                   <li>
-                    <p>Upon <a>rejection</a> of <var>p</var> with reason <var>r</var>,
+                    <p>Upon [= rejection =] of <var>p</var> with reason <var>r</var>,
                     invoke <var>failureCallback</var> with <var>r</var> as the
                     argument.</p>
                   </li>
                   <li>
-                    <p>Return a promise <a>resolved</a> with
+                    <p>Return a promise [= resolved =] with
                     <code>undefined</code>.</p>
                   </li>
                 </ol>
@@ -3409,23 +3338,22 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>Run the steps specified by
-                    <code><a>RTCPeerConnection</a></code>'s <a data-link-for=
-                    "RTCPeerConnection">setLocalDescription</a> method with
+                    {{RTCPeerConnection}}'s {{RTCPeerConnection/setLocalDescription}} method with
                     <var>description</var> as the sole argument, and let
                     <var>p</var> be the resulting promise.</p>
                   </li>
                   <li>
-                    <p>Upon <a>fulfillment</a> of <var>p</var>, invoke
+                    <p>Upon [= fulfillment =] of <var>p</var>, invoke
                     <var>successCallback</var> with <code>undefined</code> as
                     the argument.</p>
                   </li>
                   <li>
-                    <p>Upon <a>rejection</a> of <var>p</var> with reason <var>r</var>,
+                    <p>Upon [= rejection =] of <var>p</var> with reason <var>r</var>,
                     invoke <var>failureCallback</var> with <var>r</var> as the
                     argument.</p>
                   </li>
                   <li>
-                    <p>Return a promise <a>resolved</a> with
+                    <p>Return a promise [= resolved =] with
                     <code>undefined</code>.</p>
                   </li>
                 </ol>
@@ -3434,7 +3362,7 @@ interface RTCPeerConnection : EventTarget  {
               "true"><code>createAnswer</code></dfn></dt>
               <dd>
                 <div class="note">The legacy <code>createAnswer</code> method
-                does not take an <code><a>RTCAnswerOptions</a></code>
+                does not take an {{RTCAnswerOptions}}
                 parameter, since no known legacy <code>createAnswer</code>
                 implementation ever supported it.</div>
 
@@ -3451,23 +3379,22 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>Run the steps specified by
-                    <code><a>RTCPeerConnection</a></code>'s <a data-link-for=
-                    "RTCPeerConnection">createAnswer()</a> method with no
+                    {{RTCPeerConnection}}'s {{RTCPeerConnection/createAnswer()}} method with no
                     arguments, and let <var>p</var> be the resulting
                     promise.</p>
                   </li>
                   <li>
-                    <p>Upon <a>fulfillment</a> of <var>p</var> with value
+                    <p>Upon [= fulfillment =] of <var>p</var> with value
                     <var>answer</var>, invoke <var>successCallback</var> with
                     <var>answer</var> as the argument.</p>
                   </li>
                   <li>
-                    <p>Upon <a>rejection</a> of <var>p</var> with reason <var>r</var>,
+                    <p>Upon [= rejection =] of <var>p</var> with reason <var>r</var>,
                     invoke <var>failureCallback</var> with <var>r</var> as the
                     argument.</p>
                   </li>
                   <li>
-                    <p>Return a promise <a>resolved</a> with
+                    <p>Return a promise [= resolved =] with
                     <code>undefined</code>.</p>
                   </li>
                 </ol>
@@ -3493,23 +3420,22 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>Run the steps specified by
-                    <code><a>RTCPeerConnection</a></code>'s <a data-link-for=
-                    "RTCPeerConnection">setRemoteDescription</a> method with
+                    {{RTCPeerConnection}}'s {{RTCPeerConnection/setRemoteDescription}} method with
                     <var>description</var> as the sole argument, and let
                     <var>p</var> be the resulting promise.</p>
                   </li>
                   <li>
-                    <p>Upon <a>fulfillment</a> of <var>p</var>, invoke
+                    <p>Upon [= fulfillment =] of <var>p</var>, invoke
                     <var>successCallback</var> with <code>undefined</code> as
                     the argument.</p>
                   </li>
                   <li>
-                    <p>Upon <a>rejection</a> of <var>p</var> with reason <var>r</var>,
+                    <p>Upon [= rejection =] of <var>p</var> with reason <var>r</var>,
                     invoke <var>failureCallback</var> with <var>r</var> as the
                     argument.</p>
                   </li>
                   <li>
-                    <p>Return a promise <a>resolved</a> with
+                    <p>Return a promise [= resolved =] with
                     <code>undefined</code>.</p>
                   </li>
                 </ol>
@@ -3533,23 +3459,22 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>Run the steps specified by
-                    <code><a>RTCPeerConnection</a></code>'s <a data-link-for=
-                    "RTCPeerConnection">addIceCandidate()</a> method with
+                    {{RTCPeerConnection}}'s {{RTCPeerConnection/addIceCandidate()}} method with
                     <var>candidate</var> as the sole argument, and let
                     <var>p</var> be the resulting promise.</p>
                   </li>
                   <li>
-                    <p>Upon <a>fulfillment</a> of <var>p</var>, invoke
+                    <p>Upon [= fulfillment =] of <var>p</var>, invoke
                     <var>successCallback</var> with <code>undefined</code> as
                     the argument.</p>
                   </li>
                   <li>
-                    <p>Upon <a>rejection</a> of <var>p</var> with reason <var>r</var>,
+                    <p>Upon [= rejection =] of <var>p</var> with reason <var>r</var>,
                     invoke <var>failureCallback</var> with <var>r</var> as the
                     argument.</p>
                   </li>
                   <li>
-                    <p>Return a promise <a>resolved</a> with
+                    <p>Return a promise [= resolved =] with
                     <code>undefined</code>.</p>
                   </li>
                 </ol>
@@ -3563,13 +3488,12 @@ interface RTCPeerConnection : EventTarget  {
                 <pre class="idl"
 >callback RTCPeerConnectionErrorCallback = void (DOMException error);</pre>
                 <section>
-                  <h2>Callback <a class="idlType">RTCPeerConnectionErrorCallback</a>
+                  <h2>Callback {{RTCPeerConnectionErrorCallback}}
                   Parameters</h2>
                   <dl data-link-for="RTCPeerConnectionErrorCallback" data-dfn-for=
                   "RTCPeerConnectionErrorCallback" class="callback-members">
                     <dt><code>error</code> of type
-                    <code><a data-cite="!WEBIDL#idl-DOMException">
-                    DOMException</a></code></dt>
+                    {{DOMException}}</dt>
                     <dd>An error object encapsulating information about what went
                     wrong.</dd>
                   </dl>
@@ -3582,12 +3506,12 @@ interface RTCPeerConnection : EventTarget  {
                 <pre class="idl"
 >callback RTCSessionDescriptionCallback = void (RTCSessionDescriptionInit description);</pre>
                 <section>
-                  <h2>Callback <a class="idlType">RTCSessionDescriptionCallback</a>
+                  <h2>Callback {{RTCSessionDescriptionCallback}}
                   Parameters</h2>
                   <dl data-link-for="RTCSessionDescriptionCallback" data-dfn-for=
                   "RTCSessionDescriptionCallback" class="callback-members">
                     <dt><code>description</code> of type <span class=
-                    "idlMemberType"><a>RTCSessionDescriptionInit</a></span></dt>
+                    "idlMemberType">{{RTCSessionDescriptionInit}}</span></dt>
                     <dd>The object containing the SDP [[!SDP]].</dd>
                   </dl>
                 </section>
@@ -3600,19 +3524,19 @@ interface RTCPeerConnection : EventTarget  {
         <h4>Legacy configuration extensions</h4>
         <p>This section describes a set of legacy extensions that may be used to
         influence how an offer is created, in addition to the media added to
-        the <code><a>RTCPeerConnection</a></code>. Developers are encouraged to
-        use the <code><a>RTCRtpTransceiver</a></code> API instead.</p>
-        <p>When <a href="#dom-rtcpeerconnection-createoffer">createOffer</a>
+        the {{RTCPeerConnection}}. Developers are encouraged to
+        use the {{RTCRtpTransceiver}} API instead.</p>
+        <p>When {{RTCPeerConnection/createOffer}}
         is called with any of the legacy options specified in this section,
-        run the followings steps instead of the regular <a href=
-        "#dom-rtcpeerconnection-createoffer">createOffer</a> steps:</p>
+        run the followings steps instead of the regular {{RTCPeerConnection/createOffer}}
+        steps:</p>
         <ol>
           <li>
             <p>Let <var>options</var> be the methods first argument.</p>
           </li>
           <li>
             <p>Let <var>connection</var> be the current <code>
-            <a>RTCPeerConnection</a></code> object.</p>
+            {{RTCPeerConnection}}</code> object.</p>
           </li>
           <li>
             <p>For each "offerToReceive&lt;Kind&gt;" member in <var>options</var> with
@@ -3623,13 +3547,13 @@ interface RTCPeerConnection : EventTarget  {
                 <ol>
                   <li data-tests="legacy/RTCPeerConnection-createOffer-offerToReceive.html,legacy/RTCRtpTransceiver-with-OfferToReceive-options.https.html">
                     <p>For each non-stopped "sendrecv" transceiver of
-                    <a>transceiver kind</a> <var>kind</var>, set
+                    [= transceiver kind =] <var>kind</var>, set
                     <var>transceiver</var>.<a>[[\Direction]]</a> to
                     "sendonly".</p>
                   </li>
                   <li data-tests="legacy/RTCPeerConnection-createOffer-offerToReceive.html,legacy/RTCRtpTransceiver-with-OfferToReceive-options.https.html">
                     <p>For each non-stopped "recvonly" transceiver of
-                    <a>transceiver kind</a> <var>kind</var>, set
+                    [= transceiver kind =] <var>kind</var>, set
                     <var>transceiver</var>.<a>[[\Direction]]</a> to
                     "inactive".</p>
                   </li>
@@ -3638,15 +3562,15 @@ interface RTCPeerConnection : EventTarget  {
               </li>
               <li>
                 <p>If <var>connection</var> has any non-stopped "sendrecv"
-                or "recvonly" transceivers of <a>transceiver kind</a>
+                or "recvonly" transceivers of [= transceiver kind =]
                 <var>kind</var>, continue with the next option, if any.</p>
               </li>
               <li>
                 <p>Let <var>transceiver</var> be the result of invoking the
                 equivalent of
                 <code>connection.addTransceiver(kind)</code>, except
-                that this operation MUST NOT <a>update the
-                negotiation-needed flag</a>.</p>
+                that this operation MUST NOT [= update the
+                negotiation-needed flag =].</p>
               </li>
               <li>
                 <p>If <var>transceiver</var> is unset because the previous
@@ -3659,8 +3583,7 @@ interface RTCPeerConnection : EventTarget  {
             </ol>
           </li>
           <li data-tests="legacy/RTCPeerConnection-createOffer-offerToReceive.html">
-            <p>Run the steps specified by <a href=
-            "#dom-rtcpeerconnection-createoffer">createOffer</a> to create
+            <p>Run the steps specified by {{RTCPeerConnection/createOffer}} to create
           the offer.</p>
           </li>
         </ol>
@@ -3695,15 +3618,15 @@ interface RTCPeerConnection : EventTarget  {
       </section>
       <section>
         <h2>Garbage collection</h2>
-        <p>An <code><a>RTCPeerConnection</a></code> object MUST not be garbage
+        <p>An {{RTCPeerConnection}} object MUST not be garbage
         collected as long as any event can cause an event handler to be
         triggered on the object. When the object's <a>[[\IsClosed]]</a> internal
         slot is <code>true</code>, no such event handler can be triggered and
         it is therefore safe to garbage collect the object.</p>
-        <p>All <code><a>RTCDataChannel</a></code> and
-        <code><a>MediaStreamTrack</a></code> objects that are connected to an
-        <code><a>RTCPeerConnection</a></code> have a strong reference to the
-        <code><a>RTCPeerConnection</a></code> object.</p>
+        <p>All {{RTCDataChannel}} and
+        {{MediaStreamTrack}} objects that are connected to an
+        {{RTCPeerConnection}} have a strong reference to the
+        {{RTCPeerConnection}} object.</p>
       </section>
     </section>
     <section>
@@ -3720,8 +3643,8 @@ interface RTCPeerConnection : EventTarget  {
       <section>
         <h4><dfn>RTCSdpType</dfn></h4>
         <p>The RTCSdpType enum describes the type of an
-        <code><a>RTCSessionDescriptionInit</a></code> or
-        <code><a>RTCSessionDescription</a></code> instance.</p>
+        {{RTCSessionDescriptionInit}} or
+        {{RTCSessionDescription}} instance.</p>
         <div>
           <pre class="idl"
 >enum RTCSdpType {
@@ -3737,14 +3660,14 @@ interface RTCPeerConnection : EventTarget  {
                 <th colspan="2">Enumeration description</th>
               </tr>
               <tr>
-                <td data-tests="RTCPeerConnection-setLocalDescription-offer.html"><dfn data-idl><code>offer</code></dfn></td>
+                <td data-tests="RTCPeerConnection-setLocalDescription-offer.html"><dfn data-idl>offer</dfn></td>
                 <td>
                   <p>An <code>RTCSdpType</code> of <code>offer</code> indicates
                   that a description MUST be treated as an [[!SDP]] offer.</p>
                 </td>
               </tr>
               <tr>
-                <td data-tests="RTCPeerConnection-setLocalDescription-pranswer.html"><dfn data-idl><code>pranswer</code></dfn></td>
+                <td data-tests="RTCPeerConnection-setLocalDescription-pranswer.html"><dfn data-idl>pranswer</dfn></td>
                 <td>
                   <p>An <code>RTCSdpType</code> of <code>pranswer</code>
                   indicates that a description MUST be treated as an [[!SDP]]
@@ -3754,7 +3677,7 @@ interface RTCPeerConnection : EventTarget  {
                 </td>
               </tr>
               <tr data-tests="RTCPeerConnection-setLocalDescription-answer.html">
-                <td><dfn data-idl><code>answer</code></dfn></td>
+                <td><dfn data-idl>answer</dfn></td>
                 <td>
                   <p>An <code>RTCSdpType</code> of <code>answer</code>
                   indicates that a description MUST be treated as an [[!SDP]]
@@ -3765,7 +3688,7 @@ interface RTCPeerConnection : EventTarget  {
                 </td>
               </tr>
               <tr>
-                <td data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-setLocalDescription-rollback.html"><dfn data-idl><code>rollback</code></dfn></td>
+                <td data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-setLocalDescription-rollback.html"><dfn data-idl>rollback</dfn></td>
                 <td>
                   <p>An <code>RTCSdpType</code> of <code>rollback</code>
                   indicates that a description MUST be treated as canceling the
@@ -3783,8 +3706,8 @@ interface RTCPeerConnection : EventTarget  {
       </section>
       <section>
         <h4><dfn>RTCSessionDescription</dfn> Class</h4>
-        <p>The <code>RTCSessionDescription</code> class is used by
-        <code><a>RTCPeerConnection</a></code> to expose local and remote
+        <p>The {{RTCSessionDescription}} class is used by
+        {{RTCPeerConnection}} to expose local and remote
         session descriptions.</p>
         <div>
           <pre class="idl" data-tests="idlharness.https.window.js"
@@ -3805,10 +3728,10 @@ interface RTCSessionDescription {
                 "dom-sessiondescription"><code>RTCSessionDescription()</code></dfn>
                 constructor takes a dictionary argument,
                 <var>description</var>, whose content is used to
-                initialize the new <code><a>RTCSessionDescription</a></code>
+                initialize the new {{RTCSessionDescription}}
                 object. This constructor is deprecated; it exists for
                 legacy compatibility reasons only. The constructor MUST
-                <a>throw</a> a <code>TypeError</code> if
+                [= exception/throw =] a {{TypeError}} if
                 <var>description</var>.<code>type</code> is not present.
               </dd>
             </dl>
@@ -3817,10 +3740,10 @@ interface RTCSessionDescription {
             <h2>Attributes</h2>
             <dl data-link-for="RTCSessionDescription" data-dfn-for=
             "RTCSessionDescription" class="attributes">
-              <dt><dfn data-idl><code>type</code></dfn> of type <span class=
-              "idlAttrType"><a>RTCSdpType</a></span>, readonly</dt>
+              <dt><dfn data-idl>type</dfn> of type <span class=
+              "idlAttrType">{{RTCSdpType}}</span>, readonly</dt>
               <dd>The type of this RTCSessionDescription.</dd>
-              <dt data-tests="RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setLocalDescription-offer.html,RTCPeerConnection-setLocalDescription-pranswer.html"><dfn data-idl><code>sdp</code></dfn> of type <span class=
+              <dt data-tests="RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setLocalDescription-offer.html,RTCPeerConnection-setLocalDescription-pranswer.html"><dfn data-idl>sdp</dfn> of type <span class=
               "idlAttrType">DOMString</span>, readonly</dt>
               <dd>The string representation of the SDP [[!SDP]].</dd>
             </dl>
@@ -3831,8 +3754,7 @@ interface RTCSessionDescription {
             "RTCSessionDescription" class="methods">
               <dt><dfn><code>toJSON()</code></dfn></dt>
               <dd>
-                When called, run [[!WEBIDL]]'s <a data-cite=
-                "WEBIDL#default-tojson-operation">default toJSON operation</a>.
+                When called, run [[!WEBIDL]]'s [= default toJSON operation =].
               </dd>
             </dl>
           </section>
@@ -3848,18 +3770,18 @@ interface RTCSessionDescription {
             Members</h2>
             <dl data-link-for="RTCSessionDescriptionInit" data-dfn-for=
             "RTCSessionDescriptionInit" class="dictionary-members">
-              <dt><dfn data-idl><code>type</code></dfn> of type <span class=
-              "idlMemberType"><a>RTCSdpType</a></span></dt>
+              <dt><dfn data-idl>type</dfn> of type <span class=
+              "idlMemberType">{{RTCSdpType}}</span></dt>
               <dd>The type of this description. If not present, then
-              <code><a data-link-for="RTCPeerConnection">setLocalDescription</a></code>
-              will infer the type based on the <code>RTCPeerConnection</code>'s
-              <a>signaling state</a>, whereas
-              <code><a data-link-for="RTCPeerConnection">setRemoteDescription</a></code>
-              and the <a>RTCSessionDescription</a> constructor
-              will <a>throw</a> a <code>TypeError</code>, because they require
+              {{RTCPeerConnection/setLocalDescription}}
+              will infer the type based on the {{RTCPeerConnection}}'s
+              [= signaling state =], whereas
+              {{RTCPeerConnection/setRemoteDescription}}
+              and the {{RTCSessionDescription}} constructor
+              will [= exception/throw =] a {{TypeError}}, because they require
               the argument.
               </dd>
-              <dt data-tests="RTCPeerConnection-setLocalDescription-rollback.html"><dfn data-idl><code>sdp</code></dfn> of type <span class=
+              <dt data-tests="RTCPeerConnection-setLocalDescription-rollback.html"><dfn data-idl>sdp</dfn> of type <span class=
               "idlMemberType">DOMString</span></dt>
               <dd>The string representation of the SDP [[!SDP]]; if
               <code>type</code> is <code>"rollback"</code>, this member is unused.
@@ -3871,7 +3793,7 @@ interface RTCSessionDescription {
     </section>
     <section>
       <h3>Session Negotiation Model</h3>
-      <p>Many changes to state of an <code><a>RTCPeerConnection</a></code> will
+      <p>Many changes to state of an {{RTCPeerConnection}} will
       require communication with the remote side via the signaling channel, in
       order to have the desired effect. The app can be kept informed as to when
       it needs to do signaling, by listening to the
@@ -3881,32 +3803,31 @@ interface RTCSessionDescription {
       <section class="informative">
         <h4>Setting Negotiation-Needed</h4>
         <p>If an operation is performed on an
-        <code><a>RTCPeerConnection</a></code> that requires signaling, the
+        {{RTCPeerConnection}} that requires signaling, the
         connection will be marked as needing negotiation. Examples of such
         operations include adding or stopping an
-        <code><a>RTCRtpTransceiver</a></code>, or adding the first <code><a>
-        RTCDataChannel</a></code>.</p>
+        {{RTCRtpTransceiver}}, or adding the first {{
+        RTCDataChannel}}.</p>
         <p>Internal changes within the implementation can also result in the
         connection being marked as needing negotiation.</p>
-        <p>Note that the exact procedures for <a data-lt="update the
-        negotiation-needed flag">updating the negotiation-needed flag</a>
+        <p>Note that the exact procedures for [= update the
+        negotiation-needed flag | updating the negotiation-needed flag =]
         are specified below.</p>
       </section>
       <section class="informative">
         <h4>Clearing Negotiation-Needed</h4>
         <p>The negotiation-needed flag is cleared when an
-        <code><a>RTCSessionDescription</a></code> of type "answer" <a href=
-        "#set-description">is applied</a>, and the supplied description matches
+        {{RTCSessionDescription}} of type "answer" [= set an RTCSessionDescription | is applied =], and the supplied description matches
         the state of the
-        <code><a>RTCRtpTransceiver</a></code>s and
-        <code><a>RTCDataChannel</a></code>s that currently exist on the
-        <code><a>RTCPeerConnection</a></code>. Specifically, this means that all
-        non-<a data-link-for="RTCRtpTransceiver">stopped</a> transceivers have an
-        <a>associated</a> section in the local description with matching properties,
+        {{RTCRtpTransceiver}}s and
+        {{RTCDataChannel}}s that currently exist on the
+        {{RTCPeerConnection}}. Specifically, this means that all
+        non-{{RTCRtpTransceiver/stopped}} transceivers have an
+        [= associated =] section in the local description with matching properties,
         and, if any data channels have been created, a data section exists in
         the local description.</p>
-        <p>Note that the exact procedures for <a data-lt="update the
-        negotiation-needed flag">updating the negotiation-needed flag</a>
+        <p>Note that the exact procedures for [= update the
+        negotiation-needed flag | updating the negotiation-needed flag =]
         are specified below.</p>
       </section>
       <section>
@@ -3914,8 +3835,8 @@ interface RTCSessionDescription {
         <p>The process below occurs where referenced elsewhere in this document.
         It also may occur as a result of internal changes within the
         implementation that affect negotiation. If such changes occur, the user
-        agent MUST queue a task to <a>update the negotiation-needed
-        flag</a>.</p>
+        agent MUST queue a task to [= update the negotiation-needed
+        flag =].</p>
         <p>To <dfn>update the negotiation-needed flag</dfn> for
         <var>connection</var>, run the following steps:</p>
         <ol>
@@ -3924,17 +3845,17 @@ interface RTCSessionDescription {
             <code>true</code>, abort these steps.</p>
           </li>
           <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
-            <p>If <var>connection</var>'s <a>signaling state</a> is not
+            <p>If <var>connection</var>'s [= signaling state =] is not
             <code>"stable"</code>, abort these steps.</p>
 
             <p class="note">The negotiation-needed flag will be
             updated once the state transitions to "stable", as part of the steps
-            for <a href="#set-description">setting an RTCSessionDescription</a>.
+            for [= setting an RTCSessionDescription =].
             </p>
           </li>
           <li>
-            <p>If the result of <a data-lt="check if negotiation is needed">
-            checking if negotiation is needed</a> is <code>false</code>,
+            <p>If the result of [= check if negotiation is needed |
+            checking if negotiation is needed =] is <code>false</code>,
             <dfn>clear the negotiation-needed flag</dfn> by setting
             <var>connection</var>.<a>[[\NegotiationNeeded]]</a> to
             <code>false</code>, and abort these steps.</p>
@@ -3948,7 +3869,7 @@ interface RTCSessionDescription {
             <code>true</code>.</p>
           </li>
           <li>
-            <p><a href="#dfn-chain-an-operation">Chain</a> a step to queue a
+            <p>[= Chain =] a step to queue a
             task that runs the following steps, to <var>connection</var>'s
             operations chain:</p>
             <ol>
@@ -3961,11 +3882,11 @@ interface RTCSessionDescription {
                 is <code>false</code>, abort these steps.</p>
               </li>
               <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
-                <p><a>Fire an event</a> named <code><a>negotiationneeded</a></code>
+                <p>[= Fire an event =] named {{negotiationneeded}}
                 at <var>connection</var>.</p>
               </li>
             </ol>
-            <p class="note">This queueing prevents <a>negotiationneeded</a> from
+            <p class="note">This queueing prevents {{negotiationneeded}} from
             firing prematurely, in the common situation where multiple
             modifications to <var>connection</var> are being made at once.</p>
           </li>
@@ -3988,13 +3909,13 @@ interface RTCSessionDescription {
           </li>
           <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
             <p>If <var>connection</var> has created any
-            <code><a>RTCDataChannel</a></code>s, and no m= section in
+            {{RTCDataChannel}}s, and no m= section in
             <var>description</var> has been negotiated yet for data, return
             <code>true</code>.</p>
           </li>
           <li>
             <p>For each <var>transceiver</var> in <var>connection</var>'s
-            <a>set of transceivers</a>, perform the following checks:</p>
+            [= set of transceivers =], perform the following checks:</p>
             <ol>
               <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
                 <p>If <var>transceiver</var>.<a>[[\Stopping]]</a> is
@@ -4002,19 +3923,19 @@ interface RTCSessionDescription {
                 is <code>false</code>, return <code>true</code>.</p>
               </li>
               <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
-                <p>If <var>transceiver</var> isn't <a data-link-for="RTCRtpTransceiver">
-                stopped</a> and isn't yet <a>associated</a> with an m= section
+                <p>If <var>transceiver</var> isn't {{RTCRtpTransceiver/
+                stopped}} and isn't yet [= associated =] with an m= section
                 in <var>description</var>, return <code>true</code>.</p>
               </li>
               <li>
-                <p>If <var>transceiver</var> isn't <a data-link-for="RTCRtpTransceiver">
-                stopped</a> and is <a>associated</a> with an m= section
+                <p>If <var>transceiver</var> isn't {{RTCRtpTransceiver/
+                stopped}} and is [= associated =] with an m= section
                 in <var>description</var> then perform the following checks:</p>
                 <ol>
                   <li>
                     <p>If <var>transceiver</var>.<a>[[\Direction]]</a> is
                     <code>"sendrecv"</code> or <code>"sendonly"</code>,
-                    and the <a>associated</a> m= section in <var>description</var>
+                    and the [= associated =] m= section in <var>description</var>
                     either doesn't contain a single "a=msid" line, or the number
                     of MSIDs from the "a=msid" lines in this m= section,
                     or the MSID values themselves, differ from what is in
@@ -4024,7 +3945,7 @@ interface RTCSessionDescription {
                   </li>
                   <li>
                     <p>If <var>description</var> is of type <code>"offer"</code>,
-                    and the direction of the <a>associated</a> m=
+                    and the direction of the [= associated =] m=
                     section in neither
                     <var>connection</var>.<a>[[\CurrentLocalDescription]]</a> nor
                     <var>connection</var>.<a>[[\CurrentRemoteDescription]]</a>
@@ -4037,7 +3958,7 @@ interface RTCSessionDescription {
                   </li>
                   <li>
                     <p>If <var>description</var> is of type <code>"answer"</code>,
-                    and the direction of the <a>associated</a> m=
+                    and the direction of the [= associated =] m=
                     section in the <var>description</var> does not match
                     <var>transceiver</var>.<a>[[\Direction]]</a>
                     intersected with the offered direction (as described in
@@ -4047,8 +3968,8 @@ interface RTCSessionDescription {
                 </ol>
               </li>
               <li>
-                <p>If <var>transceiver</var> is <a data-link-for="RTCRtpTransceiver">
-                stopped</a> and is <a>associated</a> with an m= section, but the
+                <p>If <var>transceiver</var> is {{RTCRtpTransceiver/
+                stopped}} and is [= associated =] with an m= section, but the
                 associated m= section is not yet rejected in
                 <var>connection</var>.<a>[[\CurrentLocalDescription]]</a> or
                 <var>connection</var>.<a>[[\CurrentRemoteDescription]]</a>,
@@ -4105,45 +4026,43 @@ interface RTCIceCandidate {
               <dd>
                 <p>The <dfn><code>RTCIceCandidate()</code></dfn> constructor takes
                 a dictionary argument, <var>candidateInitDict</var>, whose
-                content is used to initialize the new <a class=
-                "idlType">RTCIceCandidate</a> object.</p>
+                content is used to initialize the new {{RTCIceCandidate}} object.</p>
                 <p>When invoked, run the following steps:</p>
                 <ol>
-                  <li data-tests="RTCIceCandidate-constructor.html">If both the <code><a
-                  data-link-for="RTCIceCandidateInit">sdpMid</a></code> and
-                  <code><a data-link-for="RTCIceCandidateInit">sdpMLineIndex</a></code>
+                  <li data-tests="RTCIceCandidate-constructor.html">If both the {{RTCIceCandidateInit/sdpMid}} and
+                  {{RTCIceCandidateInit/sdpMLineIndex}}
                   members of <var>candidateInitDict</var> are <code>null</code>,
-                  <a>throw</a> a <code>TypeError</code>.</li>
+                  [= exception/throw =] a {{TypeError}}.</li>
                   <li data-tests="RTCIceCandidate-constructor.html"><p>Return the result of
-                  <a href="#dfn-create-an-rtcicecandidate">creating an RTCIceCandidate</a>
+                  [= creating an RTCIceCandidate =]
                   with <var>candidateInitDict</var>.</p></li>
                 </ol>
-                <p>To <dfn>create an RTCIceCandidate</dfn> with a
+                <p>To <dfn data-lt="creating an RTCIceCandidate">create an RTCIceCandidate</dfn> with a
                 <var>candidateInitDict</var> dictionary, run the following steps:</p>
                 <ol>
                   <li>Let <var>iceCandidate</var> be a newly created
-                    <code>RTCIceCandidate</code> object.</li>
+                    {{RTCIceCandidate}} object.</li>
                   <li>Create internal slots for the following attributes of
                     <var>iceCandidate</var>, initilized to
-                    <code>null</code>: <a>foundation</a>,
-                    <a>component</a>, <a>priority</a>,
-                    <a>address</a>, <a>protocol</a>,
-                    <a>port</a>, <a>type</a>,
-                    <a>tcpType</a>, <a>relatedAddress</a>,
-                    and <a>relatedPort</a>.</li>
+                    <code>null</code>: {{foundation}},
+                    {{component}}, {{priority}},
+                    {{address}}, {{protocol}},
+                    {{port}}, {{type}},
+                    {{tcpType}}, {{relatedAddress}},
+                    and {{relatedPort}}.</li>
                   <li>Create internal slots for the following attributes of
                     <var>iceCandidate</var>, initilized to their namesakes in
-                    <var>candidateInitDict</var>: <a>candidate</a>,
-                    <a>sdpMid</a>, <a>sdpMLineIndex</a>,
-                    <a>usernameFragment</a>.</li>
+                    <var>candidateInitDict</var>: {{candidate}},
+                    {{sdpMid}}, {{sdpMLineIndex}},
+                    {{usernameFragment}}.</li>
                   <li>Let <var>candidate</var> be the <code>
-                    <a data-link-for="RTCIceCandidateInit">candidate</a></code>
+                    {{RTCIceCandidateInit/candidate}}</code>
                   dictionary member of <var>candidateInitDict</var>. If
                   <var>candidate</var> is not an empty string, run the following steps:
                   <ol data-tests="RTCIceCandidate-constructor.html">
-                    <li>Parse <var>candidate</var> using the <a>candidate-attribute
-                    </a> grammar.</li>
-                    <li>If parsing of <a>candidate-attribute</a> has failed, abort
+                    <li>Parse <var>candidate</var> using the [= candidate-attribute =]
+                     grammar.</li>
+                    <li>If parsing of [= candidate-attribute =] has failed, abort
                       these steps.</li>
                     <li>If any field in the parse result represents an invalid value for the
                       corresponding attribute in <var>iceCandidate</var>, abort these steps.</li>
@@ -4154,22 +4073,20 @@ interface RTCIceCandidate {
                   <li>Return <var>iceCandidate</var>.</li>
                 </ol>
                 <div class="note">
-                  <p>The constructor for <code>RTCIceCandidate</code> only does basic
+                  <p>The constructor for {{RTCIceCandidate}} only does basic
                   parsing and type checking for the dictionary members in
                   <var>candidateInitDict</var>. Detailed validation on the well-formedness
                   of <code>candidate</code>, <code>sdpMid</code>, <code>sdpMLineIndex</code>,
                   <code>usernameFragment</code> with the corresponding session description is done
-                  when passing the <code>RTCIceCandidate</code> object to
-                  <code><a data-link-for=
-                "RTCPeerConnection">addIceCandidate()</a></code>.</p>
+                  when passing the {{RTCIceCandidate}} object to
+                  {{RTCPeerConnection/addIceCandidate()}}.</p>
 
                   <p>To maintain backward compatibility, any error on parsing the
                   <var>candidate</var> attribute is ignored. In such case, the
-                  <a>candidate</a> attribute holds the raw
-                  <a data-dfn-for="idl-def-rtcicecandidateinit-candidate">
-                  candidate</a> string given in <var>candidateInitDict</var>,
-                  but derivative attributes such as <a>foundation</a>,
-                  <a>priority</a>, etc are set to <code>null</code>.</p>
+                  {{candidate}} attribute holds the raw
+                  {{RTCIceCandidateInit/candidate}} string given in <var>candidateInitDict</var>,
+                  but derivative attributes such as {{foundation}},
+                  {{priority}}, etc are set to <code>null</code>.</p>
                 </div>
               </dd>
             </dl>
@@ -4179,47 +4096,47 @@ interface RTCIceCandidate {
             <p>Most attributes below are defined in section 15.1 of [[!ICE]].</p>
             <dl data-link-for="RTCIceCandidate" data-dfn-for="RTCIceCandidate"
             class="attributes">
-              <dt><dfn data-idl><code>candidate</code></dfn> of type <span class=
+              <dt><dfn data-idl>candidate</dfn> of type <span class=
               "idlAttrType">DOMString</span>, readonly</dt>
-              <dd>This carries the <a>candidate-attribute</a> as defined
-              in section 15.1 of [[!ICE]]. If this <code>RTCIceCandidate</code>
+              <dd>This carries the [= candidate-attribute =] as defined
+              in section 15.1 of [[!ICE]]. If this {{RTCIceCandidate}}
               represents an end-of-candidates indication or a peer reflexive remote
               candidate, <code>candidate</code> is an empty string.</dd>
-              <dt><dfn data-idl><code>sdpMid</code></dfn> of type <span class=
+              <dt><dfn data-idl>sdpMid</dfn> of type <span class=
               "idlAttrType">DOMString</span>, readonly, nullable</dt>
               <dd>If not <code>null</code>, this contains the media stream
               "identification-tag" defined in [[!RFC5888]] for the
               media component this candidate is associated with.</dd>
-              <dt><dfn data-idl><code>sdpMLineIndex</code></dfn> of type <span class=
+              <dt><dfn data-idl>sdpMLineIndex</dfn> of type <span class=
               "idlAttrType">unsigned short</span>, readonly,
               nullable</dt>
               <dd>
                 If not <code>null</code>, this indicates the index (starting at
-                zero) of the <a>media description</a> in the SDP this candidate
+                zero) of the [= media description =] in the SDP this candidate
                 is associated with.
               </dd>
-              <dt><dfn data-idl><code>foundation</code></dfn> of type <span class=
+              <dt><dfn data-idl>foundation</dfn> of type <span class=
               "idlAttrType">DOMString</span>, readonly, nullable</dt>
               <dd>A unique identifier that allows ICE to correlate candidates
               that appear on multiple
-              <code><a>RTCIceTransport</a></code>s.</dd>
-              <dt><dfn data-idl><code>component</code></dfn> of type <span class=
-              "idlAttrType"><a>RTCIceComponent</a></span>, readonly, nullable</dt>
+              {{RTCIceTransport}}s.</dd>
+              <dt><dfn data-idl>component</dfn> of type <span class=
+              "idlAttrType">{{RTCIceComponent}}</span>, readonly, nullable</dt>
               <dd>The assigned network component of the candidate
               (<code>rtp</code> or <code>rtcp</code>). This corresponds to the
-              <code>component-id</code> field in <a>candidate-attribute</a>,
+              <code>component-id</code> field in [= candidate-attribute =],
               decoded to the string representation as defined in
-              <a>RTCIceComponent</a>.</dd>
-              <dt><dfn data-idl><code>priority</code></dfn> of type <span class=
+              {{RTCIceComponent}}.</dd>
+              <dt><dfn data-idl>priority</dfn> of type <span class=
               "idlAttrType">unsigned long</span>, readonly, nullable</dt>
               <dd>The assigned priority of the candidate.</dd>
-              <dt><dfn data-idl><code>address</code></dfn> of type <span class=
+              <dt><dfn data-idl>address</dfn> of type <span class=
               "idlAttrType">DOMString</span>, readonly, nullable</dt>
               <dd>
                 <p>The address of the candidate, allowing for IPv4 addresses,
                 IPv6 addresses, and fully qualified domain names (FQDNs). This
                 corresponds to the <code>connection-address</code> field in
-                <a>candidate-attribute</a>.</p>
+                [= candidate-attribute =].</p>
                 <p>Remote candidates may be exposed, for instance
                 via <code><a>[[\SelectedCandidatePair]]</a>.remote</code>.
                 By default, the user agent MUST leave the 'address' member
@@ -4232,7 +4149,7 @@ interface RTCIceCandidate {
                 <div class="note">
                   <p>The addresses exposed in candidates gathered via ICE
                   and made visibile to the application in
-                  <code>RTCIceCandidate</code> instances can reveal more
+                  {{RTCIceCandidate}} instances can reveal more
                   information about the device and the user (e.g. location,
                   local network topology) than the user might have expected in
                   a non-WebRTC enabled browser.</p>
@@ -4246,34 +4163,34 @@ interface RTCIceCandidate {
                   contribute to the fingerprinting surface of the device.</p>
                   <p>Applications can avoid exposing addresses to the
                   communicating party, either temporarily or permanently, by
-                  forcing the <a>ICE Agent</a> to report only relay candidates
+                  forcing the [= ICE Agent =] to report only relay candidates
                   via the <code>iceTransportPolicy</code> member of
-                  <code><a>RTCConfiguration</a></code>.</p>
+                  {{RTCConfiguration}}.</p>
                   <p>To limit the addresses exposed to the application
                   itself, browsers can offer their users different policies
                   regarding sharing local addresses, as defined in
                   [[RTCWEB-IP-HANDLING]].</p>
                 </div>
               </dd>
-              <dt><dfn data-idl><code>protocol</code></dfn> of type <span class=
-              "idlAttrType"><a>RTCIceProtocol</a></span>, readonly, nullable</dt>
+              <dt><dfn data-idl>protocol</dfn> of type <span class=
+              "idlAttrType">{{RTCIceProtocol}}</span>, readonly, nullable</dt>
               <dd>The protocol of the candidate
               (<code>udp</code>/<code>tcp</code>). This corresponds to the
-              <code>transport</code> field in <a>candidate-attribute</a>.</dd>
-              <dt><dfn data-idl><code>port</code></dfn> of type <span class=
+              <code>transport</code> field in [= candidate-attribute =].</dd>
+              <dt><dfn data-idl>port</dfn> of type <span class=
               "idlAttrType">unsigned short</span>, readonly, nullable</dt>
               <dd>The port of the candidate.</dd>
-              <dt><dfn data-idl><code>type</code></dfn> of type <span class=
-              "idlAttrType"><a>RTCIceCandidateType</a></span>, readonly, nullable</dt>
+              <dt><dfn data-idl>type</dfn> of type <span class=
+              "idlAttrType">{{RTCIceCandidateType}}</span>, readonly, nullable</dt>
               <dd>The type of the candidate. This corresponds to the
-              <code>candidate-types</code> field in <a>candidate-attribute</a>.</dd>
-              <dt><dfn data-idl><code>tcpType</code></dfn> of type <span class=
-              "idlAttrType"><a>RTCIceTcpCandidateType</a></span>, readonly,
+              <code>candidate-types</code> field in [= candidate-attribute =].</dd>
+              <dt><dfn data-idl>tcpType</dfn> of type <span class=
+              "idlAttrType">{{RTCIceTcpCandidateType}}</span>, readonly,
                nullable</dt>
               <dd>If <code>protocol</code> is <code>tcp</code>,
               <code>tcpType</code> represents the type of TCP candidate.
               Otherwise, <code>tcpType</code> is <code>null</code>. This corresponds
-              to the <code>tcp-type</code> field in <a>candidate-attribute</a>.</dd>
+              to the <code>tcp-type</code> field in [= candidate-attribute =].</dd>
               <dt><code>relatedAddress</code> of type <span class=
               "idlAttrType">DOMString</span>, readonly, nullable</dt>
               <dd>For a candidate that is derived from another, such as a relay
@@ -4281,7 +4198,7 @@ interface RTCIceCandidate {
               address of the candidate that it is derived from. For host
               candidates, the <code>relatedAddress</code> is
               <code>null</code>. This corresponds to the <code>rel-address</code>
-              field in <a>candidate-attribute</a>.</dd>
+              field in [= candidate-attribute =].</dd>
               <dt><code>relatedPort</code> of type <span class=
               "idlAttrType">unsigned short</span>, readonly,
               nullable</dt>
@@ -4289,7 +4206,7 @@ interface RTCIceCandidate {
               or reflexive candidate, the <dfn>relatedPort</dfn> is the port of
               the candidate that it is derived from. For host candidates, the
               <code>relatedPort</code> is <code>null</code>. This corresponds to
-              the <code>rel-port</code> field in <a>candidate-attribute</a>.</dd>
+              the <code>rel-port</code> field in [= candidate-attribute =].</dd>
               <dt><code><dfn>usernameFragment</dfn></code> of type <span class=
               "idlAttrType">DOMString</span>, readonly, nullable</dt>
               <dd>This carries the <code>ufrag</code> as defined in section
@@ -4300,13 +4217,13 @@ interface RTCIceCandidate {
             <h2>Methods</h2>
             <dl data-link-for="RTCIceCandidate" data-dfn-for="RTCIceCandidate"
             class="methods">
-              <dt><dfn data-idl><code>toJSON()</code></dfn></dt>
-              <dd>To invoke the <code>toJSON()</code> operation of the <code>RTCIceCandidate</code> interface, run the following steps:
+              <dt><dfn data-idl>toJSON()</dfn></dt>
+              <dd>To invoke the <code>toJSON()</code> operation of the {{RTCIceCandidate}} interface, run the following steps:
                 <ol>
-                  <li>Let <var>json</var> be a new <code>RTCIceCandidateInit</code> dictionary.</li>
+                  <li>Let <var>json</var> be a new {{RTCIceCandidateInit}} dictionary.</li>
                   <li>For each attribute identifier <var>attr</var> in «"candidate", "sdpMid", "sdpMLineIndex", "usernameFragment"»:
                     <ol>
-                      <li>Let <var>value</var> be the result of getting the underlying value of the attribute identified by <var>attr</var>, given this <code>RTCIceCandidate</code> object.</li>
+                      <li>Let <var>value</var> be the result of getting the underlying value of the attribute identified by <var>attr</var>, given this {{RTCIceCandidate}} object.</li>
                       <li>Set <code><var>json</var>[<var>attr</var>]</code> to <var>value</var>.</li>
                     </ol>
                   </li>
@@ -4329,26 +4246,26 @@ interface RTCIceCandidate {
             Members</h2>
             <dl data-link-for="RTCIceCandidateInit" data-dfn-for=
             "RTCIceCandidateInit" class="dictionary-members">
-              <dt><dfn data-idl><code>candidate</code></dfn> of type <span class=
+              <dt><dfn data-idl>candidate</dfn> of type <span class=
               "idlMemberType">DOMString</span>, defaulting to
               <code>""</code></dt>
               <dd>This carries the <code>candidate-attribute</code> as defined
               in section 15.1 of [[!ICE]]. If this represents an
               end-of-candidates indication, <code>candidate</code>
               is an empty string.</dd>
-              <dt><dfn data-idl><code>sdpMid</code></dfn> of type <span class=
+              <dt><dfn data-idl>sdpMid</dfn> of type <span class=
               "idlMemberType">DOMString</span>, nullable, defaulting to
               <code>null</code></dt>
               <dd>If not <code>null</code>, this contains the media stream
               "identification-tag" defined in [[!RFC5888]] for the
               media component this candidate is associated with.</dd>
-              <dt><dfn data-idl><code>sdpMLineIndex</code></dfn> of type <span class=
+              <dt><dfn data-idl>sdpMLineIndex</dfn> of type <span class=
               "idlMemberType">unsigned short</span>, nullable,
               defaulting to <code>null</code></dt>
               <dd>If not <code>null</code>, this indicates the index (starting at
-              zero) of the <a>media description</a> in the SDP this candidate
+              zero) of the [= media description =] in the SDP this candidate
               is associated with.</dd>
-              <dt><dfn data-idl><code>usernameFragment</code></dfn> of type <span class=
+              <dt><dfn data-idl>usernameFragment</dfn> of type <span class=
               "idlMemberType">DOMString</span>, nullable,
               defaulting to <code>null</code></dt>
               <dd>If not <code>null</code>, this carries the <code>ufrag</code>
@@ -4357,11 +4274,11 @@ interface RTCIceCandidate {
           </section>
         </div>
         <section>
-          <h4><dfn data-idl><code>candidate-attribute</code></dfn> Grammar</h4>
+          <h4><dfn data-idl>candidate-attribute</dfn> Grammar</h4>
           <p>The <code>candidate-attribute</code> grammar is used to parse
-          the <a href="#idl-def-rtcicecandidateinit-candidate">
-          candidate</a> member of <var>candidateInitDict</var>
-          in the <a>RTCIceCandidate()</a> constructor.</p>
+          the {{RTCIceCandidateInit/candidate}}
+          member of <var>candidateInitDict</var>
+          in the {{RTCIceCandidate()}} constructor.</p>
           <p>The primary grammar for <code>candidate-attribute</code>
           is defined in section 15.1 of [[!ICE]]. In addition, the browser
           MUST support the grammar extension for ICE TCP as defined in
@@ -4371,7 +4288,7 @@ interface RTCIceCandidate {
         </section>
         <section>
           <h4><dfn>RTCIceProtocol</dfn> Enum</h4>
-          <p>The <code>RTCIceProtocol</code> represents the protocol of the ICE
+          <p>The {{RTCIceProtocol}} represents the protocol of the ICE
           candidate.</p>
           <div>
             <pre class="idl"
@@ -4386,11 +4303,11 @@ interface RTCIceCandidate {
                   <th colspan="2">Enumeration description</th>
                 </tr>
                 <tr>
-                  <td><dfn data-idl><code>udp</code></dfn></td>
+                  <td><dfn data-idl>udp</dfn></td>
                   <td>A UDP candidate, as described in [[!ICE]].</td>
                 </tr>
                 <tr>
-                  <td><dfn data-idl><code>tcp</code></dfn></td>
+                  <td><dfn data-idl>tcp</dfn></td>
                   <td>A TCP candidate, as described in [[!RFC6544]].</td>
                 </tr>
               </tbody>
@@ -4399,7 +4316,7 @@ interface RTCIceCandidate {
         </section>
         <section>
           <h4><dfn>RTCIceTcpCandidateType</dfn> Enum</h4>
-          <p>The <code>RTCIceTcpCandidateType</code> represents the type of the
+          <p>The {{RTCIceTcpCandidateType}} represents the type of the
           ICE TCP candidate, as defined in [[!RFC6544]].</p>
           <div>
             <pre class="idl"
@@ -4415,19 +4332,19 @@ interface RTCIceCandidate {
                   <th colspan="2">Enumeration description</th>
                 </tr>
                 <tr>
-                  <td><dfn data-idl><code>active</code></dfn></td>
+                  <td><dfn data-idl>active</dfn></td>
                   <td>An <code>active</code> TCP candidate is one for which the
                   transport will attempt to open an outbound connection but
                   will not receive incoming connection requests.</td>
                 </tr>
                 <tr>
-                  <td><dfn data-idl><code>passive</code></dfn></td>
+                  <td><dfn data-idl>passive</dfn></td>
                   <td>A <code>passive</code> TCP candidate is one for which the
                   transport will receive incoming connection attempts but not
                   attempt a connection.</td>
                 </tr>
                 <tr>
-                  <td><dfn data-idl><code>so</code></dfn></td>
+                  <td><dfn data-idl>so</dfn></td>
                   <td>An <code>so</code> candidate is one for which the
                   transport will attempt to open a connection simultaneously
                   with its peer.</td>
@@ -4440,7 +4357,7 @@ interface RTCIceCandidate {
         </section>
         <section>
           <h4><dfn>RTCIceCandidateType</dfn> Enum</h4>
-          <p>The <code>RTCIceCandidateType</code> represents the type of the ICE
+          <p>The {{RTCIceCandidateType}} represents the type of the ICE
           candidate, as defined in [[!ICE]] section 15.1.</p>
           <div>
             <pre class="idl"
@@ -4457,22 +4374,22 @@ interface RTCIceCandidate {
                   <th colspan="2">Enumeration description</th>
                 </tr>
                 <tr>
-                  <td data-tests="protocol/candidate-exchange.https.html"><dfn data-idl><code>host</code></dfn></td>
+                  <td data-tests="protocol/candidate-exchange.https.html"><dfn data-idl>host</dfn></td>
                   <td>A host candidate, as defined in Section 4.1.1.1 of
                   [[!ICE]].</td>
                 </tr>
                 <tr>
-                  <td><dfn data-idl><code>srflx</code></dfn></td>
+                  <td><dfn data-idl>srflx</dfn></td>
                   <td>A server reflexive candidate, as defined in Section
                   4.1.1.2 of [[!ICE]].</td>
                 </tr>
                 <tr>
-                  <td data-tests="protocol/candidate-exchange.https.html"><dfn data-idl><code>prflx</code></dfn></td>
+                  <td data-tests="protocol/candidate-exchange.https.html"><dfn data-idl>prflx</dfn></td>
                   <td>A peer reflexive candidate, as defined in Section 4.1.1.2
                   of [[!ICE]].</td>
                 </tr>
                 <tr>
-                  <td><dfn data-idl><code>relay</code></dfn></td>
+                  <td><dfn data-idl>relay</dfn></td>
                   <td>A relay candidate, as defined in Section 7.1.3.2.1 of
                   [[!ICE]].</td>
                 </tr>
@@ -4484,53 +4401,48 @@ interface RTCIceCandidate {
       <section>
         <h4><dfn>RTCPeerConnectionIceEvent</dfn></h4>
         <p>The <code>icecandidate</code> event of the RTCPeerConnection uses
-        the <code><a>RTCPeerConnectionIceEvent</a></code> interface.</p>
-        <p data-tests="RTCPeerConnectionIceEvent-constructor.html">When firing an <code><a>RTCPeerConnectionIceEvent</a></code> event
-        that contains an <code><a>RTCIceCandidate</a></code> object, it MUST
-        include values for both <a data-link-for=
-        "RTCIceCandidate">sdpMid</a> and <a data-link-for=
-        "RTCIceCandidate">sdpMLineIndex</a>. If the
-        <code><a>RTCIceCandidate</a></code> is of type <code>srflx</code> or
+        the {{RTCPeerConnectionIceEvent}} interface.</p>
+        <p data-tests="RTCPeerConnectionIceEvent-constructor.html">When firing an {{RTCPeerConnectionIceEvent}} event
+        that contains an {{RTCIceCandidate}} object, it MUST
+        include values for both {{RTCIceCandidate/sdpMid}} and {{RTCIceCandidate/sdpMLineIndex}}. If the
+        {{RTCIceCandidate}} is of type <code>srflx</code> or
         type <code>relay</code>, the <code>url</code> property of the event
         MUST be set to the URL of the ICE server from which the candidate was
         obtained.</p>
 
         <div class="note">
-          The <code><a>icecandidate</a></code> event is used for three
+          The {{icecandidate}} event is used for three
           different types of indications:
           <ul>
             <li>
-              <p>A candidate has been gathered. The <code><a
-              data-link-for="RTCPeerConnectionIceEvent">candidate</a></code>
+              <p>A candidate has been gathered. The {{RTCPeerConnectionIceEvent/candidate}}
               member of the event will be populated normally. It should be
               signaled to the remote peer and passed into
-              <code><a data-link-for="RTCPeerConnection">addIceCandidate</a></code>.</p>
+              {{RTCPeerConnection/addIceCandidate}}.</p>
             </li>
             <li>
-              <p>An <code><a>RTCIceTransport</a></code> has finished gathering a
-              <a>generation</a> of candidates, and is providing an end-of-candidates
+              <p>An {{RTCIceTransport}} has finished gathering a
+              [= generation =] of candidates, and is providing an end-of-candidates
               indication as defined by Section 8.2 of [[TRICKLE-ICE]]. This is
-              indicated by <code><a data-link-for="RTCPeerConnectionIceEvent">candidate</a>.<a
-              data-link-for="RTCIceCandidate">candidate</a></code> being set to an
-              empty string. The <code><a
-              data-link-for="RTCPeerConnectionIceEvent">candidate</a></code> object
+              indicated by <code>{{RTCPeerConnectionIceEvent/candidate}}.{{RTCIceCandidate/candidate}}</code> being set to an
+              empty string. The <code>{{RTCPeerConnectionIceEvent/candidate}}</code> object
               should be signaled to the remote peer and passed into
-              <code><a data-link-for="RTCPeerConnection">addIceCandidate</a></code>
+              {{RTCPeerConnection/addIceCandidate}}
               like a typical ICE candidate, in order to provide the
               end-of-candidates indication to the remote peer.</p>
             </li>
             <li>
-              <p>All <code><a>RTCIceTransport</a></code>s have finished
-              gathering candidates, and the <code><a>RTCPeerConnection</a></code>'s
-              <code><a>RTCIceGatheringState</a></code> has transitioned to
-              <code>"<a data-link-for="RTCIceGatheringState">complete</a>"</code>.
+              <p>All {{RTCIceTransport}}s have finished
+              gathering candidates, and the {{RTCPeerConnection}}'s
+              {{RTCIceGatheringState}} has transitioned to
+              <code>"{{RTCIceGatheringState/complete}}"</code>.
               This is indicated by the
-              <code><a data-link-for="RTCPeerConnectionIceEvent">candidate</a></code>
+              {{RTCPeerConnectionIceEvent/candidate}}
               member of the event being set to <code>null</code>. This only
               exists for backwards compatibility, and this event does not need
               to be signaled to the remote peer. It's equivalent to an
-              <code>"<a>icegatheringstatechange</a>"</code> event with the
-              <code>"<a data-link-for="RTCIceGatheringState">complete</a>"</code>
+              <code>"{{icegatheringstatechange}}"</code> event with the
+              <code>"{{RTCIceGatheringState/complete}}"</code>
               state.</p>
             </li>
           </ul>
@@ -4556,12 +4468,12 @@ interface RTCPeerConnectionIceEvent : Event {
             <h2>Attributes</h2>
             <dl data-link-for="RTCPeerConnectionIceEvent" data-dfn-for=
             "RTCPeerConnectionIceEvent" class="attributes">
-              <dt data-tests="RTCPeerConnectionIceEvent-constructor.html"><dfn data-idl><code>candidate</code></dfn> of type <span class=
-              "idlAttrType"><a>RTCIceCandidate</a></span>, readonly,
+              <dt data-tests="RTCPeerConnectionIceEvent-constructor.html"><dfn data-idl>candidate</dfn> of type <span class=
+              "idlAttrType">{{RTCIceCandidate}}</span>, readonly,
               nullable</dt>
               <dd>
                 <p>The <code>candidate</code> attribute is the
-                <code><a>RTCIceCandidate</a></code> object with the new ICE
+                {{RTCIceCandidate}} object with the new ICE
                 candidate that caused the event.</p>
                 <p>This attribute is set to <code>null</code> when an event is
                 generated to indicate the end of candidate gathering.</p>
@@ -4569,7 +4481,7 @@ interface RTCPeerConnectionIceEvent : Event {
                 only one event containing a <code>null</code> candidate is
                 fired.</p>
               </dd>
-              <dt data-tests="RTCPeerConnectionIceEvent-constructor.html"><dfn data-idl><code>url</code></dfn> of type <span class=
+              <dt data-tests="RTCPeerConnectionIceEvent-constructor.html"><dfn data-idl>url</dfn> of type <span class=
               "idlAttrType">DOMString</span>, readonly, nullable</dt>
               <dd>
                 <p>The <code>url</code> attribute is the STUN or TURN URL that
@@ -4592,14 +4504,14 @@ interface RTCPeerConnectionIceEvent : Event {
             Members</h2>
             <dl data-link-for="RTCPeerConnectionIceEventInit" data-dfn-for=
             "RTCPeerConnectionIceEventInit" class="dictionary-members">
-              <dt data-tests="RTCPeerConnectionIceEvent-constructor.html"><dfn data-idl><code>candidate</code></dfn> of type <span class=
-              "idlMemberType"><a>RTCIceCandidate</a></span>, nullable</dt>
+              <dt data-tests="RTCPeerConnectionIceEvent-constructor.html"><dfn data-idl>candidate</dfn> of type <span class=
+              "idlMemberType">{{RTCIceCandidate}}</span>, nullable</dt>
               <dd>
                 <p>See the
-                  <code><a data-link-for="RTCPeerConnectionIceEvent">candidate</a></code> attribute of the
-                <code>RTCPeerConnectionIceEvent</code> interface.</p>
+                  {{RTCPeerConnectionIceEvent/candidate}} attribute of the
+                {{RTCPeerConnectionIceEvent}} interface.</p>
               </dd>
-              <dt data-tests="RTCPeerConnectionIceEvent-constructor.html"><dfn data-idl><code>url</code></dfn> of type <span class=
+              <dt data-tests="RTCPeerConnectionIceEvent-constructor.html"><dfn data-idl>url</dfn> of type <span class=
               "idlMemberType">DOMString</span>, nullable</dt>
               <dd>The <code>url</code> attribute is the STUN or TURN URL that
               identifies the STUN or TURN server used to gather this
@@ -4611,7 +4523,7 @@ interface RTCPeerConnectionIceEvent : Event {
       <section>
         <h4><dfn>RTCPeerConnectionIceErrorEvent</dfn></h4>
         <p>The <code>icecandidateerror</code> event of the RTCPeerConnection
-        uses the <code><a>RTCPeerConnectionIceErrorEvent</a></code>
+        uses the {{RTCPeerConnectionIceErrorEvent}}
         interface.</p>
         <div>
           <pre class="idl" data-tests="idlharness.https.window.js"
@@ -4637,7 +4549,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             <h2>Attributes</h2>
             <dl data-link-for="RTCPeerConnectionIceErrorEvent" data-dfn-for=
             "RTCPeerConnectionIceErrorEvent" class="attributes">
-              <dt><dfn data-idl><code>address</code></dfn> of type <span class=
+              <dt><dfn data-idl>address</dfn> of type <span class=
               "idlAttrType">DOMString</span>, readonly</dt>
               <dd>
                 <p>The <code>address</code> attribute is the local IP
@@ -4650,7 +4562,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 as part of a local candidate, the <code>address</code>
                 attribute will be set to <code>null</code>.</p>
               </dd>
-              <dt><dfn data-idl><code>port</code></dfn> of type <span class=
+              <dt><dfn data-idl>port</dfn> of type <span class=
               "idlAttrType">unsigned short</span>, readonly</dt>
               <dd>
                 <p>The <code>port</code> attribute is the port used to
@@ -4658,14 +4570,14 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <p>If the <code>address</code> attribute is <code>null</code>,
                  the <code>port</code> attribute is also set to <code>null</code>.</p>
               </dd>
-              <dt><dfn data-idl><code>url</code></dfn> of type <span class=
+              <dt><dfn data-idl>url</dfn> of type <span class=
               "idlAttrType">DOMString</span>, readonly</dt>
               <dd>
                 <p>The <code>url</code> attribute is the STUN or TURN URL that
                 identifies the STUN or TURN server for which the failure
                 occurred.</p>
               </dd>
-              <dt><dfn data-idl><code>errorCode</code></dfn> of type <span class=
+              <dt><dfn data-idl>errorCode</dfn> of type <span class=
               "idlAttrType">unsigned short</span>, readonly</dt>
               <dd>
                 <p>The <code>errorCode</code> attribute is the numeric STUN
@@ -4675,9 +4587,9 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <code>errorCode</code> will be set to the value 701 which is
                 outside the STUN error code range. This error is only fired
                 once per server URL while in the
-                <code>RTCIceGatheringState</code> of "gathering".</p>
+                {{RTCIceGatheringState}} of "gathering".</p>
               </dd>
-              <dt><dfn data-idl><code>errorText</code></dfn> of type <span class=
+              <dt><dfn data-idl>errorText</dfn> of type <span class=
               "idlAttrType">USVString</span>, readonly</dt>
               <dd>
                 <p>The <code>errorText</code> attribute is the STUN reason text
@@ -4703,25 +4615,25 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             <dl data-link-for="RTCPeerConnectionIceErrorEventInit"
             data-dfn-for="RTCPeerConnectionIceErrorEventInit" class=
             "dictionary-members">
-              <dt><dfn data-idl><code>hostCandidate</code></dfn> of type <span class=
+              <dt><dfn data-idl>hostCandidate</dfn> of type <span class=
               "idlMemberType">DOMString</span></dt>
               <dd>
                 <p>The local address and port used to communicate
                  with the STUN or TURN server.</p>
               </dd>
-              <dt><dfn data-idl><code>url</code></dfn> of type <span class=
+              <dt><dfn data-idl>url</dfn> of type <span class=
               "idlMemberType">DOMString</span></dt>
               <dd>
                 <p>The STUN or TURN URL that identifies the STUN
                 or TURN server for which the failure occurred.</p>
               </dd>
-              <dt><dfn data-idl><code>errorCode</code></dfn> of type <span class=
+              <dt><dfn data-idl>errorCode</dfn> of type <span class=
               "idlMemberType">unsigned short</span>, required</dt>
               <dd>
                 <p>The numeric STUN error code returned by the STUN
                 or TURN server.</p>
               </dd>
-              <dt><dfn data-idl><code>statusText</code></dfn> of type <span class=
+              <dt><dfn data-idl>statusText</dfn> of type <span class=
               "idlMemberType">USVString</span></dt>
               <dd>
                 <p>The STUN reason text returned by the STUN
@@ -4734,17 +4646,16 @@ interface RTCPeerConnectionIceErrorEvent : Event {
     </section>
     <section>
       <h2 id="sec.cert-mgmt">Certificate Management</h2>
-      <p>The certificates that <code>RTCPeerConnection</code> instances use to
-      authenticate with peers use the <a>RTCCertificate</a>
+      <p>The certificates that {{RTCPeerConnection}} instances use to
+      authenticate with peers use the {{RTCCertificate}}
       interface. These objects can be explicitly generated by applications
-      using the <a data-link-for=
-      "RTCPeerConnection">generateCertificate</a> method and
-      can be provided in the <a>RTCConfiguration</a> when
-      constructing a new <code>RTCPeerConnection</code> instance.</p>
+      using the {{RTCPeerConnection/generateCertificate}} method and
+      can be provided in the {{RTCConfiguration}} when
+      constructing a new {{RTCPeerConnection}} instance.</p>
       <p>The explicit certificate management functions provided here are
       optional. If an application does not provide the
       <code>certificates</code> configuration option when constructing an
-      <code>RTCPeerConnection</code> a new set of certificates MUST be
+      {{RTCPeerConnection}} a new set of certificates MUST be
       generated by the <a>user agent</a>. That set MUST include an ECDSA
       certificate with a private key on the P-256 curve and a signature with a
       SHA-256 hash.</p>
@@ -4758,16 +4669,16 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           <h2>Methods</h2>
           <dl data-link-for="RTCPeerConnection" data-dfn-for=
           "RTCPeerConnection" class="methods">
-            <dt data-tests="RTCPeerConnection-generateCertificate.html"><dfn data-idl><code>generateCertificate</code></dfn>, static</dt>
+            <dt data-tests="RTCPeerConnection-generateCertificate.html"><dfn data-idl>generateCertificate</dfn>, static</dt>
             <dd>
               <p>The <code>generateCertificate</code> function causes the
               <a>user agent</a> to create an X.509 certificate
               [[!X509V3]] and corresponding private key. A handle to
               information is provided in the form of the
-              <code>RTCCertificate</code> interface. The returned
-              <code>RTCCertificate</code> can be used to control the
+              {{RTCCertificate}} interface. The returned
+              {{RTCCertificate}} can be used to control the
               certificate that is offered in the DTLS sessions established by
-              <code>RTCPeerConnection</code>.</p>
+              {{RTCPeerConnection}}.</p>
               <p>The <var>keygenAlgorithm</var> argument is used to control how
               the private key associated with the certificate is generated. The
               <var>keygenAlgorithm</var> argument uses the WebCrypto
@@ -4789,7 +4700,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               signature. The validity of this signature is only relevant for
               compatibility reasons. Only the public key and the resulting
               certificate fingerprint are used by
-              <code>RTCPeerConnection</code>, but it is more likely that a
+              {{RTCPeerConnection}}, but it is more likely that a
               certificate will be accepted if the certificate is well formed.
               The browser selects the algorithm used to sign the certificate; a
               browser SHOULD select SHA-256 [[!FIPS-180-4]] if a hash algorithm
@@ -4805,7 +4716,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   <code>generateCertificate</code>.</p>
                 </li>
                 <li>
-                  <p>Let <var>expires</var> be a <code>DOMTimeStamp</code> value
+                  <p>Let <var>expires</var> be a {{DOMTimeStamp}} value
                   of 2592000000.</p>
                   <div class="note">
                     <p>This means the certificate will by default expire in 30 days
@@ -4817,13 +4728,13 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   <ol>
                     <li>
                       <p>Let <var>certificateExpiration</var> be the result of
-                      <a href="https://heycam.github.io/webidl/#dfn-convert-ecmascript-to-idl-value">converting</a>
+                      <a data-cite="webidl##dfn-convert-ecmascript-to-idl-value">converting</a>
                       the ECMAScript object represented by <var>keygenAlgorithm</var> to an
-                      <code>RTCCertificateExpiration</code> dictionary.</p>
+                      {{RTCCertificateExpiration}} dictionary.</p>
                     </li>
                     <li data-tests="RTCPeerConnection-generateCertificate.html">
                       <p>If the conversion fails with an <var>error</var>,
-                      return a promise that is <a>rejected</a> with <var>error</var>.</p>
+                      return a promise that is [= rejected =] with <var>error</var>.</p>
                     </li>
                     <li>
                       <p>If <var>certificateExpiration</var>.<code>expires</code>
@@ -4846,20 +4757,19 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   with an operation name of <code>generateKey</code> and a
                   <a data-cite="!WebCryptoAPI#dfn-supportedAlgorithms">supportedAlgorithms</a>
                   value specific to production of certificates for
-                  <code>RTCPeerConnection</code>.</p>
+                  {{RTCPeerConnection}}.</p>
                 </li>
                 <li>
                   <p>If the above normalization step fails with an <var>error</var>,
-                  return a promise that is <a>rejected</a> with <var>error</var>.</p>
+                  return a promise that is [= rejected =] with <var>error</var>.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-generateCertificate.html">
                   <p>If the <var>normalizedKeygenAlgorithm</var> parameter
                   identifies an algorithm that the <a>user agent</a> cannot
                   or will not use to generate a certificate for
-                  <code>RTCPeerConnection</code>, return a promise that is
-                  <a>rejected</a> with a
-                  <code><a data-cite="!WEBIDL#idl-DOMException">
-                  DOMException</a></code> of type <code>NotSupportedError</code>. In
+                  {{RTCPeerConnection}}, return a promise that is
+                  [= rejected =] with a
+                  {{DOMException}} of type {{NotSupportedError}}. In
                   particular, <var>normalizedKeygenAlgorithm</var> MUST be an
                   asymmetric algorithm that can be used to produce a signature
                   used to authenticate DTLS connections.</p>
@@ -4883,7 +4793,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                     </li>
                     <li>
                       <p>Let <var>certificate</var> be a new
-                      <code><a>RTCCertificate</a></code> object.</p>
+                      {{RTCCertificate}} object.</p>
                     </li>
                     <li>
                       <p>Set <var>certificate</var>.[[\Expires]] to the
@@ -4891,9 +4801,9 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                     </li>
                     <li>
                       <p>Set <var>certificate</var>.[[\Origin]] to the <a
-                      href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">current
-                      settings object's</a>
-                      <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>.</p>
+                      data-cite="html">current
+                      settings object</a>'s
+                      <a data-cite="html#concept-settings-object-origin">origin</a>.</p>
                     </li>
                     <li>
                       <p>Store the <var>generatedKeyingMaterial</var> in a
@@ -4921,9 +4831,8 @@ interface RTCPeerConnectionIceErrorEvent : Event {
       </div>
       <section>
         <h2><dfn>RTCCertificateExpiration</dfn> Dictionary</h2>
-        <p><code><a>RTCCertificateExpiration</a></code> is used to set an
-        expiration date on certificates generated by <a data-link-for=
-        "RTCPeerConnection">generateCertificate</a>.</p>
+        <p>{{RTCCertificateExpiration}} is used to set an
+        expiration date on certificates generated by {{RTCPeerConnection/generateCertificate}}.</p>
         <pre class="idl"
 >dictionary RTCCertificateExpiration {
   [EnforceRange] DOMTimeStamp expires;
@@ -4933,22 +4842,21 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           <dt data-tests="RTCPeerConnection-generateCertificate.html"><dfn>expires</dfn></dt>
           <dd>
             <p>An optional <code>expires</code> attribute MAY be added to the
-            definition of the algorithm that is passed to <a data-link-for=
-            "RTCPeerConnection">generateCertificate</a>. If this
+            definition of the algorithm that is passed to {{RTCPeerConnection/generateCertificate}}. If this
             parameter is present it indicates the maximum time that the
-            <code><a>RTCCertificate</a></code> is valid for relative to the
+            {{RTCCertificate}} is valid for relative to the
             current time.</p>
           </dd>
         </dl>
       </section>
       <section>
         <h2><dfn>RTCCertificate</dfn> Interface</h2>
-        <p>The <code>RTCCertificate</code> interface represents a
+        <p>The {{RTCCertificate}} interface represents a
         certificate used to authenticate WebRTC communications. In addition to
         the visible properties, internal slots contain a handle to the
         generated private keying materal (<dfn>[[\KeyingMaterialHandle]]</dfn>),
         a certificate
-        (<dfn>[[\Certificate]]</dfn>) that <code>RTCPeerConnection</code>
+        (<dfn>[[\Certificate]]</dfn>) that {{RTCPeerConnection}}
         uses to authenticate with a peer, and the origin (<dfn>[[\Origin]]</dfn>)
         that created the object.</p>
         <div>
@@ -4962,14 +4870,14 @@ interface RTCCertificate {
             <h2>Attributes</h2>
             <dl data-link-for="RTCCertificate" data-dfn-for="RTCCertificate"
             class="attributes">
-              <dt><dfn data-idl><code>expires</code></dfn> of type <span class=
+              <dt><dfn data-idl>expires</dfn> of type <span class=
               "idlAttrType">DOMTimeStamp</span>, readonly</dt>
               <dd>
                 <p>The <var>expires</var> attribute indicates the date and time
                 in milliseconds relative to 1970-01-01T00:00:00Z after which
                 the certificate will be considered invalid by the browser.
                 After this time, attempts to construct an
-                <code>RTCPeerConnection</code> using this certificate fail.</p>
+                {{RTCPeerConnection}} using this certificate fail.</p>
                 <p>Note that this value might not be reflected in a
                 <code>notAfter</code> parameter in the certificate itself.</p>
               </dd>
@@ -4979,7 +4887,7 @@ interface RTCCertificate {
             <h2>Methods</h2>
             <dl data-link-for="RTCCertificate" data-dfn-for="RTCCertificate"
             class="methods">
-              <dt data-tests="RTCCertificate.html"><dfn data-idl><code>getFingerprints</code></dfn></dt>
+              <dt data-tests="RTCCertificate.html"><dfn data-idl>getFingerprints</dfn></dt>
               <dd>
                 <p>Returns the list of certificate fingerprints, one of which is
                 computed with the digest algorithm used in the certificate
@@ -4993,14 +4901,14 @@ interface RTCCertificate {
         applications to access the <a>[[\KeyingMaterialHandle]]</a> internal
         slot or the keying material it references.
         Implementations MUST support applications storing and retrieving
-        <code>RTCCertificate</code> objects from persistent storage, in a manner
+        {{RTCCertificate}} objects from persistent storage, in a manner
         that also preserves the keying material referenced by
         <a>[[\KeyingMaterialHandle]]</a>.
         Implementations SHOULD store the sensitive keying material in a secure
         module safe from same-process memory attacks. This allows the private
         key to be stored and used, but not easily read using a memory attack.</p>
-        <p id="serializable-certificate" data-tests="RTCCertificate-postMessage.html"><code>RTCCertificate</code> objects are <a>serializable objects</a>
-        [[!HTML]]. Their <a>serialization steps</a>, given <var>value</var> and
+        <p id="serializable-certificate" data-tests="RTCCertificate-postMessage.html">{{RTCCertificate}} objects are [= serializable objects =]
+        [[!HTML]]. Their [= serialization steps =], given <var>value</var> and
         <var>serialized</var>, are:</p>
 
         <ol>
@@ -5039,7 +4947,7 @@ interface RTCCertificate {
           resulting from deserializing <var>serialized</var>.[[\KeyingMaterialHandle]].</li>
         </ol>
         <p class="note">Supporting structured cloning in this manner
-        allows <a>RTCCertificate</a> instances to be persisted to stores.  It
+        allows {{RTCCertificate}} instances to be persisted to stores.  It
         also allows instances to be passed to other origins using APIs
         like {{MessagePort/postMessage()}} [[html]].  However, the object cannot
         be used by any other origin than the one that originally created it.</p>
@@ -5049,27 +4957,26 @@ interface RTCCertificate {
   <section>
     <h2>RTP Media API</h2>
     <p>The <dfn>RTP media API</dfn> lets a web application send and receive
-    <code>MediaStreamTrack</code>s over a peer-to-peer connection. Tracks, when
-    added to an <code>RTCPeerConnection</code>, result in signaling; when this
+    {{MediaStreamTrack}}s over a peer-to-peer connection. Tracks, when
+    added to an {{RTCPeerConnection}}, result in signaling; when this
     signaling is forwarded to a remote peer, it causes corresponding tracks to
     be created on the remote side.</p>
     <p class="note">There is not an exact 1:1 correspondence between tracks sent
-    by one <code>RTCPeerConnection</code> and received by the other. For one,
+    by one {{RTCPeerConnection}} and received by the other. For one,
     IDs of tracks sent have no mapping to the IDs of tracks received. Also,
-    <code><a data-link-for="RTCRtpSender">replaceTrack</a></code> changes the
-    track sent by an <code><a>RTCRtpSender</a></code> without creating a new
+    {{RTCRtpSender/replaceTrack}} changes the
+    track sent by an {{RTCRtpSender}} without creating a new
     track on the receiver side; the corresponding
-    <code><a>RTCRtpReceiver</a></code> will only have a single track,
+    {{RTCRtpReceiver}} will only have a single track,
     potentially representing multiple sources of media stitched together. Both
-    <code><a data-link-for="RTCPeerConnection">addTransceiver</a></code> and
-    <code><a data-link-for="RTCRtpSender">replaceTrack</a></code> can be used to
+    {{RTCPeerConnection/addTransceiver}} and
+    {{RTCRtpSender/replaceTrack}} can be used to
     cause the same track to be sent multiple times, which will be observed on
     the receiver side as multiple receivers each with its own separate track.
     Thus it's more accurate to think of a 1:1 relationship between an
-    <code><a>RTCRtpSender</a></code> on one side and an
-    <code><a>RTCRtpReceiver</a></code>'s track on the other side, matching senders
-    and receivers using the <code><a>RTCRtpTransceiver</a></code>'s <code><a
-    data-link-for="RTCRtpTransceiver">mid</a></code> if necessary.</p>
+    {{RTCRtpSender}} on one side and an
+    {{RTCRtpReceiver}}'s track on the other side, matching senders
+    and receivers using the {{RTCRtpTransceiver}}'s {{RTCRtpTransceiver/mid}} if necessary.</p>
     <p>When sending media, the sender may need to rescale or
     resample the media to meet various requirements including the
     envelope negotiated by SDP.</p>
@@ -5085,51 +4992,51 @@ interface RTCCertificate {
     1283</a>.</p>
     <p>When video is rescaled, for example for certain combinations
     of width or height and
-    <code><a data-link-for="RTCRtpEncodingParameters">
-    scaleResolutionDownBy</a></code> values, situations when the resulting width
+    {{RTCRtpEncodingParameters/
+    scaleResolutionDownBy}} values, situations when the resulting width
     or height is not an integer may occur. In such situations the
     user agent MUST use <a href="https://tc39.github.io/ecma262/#eqn-floor">the
     integer part of the result</a>. What to transmit if the integer
     part of the scaled width or height is zero is implementation-specific.</p>
-    <p>The actual encoding and transmission of <code>MediaStreamTrack</code>s
-    is managed through objects called <code><a>RTCRtpSender</a></code>s.
-    Similarly, the reception and decoding of <code>MediaStreamTrack</code>s is
-    managed through objects called <code><a>RTCRtpReceiver</a></code>s. Each
-    <code><a>RTCRtpSender</a></code> is associated with at most one track,
+    <p>The actual encoding and transmission of {{MediaStreamTrack}}s
+    is managed through objects called {{RTCRtpSender}}s.
+    Similarly, the reception and decoding of {{MediaStreamTrack}}s is
+    managed through objects called {{RTCRtpReceiver}}s. Each
+    {{RTCRtpSender}} is associated with at most one track,
     and each track to be received is associated with exactly
-    one <code><a>RTCRtpReceiver</a></code>.</p>
-    <p>The encoding and transmission of each <code>MediaStreamTrack</code>
+    one {{RTCRtpReceiver}}.</p>
+    <p>The encoding and transmission of each {{MediaStreamTrack}}
     SHOULD be made such that its characteristics (width, height and frameRate
     for video tracks; volume, sampleSize, sampleRate and channelCount for audio
     tracks) are to a reasonable degree retained by the track created on the
     remote side. There are situations when this does not apply, there may for
     example be resource constraints at either endpoint or in the network or
-    there may be <code><a>RTCRtpSender</a></code> settings applied that
+    there may be {{RTCRtpSender}} settings applied that
     instruct the implementation to act differently.</p>
     <p>
-      An <code><a>RTCPeerConnection</a></code> object contains a <dfn id=
+      An {{RTCPeerConnection}} object contains a <dfn id=
       "transceivers-set" data-lt="set of transceivers">set of
-      <code><a>RTCRtpTransceiver</a></code>s</dfn>, representing the paired
+      {{RTCRtpTransceiver}}s</dfn>, representing the paired
       senders and receivers with some shared state. <span data-tests="RTCPeerConnection-getTransceivers.html">This set is initialized to
-      the empty set when the <code><a>RTCPeerConnection</a></code> object is
-      created.</span> <code><a>RTCRtpSender</a></code>s and
-      <code><a>RTCRtpReceiver</a></code>s are always created at the same time
-      as an <code><a>RTCRtpTransceiver</a></code>, which they will remain
+      the empty set when the {{RTCPeerConnection}} object is
+      created.</span> {{RTCRtpSender}}s and
+      {{RTCRtpReceiver}}s are always created at the same time
+      as an {{RTCRtpTransceiver}}, which they will remain
       attached to for their lifetime.
-      <code><a>RTCRtpTransceiver</a></code>s are created implicitly when the
-      application attaches a <code>MediaStreamTrack</code> to an
-      <code><a>RTCPeerConnection</a></code> via the <code>addTrack</code>
+      {{RTCRtpTransceiver}}s are created implicitly when the
+      application attaches a {{MediaStreamTrack}} to an
+      {{RTCPeerConnection}} via the {{RTCPeerConnection/addTrack()}}
       method, or explicitly when the application uses the
       <code>addTransceiver</code> method. They are also created when a remote
       description is applied that includes a new media description.
       Additionally, when a remote description is applied that indicates the
       remote endpoint has media to send, the relevant
-      <code>MediaStreamTrack</code> and <code><a>RTCRtpReceiver</a></code> are
-      surfaced to the application via the <code><a>track</a></code> event.
+      {{MediaStreamTrack}} and {{RTCRtpReceiver}} are
+      surfaced to the application via the {{track}} event.
     </p>
     <section>
       <h3>RTCPeerConnection Interface Extensions</h3>
-      <p>The RTP media API extends the <code><a>RTCPeerConnection</a></code>
+      <p>The RTP media API extends the {{RTCPeerConnection}}
       interface as described below.</p>
       <div>
         <pre class="idl" data-tests="idlharness.https.window.js" data-cite="HTML"
@@ -5147,11 +5054,11 @@ interface RTCCertificate {
           <h2>Attributes</h2>
           <dl data-link-for="RTCPeerConnection" data-dfn-for=
           "RTCPeerConnection" class="attributes">
-            <dt data-tests="RTCPeerConnection-ontrack.https.html,RTCPeerConnection-transceivers.https.html"><dfn data-idl><code>ontrack</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-ontrack.https.html,RTCPeerConnection-transceivers.https.html"><dfn data-idl>ontrack</dfn> of type <span class=
             "idlAttrType">EventHandler</span></dt>
             <dd>
               <p>The event type of this event handler is
-              <code><a>track</a></code>.</p>
+              {{track}}.</p>
             </dd>
           </dl>
         </section>
@@ -5161,18 +5068,18 @@ interface RTCCertificate {
           "RTCPeerConnection" class="methods">
             <dt data-tests="RTCPeerConnection-getTransceivers.html,RTCPeerConnection-transceivers.https.html"><code>getSenders</code></dt>
             <dd>
-              <p>Returns a sequence of <code><a>RTCRtpSender</a></code> objects
+              <p>Returns a sequence of {{RTCRtpSender}} objects
               representing the RTP senders that belong to non-stopped
-              <code><a>RTCRtpTransceiver</a></code> objects currently attached
-              to this <code><a>RTCPeerConnection</a></code> object.</p>
+              {{RTCRtpTransceiver}} objects currently attached
+              to this {{RTCPeerConnection}} object.</p>
               <p>When the <dfn id=
               "dom-peerconnection-getsenders"><code>getSenders</code></dfn>
               method is invoked, the user agent MUST return the result of
-              executing the <code><a>CollectSenders</a></code> algorithm.</p>
+              executing the {{CollectSenders}} algorithm.</p>
              <p>We define the <dfn>CollectSenders</dfn> algorithm as follows:</p>
               <ol>
                 <li>Let <var>transceivers</var> be the result of executing the
-                <code><a>CollectTransceivers</a></code> algorithm.</li>
+                {{CollectTransceivers}} algorithm.</li>
                 <li>Let <var>senders</var> be a new empty sequence.</li>
                 <li>For each <var>transceiver</var> in <var>transceivers</var>,
                   <ol>
@@ -5187,16 +5094,16 @@ interface RTCCertificate {
             </dd>
             <dt data-tests="RTCPeerConnection-addTransceiver.https.html,RTCPeerConnection-getTransceivers.html,RTCPeerConnection-transceivers.https.html"><code>getReceivers</code></dt>
             <dd>
-              <p>Returns a sequence of <code><a>RTCRtpReceiver</a></code> objects
+              <p>Returns a sequence of {{RTCRtpReceiver}} objects
               representing the RTP receivers that belong to non-stopped
-              <code><a>RTCRtpTransceiver</a></code> objects currently attached
-              to this <code><a>RTCPeerConnection</a></code> object.</p>
+              {{RTCRtpTransceiver}} objects currently attached
+              to this {{RTCPeerConnection}} object.</p>
               <p>When the <dfn id=
               "dom-peerconnection-getreceivers"><code>getReceivers</code></dfn>
               method is invoked, the user agent MUST run the following steps:</p>
               <ol>
                 <li>Let <var>transceivers</var> be the result of executing the
-                <code><a>CollectTransceivers</a></code> algorithm.</li>
+                {{CollectTransceivers}} algorithm.</li>
                 <li>Let <var>receivers</var> be a new empty sequence.</li>
                 <li>For each <var>transceiver</var> in <var>transceivers</var>,
                   <ol>
@@ -5211,42 +5118,42 @@ interface RTCCertificate {
             </dd>
             <dt data-tests="RTCPeerConnection-getTransceivers.html,RTCPeerConnection-transceivers.https.html"><code>getTransceivers</code></dt>
             <dd>
-              <p>Returns a sequence of <code><a>RTCRtpTransceiver</a></code>
+              <p>Returns a sequence of {{RTCRtpTransceiver}}
               objects representing the RTP transceivers that are currently
-              attached to this <code><a>RTCPeerConnection</a></code>
+              attached to this {{RTCPeerConnection}}
               object.</p>
               <p>The <dfn id=
               "dom-peerconnection-gettranseceivers"><code>getTransceivers</code></dfn>
               method MUST return the result of executing the
-              <code><a>CollectTransceivers</a></code> algorithm.</p>
+              {{CollectTransceivers}} algorithm.</p>
 
               <p>We define the <dfn>CollectTransceivers</dfn> algorithm as
               follows:</p>
               <ol>
                 <li>Let <var>transceivers</var> be a new sequence consisting of
-                all <code><a>RTCRtpTransceiver</a></code> objects in this
-                <code><a>RTCPeerConnection</a></code> object's
-                <a>set of transceivers</a>, in insertion order.
+                all {{RTCRtpTransceiver}} objects in this
+                {{RTCPeerConnection}} object's
+                [= set of transceivers =], in insertion order.
                 </li>
                 <li>Return <var>transceivers</var>.</li>
               </ol>
             </dd>
             <dt data-tests="RTCPeerConnection-add-track-no-deadlock.https.html"><code>addTrack</code></dt>
             <dd>
-              <p>Adds a new track to the <code><a>RTCPeerConnection</a></code>,
+              <p>Adds a new track to the {{RTCPeerConnection}},
               and indicates that it is contained in the specified
-              <code>MediaStream</code>s.</p>
-              <p>When the <dfn data-idl><code>addTrack</code></dfn> method is invoked,
+              {{MediaStream}}s.</p>
+              <p>When the <dfn data-idl>addTrack</dfn> method is invoked,
               the user agent MUST run the following steps:</p>
               <ol>
                 <li>
                   <p>Let <var>connection</var> be the
-                  <code><a>RTCPeerConnection</a></code> object on which this
+                  {{RTCPeerConnection}} object on which this
                   method was invoked.</p>
                 </li>
                 <li>
                   <p>Let <var>track</var> be the
-                  <code><a>MediaStreamTrack</a></code> object indicated by the
+                  {{MediaStreamTrack}} object indicated by the
                   method's first argument.</p>
                 </li>
                 <li>
@@ -5254,31 +5161,31 @@ interface RTCCertificate {
                 </li>
                 <li data-tests="RTCPeerConnection-setRemoteDescription-tracks.https.html">
                   <p>Let <var>streams</var> be a list of
-                  <code><a>MediaStream</a></code> objects constructed from the
+                  {{MediaStream}} objects constructed from the
                   method's remaining arguments, or an empty list if the method
                   was called with a single argument.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-addTrack.https.html">
                   <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
-                  <code>true</code>, <a>throw</a> an
-                  <code>InvalidStateError</code>.</p>
+                  <code>true</code>, [= exception/throw =] an
+                  {{InvalidStateError}}.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-addTrack.https.html">
                   <p>Let <var>senders</var> be the result of executing the
-                  <code><a>CollectSenders</a></code> algorithm. If an
-                  <code><a>RTCRtpSender</a></code> for <var>track</var> already
-                  exists in <var>senders</var>, <a>throw</a> an
-                  <code>InvalidAccessError</code>.</p>
+                  {{CollectSenders}} algorithm. If an
+                  {{RTCRtpSender}} for <var>track</var> already
+                  exists in <var>senders</var>, [= exception/throw =] an
+                  {{InvalidAccessError}}.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-addTrack.https.html,RTCPeerConnection-transceivers.https.html">
                   <p>The steps below describe how to determine if an existing
                   sender can be reused. Doing so will cause future calls to
                   <code>createOffer</code> and <code>createAnswer</code> to
-                  mark the corresponding <a>media description</a> as
+                  mark the corresponding [= media description =] as
                   <code>sendrecv</code> or <code>sendonly</code> and add the
                   MSID of the sender's streams, as defined in <span data-jsep=
                   "subsequent-offers subsequent-answers">[[!JSEP]]</span>.</p>
-                  <p>If any <code><a>RTCRtpSender</a></code> object in
+                  <p>If any {{RTCRtpSender}} object in
                   <var>senders</var> matches all the following criteria, let
                   <var>sender</var> be that object, or <code>null</code>
                   otherwise:</p>
@@ -5288,18 +5195,18 @@ interface RTCCertificate {
                     </li>
                     <li>
                       <p>The <a>transceiver kind</a> of the
-                      <code><a>RTCRtpTransceiver</a></code>, associated with
+                      {{RTCRtpTransceiver}}, associated with
                       the sender, matches <var>kind</var>.</p>
                     </li>
                     <li>
                       <p>The <a>[[\Stopping]]</a> slot of the
-                      <code><a>RTCRtpTransceiver</a></code> associated with the
+                      {{RTCRtpTransceiver}} associated with the
                       sender is <code>false</code>.</p>
                     </li>
                     <li>
                       <p>The sender has never been used to send. More
                       precisely, the <a>[[\CurrentDirection]]</a> slot of the
-                      <code><a>RTCRtpTransceiver</a></code> associated with the
+                      {{RTCRtpTransceiver}} associated with the
                       sender has never had a value of <code>sendrecv</code> or
                       <code>sendonly</code>.</p>
                     </li>
@@ -5326,7 +5233,7 @@ interface RTCCertificate {
                     </li>
                     <li>
                       <p>Let <var>transceiver</var> be the
-                      <code><a>RTCRtpTransceiver</a></code> associated with
+                      {{RTCRtpTransceiver}} associated with
                       <var>sender</var>.</p>
                     </li>
                     <li>
@@ -5355,31 +5262,31 @@ interface RTCCertificate {
                     <li>
                       <p><a>Create an RTCRtpTransceiver</a> with
                       <var>sender</var>, <var>receiver</var> and
-                      an <code><a>RTCRtpTransceiverDirection</a></code> value
+                      an {{RTCRtpTransceiverDirection}} value
                       of <code>sendrecv</code>, and let <var>transceiver</var>
                       be the result.</p>
                     </li>
                     <li>
                       <p>Add <var>transceiver</var> to <var>connection</var>'s
-                      <a href="#transceivers-set">set of transceivers</a></p>
+                      [= set of transceivers =]</p>
                     </li>
                   </ol>
                 </li>
-                <li>
+                <li data-cite="fetch">
                   <p>A track could have contents that are inaccessible to the
                   application. This can be due to anything that would make
                   a track <a data-cite="!fetch#concept-cors-check">
                   CORS cross-origin</a>. These tracks can be supplied to the
-                  <code>addTrack</code> method, and have an
-                  <code><a>RTCRtpSender</a></code> created for them, but
+                  {{RTCPeerConnection/addTrack()}} method, and have an
+                  {{RTCRtpSender}} created for them, but
                   content MUST NOT be transmitted. Silence
                   (audio), black frames (video) or equivalently absent content
                   is sent in place of track content.</p>
                   <p>Note that this property can change over time.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
-                  <p><a data-lt="update the negotiation-needed flag">Update the
-                  negotiation-needed flag</a> for <var>connection</var>.</p>
+                  <p>[= Update the
+                  negotiation-needed flag =] for <var>connection</var>.</p>
                 </li>
                 <li>
                   <p>Return <var>sender</var>.</p>
@@ -5389,17 +5296,17 @@ interface RTCCertificate {
             <dt data-tests="RTCPeerConnection-removeTrack.https.html"><code>removeTrack</code></dt>
             <dd>
               <p>Stops sending media from <var>sender</var>. The
-              <code><a>RTCRtpSender</a></code> will still appear
+              {{RTCRtpSender}} will still appear
               in <code>getSenders</code>. Doing so will cause future
               calls to <code>createOffer</code> to mark the
-              <a>media description</a> for the corresponding transceiver
+              [= media description =] for the corresponding transceiver
               as <code>recvonly</code> or <code>inactive</code>,
               as defined in <span data-jsep="subsequent-offers">
               [[!JSEP]]</span>. <!-- onended --></p>
               <p>When the other peer stops sending a track in this manner, the
-              track is removed from any remote <code><a>MediaStream</a></code>s
+              track is removed from any remote {{MediaStream}}s
               that were initially revealed in the <code>track</code> event, and
-              if the <code><a>MediaStreamTrack</a></code> is not already muted,
+              if the {{MediaStreamTrack}} is not already muted,
               a <code title="event-MediaStreamTrack-mute">mute</code> event is
               fired at the track.</p>
               <div class="note">The same effect as <code>removeTrack()</code>
@@ -5409,7 +5316,7 @@ interface RTCCertificate {
               <code>RTCRtpSender.replaceTrack(null)</code> on the sender. One
               minor difference is that <code>replaceTrack()</code> is
               asynchronous and <code>removeTrack()</code> is synchronous.</div>
-              <p>When the <dfn data-idl><code>removeTrack</code></dfn> method is
+              <p>When the <dfn data-idl>removeTrack</dfn> method is
               invoked, the user agent MUST run the following steps:</p>
               <ol>
                 <li>
@@ -5418,27 +5325,27 @@ interface RTCCertificate {
                 </li>
                 <li>
                   <p>Let <var>connection</var> be the
-                  <code><a>RTCPeerConnection</a></code> object on which
+                  {{RTCPeerConnection}} object on which
                   the method was invoked.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-removeTrack.https.html,RTCRtpTransceiver.https.html">
                   <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
-                  <code>true</code>, <a>throw</a> an
-                  <code>InvalidStateError</code>.</p>
+                  <code>true</code>, [= exception/throw =] an
+                  {{InvalidStateError}}.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-removeTrack.https.html">
                   <p>If <var>sender</var> was not created by
-                  <var>connection</var>, <a>throw</a> an
-                  <code>InvalidAccessError</code>.</p>
+                  <var>connection</var>, [= exception/throw =] an
+                  {{InvalidAccessError}}.</p>
                 </li>
                 <li>
                   <p>Let <var>senders</var> be the result of executing the
-                  <code><a>CollectSenders</a></code> algorithm.</p>
+                  {{CollectSenders}} algorithm.</p>
                 </li>
                 <li>
                   <p>If <var>sender</var> is not in <var>senders</var> (which
                   indicates its transceiver was stopped or removed due to
-                  <a href="#set-description">setting an RTCSessionDescription</a>
+                  [= setting an RTCSessionDescription =]
                   of type "rollback"), then abort these steps.</p>
                 </li>
                 <li>
@@ -5450,7 +5357,7 @@ interface RTCCertificate {
                 </li>
                 <li>
                   <p>Let <var>transceiver</var> be the
-                  <code><a>RTCRtpTransceiver</a></code> object corresponding
+                  {{RTCRtpTransceiver}} object corresponding
                   to <var>sender</var>.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-removeTrack.https.html">
@@ -5462,22 +5369,21 @@ interface RTCCertificate {
                   is <code>sendonly</code>, set <var>transceiver</var>.<a>[[\Direction]]</a> to <code>inactive</code>.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
-                  <p><a data-lt="update the negotiation-needed flag">Update the
-                  negotiation-needed flag</a> for <var>connection</var>.</p>
+                  <p>[= Update the
+                  negotiation-needed flag =] for <var>connection</var>.</p>
                 </li>
               </ol>
             </dd>
-            <dt data-tests="RTCRtpTransceiver.https.html"><dfn data-idl><code>addTransceiver</code></dfn></dt>
+            <dt data-tests="RTCRtpTransceiver.https.html"><dfn data-idl>addTransceiver</dfn></dt>
             <dd>
-              <p>Create a new <code><a>RTCRtpTransceiver</a></code> and add it
-              to the <a>set of transceivers</a>.</p>
+              <p>Create a new {{RTCRtpTransceiver}} and add it
+              to the [= set of transceivers =].</p>
               <p>Adding a transceiver will cause future calls to
-              <code>createOffer</code> to add a <a>media description</a> for
+              <code>createOffer</code> to add a [= media description =] for
               the corresponding transceiver, as defined in <span data-jsep=
               "subsequent-offers">[[!JSEP]]</span>.</p>
-              <p data-tests="RTCPeerConnection-addTransceiver.https.html">The initial value of <code><a data-link-for=
-              "RTCRtpTransceiver">mid</a></code> is null. Setting a new
-              <code><a>RTCSessionDescription</a></code> may change it to a
+              <p data-tests="RTCPeerConnection-addTransceiver.https.html">The initial value of {{RTCRtpTransceiver/mid}} is null. Setting a new
+              {{RTCSessionDescription}} may change it to a
               non-null value, as defined in <span data-jsep=
               "processing-a-local-desc processing-a-remote-desc">[[!JSEP]]</span>.</p>
               <p data-tests="protocol/simulcast-offer.html">The <code>sendEncodings</code> argument can be used to
@@ -5507,8 +5413,8 @@ interface RTCCertificate {
                   <ol>
                     <li>
                       <p>If <var>kind</var> is not a legal
-                      <code><a>MediaStreamTrack</a></code> <code>kind</code>,
-                      <a>throw</a> a <code>TypeError</code>.</p>
+                      {{MediaStreamTrack}} <code>kind</code>,
+                      [= exception/throw =] a {{TypeError}}.</p>
                     </li>
                     <li>
                       <p>Let <var>track</var> be <code>null</code>.</p>
@@ -5517,35 +5423,35 @@ interface RTCCertificate {
                 </li>
                 <li data-tests="RTCPeerConnection-addTransceiver.https.html,RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html">
                   <p>If the first argument is a
-                  <code><a>MediaStreamTrack</a></code>, let it be
+                  {{MediaStreamTrack}}, let it be
                   <var>track</var> and let <var>kind</var> be
                   <var>track.kind</var>.</p>
                 </li>
                 <li>
                   <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
-                  <code>true</code>, <a>throw</a> an
-                  <code>InvalidStateError</code>.</p>
+                  <code>true</code>, [= exception/throw =] an
+                  {{InvalidStateError}}.</p>
                 </li>
                 <li>Validate <var>sendEncodings</var> by running the following steps:
                 <ol>
                   <li data-tests="RTCPeerConnection-addTransceiver.https.html">
-                    <p>Verify that each <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>
+                    <p>Verify that each {{RTCRtpCodingParameters/rid}}
                     value in <var>sendEncodings</var> conforms to the grammar specified in
                     Section 10 of [[!MMUSIC-RID]]. If one of the RIDs does not meet
-                    these requirements, <a>throw</a> a <code>TypeError</code>.</p>
+                    these requirements, [= exception/throw =] a {{TypeError}}.</p>
                   </li>
                   <li>
-                    <p>If any <code><a>RTCRtpEncodingParameters</a></code>
+                    <p>If any {{RTCRtpEncodingParameters}}
                     dictionary in <var>sendEncodings</var> contains a
                     <a>read-only parameter</a> other than
-                    <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>,
-                    <a>throw</a> an <code>InvalidAccessError</code>.</p>
+                    {{RTCRtpCodingParameters/rid}},
+                    [= exception/throw =] an {{InvalidAccessError}}.</p>
                   </li>
                   <li data-tests="RTCRtpParameters-encodings.html">
-                    <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">scaleResolutionDownBy</a></code>
+                    <p>Verify that each {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
                     value in <var>sendEncodings</var> is greater than or equal to 1.0. If
                     one of the <code>scaleResolutionDownBy</code> values does not meet
-                    this requirement, <a>throw</a> a <code>RangeError</code>.</p>
+                    this requirement, [= exception/throw =] a {{RangeError}}.</p>
                   </li>
                   <li>
                     <p>Let <var>maxN</var> be the maximum number of total simultaneous
@@ -5554,20 +5460,20 @@ interface RTCCertificate {
                     codec to be used is not known yet.</p>
                   </li>
                   <li>
-                    <p>If the number of <code><a>RTCRtpEncodingParameters</a></code>
+                    <p>If the number of {{RTCRtpEncodingParameters}}
                     stored in <var>sendEncodings</var> exceeds <var>maxN</var>,
                     then trim <var>sendEncodings</var> from the tail until its length
                     is <var>maxN</var>.</p>
                    </li>
                    <li>
-                     <p>If the number of <code><a>RTCRtpEncodingParameters</a></code> now
+                     <p>If the number of {{RTCRtpEncodingParameters}} now
                      stored in <var>sendEncodings</var> is <code>1</code>, then remove any
-                     <code><a data-link-for="RTCRtpCodingParameters">rid</a></code>
+                     {{RTCRtpCodingParameters/rid}}
                      member from the lone entry.</p>
                      <div class="note">Providing a single, default
-                     <code><a>RTCRtpEncodingParameters</a></code> in <var>sendEncodings</var>
+                     {{RTCRtpEncodingParameters}} in <var>sendEncodings</var>
                      allows the application to subsequently set encoding parameters using
-                     <code><a data-link-for="RTCRtpSender">setParameters</a></code>, even
+                     {{RTCRtpSender/setParameters}}, even
                      when simulcast isn't used.</div>
                    </li>
                 </ol>
@@ -5584,7 +5490,7 @@ interface RTCCertificate {
                   corresponding remote description that is able to receive
                   multiple RTP encodings as defined in <span data-jsep=
                   "simulcast">[[!JSEP]]</span>, the
-                  <code><a>RTCRtpSender</a></code> may send multiple RTP
+                  {{RTCRtpSender}} may send multiple RTP
                   encodings and the parameters retrieved via the transceiver's
                   <code>sender.getParameters()</code> will reflect the
                   encodings negotiated.</p>
@@ -5600,11 +5506,11 @@ interface RTCCertificate {
                 </li>
                 <li data-tests="RTCPeerConnection-addTransceiver.https.html,RTCRtpTransceiver.https.html">
                   <p>Add <var>transceiver</var> to <var>connection</var>'s
-                  <a href="#transceivers-set">set of transceivers</a></p>
+                  [= set of transceivers =]</p>
                 </li>
                 <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
-                  <p><a data-lt="update the negotiation-needed flag">Update the
-                  negotiation-needed flag</a> for <var>connection</var>.</p>
+                  <p>[= Update the
+                  negotiation-needed flag =] for <var>connection</var>.</p>
                 </li>
                 <li>
                   <p>Return <var>transceiver</var>.</p>
@@ -5626,19 +5532,19 @@ interface RTCCertificate {
           Members</h2>
           <dl data-link-for="RTCRtpTransceiverInit" data-dfn-for=
           "RTCRtpTransceiverInit" class="dictionary-members">
-            <dt data-tests="RTCPeerConnection-addTransceiver.https.html, RTCRtpTransceiver-direction.html"><dfn data-idl><code>direction</code></dfn> of type <span class=
-            "idlMemberType"><a>RTCRtpTransceiverDirection</a></span>,
+            <dt data-tests="RTCPeerConnection-addTransceiver.https.html, RTCRtpTransceiver-direction.html"><dfn data-idl>direction</dfn> of type <span class=
+            "idlMemberType">{{RTCRtpTransceiverDirection}}</span>,
             defaulting to <code>"sendrecv"</code></dt>
-            <dd>The direction of the <code>RTCRtpTransceiver</code>.</dd>
-            <dt><dfn data-idl><code>streams</code></dfn> of type <span class=
-            "idlMemberType">sequence&lt;<a>MediaStream</a>&gt;</span></dt>
+            <dd>The direction of the {{RTCRtpTransceiver}}.</dd>
+            <dt><dfn data-idl>streams</dfn> of type <span class=
+            "idlMemberType">sequence&lt;{{MediaStream}}&gt;</span></dt>
             <dd>
               <p>When the remote PeerConnection's track event fires
-              corresponding to the <code><a>RTCRtpReceiver</a></code> being
+              corresponding to the {{RTCRtpReceiver}} being
               added, these are the streams that will be put in the event.</p>
             </dd>
-            <dt data-tests="RTCRtpParameters-encodings.html"><dfn data-idl><code>sendEncodings</code></dfn> of type <span class=
-            "idlMemberType">sequence&lt;<a>RTCRtpEncodingParameters</a>&gt;</span></dt>
+            <dt data-tests="RTCRtpParameters-encodings.html"><dfn data-idl>sendEncodings</dfn> of type <span class=
+            "idlMemberType">sequence&lt;{{RTCRtpEncodingParameters}}&gt;</span></dt>
             <dd>
               <p>A sequence containing parameters for sending RTP encodings of
               media.</p>
@@ -5662,49 +5568,49 @@ interface RTCCertificate {
               <th colspan="2"><dfn>RTCRtpTransceiverDirection</dfn> Enumeration description</th>
             </tr>
             <tr>
-              <td data-tests="RTCPeerConnection-transceivers.https.html"><dfn data-idl><code>sendrecv</code></dfn></td>
-              <td>The <code><a>RTCRtpTransceiver</a></code>'s
-              <code><a>RTCRtpSender</a></code> <var>sender</var> will offer to
+              <td data-tests="RTCPeerConnection-transceivers.https.html"><dfn data-idl>sendrecv</dfn></td>
+              <td>The {{RTCRtpTransceiver}}'s
+              {{RTCRtpSender}} <var>sender</var> will offer to
               send RTP, and will send RTP if the remote peer accepts and
               <code><var>sender.getParameters().encodings[i].active</var></code>
               is <code>true</code> for any value of <var>i</var>. The
-              <code><a>RTCRtpTransceiver</a></code>'s
-              <code><a>RTCRtpReceiver</a></code> will offer to receive RTP, and
+              {{RTCRtpTransceiver}}'s
+              {{RTCRtpReceiver}} will offer to receive RTP, and
               will receive RTP if the remote peer accepts.</td>
             </tr>
             <tr>
-              <td data-tests="RTCPeerConnection-transceivers.https.html"><dfn data-idl><code>sendonly</code></dfn></td>
-              <td>The <code><a>RTCRtpTransceiver</a></code>'s
-              <code><a>RTCRtpSender</a></code> <var>sender</var> will offer to
+              <td data-tests="RTCPeerConnection-transceivers.https.html"><dfn data-idl>sendonly</dfn></td>
+              <td>The {{RTCRtpTransceiver}}'s
+              {{RTCRtpSender}} <var>sender</var> will offer to
               send RTP, and will send RTP if the remote peer accepts and
               <code><var>sender.getParameters().encodings[i].active</var></code>
               is <code>true</code> for any value of <var>i</var>. The
-              <code><a>RTCRtpTransceiver</a></code>'s
-              <code><a>RTCRtpReceiver</a></code> will not offer to receive RTP,
+              {{RTCRtpTransceiver}}'s
+              {{RTCRtpReceiver}} will not offer to receive RTP,
               and will not receive RTP.</td>
             </tr>
             <tr>
-              <td data-tests="RTCPeerConnection-transceivers.https.html"><dfn data-idl><code>recvonly</code></dfn></td>
-              <td>The <code><a>RTCRtpTransceiver</a></code>'s
-              <code><a>RTCRtpSender</a></code> will not offer to send RTP, and
-              will not send RTP. The <code><a>RTCRtpTransceiver</a></code>'s
-              <code><a>RTCRtpReceiver</a></code> will offer to receive RTP, and
+              <td data-tests="RTCPeerConnection-transceivers.https.html"><dfn data-idl>recvonly</dfn></td>
+              <td>The {{RTCRtpTransceiver}}'s
+              {{RTCRtpSender}} will not offer to send RTP, and
+              will not send RTP. The {{RTCRtpTransceiver}}'s
+              {{RTCRtpReceiver}} will offer to receive RTP, and
               will receive RTP if the remote peer accepts.</td>
             </tr>
             <tr>
-              <td data-tests="RTCPeerConnection-transceivers.https.html"><dfn data-idl><code>inactive</code></dfn></td>
-              <td>The <code><a>RTCRtpTransceiver</a></code>'s
-              <code><a>RTCRtpSender</a></code> will not offer to send RTP, and
-              will not send RTP. The <code><a>RTCRtpTransceiver</a></code>'s
-              <code><a>RTCRtpReceiver</a></code> will not offer to receive RTP,
+              <td data-tests="RTCPeerConnection-transceivers.https.html"><dfn data-idl>inactive</dfn></td>
+              <td>The {{RTCRtpTransceiver}}'s
+              {{RTCRtpSender}} will not offer to send RTP, and
+              will not send RTP. The {{RTCRtpTransceiver}}'s
+              {{RTCRtpReceiver}} will not offer to receive RTP,
               and will not receive RTP.</td>
             </tr>
             <tr>
-              <td data-tests="RTCPeerConnection-transceivers.https.html"><dfn data-idl><code>stopped</code></dfn></td>
-              <td>The <code><a>RTCRtpTransceiver</a></code> will neither send
+              <td data-tests="RTCPeerConnection-transceivers.https.html"><dfn data-idl>stopped</dfn></td>
+              <td>The {{RTCRtpTransceiver}} will neither send
               nor receive RTP. It will generate a zero port in the offer. In
-              answers, its <code><a>RTCRtpSender</a></code> will not offer to
-              send RTP, and its <code><a>RTCRtpReceiver</a></code> will not
+              answers, its {{RTCRtpSender}} will not offer to
+              send RTP, and its {{RTCRtpReceiver}} will not
               offer to receive RTP. This is a terminal state.</td>
             </tr>
           </tbody>
@@ -5717,10 +5623,10 @@ interface RTCCertificate {
         off both directions temporarily, or to <code>"sendonly"</code> to reject
         only the incoming side. To permanently reject an m-line in a manner that
         makes it available for reuse, the application would need to call
-        <code>RTCRtpTransceiver.<a data-link-for="RTCRtpTransceiver">stop</a>()</code>
+        <code>RTCRtpTransceiver.{{RTCRtpTransceiver/stop}}()</code>
         and subsequently initiate negotiation from its end.</p>
         <p>To <dfn id="process-remote-tracks">
-        process remote tracks</dfn> given an <code>RTCRtpTransceiver</code>
+        process remote tracks</dfn> given an {{RTCRtpTransceiver}}
         <var>transceiver</var>, <var>direction</var>, <var>msids</var>,
         <var>addList</var>, <var>removeList</var>, and <var>trackEventInits</var>,
         run the following steps:</p>
@@ -5759,7 +5665,7 @@ interface RTCCertificate {
         </ol>
         <p>To <dfn id="process-remote-track-addition">
         process the addition of a remote track</dfn> given an
-        <code>RTCRtpTransceiver</code> <var>transceiver</var> and
+        {{RTCRtpTransceiver}} <var>transceiver</var> and
         <var>trackEventInits</var>, run the following steps:</p>
         <ol data-tests="RTCPeerConnection-transceivers.https.html">
           <li>
@@ -5775,7 +5681,7 @@ interface RTCCertificate {
             </p>
           </li>
           <li>
-            <p>Create a new <code><a>RTCTrackEventInit</a></code>
+            <p>Create a new {{RTCTrackEventInit}}
             dictionary with <var>receiver</var>, <var>track</var>,
             <var>streams</var> and <var>transceiver</var> as members
             and add it to <var>trackEventInits</var>.</p>
@@ -5783,7 +5689,7 @@ interface RTCCertificate {
         </ol>
         <p>To <dfn id="process-remote-track-removal">
         process the removal of a remote track</dfn> with an
-        <code>RTCRtpTransceiver</code> <var>transceiver</var> and
+        {{RTCRtpTransceiver}} <var>transceiver</var> and
         <var>muteTracks</var>, run the following steps:</p>
         <ol data-tests="RTCPeerConnection-remote-track-mute.https.html">
           <li>
@@ -5800,24 +5706,24 @@ interface RTCCertificate {
           </li>
         </ol>
         <p>To <dfn id="set-associated-remote-streams">set the associated remote streams</dfn> given
-        <code>RTCRtpReceiver</code> <var>receiver</var>, <var>msids</var>,
+        {{RTCRtpReceiver}} <var>receiver</var>, <var>msids</var>,
         <var>addList</var>, and <var>removeList</var>, run the following steps:</p>
         <ol>
           <li>
             <p>Let <var>connection</var> be the
-            <code><a>RTCPeerConnection</a></code> object associated with
+            {{RTCPeerConnection}} object associated with
             <var>receiver</var>.</p>
           </li>
           <li data-tests="RTCPeerConnection-ontrack.https.html,protocol/msid-parse.html">
             <p>For each MSID in <var>msids</var>, unless a
-            <code><a>MediaStream</a></code> object has previously been created
+            {{MediaStream}} object has previously been created
             with that <code>id</code> for this <var>connection</var>, create a
-            <code><a>MediaStream</a></code> object with that
+            {{MediaStream}} object with that
             <code>id</code>.</p>
           </li>
           <li>
             <p>Let <var>streams</var> be a list of the
-            <code><a>MediaStream</a></code> objects created for this
+            {{MediaStream}} objects created for this
             <var>connection</var> with the <code>id</code>s corresponding to
             <var>msids</var>.</p>
           </li>
@@ -5846,21 +5752,21 @@ interface RTCCertificate {
     </section>
     <section>
       <h3><dfn>RTCRtpSender</dfn> Interface</h3>
-      <p>The <code>RTCRtpSender</code> interface allows an
-      application to control how a given <code>MediaStreamTrack</code> is
+      <p>The {{RTCRtpSender}} interface allows an
+      application to control how a given {{MediaStreamTrack}} is
       encoded and transmitted to a remote peer. When <code>setParameters</code>
-      is called on an <code><a>RTCRtpSender</a></code> object, the encoding is
+      is called on an {{RTCRtpSender}} object, the encoding is
       changed appropriately.</p>
 
       <p>To <dfn>create an RTCRtpSender</dfn> with a
-      <code><a>MediaStreamTrack</a></code>, <var>track</var>, a string,
+      {{MediaStreamTrack}}, <var>track</var>, a string,
       <var>kind</var>, a list of
-      <code><a>MediaStream</a></code> objects, <var>streams</var>, and
-      optionally a list of <code><a>RTCRtpEncodingParameters</a></code>
+      {{MediaStream}} objects, <var>streams</var>, and
+      optionally a list of {{RTCRtpEncodingParameters}}
       objects, <var>sendEncodings</var>, run the following steps:</p>
       <ol>
         <li>
-          <p>Let <var>sender</var> be a new <code><a>RTCRtpSender</a></code>
+          <p>Let <var>sender</var> be a new {{RTCRtpSender}}
           object.</p>
         </li>
         <li data-tests="RTCPeerConnection-addTransceiver.https.html">
@@ -5888,7 +5794,7 @@ interface RTCCertificate {
         <li>
           <p>Let <var>sender</var> have an
           <dfn>[[\AssociatedMediaStreamIds]]</dfn> internal slot, representing a
-          list of Ids of <code><a>MediaStream</a></code> objects that this
+          list of Ids of {{MediaStream}} objects that this
           sender is to be associated with. The
           <a>[[\AssociatedMediaStreamIds]]</a> slot is used when
           <var>sender</var> is represented in SDP as described in
@@ -5907,26 +5813,26 @@ interface RTCCertificate {
         <li>
           <p>Let <var>sender</var> have a <dfn>[[\SendEncodings]]</dfn>
           internal slot, representing a list of
-          <code><a>RTCRtpEncodingParameters</a></code> dictionaries.</p>
+          {{RTCRtpEncodingParameters}} dictionaries.</p>
         </li>
         <li data-tests="RTCPeerConnection-transceivers.https.html,protocol/simulcast-offer.html">
           <p>If <var>sendEncodings</var> is given as input to this algorithm,
           and is non-empty, set the <a>[[\SendEncodings]]</a> slot to
           <var>sendEncodings</var>. Otherwise, set it to a list containing a
-          single <code><a>RTCRtpEncodingParameters</a></code> with
+          single {{RTCRtpEncodingParameters}} with
           <code>active</code> set to <code>true</code>.</p>
         </li>
         <li>
           <p>Let <var>sender</var> have a <dfn>[[\SendCodecs]]</dfn>
           internal slot, representing a list of
-          <code><a>RTCRtpCodecParameters</a></code> dictionaries, and
+          {{RTCRtpCodecParameters}} dictionaries, and
           initialized to an empty list.</p>
         </li>
         <li>
           <p>Let <var>sender</var> have a <dfn>[[\LastReturnedParameters]]</dfn>
           internal slot, which will be used to match
-          <code><a data-link-for="RTCRtpSender">getParameters</a></code> and
-          <code><a data-link-for="RTCRtpSender">setParameters</a></code> transactions.</p>
+          {{RTCRtpSender/getParameters}} and
+          {{RTCRtpSender/setParameters}} transactions.</p>
         </li>
         <li>
           <p>Return <var>sender</var>.</p>
@@ -5949,32 +5855,32 @@ interface RTCRtpSender {
           <h2>Attributes</h2>
           <dl data-link-for="RTCRtpSender" data-dfn-for="RTCRtpSender" class=
           "attributes">
-            <dt><dfn data-idl><code>track</code></dfn> of type <span class=
-            "idlAttrType"><a>MediaStreamTrack</a></span>, readonly,
+            <dt><dfn data-idl>track</dfn> of type <span class=
+            "idlAttrType">{{MediaStreamTrack}}</span>, readonly,
             nullable</dt>
             <dd>
               <p>The <code>track</code> attribute is the track that is
-              associated with this <code><a>RTCRtpSender</a></code> object. If
+              associated with this {{RTCRtpSender}} object. If
               <code>track</code> is ended, or if the track's output is disabled,
               i.e. the track is disabled and/or muted, the <code>
-              <a>RTCRtpSender</a></code> MUST send black frames (video) and
+              {{RTCRtpSender}}</code> MUST send black frames (video) and
               MUST NOT send (audio).  In the case of video,
-              the <code><a>RTCRtpSender</a></code> SHOULD send one
+              the {{RTCRtpSender}} SHOULD send one
               black frame per second. If <code>track</code> is null then
-              the <code>RTCRtpSender</code> does not send. On getting, the
+              the {{RTCRtpSender}} does not send. On getting, the
               attribute MUST return the value of the <a>[[\SenderTrack]]</a>
               slot.</p>
             </dd>
-            <dt data-tests="RTCDtlsTransport-state.html,RTCRtpSender-transport.https.html"><dfn data-idl><code>transport</code></dfn> of type <span class=
-            "idlAttrType"><a>RTCDtlsTransport</a></span>, readonly,
+            <dt data-tests="RTCDtlsTransport-state.html,RTCRtpSender-transport.https.html"><dfn data-idl>transport</dfn> of type <span class=
+            "idlAttrType">{{RTCDtlsTransport}}</span>, readonly,
             nullable</dt>
             <dd>
               <p>The <code>transport</code> attribute is the transport over
               which media from <code>track</code> is sent in the form of RTP
               packets. Prior to construction of the
-              <code><a>RTCDtlsTransport</a></code> object, the
+              {{RTCDtlsTransport}} object, the
               <code>transport</code> attribute will be null. When bundling is
-              used, multiple <code><a>RTCRtpSender</a></code> objects will
+              used, multiple {{RTCRtpSender}} objects will
               share one <code>transport</code> and will all send RTP and RTCP
               over the same transport.</p>
               <p>On getting, the attribute MUST return the value of the
@@ -6004,7 +5910,7 @@ interface RTCRtpSender {
               privacy-sensitive contexts, browsers can consider mitigations
               such as reporting only a common subset of the capabilities.</p>
             </dd>
-            <dt data-tests="RTCRtpParameters-codecs.html,RTCRtpSender-setParameters.html"><dfn data-idl><code>setParameters</code></dfn></dt>
+            <dt data-tests="RTCRtpParameters-codecs.html,RTCRtpSender-setParameters.html"><dfn data-idl>setParameters</dfn></dt>
             <dd>
               <p>The <code>setParameters</code> method updates how
               <code>track</code> is encoded and transmitted to a remote
@@ -6015,21 +5921,21 @@ interface RTCRtpSender {
                 <li>Let <var>parameters</var> be the method's first argument.
                 </li>
                 <li>Let <var>sender</var> be the
-                <code><a>RTCRtpSender</a></code> object on which
+                {{RTCRtpSender}} object on which
                 <code>setParameters</code> is invoked.</li>
                 <li>Let <var>transceiver</var> be the
-                <code><a>RTCRtpTransceiver</a></code> object associated
+                {{RTCRtpTransceiver}} object associated
                 with <var>sender</var> (i.e. <var>sender</var> is
                 <var>transceiver</var>.<a>[[\Sender]]</a>).</li>
                 <li data-tests="RTCRtpSender-setParameters.html,RTCRtpTransceiver.https.html">If <var>transceiver</var>.<a>[[\Stopped]]</a> is
-                <code>true</code>, return a promise <a>rejected</a> with a newly
-                <a data-link-for="exception" data-lt="create">created</a>
-                <code>InvalidStateError</code>.</li>
+                <code>true</code>, return a promise [= rejected =] with a newly
+                [= exception/create | created =]
+                {{InvalidStateError}}.</li>
                 <li data-tests="RTCRtpParameters-transactionId.html">If <var>sender</var>.<a>[[\LastReturnedParameters]]</a>
                 is <code>null</code>, return a promise
-                <a>rejected</a> with a newly
-                <a data-link-for="exception" data-lt="create">created</a>
-                <code>InvalidStateError</code>.</li>
+                [= rejected =] with a newly
+                [= exception/create | created =]
+                {{InvalidStateError}}.</li>
                 <li>Validate <var>parameters</var> by running the following steps:
                 <ol>
                  <li>
@@ -6040,14 +5946,14 @@ interface RTCRtpSender {
                  </li>
                  <li>
                    Let <var>N</var> be the number of
-                   <code><a>RTCRtpEncodingParameters</a></code> stored in
+                   {{RTCRtpEncodingParameters}} stored in
                    <var>sender</var>.<a>[[\SendEncodings]]</a>.
                  </li>
                  <li>
                    If any of the following conditions are met, return a promise
-                   <a>rejected</a> with a newly
-                   <a data-link-for="exception" data-lt="create">created</a>
-                   <code>InvalidModificationError</code>:
+                   [= rejected =] with a newly
+                   [= exception/create | created =]
+                   {{InvalidModificationError}}:
                    <ol>
                      <li data-tests="RTCRtpParameters-encodings.html">
                        <code><var>encodings</var>.length</code> is different from <var>N</var>.
@@ -6065,12 +5971,12 @@ interface RTCRtpSender {
                    </ol>
                  </li>
                  <li data-tests="RTCRtpParameters-encodings.html">
-                   <p>Verify that each <code><a data-link-for="RTCRtpEncodingParameters">scaleResolutionDownBy</a></code>
+                   <p>Verify that each {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
                    value in <var>encodings</var> is greater than or equal to 1.0. If
                    one of the <code>scaleResolutionDownBy</code> values does not meet
-                   this requirement, return a promise <a>rejected</a> with a newly
-                   <a data-link-for="exception" data-lt="create">created</a>
-                   <code>RangeError</code>.</p>
+                   this requirement, return a promise [= rejected =] with a newly
+                   [= exception/create | created =]
+                   {{RangeError}}.</p>
                  </li>
                 </ol>
                 </li>
@@ -6087,26 +5993,26 @@ interface RTCRtpSender {
                         <code>null</code>.</li>
                         <li>Set <var>sender</var>.<a>[[\SendEncodings]]</a> to <code>
                         <var>parameters</var>.encodings</code>.</li>
-                        <li><a>Resolve</a> <var>p</var> with <code>undefined</code>.
+                        <li>[= Resolve =] <var>p</var> with <code>undefined</code>.
                       </ol>
                     </li>
                     <li>If any error occurred while configuring the media stack,
                     queue a task to run the following steps:
                       <ol>
                         <li>If an error occurred due to hardware resources not
-                        being available, <a>reject</a> <var>p</var> with a newly
-                        created <code><a>RTCError</a></code> whose
+                        being available, [= reject =] <var>p</var> with a newly
+                        created {{RTCError}} whose
                         <code>errorDetail</code> is set to
                         "hardware-encoder-not-available" and abort these steps.</li>
                         <li>If an error occurred due to a hardware encoder not
-                        supporting <var>parameters</var>, <a>reject</a>
+                        supporting <var>parameters</var>, [= reject =]
                         <var>p</var> with a newly created <code>
-                        <a>RTCError</a></code> whose <code>errorDetail</code>
+                        {{RTCError}}</code> whose <code>errorDetail</code>
                         is set to "hardware-encoder-error" and abort these
                         steps.</li>
-                        <li>For all other errors, <a>reject</a> <var>p</var>
-                        with a newly <a data-link-for="exception" data-lt=
-                        "create">created</a> <code>OperationError</code>.</li>
+                        <li>For all other errors, [= reject =] <var>p</var>
+                        with a newly [= exception/create | created =]
+                        {{OperationError}}.</li>
                       </ol>
                     </li>
                   </ol>
@@ -6116,7 +6022,7 @@ interface RTCRtpSender {
               <p><code>setParameters</code> does not cause SDP renegotiation
               and can only be used to change what the media stack is sending or
               receiving within the envelope negotiated by Offer/Answer. The
-              attributes in the <code><a>RTCRtpSendParameters</a></code> dictionary
+              attributes in the {{RTCRtpSendParameters}} dictionary
               are designed to not enable this, so attributes like
               <code>cname</code> that cannot be changed are read-only. Other
               things, like bitrate, are controlled using limits such as
@@ -6129,15 +6035,15 @@ interface RTCRtpSender {
             <dt data-tests="RTCRtpParameters-codecs.html,protocol/video-codecs.https.html"><code>getParameters</code></dt>
             <dd>
               <p>The <dfn data-idl>getParameters()</dfn> method
-              returns the <code><a>RTCRtpSender</a></code> object's current
+              returns the {{RTCRtpSender}} object's current
               parameters for how <code>track</code> is encoded and transmitted
-              to a remote <code><a>RTCRtpReceiver</a></code>.</p>
+              to a remote {{RTCRtpReceiver}}.</p>
 
               <p>When <code>getParameters</code> is called, the user agent MUST
               run the following steps:</p>
               <ol>
                 <li>
-                  <p>Let <var>sender</var> be the <code><a>RTCRtpSender</a></code>
+                  <p>Let <var>sender</var> be the {{RTCRtpSender}}
                   object on which the getter was invoked.</p>
                 </li>
                 <li>
@@ -6148,32 +6054,32 @@ interface RTCRtpSender {
                 </li>
                 <li>
                   <p>Let <var>result</var> be a new
-                  <code><a>RTCRtpSendParameters</a></code> dictionary constructed
+                  {{RTCRtpSendParameters}} dictionary constructed
                   as follows:</p>
                   <ul>
                     <li data-tests="RTCRtpParameters-codecs.html,RTCRtpParameters-encodings.html,RTCRtpParameters-transactionId.html">
-                      <code><a data-link-for="RTCRtpSendParameters">transactionId</a></code>
+                      {{RTCRtpSendParameters/transactionId}}
                       is set to a new unique identifier.
                     </li>
                     <li data-tests="RTCRtpParameters-encodings.html">
-                      <code><a data-link-for="RTCRtpSendParameters">encodings</a></code>
+                      {{RTCRtpSendParameters/encodings}}
                       is set to the value of the <a>[[\SendEncodings]]</a> internal
                       slot.
                     </li>
                     <li data-tests="RTCRtpParameters-headerExtensions.html">
-                      The <code><a data-link-for="RTCRtpParameters">headerExtensions</a></code>
+                      The {{RTCRtpParameters/headerExtensions}}
                       sequence is populated based on the header extensions that
                       have been negotiated for sending.
                     </li>
                     <li data-tests="RTCRtpParameters-codecs.html,protocol/video-codecs.https.html">
-                      <code><a data-link-for="RTCRtpParameters">codecs</a></code>
+                      {{RTCRtpParameters/codecs}}
                       is set to the value of the <a>[[\SendCodecs]]</a> internal slot.
                     </li>
                     <li data-tests="RTCRtpParameters-encodings.html">
-                      <code><a data-link-for="RTCRtpParameters">rtcp</a>.cname</code>
+                      <code>{{RTCRtpParameters/rtcp}}.cname</code>
                       is set to the CNAME of the associated
-                      <code><a>RTCPeerConnection</a></code>.
-                      <code><a data-link-for="RTCRtpParameters">rtcp</a>.reducedSize</code>
+                      {{RTCPeerConnection}}.
+                      <code>{{RTCRtpParameters/rtcp}}.reducedSize</code>
                       is set to <code>true</code> if reduced-size RTCP has been negotiated
                       for sending, and <code>false</code> otherwise.
                     </li>
@@ -6213,25 +6119,25 @@ async function updateParameters() {
             </dd>
             <dt data-tests="RTCPeerConnection-setRemoteDescription-replaceTrack.https.html,RTCRtpSender-replaceTrack.https.html"><code>replaceTrack</code></dt>
             <dd>
-              <p>Attempts to replace the <code><a>RTCRtpSender</a></code>'s
+              <p>Attempts to replace the {{RTCRtpSender}}'s
               current <code>track</code> with another track provided (or
               with a null track), without renegotiation.</p>
-              <p>When the <dfn data-idl><code>replaceTrack</code></dfn> method is
+              <p>When the <dfn data-idl>replaceTrack</dfn> method is
               invoked, the user agent MUST run the following steps:</p>
               <ol>
                 <li>
                   <p>Let <var>sender</var> be the
-                  <code><a>RTCRtpSender</a></code> object on which
+                  {{RTCRtpSender}} object on which
                   <code>replaceTrack</code> is invoked.</p>
                 </li>
                 <li>
                   <p>Let <var>transceiver</var> be the
-                  <code><a>RTCRtpTransceiver</a></code> object associated with
+                  {{RTCRtpTransceiver}} object associated with
                   <var>sender</var>.</p>
                 </li>
                 <li>
                   <p>Let <var>connection</var> be the
-                  <code><a>RTCPeerConnection</a></code> object associated with
+                  {{RTCPeerConnection}} object associated with
                   <var>sender</var>.</p>
                 </li>
                 <li>
@@ -6242,20 +6148,19 @@ async function updateParameters() {
                   <p>If <code><var>withTrack</var></code> is non-null and
                   <code><var>withTrack</var>.kind</code> differs from the
                   <a>transceiver kind</a> of <var>transceiver</var>, return a
-                  promise <a>rejected</a> with a newly
-                  <a data-link-for="exception" data-lt="create">created</a>
-                  <code>TypeError</code>.</p>
+                  promise [= rejected =] with a newly
+                  [= exception/create | created =]
+                  {{TypeError}}.</p>
                 </li>
                 <li>
-                  <p>Return the result of <a href=
-                    "#dfn-chain-an-operation">chaining</a> the following
+                  <p>Return the result of [= chaining =] the following
                   steps to <var>connection</var>'s operations chain:</p>
                   <ol>
                   <li data-tests="RTCPeerConnection-setRemoteDescription-replaceTrack.https.html,RTCRtpSender-replaceTrack.https.html,RTCRtpTransceiver.https.html">
                     <p>If <var>transceiver</var>.<a>[[\Stopped]]</a> is
-                    <code>true</code>, return a promise <a>rejected</a>
-                    with a newly <a data-link-for="exception" data-lt="create">
-                    created</a> <code>InvalidStateError</code>.</p>
+                    <code>true</code>, return a promise [= rejected =]
+                    with a newly [= exception/create | created =]
+                    {{InvalidStateError}}.</p>
                   </li>
                     <li>
                       <p>Let <var>p</var> be a new promise.</p>
@@ -6280,9 +6185,9 @@ async function updateParameters() {
                           determine if <var>withTrack</var> can be sent
                           immediately by the sender without violating the
                           sender's already-negotiated envelope, and if it
-                          cannot, then <a>reject</a> <var>p</var> with a newly
-                          <a data-link-for="exception" data-lt="create">created</a>
-                          <code>InvalidModificationError</code>, and abort these
+                          cannot, then [= reject =] <var>p</var> with a newly
+                          [= exception/create | created =]
+                          {{InvalidModificationError}}, and abort these
                           steps.</p>
                         </li>
                         <li>
@@ -6303,7 +6208,7 @@ async function updateParameters() {
                               <p>Set <var>sender</var>.<a>[[\SenderTrack]]</a> to <var>withTrack</var>.</p>
                             </li>
                             <li>
-                              <p><a>Resolve</a> <var>p</var> with
+                              <p>[= Resolve =] <var>p</var> with
                               <code>undefined</code>.</p>
                             </li>
                           </ol>
@@ -6338,29 +6243,29 @@ async function updateParameters() {
             </dd>
             <dt data-tests="RTCRtpSender-setStreams.https.html,RTCPeerConnection-onnegotiationneeded.html"><code>setStreams</code></dt>
             <dd>
-              <p>Sets the <code>MediaStream</code>s to be associated with this
+              <p>Sets the {{MediaStream}}s to be associated with this
               sender's track.</p>
-              <p>When the <dfn data-idl><code>setStreams</code></dfn> method is invoked,
+              <p>When the <dfn data-idl>setStreams</dfn> method is invoked,
               the user agent MUST run the following steps:</p>
               <ol>
                 <li>
                   <p>Let <var>sender</var> be the
-                  <code><a>RTCRtpSender</a></code> object on which this method
+                  {{RTCRtpSender}} object on which this method
                   was invoked.</p>
                 </li>
                 <li>
                   <p>Let <var>connection</var> be the
-                  <code><a>RTCPeerConnection</a></code> object on which this
+                  {{RTCPeerConnection}} object on which this
                   method was invoked.</p>
                 </li>
                 <li data-tests="RTCRtpSender-setStreams.https.html">
                   <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
-                  <code>true</code>, <a>throw</a> an
-                  <code>InvalidStateError</code>.</p>
+                  <code>true</code>, [= exception/throw =] an
+                  {{InvalidStateError}}.</p>
                 </li>
                 <li>
                   <p>Let <var>streams</var> be a list of
-                  <code><a>MediaStream</a></code> objects constructed from the
+                  {{MediaStream}} objects constructed from the
                   method's arguments, or an empty list if the method was called
                   without arguments.</p>
                 </li>
@@ -6376,8 +6281,8 @@ async function updateParameters() {
                   </p>
                 </li>
                 <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
-                  <p><a data-lt="update the negotiation-needed flag">Update the
-                    negotiation-needed flag</a> for <var>connection</var>.</p>
+                  <p>[= Update the
+                    negotiation-needed flag =] for <var>connection</var>.</p>
                 </li>
               </ol>
             </dd>
@@ -6392,7 +6297,7 @@ async function updateParameters() {
               <ol data-tests="RTCRtpSender-getStats.https.html">
                 <li>
                   <p>Let <var>selector</var> be the
-                  <code><a>RTCRtpSender</a></code> object on which the method
+                  {{RTCRtpSender}} object on which the method
                   was invoked.</p>
                 </li>
                 <li>
@@ -6401,11 +6306,11 @@ async function updateParameters() {
                   <ol>
                     <li>
                       <p>Gather the stats indicated by <var>selector</var>
-                      according to the <a>stats selection algorithm</a>.</p>
+                      according to the [= stats selection algorithm =].</p>
                     </li>
                     <li>
-                      <p><a>Resolve</a> <var>p</var> with the resulting
-                      <code><a>RTCStatsReport</a></code> object, containing
+                      <p>[= Resolve =] <var>p</var> with the resulting
+                      {{RTCStatsReport}} object, containing
                       the gathered stats.</p>
                     </li>
                   </ol>
@@ -6428,27 +6333,27 @@ async function updateParameters() {
   required sequence&lt;RTCRtpCodecParameters&gt; codecs;
 };</pre>
         <section>
-          <h2>Dictionary <code><a>RTCRtpParameters</a></code> Members</h2>
+          <h2>Dictionary {{RTCRtpParameters}} Members</h2>
           <dl data-link-for="RTCRtpParameters" data-dfn-for="RTCRtpParameters"
           class="dictionary-members">
-            <dt data-tests="RTCRtpParameters-headerExtensions.html"><dfn data-idl><code>headerExtensions</code></dfn> of type <span class=
-            "idlMemberType">sequence&lt;<a>RTCRtpHeaderExtensionParameters</a>&gt;</span>,
+            <dt data-tests="RTCRtpParameters-headerExtensions.html"><dfn data-idl>headerExtensions</dfn> of type <span class=
+            "idlMemberType">sequence&lt;{{RTCRtpHeaderExtensionParameters}}&gt;</span>,
             required</dt>
             <dd>
               <p>A sequence containing parameters for RTP header
               extensions. <a>Read-only parameter</a>.</p>
             </dd>
-            <dt data-tests="RTCRtpParameters-rtcp.html"><dfn data-idl><code>rtcp</code></dfn> of type <span class=
-            "idlMemberType"><a>RTCRtcpParameters</a></span>, required</dt>
+            <dt data-tests="RTCRtpParameters-rtcp.html"><dfn data-idl>rtcp</dfn> of type <span class=
+            "idlMemberType">{{RTCRtcpParameters}}</span>, required</dt>
             <dd>
               <p>Parameters used for RTCP. <a>Read-only parameter</a>.</p>
             </dd>
-            <dt data-tests="RTCRtpParameters-codecs.html,protocol/video-codecs.https.html"><dfn data-idl><code>codecs</code></dfn> of type <span class=
-            "idlMemberType">sequence&lt;<a>RTCRtpCodecParameters</a>&gt;</span>,
+            <dt data-tests="RTCRtpParameters-codecs.html,protocol/video-codecs.https.html"><dfn data-idl>codecs</dfn> of type <span class=
+            "idlMemberType">sequence&lt;{{RTCRtpCodecParameters}}&gt;</span>,
             required</dt>
             <dd>
               <p>A sequence containing the media codecs that an
-              <code><a>RTCRtpSender</a></code> will choose from, as well as
+              {{RTCRtpSender}} will choose from, as well as
               entries for RTX, RED and FEC mechanisms. Corresponding to each
               media codec where retransmission via RTX is enabled, there will
               be an entry in <code>codecs[]</code> with a <code>mimeType</code>
@@ -6469,18 +6374,18 @@ async function updateParameters() {
   required sequence&lt;RTCRtpEncodingParameters&gt; encodings;
 };</pre>
         <section>
-          <h2>Dictionary <code><a>RTCRtpSendParameters</a></code> Members</h2>
+          <h2>Dictionary {{RTCRtpSendParameters}} Members</h2>
           <dl data-link-for="RTCRtpSendParameters" data-dfn-for="RTCRtpSendParameters"
           class="dictionary-members">
-            <dt data-tests="RTCRtpParameters-transactionId.html"><dfn data-idl><code>transactionId</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-transactionId.html"><dfn data-idl>transactionId</dfn> of type <span class=
             "idlMemberType">DOMString</span>, required</dt>
             <dd>
               <p>An unique identifier for the last set of parameters applied.
               Ensures that setParameters can only be called based on a previous
               getParameters, and that there are no intervening changes.
               <a>Read-only parameter</a>.</p></dd>
-            <dt><dfn data-idl><code>encodings</code></dfn> of type <span class=
-            "idlMemberType">sequence&lt;<a>RTCRtpEncodingParameters</a>&gt;</span>,
+            <dt><dfn data-idl>encodings</dfn> of type <span class=
+            "idlMemberType">sequence&lt;{{RTCRtpEncodingParameters}}&gt;</span>,
             required</dt>
             <dd>
               <p>A sequence containing parameters for RTP encodings of
@@ -6506,11 +6411,11 @@ async function updateParameters() {
   DOMString rid;
 };</pre>
         <section>
-          <h2>Dictionary <code><a>RTCRtpCodingParameters</a></code>
+          <h2>Dictionary {{RTCRtpCodingParameters}}
           Members</h2>
           <dl data-link-for="RTCRtpCodingParameters" data-dfn-for=
           "RTCRtpCodingParameters" class="dictionary-members">
-            <dt data-tests="RTCRtpParameters-encodings.html"><dfn data-idl><code>rid</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-encodings.html"><dfn data-idl>rid</dfn> of type <span class=
             "idlMemberType">DOMString</span></dt>
             <dd>
               <p>If set, this RTP encoding will be sent with the RID header
@@ -6541,11 +6446,11 @@ async function updateParameters() {
   double scaleResolutionDownBy;
 };</pre>
         <section>
-          <h2>Dictionary <code><a>RTCRtpEncodingParameters</a></code>
+          <h2>Dictionary {{RTCRtpEncodingParameters}}
           Members</h2>
           <dl data-link-for="RTCRtpEncodingParameters" data-dfn-for=
           "RTCRtpEncodingParameters" class="dictionary-members">
-            <dt data-tests="RTCPeerConnection-transceivers.https.html,RTCRtpParameters-encodings.html"><dfn data-idl><code>active</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-transceivers.https.html,RTCRtpParameters-encodings.html"><dfn data-idl>active</dfn> of type <span class=
             "idlMemberType">boolean</span>, defaulting to
             <code>true</code></dt>
             <dd>
@@ -6555,7 +6460,7 @@ async function updateParameters() {
               causes this encoding to be sent. Since setting the value to <code>false</code>
               does not cause the SSRC to be removed, an RTCP BYE is not sent.</p>
             </dd>
-            <dt data-tests="RTCRtpParameters-encodings.html"><dfn data-idl><code>maxBitrate</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-encodings.html"><dfn data-idl>maxBitrate</dfn> of type <span class=
             "idlMemberType">unsigned long</span></dt>
             <dd>
               <p>When present, indicates the maximum bitrate that can be used to send this
@@ -6578,7 +6483,7 @@ async function updateParameters() {
                 sent.
               </p>
             </dd>
-            <dt data-tests="RTCRtpParameters-encodings.html"><dfn data-idl><code>scaleResolutionDownBy</code></dfn> of type
+            <dt data-tests="RTCRtpParameters-encodings.html"><dfn data-idl>scaleResolutionDownBy</dfn> of type
             <span class="idlMemberType">double</span></dt>
             <dd>
               <p>This member is only present if the sender's <code>kind</code>
@@ -6604,16 +6509,16 @@ async function updateParameters() {
   boolean reducedSize;
 };</pre>
         <section>
-          <h2>Dictionary <code><a>RTCRtcpParameters</a></code> Members</h2>
+          <h2>Dictionary {{RTCRtcpParameters}} Members</h2>
           <dl data-link-for="RTCRtcpParameters" data-dfn-for=
           "RTCRtcpParameters" class="dictionary-members">
-            <dt data-tests="RTCRtpParameters-encodings.html, RTCRtpParameters-rtcp.html,RTCRtpReceiver-getParameters.html"><dfn data-idl><code>cname</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-encodings.html, RTCRtpParameters-rtcp.html,RTCRtpReceiver-getParameters.html"><dfn data-idl>cname</dfn> of type <span class=
             "idlMemberType">DOMString</span></dt>
             <dd>
               <p>The Canonical Name (CNAME) used by RTCP (e.g. in SDES
               messages). <a>Read-only parameter</a>.</p>
             </dd>
-            <dt data-tests="RTCRtpParameters-encodings.html,RTCRtpParameters-rtcp.html,RTCRtpReceiver-getParameters.html"><dfn data-idl><code>reducedSize</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-encodings.html,RTCRtpParameters-rtcp.html,RTCRtpReceiver-getParameters.html"><dfn data-idl>reducedSize</dfn> of type <span class=
             "idlMemberType">boolean</span></dt>
             <dd>
               <p>Whether reduced size RTCP [[RFC5506]] is configured (if true)
@@ -6634,23 +6539,23 @@ async function updateParameters() {
   boolean encrypted = false;
 };</pre>
         <section>
-          <h2>Dictionary <code><a>RTCRtpHeaderExtensionParameters</a></code>
+          <h2>Dictionary {{RTCRtpHeaderExtensionParameters}}
           Members</h2>
           <dl data-link-for="RTCRtpHeaderExtensionParameters" data-dfn-for=
           "RTCRtpHeaderExtensionParameters" class="dictionary-members">
-            <dt data-tests="RTCRtpParameters-headerExtensions.html,RTCRtpReceiver-getParameters.html"><dfn data-idl><code>uri</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-headerExtensions.html,RTCRtpReceiver-getParameters.html"><dfn data-idl>uri</dfn> of type <span class=
             "idlMemberType">DOMString</span>, required</dt>
             <dd>
               <p>The URI of the RTP header extension, as defined in
               [[RFC5285]]. <a>Read-only parameter</a>.</p>
             </dd>
-            <dt data-tests="RTCRtpParameters-headerExtensions.html,RTCRtpReceiver-getParameters.html"><dfn data-idl><code>id</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-headerExtensions.html,RTCRtpReceiver-getParameters.html"><dfn data-idl>id</dfn> of type <span class=
             "idlMemberType">unsigned short</span>, required</dt>
             <dd>
               <p>The value put in the RTP packet to identify the header
               extension. <a>Read-only parameter</a>.</p>
             </dd>
-            <dt data-tests="RTCRtpParameters-headerExtensions.html,RTCRtpReceiver-getParameters.html"><dfn data-idl><code>encrypted</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-headerExtensions.html,RTCRtpReceiver-getParameters.html"><dfn data-idl>encrypted</dfn> of type <span class=
             "idlMemberType">boolean</span></dt>
             <dd>
               <p>Whether the header extension is encrypted or not. <a>Read-only
@@ -6660,11 +6565,11 @@ async function updateParameters() {
         </section>
       </div>
       <div class="note">
-      <p>The <code>RTCRtpHeaderExtensionParameters</code> dictionary
+      <p>The {{RTCRtpHeaderExtensionParameters}} dictionary
       enables an application to determine whether a header extension
-      is configured for use within an <code><a>RTCRtpSender</a></code>
-      or <code><a>RTCRtpReceiver</a></code>. For an
-      <code>RTCRtpTransceiver</code> <var>transceiver</var>, an
+      is configured for use within an {{RTCRtpSender}}
+      or {{RTCRtpReceiver}}. For an
+      {{RTCRtpTransceiver}} <var>transceiver</var>, an
       application can determine the "direction" parameter (defined in
       Section 5 of [[RFC5285]]) of a header extension as follows
       without having to parse SDP:</p>
@@ -6694,43 +6599,43 @@ async function updateParameters() {
   DOMString sdpFmtpLine;
 };</pre>
         <section>
-          <h2>Dictionary <code><a>RTCRtpCodecParameters</a></code> Members</h2>
+          <h2>Dictionary {{RTCRtpCodecParameters}} Members</h2>
           <dl data-link-for="RTCRtpCodecParameters" data-dfn-for=
           "RTCRtpCodecParameters" class="dictionary-members">
-            <dt data-tests="RTCRtpParameters-codecs.html"><dfn data-idl><code>payloadType</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-codecs.html"><dfn data-idl>payloadType</dfn> of type <span class=
             "idlMemberType">octet</span></dt>
             <dd>
               <p>The RTP payload type used to identify this codec. <a>Read-only
               parameter</a>.</p>
             </dd>
-            <dt data-tests="RTCRtpParameters-codecs.html,protocol/video-codecs.https.html"><dfn data-idl><code>mimeType</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-codecs.html,protocol/video-codecs.https.html"><dfn data-idl>mimeType</dfn> of type <span class=
             "idlMemberType">DOMString</span></dt>
             <dd>
               <p>The codec MIME media type/subtype. Valid media types and
               subtypes are listed in [[IANA-RTP-2]]. <a>Read-only
               parameter</a>.</p>
             </dd>
-            <dt data-tests="RTCRtpParameters-codecs.html"><dfn data-idl><code>clockRate</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-codecs.html"><dfn data-idl>clockRate</dfn> of type <span class=
             "idlMemberType">unsigned long</span></dt>
             <dd>
               <p>The codec clock rate expressed in Hertz. <a>Read-only
               parameter</a>.</p>
             </dd>
-            <dt data-tests="RTCRtpParameters-codecs.html"><dfn data-idl><code>channels</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-codecs.html"><dfn data-idl>channels</dfn> of type <span class=
             "idlMemberType">unsigned short</span></dt>
             <dd>
               <p>When present, indicates the number of channels (mono=1, stereo=2). <a>Read-only
               parameter</a>.</p>
             </dd>
-            <dt data-tests="RTCRtpParameters-codecs.html"><dfn data-idl><code>sdpFmtpLine</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpParameters-codecs.html"><dfn data-idl>sdpFmtpLine</dfn> of type <span class=
             "idlMemberType">DOMString</span></dt>
             <dd>
               <p>The "format specific parameters" field from the "a=fmtp" line
               in the SDP corresponding to the codec, if one exists, as defined
               by <span data-jsep="parsing-a-desc">[[!JSEP]]</span>. For an
-              <a>RTCRtpSender</a>, these parameters come from the
+              {{RTCRtpSender}}, these parameters come from the
               remote description, and for an
-              <a>RTCRtpReceiver</a>, they come from the local
+              {{RTCRtpReceiver}}, they come from the local
               description. <a>Read-only parameter</a>.</p>
             </dd>
           </dl>
@@ -6746,19 +6651,19 @@ async function updateParameters() {
   required sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensions;
 };</pre>
         <section>
-          <h2>Dictionary <code><a>RTCRtpCapabilities</a></code> Members</h2>
+          <h2>Dictionary {{RTCRtpCapabilities}} Members</h2>
           <dl data-link-for="RTCRtpCapabilities" data-dfn-for=
           "RTCRtpCapabilities" class="dictionary-members">
-            <dt data-tests="RTCRtpReceiver-getCapabilities.html"><dfn data-idl><code>codecs</code></dfn> of type <span class=
-            "idlMemberType">sequence&lt;<a>RTCRtpCodecCapability</a>&gt;</span>, required</dt>
+            <dt data-tests="RTCRtpReceiver-getCapabilities.html"><dfn data-idl>codecs</dfn> of type <span class=
+            "idlMemberType">sequence&lt;{{RTCRtpCodecCapability}}&gt;</span>, required</dt>
             <dd>
               <p>Supported media codecs as well as entries for RTX, RED and FEC
               mechanisms. There will only be a single entry in
               <code>codecs[]</code> for retransmission via RTX, with
               <code>sdpFmtpLine</code> not present.</p>
             </dd>
-            <dt data-tests="RTCRtpReceiver-getCapabilities.html"><dfn data-idl><code>headerExtensions</code></dfn> of type <span class=
-            "idlMemberType">sequence&lt;<a>RTCRtpHeaderExtensionCapability</a>&gt;</span>, required</dt>
+            <dt data-tests="RTCRtpReceiver-getCapabilities.html"><dfn data-idl>headerExtensions</dfn> of type <span class=
+            "idlMemberType">sequence&lt;{{RTCRtpHeaderExtensionCapability}}&gt;</span>, required</dt>
             <dd>
               <p>Supported RTP header extensions.</p>
             </dd>
@@ -6777,8 +6682,8 @@ async function updateParameters() {
   DOMString sdpFmtpLine;
 };</pre>
         <section>
-          <h2>Dictionary <code><a>RTCRtpCodecCapability</a></code> Members </h2>
-          <p>The <code>RTCRtpCodecCapability</code> dictionary provides
+          <h2>Dictionary {{RTCRtpCodecCapability}} Members </h2>
+          <p>The {{RTCRtpCodecCapability}} dictionary provides
           information about codec capabilities. Only capability
           combinations that would utilize distinct payload types in a
           generated SDP offer are provided.  For example:</p>
@@ -6789,23 +6694,23 @@ async function updateParameters() {
           </ol>
           <dl data-link-for="RTCRtpCodecCapability" data-dfn-for=
           "RTCRtpCodecCapability" class="dictionary-members">
-            <dt data-tests="RTCRtpReceiver-getCapabilities.html"><dfn data-idl><code>mimeType</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpReceiver-getCapabilities.html"><dfn data-idl>mimeType</dfn> of type <span class=
             "idlMemberType">DOMString</span>, required</dt>
             <dd>
               <p>The codec MIME media type/subtype. Valid media types and
               subtypes are listed in [[IANA-RTP-2]].</p>
             </dd>
-            <dt data-tests="RTCRtpReceiver-getCapabilities.html"><dfn data-idl><code>clockRate</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpReceiver-getCapabilities.html"><dfn data-idl>clockRate</dfn> of type <span class=
             "idlMemberType">unsigned long</span>, required</dt>
             <dd>
               <p>The codec clock rate expressed in Hertz.</p>
             </dd>
-            <dt data-tests="RTCRtpReceiver-getCapabilities.html"><dfn data-idl><code>channels</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpReceiver-getCapabilities.html"><dfn data-idl>channels</dfn> of type <span class=
             "idlMemberType">unsigned short</span></dt>
             <dd>
               <p>If present, indicates the maximum number of channels (mono=1, stereo=2).</p>
             </dd>
-            <dt data-tests="RTCRtpReceiver-getCapabilities.html"><dfn data-idl><code>sdpFmtpLine</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpReceiver-getCapabilities.html"><dfn data-idl>sdpFmtpLine</dfn> of type <span class=
             "idlMemberType">DOMString</span></dt>
             <dd>
               <p>The "format specific parameters" field from the "a=fmtp" line
@@ -6823,10 +6728,10 @@ async function updateParameters() {
   DOMString uri;
 };</pre>
         <section>
-          <h2>Dictionary <code><a>RTCRtpHeaderExtensionCapability</a></code> Members</h2>
+          <h2>Dictionary {{RTCRtpHeaderExtensionCapability}} Members</h2>
           <dl data-link-for="RTCRtpHeaderExtensionCapability" data-dfn-for=
           "RTCRtpHeaderExtensionCapability" class="dictionary-members">
-            <dt data-tests="RTCRtpReceiver-getCapabilities.html"><dfn data-idl><code>uri</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpReceiver-getCapabilities.html"><dfn data-idl>uri</dfn> of type <span class=
             "idlMemberType">DOMString</span></dt>
             <dd>
               <p>The URI of the RTP header extension, as defined in
@@ -6839,17 +6744,17 @@ async function updateParameters() {
     </section>
     <section>
       <h3><dfn>RTCRtpReceiver</dfn> Interface</h3>
-      <p>The <code>RTCRtpReceiver</code> interface allows an application to
-      inspect the receipt of a <code>MediaStreamTrack</code>.</p>
+      <p>The {{RTCRtpReceiver}} interface allows an application to
+      inspect the receipt of a {{MediaStreamTrack}}.</p>
       <p>To <dfn>create an RTCRtpReceiver</dfn> with a string, <var>kind</var>, run
       the following steps:</p>
       <ol>
         <li>
-          <p>Let <var>receiver</var> be a new <code><a>RTCRtpReceiver</a></code>
+          <p>Let <var>receiver</var> be a new {{RTCRtpReceiver}}
           object.</p>
         </li>
         <li>
-          <p>Let <var>track</var> be a new <code><a>MediaStreamTrack</a></code>
+          <p>Let <var>track</var> be a new {{MediaStreamTrack}}
           object [[!GETUSERMEDIA]]. The source of <var>track</var> is a
           <dfn>remote source</dfn> provided by <var>receiver</var>. Note that
           the <var>track.id</var> is generated by the <a>user agent</a> and does
@@ -6869,7 +6774,7 @@ async function updateParameters() {
           <p>Initialize <var>track.muted</var> to <code>true</code>. See the
           <a href="#mediastreamtrack-network-use">MediaStreamTrack</a> section
           about how the <code>muted</code> attribute reflects if a
-          <code><a>MediaStreamTrack</a></code> is receiving media data or
+          {{MediaStreamTrack}} is receiving media data or
           not.</p>
         </li>
         <li data-tests="RTCPeerConnection-addTransceiver.https.html">
@@ -6888,8 +6793,8 @@ async function updateParameters() {
         <li>
           <p>Let <var>receiver</var> have an
           <dfn>[[\AssociatedRemoteMediaStreams]]</dfn> internal slot,
-          representing a list of <code><a>MediaStream</a></code> objects that
-          the <code><a>MediaStreamTrack</a></code> object of this receiver is
+          representing a list of {{MediaStream}} objects that
+          the {{MediaStreamTrack}} object of this receiver is
           associated with, and initialized to an empty list.</p>
         </li>
         <li>
@@ -6900,7 +6805,7 @@ async function updateParameters() {
         <li>
           <p>Let <var>receiver</var> have a <dfn>[[\ReceiveCodecs]]</dfn>
           internal slot, representing a list of
-          <code><a>RTCRtpCodecParameters</a></code> dictionaries, and
+          {{RTCRtpCodecParameters}} dictionaries, and
           initialized to an empty list.</p>
         </li>
         <li>
@@ -6928,12 +6833,12 @@ interface RTCRtpReceiver {
           <h2>Attributes</h2>
           <dl data-link-for="RTCRtpReceiver" data-dfn-for="RTCRtpReceiver"
           class="attributes">
-            <dt><dfn data-idl><code>track</code></dfn> of type <span class=
-            "idlAttrType"><a>MediaStreamTrack</a></span>, readonly</dt>
+            <dt><dfn data-idl>track</dfn> of type <span class=
+            "idlAttrType">{{MediaStreamTrack}}</span>, readonly</dt>
             <dd>
               <p>The <code id="dom-rtpreceiver-track">track</code>
               attribute is the track that is associated with this
-              <code><a>RTCRtpReceiver</a></code> object <var>receiver</var>.
+              {{RTCRtpReceiver}} object <var>receiver</var>.
               </p>
               <p>Note that <code>track.stop()</code> is final, although
               clones are not affected. Since
@@ -6943,15 +6848,15 @@ interface RTCRtpReceiver {
               return the value of the <a>[[\ReceiverTrack]]</a> slot.</p>
             </dd>
             <dt><code>transport</code> of type <span class=
-            "idlAttrType"><a>RTCDtlsTransport</a></span>, readonly,
+            "idlAttrType">{{RTCDtlsTransport}}</span>, readonly,
             nullable</dt>
             <dd>
-              <p>The <dfn data-idl><code>transport</code></dfn> attribute is the
+              <p>The <dfn data-idl>transport</dfn> attribute is the
               transport over which media for the receiver's <code>track</code>
               is received in the form of RTP packets. Prior to construction of
-              the <code><a>RTCDtlsTransport</a></code> object, the
+              the {{RTCDtlsTransport}} object, the
               <code>transport</code> attribute will be null. When bundling is
-              used, multiple <code><a>RTCRtpReceiver</a></code> objects will
+              used, multiple {{RTCRtpReceiver}} objects will
               share one <code>transport</code> and will all receive RTP and
               RTCP over the same transport.</p>
               <p>On getting, the attribute MUST return the value of the
@@ -6984,20 +6889,20 @@ interface RTCRtpReceiver {
             <dt data-tests="RTCRtpReceiver-getParameters.html"><code>getParameters</code></dt>
             <dd>
               <p>The <dfn data-idl>getParameters()</dfn> method returns the
-              <code>RTCRtpReceiver</code> object's current parameters for how
+              {{RTCRtpReceiver}} object's current parameters for how
               <code>track</code> is decoded.</p>
 
               <p>When <code>getParameters</code> is called, the
-              <code><a>RTCRtpReceiveParameters</a></code> dictionary is
+              {{RTCRtpReceiveParameters}} dictionary is
               constructed as follows:</p>
               <ul>
                 <li data-tests="RTCRtpReceiver-getParameters.html">
-                  The <code><a data-link-for="RTCRtpParameters">headerExtensions</a></code>
+                  The {{RTCRtpParameters/headerExtensions}}
                   sequence is populated based on the header extensions that the
                   receiver is currently prepared to receive.
                 </li>
                 <li data-tests="RTCRtpReceiver-getParameters.html">
-                  <p><code><a data-link-for="RTCRtpParameters">codecs</a></code>
+                  <p>{{RTCRtpParameters/codecs}}
                   is set to the value of the <a>[[\ReceiveCodecs]]</a> internal
                   slot.</p>
                   <div class="note">Both the local and remote description may
@@ -7010,24 +6915,24 @@ interface RTCRtpReceiver {
                   to be prepared to receive it.</div>
                 </li>
                 <li data-tests="RTCRtpReceiver-getParameters.html">
-                  <code><a data-link-for="RTCRtpParameters">rtcp</a>.reducedSize</code>
+                  <code>{{RTCRtpParameters/rtcp}}.reducedSize</code>
                   is set to <code>true</code> if the receiver is currently prepared to
                   receive reduced-size RTCP packets, and <code>false</code> otherwise.
-                  <code><a data-link-for="RTCRtpParameters">rtcp</a>.cname</code> is
+                  <code>{{RTCRtpParameters/rtcp}}.cname</code> is
                   left out.
                 </li>
               </ul>
             </dd>
-            <dt data-tests="RTCRtpReceiver-getContributingSources.https.html"><dfn data-idl><code>getContributingSources</code></dfn></dt>
+            <dt data-tests="RTCRtpReceiver-getContributingSources.https.html"><dfn data-idl>getContributingSources</dfn></dt>
             <dd>
-              <p>Returns an <code><a>RTCRtpContributingSource</a></code> for
+              <p>Returns an {{RTCRtpContributingSource}} for
               each unique CSRC identifier received by this RTCRtpReceiver in
               the last 10 seconds, in descending <code>timestamp</code> order.
               </p>
             </dd>
-            <dt data-tests="RTCRtpReceiver-getSynchronizationSources.https.html"><dfn data-idl><code>getSynchronizationSources</code></dfn></dt>
+            <dt data-tests="RTCRtpReceiver-getSynchronizationSources.https.html"><dfn data-idl>getSynchronizationSources</dfn></dt>
             <dd>
-              <p>Returns an <code><a>RTCRtpSynchronizationSource</a></code> for
+              <p>Returns an {{RTCRtpSynchronizationSource}} for
               each unique SSRC identifier received by this RTCRtpReceiver in
               the last 10 seconds, in descending <code>timestamp</code> order.
               </p>
@@ -7043,7 +6948,7 @@ interface RTCRtpReceiver {
               <ol data-tests="RTCRtpReceiver-getStats.https.html">
                 <li>
                   <p>Let <var>selector</var> be the
-                  <code><a>RTCRtpReceiver</a></code> object on which the method
+                  {{RTCRtpReceiver}} object on which the method
                   was invoked.</p>
                 </li>
                 <li>
@@ -7052,11 +6957,11 @@ interface RTCRtpReceiver {
                   <ol>
                     <li>
                       <p>Gather the stats indicated by <var>selector</var>
-                      according to the <a>stats selection algorithm</a>.</p>
+                      according to the [= stats selection algorithm =].</p>
                     </li>
                     <li>
-                      <p><a>Resolve</a> <var>p</var> with the resulting
-                      <code><a>RTCStatsReport</a></code> object, containing
+                      <p>[= Resolve =] <var>p</var> with the resulting
+                      {{RTCStatsReport}} object, containing
                       the gathered stats.</p>
                     </li>
                   </ol>
@@ -7073,21 +6978,21 @@ interface RTCRtpReceiver {
       <dfn>RTCRtpSynchronizationSource</dfn> dictionaries contain information
       about a given contributing source (CSRC) or synchronization source (SSRC)
       respectively. When an audio or video frame from one or more RTP packets
-      is delivered to the <code><a>RTCRtpReceiver</a></code>'s
-      <code><a>MediaStreamTrack</a></code>, the user agent MUST queue a task to
+      is delivered to the {{RTCRtpReceiver}}'s
+      {{MediaStreamTrack}}, the user agent MUST queue a task to
       update the relevant information for the
-      <code>RTCRtpContributingSource</code> and
-      <code>RTCRtpSynchronizationSource</code> dictionaries based on the
+      {{RTCRtpContributingSource}} and
+      {{RTCRtpSynchronizationSource}} dictionaries based on the
       content of those packets. The information relevant to the
-      <code>RTCRtpSynchronizationSource</code> dictionary corresponding to the
+      {{RTCRtpSynchronizationSource}} dictionary corresponding to the
       SSRC identifier, is updated each time, and if an RTP packet contains CSRC
       identifiers, then the information relevant to the
-      <code>RTCRtpContributingSource</code> dictionaries corresponding to those
+      {{RTCRtpContributingSource}} dictionaries corresponding to those
       CSRC identifiers is also updated. The user agent MUST process RTP packets
       in order of ascending RTP timestamps. The user agent MUST keep information
-      from RTP packets delivered to the <code><a>RTCRtpReceiver</a></code>'s
-      <code><a>MediaStreamTrack</a></code> in the previous 10 seconds.</p>
-      <div class="note">Even if the <a>MediaStreamTrack</a> is not attached to
+      from RTP packets delivered to the {{RTCRtpReceiver}}'s
+      {{MediaStreamTrack}} in the previous 10 seconds.</p>
+      <div class="note">Even if the {{MediaStreamTrack}} is not attached to
       any sink for playout, <code>getSynchronizationSources</code> and
       <code>getContributingSources</code> returns up-to-date information as long
       as the track is not ended; sinks are not a prerequisite for decoding RTP
@@ -7097,9 +7002,9 @@ interface RTCRtpReceiver {
       any manner so long as the end result is equivalent. So, an
       implementation does not need to literally queue a task for every frame,
       as long as the end result is that within a single event loop task
-      execution, all returned <code><a>RTCRtpSynchronizationSource</a></code>
-      and <code><a>RTCRtpContributingSource</a></code> dictionaries for a
-      particular <code><a>RTCRtpReceiver</a></code> contain information from a
+      execution, all returned {{RTCRtpSynchronizationSource}}
+      and {{RTCRtpContributingSource}} dictionaries for a
+      particular {{RTCRtpReceiver}} contain information from a
       single point in the RTP stream.</div>
       <div>
         <pre class="idl" data-cite="HR-TIME"
@@ -7113,23 +7018,22 @@ interface RTCRtpReceiver {
           <h2>Dictionary RTCRtpContributingSource Members</h2>
           <dl data-link-for="RTCRtpContributingSource" data-dfn-for=
           "RTCRtpContributingSource" class="dictionary-members">
-            <dt data-tests="RTCRtpReceiver-getSynchronizationSources.https.html"><dfn data-idl><code>timestamp</code></dfn> of type <span class=
-            "idlMemberType"><a data-cite="!hr-time#dom-domhighrestimestamp">DOMHighResTimeStamp</a></span>, required</dt>
+            <dt data-tests="RTCRtpReceiver-getSynchronizationSources.https.html"><dfn data-idl>timestamp</dfn> of type {{DOMHighResTimeStamp}}, required</dt>
             <dd>
               <p>The <code>timestamp</code> indicating the most recent time a
               frame from an RTP packet, originating from this source, was
-              delivered to the <code><a>RTCRtpReceiver</a></code>'s
-              <code><a>MediaStreamTrack</a></code>. The <code>timestamp</code>
-              is defined as <a>performance.timeOrigin</a> +
-              <a>performance.now()</a> at that time.</p>
+              delivered to the {{RTCRtpReceiver}}'s
+              {{MediaStreamTrack}}. The <code>timestamp</code>
+              is defined as {{Performance.timeOrigin}} +
+              {{Performance.now()}} at that time.</p>
             </dd>
-            <dt data-tests="RTCRtpReceiver-getSynchronizationSources.https.html"><dfn data-idl><code>source</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpReceiver-getSynchronizationSources.https.html"><dfn data-idl>source</dfn> of type <span class=
             "idlMemberType">unsigned long</span>, required</dt>
             <dd>
               <p>The CSRC or SSRC identifier of the contributing or
               synchronization source.</p>
             </dd>
-            <dt data-tests="RTCRtpReceiver-getSynchronizationSources.https.html"><dfn data-idl><code>audioLevel</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpReceiver-getSynchronizationSources.https.html"><dfn data-idl>audioLevel</dfn> of type <span class=
             "idlMemberType">double</span></dt>
             <dd>
               <p>Only present for audio receivers. This is a value between 0..1
@@ -7153,7 +7057,7 @@ interface RTCRtpReceiver {
               127 is converted to 0, and all other values are converted using
               the equation: <code>10^(-rfc_level/20)</code>.</p>
             </dd>
-            <dt data-tests="RTCRtpReceiver-getSynchronizationSources.https.html"><dfn data-idl><code>rtpTimestamp</code></dfn> of type
+            <dt data-tests="RTCRtpReceiver-getSynchronizationSources.https.html"><dfn data-idl>rtpTimestamp</dfn> of type
                 <span class="idlMemberType">unsigned long</span>, required</dt>
             <dd>
               <p>The last RTP timestamp, as defined in [[!RFC3550]] Section 5.1,
@@ -7171,7 +7075,7 @@ interface RTCRtpReceiver {
           <h2>Dictionary RTCRtpSynchronizationSource Members</h2>
           <dl data-link-for="RTCRtpSynchronizationSource" data-dfn-for=
           "RTCRtpSynchronizationSource" class="dictionary-members">
-            <dt data-tests="RTCRtpReceiver-getSynchronizationSources.https.html"><dfn data-idl><code>voiceActivityFlag</code></dfn> of type <span class=
+            <dt data-tests="RTCRtpReceiver-getSynchronizationSources.https.html"><dfn data-idl>voiceActivityFlag</dfn> of type <span class=
             "idlMemberType">boolean</span></dt>
             <dd>
               <p>Only present for audio receivers. Whether the last RTP packet,
@@ -7187,28 +7091,28 @@ interface RTCRtpReceiver {
     </section>
     <section>
       <h3><dfn>RTCRtpTransceiver</dfn> Interface</h3>
-      <p>The <a>RTCRtpTransceiver</a> interface represents a
-      combination of an <a>RTCRtpSender</a> and an
-      <a>RTCRtpReceiver</a> that share a common
+      <p>The {{RTCRtpTransceiver}} interface represents a
+      combination of an {{RTCRtpSender}} and an
+      {{RTCRtpReceiver}} that share a common
       <code>mid</code>. As defined in <span data-jsep="rtptransceivers">[[!JSEP]]</span>,
-      an <a>RTCRtpTransceiver</a> is said to be <dfn>associated</dfn> with
-      a <a>media description</a> if its <code><a data-link-for=RTCRtpTransceiver>mid</a></code>
+      an {{RTCRtpTransceiver}} is said to be <dfn>associated</dfn> with
+      a [= media description =] if its {{RTCRtpTransceiver/mid}}
       property is non-null; otherwise it is said to be disassociated. Conceptually, an
-      <a>associated</a> transceiver is one that's represented in the last applied session
+      [= associated =] transceiver is one that's represented in the last applied session
       description.</p>
       <p>The <dfn>transceiver kind</dfn> of an
-      <code><a>RTCRtpTransceiver</a></code> is defined by the kind of the
-      associated <code><a>RTCRtpReceiver</a></code>'s
-      <code><a>MediaStreamTrack</a></code> object.</p>
+      {{RTCRtpTransceiver}} is defined by the kind of the
+      associated {{RTCRtpReceiver}}'s
+      {{MediaStreamTrack}} object.</p>
       <p>To <dfn>create an RTCRtpTransceiver</dfn> with an
-      <code><a>RTCRtpReceiver</a></code> object, <var>receiver</var>,
-      <code><a>RTCRtpSender</a></code> object, <var>sender</var>, and an
-      <code><a>RTCRtpTransceiverDirection</a></code> value,
+      {{RTCRtpReceiver}} object, <var>receiver</var>,
+      {{RTCRtpSender}} object, <var>sender</var>, and an
+      {{RTCRtpTransceiverDirection}} value,
       <var>direction</var>, run the following steps:</p>
       <ol>
         <li>
           <p>Let <var>transceiver</var> be a new
-          <code><a>RTCRtpTransceiver</a></code> object.</p>
+          {{RTCRtpTransceiver}} object.</p>
         </li>
         <li data-tests="RTCPeerConnection-addTransceiver.https.html">
           <p>Let <var>transceiver</var> have a <dfn>[[\Sender]]</dfn> internal
@@ -7251,10 +7155,10 @@ interface RTCRtpReceiver {
         </li>
       </ol>
       <div class="note">Creating a transceiver does not create the underlying
-      <code><a>RTCDtlsTransport</a></code> and
-      <code><a>RTCIceTransport</a></code> objects. This will only occur as part
-      of the process of <a data-lt="set the RTCSessionDescription">setting an
-      <code>RTCSessionDescription</code></a>.</div>
+      {{RTCDtlsTransport}} and
+      {{RTCIceTransport}} objects. This will only occur as part
+      of the process of [= set the RTCSessionDescription | setting an
+      RTCSessionDescription =].</div>
       <div>
         <pre class="idl" data-tests="idlharness.https.window.js"
 >[Exposed=Window]
@@ -7282,33 +7186,31 @@ interface RTCRtpTransceiver {
               After rollbacks, the value may change from a non-null value
               to null.</p>
             </dd>
-            <dt data-tests="RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html"><dfn data-idl><code>sender</code></dfn> of type <span class=
-            "idlAttrType"><a>RTCRtpSender</a></span>, readonly</dt>
+            <dt data-tests="RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html"><dfn data-idl>sender</dfn> of type <span class=
+            "idlAttrType">{{RTCRtpSender}}</span>, readonly</dt>
             <dd>
               <p>The <code>sender</code> attribute exposes the
-              <a>RTCRtpSender</a> corresponding to the RTP media
-              that may be sent with mid = <a>mid</a>. On getting,
+              {{RTCRtpSender}} corresponding to the RTP media
+              that may be sent with mid = {{mid}}. On getting,
               the attribute MUST return the value of the <a>[[\Sender]]</a>
               slot.</p>
             </dd>
-            <dt data-tests="RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html"><dfn data-idl><code>receiver</code></dfn> of type <span class=
-            "idlAttrType"><a>RTCRtpReceiver</a></span>, readonly</dt>
+            <dt data-tests="RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html"><dfn data-idl>receiver</dfn> of type <span class=
+            "idlAttrType">{{RTCRtpReceiver}}</span>, readonly</dt>
             <dd>
               <p>The <code>receiver</code> attribute is the
-              <a>RTCRtpReceiver</a> corresponding to the RTP media
-              that may be received with mid = <a>mid</a>. On
+              {{RTCRtpReceiver}} corresponding to the RTP media
+              that may be received with mid = {{mid}}. On
               getting the attribute MUST return the value of the
               <a>[[\Receiver]]</a> slot.</p>
             </dd>
-            <dt data-tests="RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html"><dfn data-idl><code>direction</code></dfn> of type <span class=
-            "idlAttrType"><a>RTCRtpTransceiverDirection</a></span></dt>
+            <dt data-tests="RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html"><dfn data-idl>direction</dfn> of type <span class=
+            "idlAttrType">{{RTCRtpTransceiverDirection}}</span></dt>
             <dd>
               <p>As defined in <span data-jsep=
               "transceiver-direction">[[!JSEP]]</span>, the
               <var>direction</var> attribute indicates the preferred direction
-              of this transceiver, which will be used in calls to <code><a
-              data-link-for="RTCPeerConnection">createOffer</a></code> and <code><a
-              data-link-for="RTCPeerConnection">createAnswer</a></code>. An update
+              of this transceiver, which will be used in calls to {{RTCPeerConnection/createOffer}} and {{RTCPeerConnection/createAnswer}}. An update
               of directionality does not take effect immediately. Instead,
               future calls to <code>createOffer</code>
               and <code>createAnswer</code> mark the corresponding media
@@ -7320,7 +7222,7 @@ interface RTCRtpTransceiver {
               <ol>
                 <li>
                   <p>Let <var>transceiver</var> be the
-                  <code><a>RTCRtpTransceiver</a></code> object on which the
+                  {{RTCRtpTransceiver}} object on which the
                   getter is invoked.</p>
                 </li>
                 <li>
@@ -7337,19 +7239,19 @@ interface RTCRtpTransceiver {
               <ol>
                 <li>
                   <p>Let <var>transceiver</var> be the
-                  <code><a>RTCRtpTransceiver</a></code>
+                  {{RTCRtpTransceiver}}
                   object on which the setter is
                   invoked.</p>
                 </li>
                 <li>
                   <p>Let <var>connection</var> be the
-                  <code><a>RTCPeerConnection</a></code> object
+                  {{RTCPeerConnection}} object
                   associated with <var>transceiver</var>.</p>
                 </li>
                 <li>
                   <p>If <var>transceiver</var>.<a>[[\Stopping]]</a> is
-                  <code>true</code>, <a>throw</a> an
-                  <code>InvalidStateError</code>.</p>
+                  <code>true</code>, [= exception/throw =] an
+                  {{InvalidStateError}}.</p>
                 </li>
                 <li>
                   <p>Let <var>newDirection</var> be the argument to the
@@ -7361,7 +7263,7 @@ interface RTCRtpTransceiver {
                 </li>
                 <li data-tests="RTCRtpTransceiver-direction.html">
                   <p>If <var>newDirection</var> is equal to
-                  <code>"stopped"</code>, <a>throw</a> a <code>TypeError</code>.
+                  <code>"stopped"</code>, [= exception/throw =] a {{TypeError}}.
                   </p>
                 </li>
                 <li>
@@ -7374,8 +7276,8 @@ interface RTCRtpTransceiver {
                 </li>
               </ol>
             </dd>
-            <dt data-tests="RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver-direction.html"><dfn data-idl><code>currentDirection</code></dfn> of type <span class=
-            "idlAttrType"><a>RTCRtpTransceiverDirection</a></span>,
+            <dt data-tests="RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver-direction.html"><dfn data-idl>currentDirection</dfn> of type <span class=
+            "idlAttrType">{{RTCRtpTransceiverDirection}}</span>,
             readonly, nullable</dt>
             <dd>
               <p>As defined in <span data-jsep=
@@ -7383,18 +7285,17 @@ interface RTCRtpTransceiver {
               <var>currentDirection</var> attribute indicates the current
               direction negotiated for this transceiver. The value of
               <var>currentDirection</var> is independent of the value of
-              <code>RTCRtpEncodingParameters.<a data-link-for=
-              "RTCRtpEncodingParameters">active</a></code> since one cannot be
+              <code>RTCRtpEncodingParameters.{{RTCRtpEncodingParameters/active}}</code> since one cannot be
               deduced from the other. If this transceiver has never been
               represented in an offer/answer exchange, the value is
               <code>null</code>. If the transceiver is
-              <code><a>stopped</a></code>, the value is <code>"stopped"</code>.
+              {{stopped}}, the value is <code>"stopped"</code>.
               </p>
               <p>On getting, the user agent MUST run the following steps:</p>
               <ol>
                 <li>
                   <p>Let <var>transceiver</var> be the
-                  <code><a>RTCRtpTransceiver</a></code> object on which the
+                  {{RTCRtpTransceiver}} object on which the
                   getter is invoked.</p>
                 </li>
                 <li>
@@ -7415,60 +7316,60 @@ interface RTCRtpTransceiver {
           "RTCRtpTransceiver" class="methods">
             <dt data-tests="RTCRtpTransceiver-stop.html"><code>stop</code></dt>
             <dd>
-              <p>Irreversibly marks the transceiver as <a>stopping</a>, unless
-              it is already <a>stopped</a>. This will immediately cause the
+              <p>Irreversibly marks the transceiver as {{stopping}}, unless
+              it is already {{stopped}}. This will immediately cause the
               transceiver's sender to no longer send, and its receiver to no
-              longer receive. Calling <code>stop()</code> also <a data-lt=
-              "update the negotiation-needed flag">updates the
-              negotiation-needed flag</a> for the
-              <code>RTCRtpTransceiver</code>'s associated
-              <code><a>RTCPeerConnection</a></code>.</p>
+              longer receive. Calling <code>stop()</code> also [=
+              update the negotiation-needed flag | updates the
+              negotiation-needed flag =] for the
+              {{RTCRtpTransceiver}}'s associated
+              {{RTCPeerConnection}}.</p>
               <p>A <dfn>stopping</dfn> transceiver will cause future calls to
               <code>createOffer</code> to generate a zero port in the
-              <a>media description</a> for the corresponding transceiver, as
+              [= media description =] for the corresponding transceiver, as
               defined in <span data-jsep="stop">[[!JSEP]]</span> (The user agent
-              MUST treat a <a>stopping</a> transceiver as <a>stopped</a> for the
+              MUST treat a {{stopping}} transceiver as {{stopped}} for the
               purposes of JSEP only in this case). However, to avoid problems
-              with [[!BUNDLE]], a transceiver that is <a>stopping</a>, but not
-              <a>stopped</a>, will not affect <code>createAnswer</code>.</p>
+              with [[!BUNDLE]], a transceiver that is {{stopping}}, but not
+              {{stopped}}, will not affect <code>createAnswer</code>.</p>
               <p>A <dfn>stopped</dfn> transceiver will cause future calls to
               <code>createOffer</code> or <code>createAnswer</code> to generate
-              a zero port in the <a>media description</a> for the corresponding
+              a zero port in the [= media description =] for the corresponding
               transceiver, as defined in
               <span data-jsep="stop">[[!JSEP]]</span>.</p>
-              <p>The transceiver will remain in the <a>stopping</a> state,
-              unless it becomes <a>stopped</a> by <code>setRemoteDescription</code>
+              <p>The transceiver will remain in the {{stopping}} state,
+              unless it becomes {{stopped}} by <code>setRemoteDescription</code>
               processing a rejected m-line in a remote offer or answer.</p>
-              <p class="note">A transceiver that is <a>stopping</a> but not
-              <a>stopped</a> will always need negotiation. In practice, this
+              <p class="note">A transceiver that is {{stopping}} but not
+              {{stopped}} will always need negotiation. In practice, this
               means that calling <code>stop()</code> on a transceiver will cause
-              the transceiver to become <a>stopped</a> eventually, provided
+              the transceiver to become {{stopped}} eventually, provided
               negotiation is allowed to complete on both ends.</p>
-              <p>When the <dfn data-idl><code>stop</code></dfn> method is
+              <p>When the <dfn data-idl>stop</dfn> method is
               invoked, the user agent MUST run the following steps:</p>
               <ol>
                 <li>
                   <p>Let <var>transceiver</var> be the
-                  <code><a>RTCRtpTransceiver</a></code> object on which the
+                  {{RTCRtpTransceiver}} object on which the
                   method is invoked.</p>
                 </li>
                 <li>
                   <p>Let <var>connection</var> be the
-                  <code><a>RTCPeerConnection</a></code> object associated with
+                  {{RTCPeerConnection}} object associated with
                   <var>transceiver</var>.</p>
                 </li>
                 <li>
                   <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
-                  <code>true</code>, <a>throw</a> an
-                  <code>InvalidStateError</code>.</p>
+                  <code>true</code>, [= exception/throw =] an
+                  {{InvalidStateError}}.</p>
                 </li>
                 <li>
                   <p>If <var>transceiver</var>.<a>[[\Stopping]]</a> is
                   <code>true</code>, abort these steps.</p>
                 </li>
                 <li>
-                  <p><a data-lt="stop sending and receiving">
-                      Stop sending and receiving</a> given
+                  <p>[=
+                      Stop sending and receiving =] given
                   <var>transceiver</var>, and
                   <a>update the negotiation-needed flag</a> for
                   <var>connection</var>.</p>
@@ -7511,7 +7412,7 @@ interface RTCRtpTransceiver {
               <ol>
                 <li>
                   <p>If <var>transceiver</var>.<a>[[\Stopping]]</a> is
-                  <code>false</code>, <a>stop sending and receiving</a> given
+                  <code>false</code>, [= stop sending and receiving =] given
                   <var>transceiver</var>.</p>
                 </li>
                 <li>
@@ -7528,7 +7429,7 @@ interface RTCRtpTransceiver {
                 </li>
               </ol>
             </dd>
-            <dt data-tests="RTCRtpTransceiver-setCodecPreferences.html"><dfn data-idl><code>setCodecPreferences</code></dfn></dt>
+            <dt data-tests="RTCRtpTransceiver-setCodecPreferences.html"><dfn data-idl>setCodecPreferences</dfn></dt>
             <dd>
               <p>The <code>setCodecPreferences</code> method overrides the
               default codec preferences used by the <a>user agent</a>. When
@@ -7536,7 +7437,7 @@ interface RTCRtpTransceiver {
               <code>createOffer</code> or <code>createAnswer</code>, the
               <a>user agent</a> MUST use the indicated codecs, in the order
               specified in the <var>codecs</var> argument, for the media
-              section corresponding to this <code>RTCRtpTransceiver</code>.
+              section corresponding to this {{RTCRtpTransceiver}}.
               </p>
               <p>This method allows applications to disable the negotiation of
               specific codecs (including RTX/RED/FEC). It also allows an
@@ -7544,7 +7445,7 @@ interface RTCRtpTransceiver {
               appears first in the list for sending.</p>
               <p>Codec preferences remain in effect for all calls to
               <code>createOffer</code> and <code>createAnswer</code> that
-              include this <code>RTCRtpTransceiver</code> until this method is
+              include this {{RTCRtpTransceiver}} until this method is
               called again. Setting <var>codecs</var> to an empty sequence
               resets codec preferences to any default value.</p>
               <p>The <code>codecs</code> sequence passed into
@@ -7552,11 +7453,11 @@ interface RTCRtpTransceiver {
               returned by <code>RTCRtpSender.getCapabilities(kind)</code> or
               <code>RTCRtpReceiver.getCapabilities(kind)</code>, where
               <code>kind</code> is the kind of the
-              <code>RTCRtpTransceiver</code> on which the method is called.
-              Additionally, the <code>RTCRtpCodecCapability</code> dictionary
+              {{RTCRtpTransceiver}} on which the method is called.
+              Additionally, the {{RTCRtpCodecCapability}} dictionary
               members cannot be modified. If <code>codecs</code> does not
-              fulfill these requirements, the user agent MUST <a>throw</a> an
-              <code>InvalidModificationError</code>.</p>
+              fulfill these requirements, the user agent MUST [= exception/throw =] an
+              {{InvalidModificationError}}.</p>
               <p class="note">
               Due to a recommendation in [[!SDP]], calls to
               <code>createAnswer</code> SHOULD use only the common subset of
@@ -7570,7 +7471,7 @@ interface RTCRtpTransceiver {
               MUST run the following steps:</p>
               <ol>
                 <li>
-                  <p>Let <var>transceiver</var> be the <code><a>RTCRtpTransceiver</a></code>
+                  <p>Let <var>transceiver</var> be the {{RTCRtpTransceiver}}
                   object this method was invoked on.</p>
                 </li>
                 <li>
@@ -7595,8 +7496,8 @@ interface RTCRtpTransceiver {
                   between <var>codecs</var> and
                   <code>RTCRtpReceiver.getCapabilities(kind).codecs</code> only contains RTX, RED
                   or FEC codecs or is an empty set,
-                  throw <code>InvalidModificationError</code>. This ensures that we always have
-                  something to offer, regardless of <code><var>transceiver</var>.<a data-link-for="RTCRtpTransceiver">direction</a></code>.</p>
+                  throw {{InvalidModificationError}}. This ensures that we always have
+                  something to offer, regardless of <code><var>transceiver</var>.{{RTCRtpTransceiver/direction}}</code>.</p>
                 </li>
                 <li>
                   <p>Let <var>codecCapabilities</var> be the union of
@@ -7607,7 +7508,7 @@ interface RTCRtpTransceiver {
                   <p>For each <var>codec</var> in <var>codecs</var>,</p>
                   <ol>
                     <li>If <var>codec</var> is not in <var>codecCapabilities</var>, throw
-                    <code>InvalidModificationError</code>.</li>
+                    {{InvalidModificationError}}.</li>
                   </ol>
                 </li>
                 <li data-tests="RTCRtpTransceiver-setCodecPreferences.html">
@@ -7629,22 +7530,22 @@ interface RTCRtpTransceiver {
       <section>
         <h3>Simulcast functionality</h3>
         <p>Simulcast functionality is provided via the <code>addTransceiver</code> method of the
-        <code><a>RTCPeerConnection</a></code> object and the <code>setParameters</code> method of the
-        <code><a>RTCRtpSender</a></code> object.</p>
+        {{RTCPeerConnection}} object and the <code>setParameters</code> method of the
+        {{RTCRtpSender}} object.</p>
         <p>The <code>addTransceiver</code> method establishes the <dfn>simulcast envelope</dfn> which
         includes the maximum number of simulcast streams that can be sent, as well as the ordering of the
         <code>encodings</code>. While characteristics of individual simulcast streams can be modified using
-        the <code>setParameters</code> method, the <a>simulcast envelope</a> cannot be changed. One of the
-        implications of this model is that the <code>addTrack</code> method cannot provide simulcast
+        the <code>setParameters</code> method, the [= simulcast envelope =] cannot be changed. One of the
+        implications of this model is that the {{RTCPeerConnection/addTrack()}} method cannot provide simulcast
         functionality since it does not take <code>sendEncodings</code> as an argument, and therefore cannot
-        configure an <code><a>RTCRtpTransceiver</a></code> to send simulcast.</p>
-        <p>Another implication is that the answerer cannot set the <a>simulcast envelope</a> directly.
-        Upon calling the <code>setRemoteDescription</code> method of the <code><a>RTCPeerConnection</a></code>
-        object, the <a>simulcast envelope</a> is configured on the <code><a>RTCRtpTransceiver</a></code>
-        to contain the layers described by the specified <code><a>RTCSessionDescription</a></code>.
+        configure an {{RTCRtpTransceiver}} to send simulcast.</p>
+        <p>Another implication is that the answerer cannot set the [= simulcast envelope =] directly.
+        Upon calling the <code>setRemoteDescription</code> method of the {{RTCPeerConnection}}
+        object, the [= simulcast envelope =] is configured on the {{RTCRtpTransceiver}}
+        to contain the layers described by the specified {{RTCSessionDescription}}.
         Once the envelope is determined, layers cannot be removed. They can be marked as inactive by setting
         the <code>active</code> attribute to <code>false</code> effectively disabling the layer.</p>
-        <p>While <code>setParameters</code> cannot modify the <a>simulcast envelope</a>, it is still possible
+        <p>While <code>setParameters</code> cannot modify the [= simulcast envelope =], it is still possible
         to control the number of streams that are sent and the characteristics of those streams. Using
         <code>setParameters</code>, simulcast streams can be made inactive by setting the <code>active</code>
         attribute to <code>false</code>, or can be reactivated by setting the <code>active</code>
@@ -7667,15 +7568,15 @@ interface RTCRtpTransceiver {
         <p>This specification does not define how to configure <code>createOffer</code> to receive multiple
         RTP encodings. However when <code>setRemoteDescription</code> is called with a corresponding remote
         description that is able to send multiple RTP encodings as defined in [[!JSEP]], the
-        <code><a>RTCRtpReceiver</a></code> may receive multiple RTP encodings and the parameters retrieved
+        {{RTCRtpReceiver}} may receive multiple RTP encodings and the parameters retrieved
         via the transceiver's <code>receiver.getParameters()</code> will reflect the encodings negotiated.</p>
-        <p class="note">An <code><a>RTCRtpReceiver</a></code> can receive multiple RTP streams in a scenario
+        <p class="note">An {{RTCRtpReceiver}} can receive multiple RTP streams in a scenario
         where a Selective Forwarding Unit (SFU) switches between simulcast streams it receives from user agents.
         If the SFU does not rewrite RTP headers so as to arrange the switched streams into a single RTP
-        stream prior to forwarding, the <code><a>RTCRtpReceiver</a></code> will receive packets from distinct
+        stream prior to forwarding, the {{RTCRtpReceiver}} will receive packets from distinct
         RTP streams, each with their own SSRC and sequence number space. While the SFU may only forward a single
         RTP stream at any given time, packets from multiple RTP streams can become intermingled at the receiver
-        due to reordering. An <code><a>RTCRtpReceiver</a></code> equipped to receive multiple RTP streams will
+        due to reordering. An {{RTCRtpReceiver}} equipped to receive multiple RTP streams will
         therefore need to be able to correctly order the received packets, recognize potential loss events and
         react to them. Correct operation in this scenario is non-trivial and therefore is optional for
         implementations of this specification.</p>
@@ -7697,10 +7598,8 @@ var encodings = [
       </section>
       <section class="informative">
         <h3>"Hold" functionality</h3>
-        <p>Together, the <code><a data-link-for=
-        "RTCRtpTransceiver">direction</a></code> attribute and
-        the <code><a data-link-for=
-        "RTCRtpSender">replaceTrack</a></code> method enable
+        <p>Together, the {{RTCRtpTransceiver/direction}} attribute and
+        the {{RTCRtpSender/replaceTrack}} method enable
         developers to implement "hold" scenarios.</p>
         <p>To send music to a peer and cease rendering received audio (music-on-hold):</p>
         <pre class="example highlight">
@@ -7768,33 +7667,32 @@ async function onOffHold() {
     </section>
     <section>
       <h3><dfn>RTCDtlsTransport</dfn> Interface</h3>
-      <p>The <code><a>RTCDtlsTransport</a></code> interface allows an
+      <p>The {{RTCDtlsTransport}} interface allows an
       application access to information about the Datagram Transport Layer
       Security (DTLS) transport over which RTP and RTCP packets are sent and
-      received by <code><a>RTCRtpSender</a></code> and
-      <code><a>RTCRtpReceiver</a></code> objects, as well other data such as
+      received by {{RTCRtpSender}} and
+      {{RTCRtpReceiver}} objects, as well other data such as
       SCTP packets sent and received by data channels. In particular, DTLS adds
       security to an underlying transport, and the
-      <code>RTCDtlsTransport</code> interface allows access to information
+      {{RTCDtlsTransport}} interface allows access to information
       about the underlying transport and the security added.
-      <code><a>RTCDtlsTransport</a></code> objects are constructed as a result
+      {{RTCDtlsTransport}} objects are constructed as a result
       of calls to <code>setLocalDescription()</code> and
       <code>setRemoteDescription()</code>. Each
-      <code><a>RTCDtlsTransport</a></code> object represents the DTLS transport
-      layer for the RTP or RTCP <code><a data-link-for="RTCIceTransport">component</a></code>
-      of a specific <code><a>RTCRtpTransceiver</a></code>, or a group of
-      <code><a>RTCRtpTransceiver</a></code>s if such a group has been
+      {{RTCDtlsTransport}} object represents the DTLS transport
+      layer for the RTP or RTCP {{RTCIceTransport/component}}
+      of a specific {{RTCRtpTransceiver}}, or a group of
+      {{RTCRtpTransceiver}}s if such a group has been
       negotiated via [[!BUNDLE]].</p>
 
       <div class="note">A new DTLS association for an existing
-      <code><a>RTCRtpTransceiver</a></code> will be represented by an existing
-      <code><a>RTCDtlsTransport</a></code> object, whose <code><a
-      data-link-for="RTCDtlsTransport">state</a></code> will be updated accordingly,
+      {{RTCRtpTransceiver}} will be represented by an existing
+      {{RTCDtlsTransport}} object, whose {{RTCDtlsTransport/state}} will be updated accordingly,
       as opposed to being represented by a new object.</div>
 
-      <p data-tests="RTCDtlsTransport-getRemoteCertificates.html">An <code><a>RTCDtlsTransport</a></code> has a
+      <p data-tests="RTCDtlsTransport-getRemoteCertificates.html">An {{RTCDtlsTransport}} has a
       <dfn>[[\DtlsTransportState]]</dfn> internal slot initialized to <code>
-      <a data-link-for="RTCDtlsTransportState">new</a></code> and a
+      {{RTCDtlsTransportState/new}}</code> and a
       <dfn>[[\RemoteCertificates]]</dfn> slot initialized to an empty list.</p>
       <p>When the underlying DTLS transport experiences an error, such as
         a certificate validation failure, or a fatal alert (see [[RFC5246]]
@@ -7804,7 +7702,7 @@ async function onOffHold() {
       <ol>
         <li>
           <p>Let <var>transport</var> be the <code>
-              <a>RTCDtlsTransport</a></code> object to receive the state update
+              {{RTCDtlsTransport}}</code> object to receive the state update
             and error notification.</p>
         </li>
         <li>
@@ -7818,29 +7716,29 @@ async function onOffHold() {
         </li>
         <li>
           <p>
-            <a>Fire an event</a> named
+            [= Fire an event =] named
             <code><a data-lt="RTCDtlsTransport error">error</a></code>
-            using the <a>RTCErrorEvent</a> interface with its
+            using the {{RTCErrorEvent}} interface with its
             errorDetail attribute set to either "dtls-failure" or
             "fingerprint-failure", as appropriate, and other fields
-            set as described under the <a>RTCErrorDetailType</a> enum
+            set as described under the {{RTCErrorDetailType}} enum
             description, at <var>transport</var>.
           </p>
         </li>
         <li>
-          <p><a>Fire an event</a>
+          <p>[= Fire an event =]
           named <code><a data-lt="RTCDtlsTransport state
           change">statechange</a></code> at <var>transport</var>.</p>
         </li>
       </ol>
       <p>When the underlying DTLS transport needs to update the state of the
-        corresponding <code><a>RTCDtlsTransport</a></code> object for any other
+        corresponding {{RTCDtlsTransport}} object for any other
         reason, the user agent
         MUST queue a task that runs the following steps:</p>
       <ol>
         <li>
           <p>Let <var>transport</var> be the <code>
-          <a>RTCDtlsTransport</a></code> object to receive the state update.</p>
+          {{RTCDtlsTransport}}</code> object to receive the state update.</p>
         </li>
         <li>
           <p>Let <var>newState</var> be the new state.</p>
@@ -7851,7 +7749,7 @@ async function onOffHold() {
         </li>
         <li data-tests="RTCDtlsTransport-getRemoteCertificates.html">
           <p>If <var>newState</var> is
-          <code><a data-link-for="RTCDtlsTransportState">connected</a></code>
+          {{RTCDtlsTransportState/connected}}
           then let <var>newRemoteCertificates</var> be the certificate chain in
           use by the remote side, with each certificate encoded in binary
           Distinguished Encoding Rules (DER) [[!X690]], and set
@@ -7859,7 +7757,7 @@ async function onOffHold() {
           <var>newRemoteCertificates</var>.</p>
         </li>
         <li data-tests="RTCDtlsTransport-state.html">
-          <p><a>Fire an event</a> named <code><a data-lt="RTCDtlsTransport state change">statechange</a></code>
+          <p>[= Fire an event =] named <code><a data-lt="RTCDtlsTransport state change">statechange</a></code>
           at <var>transport</var>.</p>
         </li>
       </ol>
@@ -7878,37 +7776,37 @@ interface RTCDtlsTransport : EventTarget {
           <dl data-link-for="RTCDtlsTransport" data-dfn-for="RTCDtlsTransport"
           class="attributes">
             <dt data-tests="RTCIceTransport.html,RTCPeerConnection-connectionState.https.html,RTCPeerConnection-iceConnectionState.https.html,RTCPeerConnection-iceGatheringState.html"
-                ><dfn data-idl><code>iceTransport</code></dfn> of type <span class=
-            "idlAttrType"><a>RTCIceTransport</a></span>, readonly</dt>
+                ><dfn data-idl>iceTransport</dfn> of type <span class=
+            "idlAttrType">{{RTCIceTransport}}</span>, readonly</dt>
             <dd>
               <p>The <code>iceTransport</code> attribute is the underlying
               transport that is used to send and receive packets. The
               underlying transport may not be shared between multiple active
-              <code><a>RTCDtlsTransport</a></code> objects.</p>
+              {{RTCDtlsTransport}} objects.</p>
             </dd>
-            <dt data-tests="RTCDtlsTransport-state.html,RTCPeerConnection-connectionState.https.html"><dfn data-idl><code>state</code></dfn> of type <span class=
-            "idlAttrType"><a>RTCDtlsTransportState</a></span>, readonly</dt>
+            <dt data-tests="RTCDtlsTransport-state.html,RTCPeerConnection-connectionState.https.html"><dfn data-idl>state</dfn> of type <span class=
+            "idlAttrType">{{RTCDtlsTransportState}}</span>, readonly</dt>
             <dd>
               <p>The <code>state</code> attribute MUST, on getting, return the
               value of the <a>[[\DtlsTransportState]]</a> slot.</p>
             </dd>
-            <dt data-tests="RTCDtlsTransport-state.html"><dfn data-idl><code>onstatechange</code></dfn> of type <span class=
+            <dt data-tests="RTCDtlsTransport-state.html"><dfn data-idl>onstatechange</dfn> of type <span class=
             "idlAttrType">EventHandler</span></dt>
             <dd>
               The event type of this event handler is <code>
               <a data-lt="RTCDtlsTransport state change">statechange</a></code>.
             </dd>
-            <dt><dfn data-idl><code>onerror</code></dfn> of type
+            <dt><dfn data-idl>onerror</dfn> of type
               <span class="idlAttrType">EventHandler</span></dt>
               <dd>The event type of this event handler is
-              <code><a>error</a></code>.</dd>
+              {{error}}.</dd>
           </dl>
         </section>
         <section>
           <h2>Methods</h2>
           <dl data-link-for="RTCDtlsTransport" data-dfn-for="RTCDtlsTransport"
           class="methods">
-            <dt data-tests="RTCDtlsTransport-getRemoteCertificates.html"><dfn data-idl><code>getRemoteCertificates</code></dfn></dt>
+            <dt data-tests="RTCDtlsTransport-getRemoteCertificates.html"><dfn data-idl>getRemoteCertificates</dfn></dt>
             <dd>
               <p>Returns the value of <a>[[\RemoteCertificates]]</a>.</p>
             </dd>
@@ -7932,26 +7830,26 @@ interface RTCDtlsTransport : EventTarget {
               <th colspan="2">Enumeration description</th>
             </tr>
             <tr>
-              <td><dfn data-idl><code>new</code></dfn></td>
+              <td><dfn data-idl>new</dfn></td>
               <td>DTLS has not started negotiating yet.</td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>connecting</code></dfn></td>
+              <td><dfn data-idl>connecting</dfn></td>
               <td>DTLS is in the process of negotiating a secure connection
               and verifying the remote fingerprint.</td>
             </tr>
             <tr>
-              <td data-tests="RTCDtlsTransport-state.html,RTCPeerConnection-connectionState.https.html"><dfn data-idl><code>connected</code></dfn></td>
+              <td data-tests="RTCDtlsTransport-state.html,RTCPeerConnection-connectionState.https.html"><dfn data-idl>connected</dfn></td>
               <td>DTLS has completed negotiation of a secure connection and
               verified the remote fingerprint.</td>
             </tr>
             <tr>
-              <td data-tests="RTCDtlsTransport-state.html"><dfn data-idl><code>closed</code></dfn></td>
+              <td data-tests="RTCDtlsTransport-state.html"><dfn data-idl>closed</dfn></td>
               <td>The transport has been closed intentionally as the result of
               receipt of a close_notify alert, or calling <code>close()</code>.</td>
             </tr>
             <tr>
-              <td data-tests="protocol/dtls-fingerprint-validation.html"><dfn data-idl><code>failed</code></dfn></td>
+              <td data-tests="protocol/dtls-fingerprint-validation.html"><dfn data-idl>failed</dfn></td>
               <td>The transport has failed as the result of an error (such as
               receipt of an error alert or failure to validate the remote fingerprint).</td>
             </tr>
@@ -7960,7 +7858,7 @@ interface RTCDtlsTransport : EventTarget {
       </div>
       <section id="rtcdtlsfingerprint">
         <h3><dfn>RTCDtlsFingerprint</dfn> Dictionary</h3>
-        <p data-tests="RTCCertificate.html">The <code>RTCDtlsFingerprint</code> dictionary includes
+        <p data-tests="RTCCertificate.html">The {{RTCDtlsFingerprint}} dictionary includes
         the hash function algorithm and certificate fingerprint as described in
         [[!RFC4572]].</p>
         <div>
@@ -7974,13 +7872,13 @@ interface RTCDtlsTransport : EventTarget {
             Members</h2>
             <dl data-link-for="RTCDtlsFingerprint" data-dfn-for=
             "RTCDtlsFingerprint" class="dictionary-members">
-              <dt><dfn data-idl><code>algorithm</code></dfn> of type <span class=
+              <dt><dfn data-idl>algorithm</dfn> of type <span class=
               "idlMemberType">DOMString</span></dt>
               <dd>
                 <p>One of the the hash function algorithms defined in the 'Hash
                 function Textual Names' registry [[!IANA-HASH-FUNCTION]].</p>
               </dd>
-              <dt><dfn data-idl><code>value</code></dfn> of type <span class=
+              <dt><dfn data-idl>value</dfn> of type <span class=
               "idlMemberType">DOMString</span></dt>
               <dd>
                 <p>The value of the certificate fingerprint in lowercase hex
@@ -7994,52 +7892,50 @@ interface RTCDtlsTransport : EventTarget {
     </section>
     <section id="rtcicetransport">
       <h3><dfn>RTCIceTransport</dfn> Interface</h3>
-      <p>The <code><a>RTCIceTransport</a></code> interface allows an
+      <p>The {{RTCIceTransport}} interface allows an
       application access to information about the ICE transport over which
       packets are sent and received. In particular, ICE manages peer-to-peer
       connections which involve state which the application may want to access.
-      <code><a>RTCIceTransport</a></code> objects are constructed as a result
+      {{RTCIceTransport}} objects are constructed as a result
       of calls to <code>setLocalDescription()</code> and
       <code>setRemoteDescription()</code>. The underlying ICE state is managed
       by the <a>ICE agent</a>; as such, the state of an
-      <code><a>RTCIceTransport</a></code> changes when the <a>ICE Agent</a>
+      {{RTCIceTransport}} changes when the [= ICE Agent =]
       provides indications to the user agent as described below. Each
-      <code><a>RTCIceTransport</a></code> object represents the ICE transport
-      layer for the RTP or RTCP <code><a data-link-for="RTCIceTransport">component</a></code>
-      of a specific <code><a>RTCRtpTransceiver</a></code>, or a group of
-      <code><a>RTCRtpTransceiver</a></code>s if such a group has been
+      {{RTCIceTransport}} object represents the ICE transport
+      layer for the RTP or RTCP {{RTCIceTransport/component}}
+      of a specific {{RTCRtpTransceiver}}, or a group of
+      {{RTCRtpTransceiver}}s if such a group has been
       negotiated via [[!BUNDLE]].</p>
 
       <div class="note">An ICE restart for an existing
-      <code><a>RTCRtpTransceiver</a></code> will be represented by an existing
-      <code><a>RTCIceTransport</a></code> object, whose <code><a
-      data-link-for="RTCIceTransport">state</a></code> will be updated
+      {{RTCRtpTransceiver}} will be represented by an existing
+      {{RTCIceTransport}} object, whose {{RTCIceTransport/state}} will be updated
       accordingly, as opposed to being represented by a new object.</div>
 
-      <p>When the <a>ICE Agent</a> indicates that it began gathering a
-      <a>generation</a> of candidates for an <code><a>RTCIceTransport</a></code>, the
+      <p>When the [= ICE Agent =] indicates that it began gathering a
+      [= generation =] of candidates for an {{RTCIceTransport}}, the
       user agent MUST queue a task that runs the following steps:</p>
       <ol>
         <li>
           <p>Let <var>connection</var> be the
-          <code><a>RTCPeerConnection</a></code> object associated with this
-          <a>ICE Agent</a>.</p>
+          {{RTCPeerConnection}} object associated with this
+          [= ICE Agent =].</p>
         </li>
         <li>
           <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
           <code>true</code>, abort these steps.</p>
         </li>
         <li>
-          <p>Let <var>transport</var> be the <code><a>RTCIceTransport</a></code>
+          <p>Let <var>transport</var> be the {{RTCIceTransport}}
           for which candidate gathering began.</p>
         </li>
         <li>
           <p>Set <var>transport</var>.<a>[[\IceGathererState]]</a>
-          to <code><a data-link-for=
-          "RTCIceGathererState">gathering</a></code>.</p>
+          to {{RTCIceGathererState/gathering}}.</p>
         </li>
         <li>
-          <p><a>Fire an event</a> named <code><a>gatheringstatechange</a></code>
+          <p>[= Fire an event =] named {{gatheringstatechange}}
           at <var>transport</var>.</p>
         </li>
         <li>
@@ -8047,59 +7943,58 @@ interface RTCDtlsTransport : EventTarget {
         </li>
       </ol>
 
-      <p>When the <a>ICE Agent</a> is finished gathering a <a>generation</a> of
-      candidates for an <code><a>RTCIceTransport</a></code>, and those
+      <p>When the [= ICE Agent =] is finished gathering a [= generation =] of
+      candidates for an {{RTCIceTransport}}, and those
       candidates have been surfaced to the application, the user agent MUST
       queue a task that runs the following steps:</p>
       <ol>
         <li>
           <p>Let <var>connection</var> be the
-          <code><a>RTCPeerConnection</a></code> object associated with this
-          <a>ICE Agent</a>.</p>
+          {{RTCPeerConnection}} object associated with this
+          [= ICE Agent =].</p>
         </li>
         <li>
           <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
           <code>true</code>, abort these steps.</p>
         </li>
         <li>
-          <p>Let <var>transport</var> be the <code><a>RTCIceTransport</a></code>
+          <p>Let <var>transport</var> be the {{RTCIceTransport}}
           for which candidate gathering finished.</p>
         </li>
         <li>
           <p>Let <var>newCandidate</var> be the result of
-          <a href="#dfn-create-an-rtcicecandidate">creating an RTCIceCandidate</a>
+          [= creating an RTCIceCandidate =]
           with a new dictionary whose
-          <code><a data-link-for="RTCIceCandidateInit">sdpMid</a></code> and
-          <code><a data-link-for="RTCIceCandidateInit">sdpMLineIndex</a></code>
+          {{RTCIceCandidateInit/sdpMid}} and
+          {{RTCIceCandidateInit/sdpMLineIndex}}
           are set to the values associated with this
-          <code><a>RTCIceTransport</a></code>,
-          <code><a data-link-for="RTCIceCandidateInit">usernameFragment</a></code>
-          is set to the username fragment of the <a>generation</a> of candidates
+          {{RTCIceTransport}},
+          {{RTCIceCandidateInit/usernameFragment}}
+          is set to the username fragment of the [= generation =] of candidates
           for which gathering finished, and
-          <code><a data-link-for="RTCIceCandidateInit">candidate</a></code> is
+          {{RTCIceCandidateInit/candidate}} is
           set to an empty string.</p>
         </li>
         <li>
-          <p><a>Fire an event</a> named <code><a>icecandidate</a></code> using
-          the <code><a>RTCPeerConnectionIceEvent</a></code> interface with the
+          <p>[= Fire an event =] named {{icecandidate}} using
+          the {{RTCPeerConnectionIceEvent}} interface with the
           candidate attribute set to <var>newCandidate</var> at
           <var>connection</var>.</p>
         </li>
         <li>
-          <p>If another <a>generation</a> of candidates is still being gathered, abort
+          <p>If another [= generation =] of candidates is still being gathered, abort
           these steps.</p>
           <div class="note">
             This may occur if an ICE restart is initiated while the ICE agent
-            is still gathering the previous <a>generation</a> of candidates.
+            is still gathering the previous [= generation =] of candidates.
           </div>
         </li>
         <li>
           <p>Set <var>transport</var>.<a>[[\IceGathererState]]</a>
-          to <code><a data-link-for=
-          "RTCIceGathererState">complete</a></code>.</p>
+          to {{RTCIceGathererState/complete}}.</p>
         </li>
         <li>
-          <p><a>Fire an event</a> named <code><a>gatheringstatechange</a></code>
+          <p>[= Fire an event =] named {{gatheringstatechange}}
           at <var>transport</var>.</p>
         </li>
         <li>
@@ -8107,9 +8002,9 @@ interface RTCDtlsTransport : EventTarget {
         </li>
       </ol>
 
-      <p>When the <a>ICE Agent</a> indicates that a new ICE candidate is
-      available for an <code><a>RTCIceTransport</a></code>, either by taking one
-      from the <a data-lt="ICE candidate pool size">ICE candidate pool</a> or
+      <p>When the [= ICE Agent =] indicates that a new ICE candidate is
+      available for an {{RTCIceTransport}}, either by taking one
+      from the [= ICE candidate pool size | ICE candidate pool =] or
       gathering it from scratch, the user agent MUST queue a task that runs the
       following steps:</p>
       <ol>
@@ -8118,8 +8013,8 @@ interface RTCDtlsTransport : EventTarget {
         </li>
         <li>
           <p>Let <var>connection</var> be the
-          <code><a>RTCPeerConnection</a></code> object associated with this
-          <a>ICE Agent</a>.</p>
+          {{RTCPeerConnection}} object associated with this
+          [= ICE Agent =].</p>
         </li>
         <li>
           <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
@@ -8128,9 +8023,9 @@ interface RTCDtlsTransport : EventTarget {
         <li>
           <p>If either <var>connection</var>.<a>[[\PendingLocalDescription]]</a>
           or <var>connection</var>.<a>[[\CurrentLocalDescription]]</a> are not
-          <code>null</code>, and represent the ICE <a>generation</a> for which
+          <code>null</code>, and represent the ICE [= generation =] for which
           <var>candidate</var> was gathered,
-          <a href="#dfn-surface-a-candidate">surface the candidate</a> with
+          [= surface the candidate =] with
           <var>candidate</var> and <var>connection</var>, and abort these steps.
           </p>
         </li>
@@ -8139,7 +8034,7 @@ interface RTCDtlsTransport : EventTarget {
           <var>connection</var>.<a>[[\EarlyCandidates]]</a>.</p>
         </li>
       </ol>
-      <p>When the <a>ICE Agent</a> signals that the ICE role has changed
+      <p>When the [= ICE Agent =] signals that the ICE role has changed
         due to an ICE binding request with a role collision per [[RFC8445]]
         section 7.3.1.1, the UA will queue a task to set the value of
         <a>[[\IceRole]]</a> to the new value.
@@ -8149,8 +8044,8 @@ interface RTCDtlsTransport : EventTarget {
       <ol>
         <li>
           <p>For each candidate, <var>candidate</var>, in
-          <var>connection</var>.<a>[[\EarlyCandidates]]</a>, queue a task to <a
-            href="#dfn-surface-a-candidate">surface the candidate</a>
+          <var>connection</var>.<a>[[\EarlyCandidates]]</a>, queue a task to [=
+          surface the candidate =]
           with <var>candidate</var> and <var>connection</var>.</p>
         </li>
         <li>
@@ -8158,7 +8053,7 @@ interface RTCDtlsTransport : EventTarget {
           to an empty list.</p>
         </li>
       </ol>
-      <p>To <dfn>surface a candidate</dfn> with <var>candidate</var> and
+      <p>To <dfn data-lt="surface the candidate">surface a candidate</dfn> with <var>candidate</var> and
       <var>connection</var>, run the following steps:</p>
       <ol>
         <li>
@@ -8166,33 +8061,33 @@ interface RTCDtlsTransport : EventTarget {
           <code>true</code>, abort these steps.</p>
         </li>
         <li>
-          <p>Let <var>transport</var> be the <code><a>RTCIceTransport</a></code>
+          <p>Let <var>transport</var> be the {{RTCIceTransport}}
           for which <var>candidate</var> is being made available.</p>
         </li>
         <li>
           <p>If <var>connection</var>.<a>[[\PendingLocalDescription]]</a> is
-          not <code>null</code>, and represents the ICE <a>generation</a> for
+          not <code>null</code>, and represents the ICE [= generation =] for
           which <var>candidate</var> was gathered, add <var>candidate</var> to
           the <var>connection</var>.<a>[[\PendingLocalDescription]]</a>.sdp.</p>
         </li>
         <li>
           <p>If <var>connection</var>.<a>[[\CurrentLocalDescription]]</a>
-          is not <code>null</code>, and represents the ICE <a>generation</a> for
+          is not <code>null</code>, and represents the ICE [= generation =] for
           which <var>candidate</var> was gathered, add <var>candidate</var> to
           the <var>connection</var>.<a>[[\CurrentLocalDescription]]</a>.sdp.</p>
         </li>
         <li>
           <p>Let <var>newCandidate</var> be the result of
-          <a href="#dfn-create-an-rtcicecandidate">creating an RTCIceCandidate</a>
+          [= creating an RTCIceCandidate =]
           with a new dictionary whose
-          <code><a data-link-for="RTCIceCandidateInit">sdpMid</a></code> and
-          <code><a data-link-for="RTCIceCandidateInit">sdpMLineIndex</a></code>
+          {{RTCIceCandidateInit/sdpMid}} and
+          {{RTCIceCandidateInit/sdpMLineIndex}}
           are set to the values associated with this
-          <code><a>RTCIceTransport</a></code>,
-          <code><a data-link-for="RTCIceCandidateInit">usernameFragment</a></code>
+          {{RTCIceTransport}},
+          {{RTCIceCandidateInit/usernameFragment}}
           is set to the username fragment of the candidate, and
-          <code><a data-link-for="RTCIceCandidateInit">candidate</a></code> is
-          set to a string encoded using the <a>candidate-attribute</a>
+          {{RTCIceCandidateInit/candidate}} is
+          set to a string encoded using the [= candidate-attribute =]
           grammar to represent <var>candidate</var>.</p>
         </li>
         <li>
@@ -8200,39 +8095,39 @@ interface RTCDtlsTransport : EventTarget {
           candidates.</p>
         </li>
         <li>
-          <p><a>Fire an event</a> named <code><a>icecandidate</a></code>  using
-          the <code><a>RTCPeerConnectionIceEvent</a></code> interface with the
+          <p>[= Fire an event =] named {{icecandidate}}  using
+          the {{RTCPeerConnectionIceEvent}} interface with the
           candidate attribute set to <var>newCandidate</var> at
           <var>connection</var>.</p>
         </li>
       </ol>
 
-      <p>When the <a>ICE Agent</a> indicates that the
-      <code><a>RTCIceTransportState</a></code> for an
-      <code><a>RTCIceTransport</a></code> has changed, the user agent MUST queue
+      <p>When the [= ICE Agent =] indicates that the
+      {{RTCIceTransportState}} for an
+      {{RTCIceTransport}} has changed, the user agent MUST queue
       a task that runs the following steps:</p>
       <ol>
         <li>
           <p>Let <var>connection</var> be the
-          <code><a>RTCPeerConnection</a></code> object associated with this
-          <a>ICE Agent</a>.</p>
+          {{RTCPeerConnection}} object associated with this
+          [= ICE Agent =].</p>
         </li>
         <li>
           <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
           <code>true</code>, abort these steps.</p>
         </li>
         <li>
-          <p>Let <var>transport</var> be the <code><a>RTCIceTransport</a></code>
+          <p>Let <var>transport</var> be the {{RTCIceTransport}}
           whose state is changing.</p>
         </li>
         <li>
           <p>Set <var>transport</var>.<a>[[\IceTransportState]]</a> to the new
-          indicated <code><a>RTCIceTransportState</a></code>.</p>
+          indicated {{RTCIceTransportState}}.</p>
         </li>
         <li>
           <p>Set <var>connection</var>'s <a>ice connection state</a> to the
           value of deriving a new state value as described by the
-          <a>RTCIceConnectionState</a> enum.</p>
+          {{RTCIceConnectionState}} enum.</p>
         </li>
         <li>
           <p>Let <var>iceConnectionStateChanged</var> be <code>true</code> if
@@ -8240,53 +8135,53 @@ interface RTCDtlsTransport : EventTarget {
           otherwise <code>false</code>.</p>
         </li>
         <li>
-          <p>Set <var>connection</var>'s <a>connection state</a> to the value of
+          <p>Set <var>connection</var>'s [= connection state =] to the value of
           deriving a new state value as described by the
-          <a>RTCPeerConnectionState</a> enum.</p>
+          {{RTCPeerConnectionState}} enum.</p>
         </li>
         <li>
           <p>Let <var>connectionStateChanged</var> be <code>true</code> if
-          the <a>connection state</a> changed in the previous step, otherwise
+          the [= connection state =] changed in the previous step, otherwise
           <code>false</code>.</p>
         </li>
         <li>
-          <p><a>Fire an event</a> named <code><a>statechange</a></code> at
+          <p>[= Fire an event =] named {{statechange}} at
           <var>transport</var>.</p>
         </li>
         <li data-tests="RTCIceConnectionState-candidate-pair.https.html,RTCPeerConnection-getStats.https.html,RTCPeerConnection-iceConnectionState-disconnected.https.html,RTCPeerConnection-iceConnectionState.https.html,RTCPeerConnection-track-stats.https.html">
           <p>If <var>iceConnectionStateChanged</var> is <code>true</code>,
-          <a>fire an event</a> named
-          <code><a>iceconnectionstatechange</a></code> at
+          [= fire an event =] named
+          {{iceconnectionstatechange}} at
           <var>connection</var>.</p>
         </li>
         <li>
           <p>If <var>connectionStateChanged</var> is <code>true</code>,
-          <a>fire an event</a> named
-          <code><a>connectionstatechange</a></code> at
+          [= fire an event =] named
+          {{connectionstatechange}} at
           <var>connection</var>.</p>
         </li>
       </ol>
 
-      <p>When the <a>ICE Agent</a> indicates that the selected candidate pair
-      for an <code><a>RTCIceTransport</a></code> has changed, the user agent
+      <p>When the [= ICE Agent =] indicates that the selected candidate pair
+      for an {{RTCIceTransport}} has changed, the user agent
       MUST queue a task that runs the following steps:</p>
       <ol>
         <li>
           <p>Let <var>connection</var> be the
-          <code><a>RTCPeerConnection</a></code> object associated with this
-          <a>ICE Agent</a>.</p>
+          {{RTCPeerConnection}} object associated with this
+          [= ICE Agent =].</p>
         </li>
         <li>
           <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
           <code>true</code>, abort these steps.</p>
         </li>
         <li>
-          <p>Let <var>transport</var> be the <code><a>RTCIceTransport</a></code>
+          <p>Let <var>transport</var> be the {{RTCIceTransport}}
           whose selected candidate pair is changing.</p>
         </li>
         <li>
           <p>Let <var>newCandidatePair</var> be a newly created
-          <code><a>RTCIceCandidatePair</a></code> representing the indicated
+          {{RTCIceCandidatePair}} representing the indicated
           pair if one is selected, and <code>null</code> otherwise.</p>
         </li>
         <li data-tests="RTCIceTransport.html">
@@ -8294,21 +8189,21 @@ interface RTCDtlsTransport : EventTarget {
           to <var>newCandidatePair</var>.</p>
         </li>
         <li>
-          <p><a>Fire an event</a> named
-          <code><a>selectedcandidatepairchange</a></code> at
+          <p>[= Fire an event =] named
+          {{selectedcandidatepairchange}} at
           <var>transport</var>.</p>
         </li>
       </ol>
-      <p>An <a>RTCIceTransport</a> object has the following internal slots:</p>
+      <p>An {{RTCIceTransport}} object has the following internal slots:</p>
       <ul>
         <li><dfn>[[\IceTransportState]]</dfn> initialized to <code>
-        <a data-link-for="RTCIceTransportState">new</a></code></li>
+        {{RTCIceTransportState/new}}</code></li>
         <li><dfn>[[\IceGathererState]]</dfn> initialized to <code>
-        <a data-link-for="RTCIceGatheringState">new</a></code></li>
+        {{RTCIceGatheringState/new}}</code></li>
         <li data-tests="RTCIceTransport.html"><dfn>[[\SelectedCandidatePair]]</dfn> initialized to
           <code>null</code></li>
         <li><dfn>[[\IceRole]]</dfn> initialized to <code>
-            <a data-link-for="RTCIceRole">unknown</a></code>
+            {{RTCIceRole/unknown}}</code>
         </li>
       </ul>
       <div>
@@ -8333,57 +8228,57 @@ interface RTCIceTransport : EventTarget {
           <dl data-link-for="RTCIceTransport" data-dfn-for="RTCIceTransport"
           class="attributes">
             <dt><code>role</code> of type <span class=
-            "idlAttrType"><a>RTCIceRole</a></span>, readonly</dt>
+            "idlAttrType">{{RTCIceRole}}</span>, readonly</dt>
             <dd>
               <p>The <dfn id="dom-icetransport-role"><code>role</code></dfn>
                 attribute MUST, on getting, return the value of the [[\IceRole]]
                 internal slot.</p>
             </dd>
             <dt><code>component</code> of type <span class=
-            "idlAttrType"><a>RTCIceComponent</a></span>, readonly</dt>
+            "idlAttrType">{{RTCIceComponent}}</span>, readonly</dt>
             <dd>
               <p>The <dfn id=
               "dom-icetransport-component"><code>component</code></dfn>
               attribute MUST return the ICE component of the transport. When
               RTCP mux is used, a single
-              <code><a>RTCIceTransport</a></code> transports both RTP and RTCP
+              {{RTCIceTransport}} transports both RTP and RTCP
               and <code>component</code> is set to "RTP".</p>
             </dd>
             <dt><code>state</code> of type <span class=
-            "idlAttrType"><a>RTCIceTransportState</a></span>, readonly</dt>
+            "idlAttrType">{{RTCIceTransportState}}</span>, readonly</dt>
             <dd>
               <p>The <dfn id="dom-icetransport-state"><code>state</code></dfn>
               attribute MUST, on getting, return the value of the
               <a>[[\IceTransportState]]</a> slot.</p>
             </dd>
-            <dt><dfn data-idl><code>gatheringState</code></dfn> of type <span class=
-            "idlAttrType"><a>RTCIceGathererState</a></span>, readonly</dt>
+            <dt><dfn data-idl>gatheringState</dfn> of type <span class=
+            "idlAttrType">{{RTCIceGathererState}}</span>, readonly</dt>
             <dd>
               <p>The <dfn id="dom-icetransport-gatheringstate"><code>gathering
               state</code></dfn> attribute MUST, on getting, return the value
               of the <a>[[\IceGathererState]]</a> slot.</p>
             </dd>
-            <dt><dfn data-idl><code>onstatechange</code></dfn> of type <span class=
+            <dt><dfn data-idl>onstatechange</dfn> of type <span class=
             "idlAttrType">EventHandler</span></dt>
             <dd>
               This event handler, of event handler event type
-              <code><a>statechange</a></code>, MUST be fired any time the
-              <a>RTCIceTransport</a>
-              <a data-link-for="RTCIceTransport">state</a> changes.
+              {{statechange}}, MUST be fired any time the
+              {{RTCIceTransport}}
+              {{RTCIceTransport/state}} changes.
             </dd>
-            <dt><dfn data-idl><code>ongatheringstatechange</code></dfn> of type
+            <dt><dfn data-idl>ongatheringstatechange</dfn> of type
             <span class="idlAttrType">EventHandler</span></dt>
             <dd>
               This event handler, of event handler event type
-              <code><a>gatheringstatechange</a></code>, MUST be fired any time
-              the <code>RTCIceTransport</code> <a>gathering state</a>
+              {{gatheringstatechange}}, MUST be fired any time
+              the {{RTCIceTransport}} [= gathering state =]
               changes.
             </dd>
-            <dt><dfn data-idl><code>onselectedcandidatepairchange</code></dfn> of type
+            <dt><dfn data-idl>onselectedcandidatepairchange</dfn> of type
             <span class="idlAttrType">EventHandler</span></dt>
             <dd>This event handler, of event handler event type
-            <code><a>selectedcandidatepairchange</a></code>, MUST be fired any
-            time the <code><a>RTCIceTransport</a></code>'s selected candidate
+            {{selectedcandidatepairchange}}, MUST be fired any
+            time the {{RTCIceTransport}}'s selected candidate
             pair changes.</dd>
           </dl>
         </section>
@@ -8391,46 +8286,41 @@ interface RTCIceTransport : EventTarget {
           <h2>Methods</h2>
           <dl data-link-for="RTCIceTransport" data-dfn-for="RTCIceTransport"
           class="methods">
-            <dt data-tests="RTCIceTransport.html"><dfn data-idl><code>getLocalCandidates</code></dfn></dt>
+            <dt data-tests="RTCIceTransport.html"><dfn data-idl>getLocalCandidates</dfn></dt>
             <dd>
               <p>Returns a sequence describing the local ICE candidates
-              gathered for this <code><a>RTCIceTransport</a></code> and sent in
-              <code><a data-link-for=
-              "RTCPeerConnection">onicecandidate</a></code></p>
+              gathered for this {{RTCIceTransport}} and sent in
+              {{RTCPeerConnection/onicecandidate}}</p>
             </dd>
-            <dt data-tests="RTCIceTransport.html"><dfn data-idl><code>getRemoteCandidates</code></dfn></dt>
+            <dt data-tests="RTCIceTransport.html"><dfn data-idl>getRemoteCandidates</dfn></dt>
             <dd>
               <p>Returns a sequence describing the remote ICE candidates
-              received by this <code><a>RTCIceTransport</a></code> via
-              <code><a data-link-for=
-              "RTCPeerConnection">addIceCandidate()</a></code></p>
+              received by this {{RTCIceTransport}} via
+              {{RTCPeerConnection/addIceCandidate()}}</p>
               <div class="note">
                 <code>getRemoteCandidates</code> will not expose peer reflexive
-                candidates since they are not received via <code><a
-                data-link-for="RTCPeerConnection">addIceCandidate()</a></code>.
+                candidates since they are not received via {{RTCPeerConnection/addIceCandidate()}}.
               </div>
             </dd>
-            <dt data-tests="RTCIceTransport.html"><dfn data-idl><code>getSelectedCandidatePair</code></dfn></dt>
+            <dt data-tests="RTCIceTransport.html"><dfn data-idl>getSelectedCandidatePair</dfn></dt>
             <dd>
               <p>Returns the selected candidate pair on which packets are sent. This
               method MUST return the value of the <a>[[\SelectedCandidatePair]]</a>
-              slot. When <code><a>RTCIceTransport</a>.state</code> is <code>"new"</code> or
+              slot. When <code>{{RTCIceTransport}}.state</code> is <code>"new"</code> or
               <code>"closed"</code> <code>getSelectedCandidatePair</code> returns
               <code>null</code>.</p>
             </dd>
-            <dt data-tests="RTCIceTransport.html"><dfn data-idl><code>getLocalParameters</code></dfn></dt>
+            <dt data-tests="RTCIceTransport.html"><dfn data-idl>getLocalParameters</dfn></dt>
             <dd>
               <p>Returns the local ICE parameters received by this
-              <code><a>RTCIceTransport</a></code> via <code><a data-link-for=
-              "RTCPeerConnection">setLocalDescription</a></code>, or
+              {{RTCIceTransport}} via {{RTCPeerConnection/setLocalDescription}}, or
               <code>null</code> if the parameters have not yet been
               received.</p>
             </dd>
-            <dt data-tests="RTCIceTransport.html"><dfn data-idl><code>getRemoteParameters</code></dfn></dt>
+            <dt data-tests="RTCIceTransport.html"><dfn data-idl>getRemoteParameters</dfn></dt>
             <dd>
               <p>Returns the remote ICE parameters received by this
-              <code><a>RTCIceTransport</a></code> via <code><a data-link-for=
-              "RTCPeerConnection">setRemoteDescription</a></code> or
+              {{RTCIceTransport}} via {{RTCPeerConnection/setRemoteDescription}} or
               <code>null</code> if the parameters have not yet been
               received.</p>
             </dd>
@@ -8446,16 +8336,16 @@ interface RTCIceTransport : EventTarget {
   DOMString password;
 };</pre>
         <section>
-          <h2>Dictionary <code><a>RTCIceParameters</a></code> Members</h2>
+          <h2>Dictionary {{RTCIceParameters}} Members</h2>
           <dl data-link-for="RTCIceParameters" data-dfn-for="RTCIceParameters"
           class="dictionary-members">
-            <dt><dfn data-idl><code>usernameFragment</code></dfn> of type <span class=
+            <dt><dfn data-idl>usernameFragment</dfn> of type <span class=
             "idlMemberType">DOMString</span></dt>
             <dd>
               <p>The ICE username fragment as defined in [[!ICE]], Section
               7.1.2.3.</p>
             </dd>
-            <dt><dfn data-idl><code>password</code></dfn> of type <span class=
+            <dt><dfn data-idl>password</dfn> of type <span class=
             "idlMemberType">DOMString</span></dt>
             <dd>
               <p>The ICE password as defined in [[!ICE]], Section 7.1.2.3.</p>
@@ -8473,17 +8363,17 @@ interface RTCIceTransport : EventTarget {
   RTCIceCandidate remote;
 };</pre>
         <section>
-          <h2>Dictionary <code><a>RTCIceCandidatePair</a></code>
+          <h2>Dictionary {{RTCIceCandidatePair}}
           Members</h2>
           <dl data-link-for="RTCIceCandidatePair" data-dfn-for=
           "RTCIceCandidatePair" class="dictionary-members">
-            <dt><dfn data-idl><code>local</code></dfn> of type <span class=
-            "idlMemberType"><a>RTCIceCandidate</a></span></dt>
+            <dt><dfn data-idl>local</dfn> of type <span class=
+            "idlMemberType">{{RTCIceCandidate}}</span></dt>
             <dd>
               <p>The local ICE candidate.</p>
             </dd>
-            <dt><dfn data-idl><code>remote</code></dfn> of type <span class=
-            "idlMemberType"><a>RTCIceCandidate</a></span></dt>
+            <dt><dfn data-idl>remote</dfn> of type <span class=
+            "idlMemberType">{{RTCIceCandidate}}</span></dt>
             <dd>
               <p>The remote ICE candidate.</p>
             </dd>
@@ -8504,21 +8394,21 @@ interface RTCIceTransport : EventTarget {
         "RTCIceGathererState" class="simple">
           <tbody>
             <tr>
-              <th colspan="2"><code><a>RTCIceGathererState</a></code> Enumeration description</th>
+              <th colspan="2">{{RTCIceGathererState}} Enumeration description</th>
             </tr>
             <tr>
-              <td><dfn data-idl><code>new</code></dfn></td>
-              <td>The <code><a>RTCIceTransport</a></code> was just created, and
+              <td><dfn data-idl>new</dfn></td>
+              <td>The {{RTCIceTransport}} was just created, and
               has not started gathering candidates yet.</td>
             </tr>
             <tr>
-              <td data-tests="RTCPeerConnection-iceGatheringState.html"><dfn data-idl><code>gathering</code></dfn></td>
-              <td>The <code><a>RTCIceTransport</a></code> is in the process of
+              <td data-tests="RTCPeerConnection-iceGatheringState.html"><dfn data-idl>gathering</dfn></td>
+              <td>The {{RTCIceTransport}} is in the process of
               gathering candidates.</td>
             </tr>
             <tr>
-              <td data-tests="RTCPeerConnection-iceGatheringState.html,protocol/candidate-exchange.https.html"><dfn data-idl><code>complete</code></dfn></td>
-              <td>The <code><a>RTCIceTransport</a></code> has completed
+              <td data-tests="RTCPeerConnection-iceGatheringState.html,protocol/candidate-exchange.https.html"><dfn data-idl>complete</dfn></td>
+              <td>The {{RTCIceTransport}} has completed
               gathering and the end-of-candidates indication for this transport
               has been sent. It will not gather candidates again until an ICE
               restart causes it to restart.</td>
@@ -8544,25 +8434,25 @@ interface RTCIceTransport : EventTarget {
         "RTCIceTransportState" class="simple">
           <tbody>
             <tr>
-              <th colspan="2"><code><a>RTCIceTransportState</a></code> Enumeration description</th>
+              <th colspan="2">{{RTCIceTransportState}} Enumeration description</th>
             </tr>
             <tr>
-              <td><dfn data-idl><code>new</code></dfn></td>
-              <td>The <code><a>RTCIceTransport</a></code> is gathering
+              <td><dfn data-idl>new</dfn></td>
+              <td>The {{RTCIceTransport}} is gathering
               candidates and/or waiting for remote candidates to be supplied,
               and has not yet started checking.</td>
             </tr>
             <tr>
-              <td data-tests="RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl><code>checking</code></dfn></td>
-              <td>The <code><a>RTCIceTransport</a></code> has received at least
+              <td data-tests="RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl>checking</dfn></td>
+              <td>The {{RTCIceTransport}} has received at least
               one remote candidate and is checking candidate pairs and has
               either not yet found a connection or consent checks [[!RFC7675]]
               have failed on all previously successful candidate pairs. In
               addition to checking, it may also still be gathering.</td>
             </tr>
             <tr>
-              <td data-tests="RTCPeerConnection-connectionState.https.html, RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl><code>connected</code></dfn></td>
-              <td>The <code><a>RTCIceTransport</a></code> has found a usable
+              <td data-tests="RTCPeerConnection-connectionState.https.html, RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl>connected</dfn></td>
+              <td>The {{RTCIceTransport}} has found a usable
               connection, but is still checking other candidate pairs to see if
               there is a better connection. It may also still be gathering
               and/or waiting for additional remote candidates. If consent
@@ -8574,8 +8464,8 @@ interface RTCIceTransport : EventTarget {
               additional remote candidates).</td>
             </tr>
             <tr>
-              <td data-tests="RTCPeerConnection-connectionState.https.html,RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl><code>completed</code></dfn></td>
-              <td>The <code><a>RTCIceTransport</a></code> has finished
+              <td data-tests="RTCPeerConnection-connectionState.https.html,RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl>completed</dfn></td>
+              <td>The {{RTCIceTransport}} has finished
               gathering, received an indication that there are no more remote
               candidates, finished checking all candidate pairs and found a
               connection. If consent checks [[!RFC7675]] subsequently fail on
@@ -8583,10 +8473,10 @@ interface RTCIceTransport : EventTarget {
               "failed".</td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>disconnected</code></dfn></td>
+              <td><dfn data-idl>disconnected</dfn></td>
               <td>
-                The <a>ICE Agent</a> has determined that connectivity is
-                currently lost for this <code><a>RTCIceTransport</a></code>.
+                The [= ICE Agent =] has determined that connectivity is
+                currently lost for this {{RTCIceTransport}}.
                 This is a transient state that may
                 trigger intermittently (and resolve itself without action) on a
                 flaky network. The way this state is determined is
@@ -8596,7 +8486,7 @@ interface RTCIceTransport : EventTarget {
                   use.</li>
                   <li>Repeatedly failing to receive a response to STUN
                   requests.</li>
-                </ul>Alternatively, the <code><a>RTCIceTransport</a></code> has
+                </ul>Alternatively, the {{RTCIceTransport}} has
                 finished checking all existing candidates pairs and not found a
                 connection (or consent checks [[!RFC7675]] once
                 successful, have now failed), but it is still gathering and/or
@@ -8604,8 +8494,8 @@ interface RTCIceTransport : EventTarget {
               </td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>failed</code></dfn></td>
-              <td>The <code><a>RTCIceTransport</a></code> has finished
+              <td><dfn data-idl>failed</dfn></td>
+              <td>The {{RTCIceTransport}} has finished
               gathering, received an indication that there are no more remote
               candidates, finished checking all candidate pairs, and all pairs
               have either failed connectivity checks or have lost consent.
@@ -8616,8 +8506,8 @@ interface RTCIceTransport : EventTarget {
               tracks to mute.</td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>closed</code></dfn></td>
-              <td>The <code><a>RTCIceTransport</a></code> has shut down and is
+              <td><dfn data-idl>closed</dfn></td>
+              <td>The {{RTCIceTransport}} has shut down and is
               no longer responding to STUN requests.</td>
             </tr>
           </tbody>
@@ -8638,14 +8528,13 @@ interface RTCIceTransport : EventTarget {
       previously lost.</p>
       <p>The <code>failed</code> and <code>completed</code> states require an
       indication that there are no additional remote candidates. This can be
-      indicated by calling <code><a data-link-for="RTCPeerConnection">addIceCandidate</a></code> with
+      indicated by calling {{RTCPeerConnection/addIceCandidate}} with
       a candidate value whose <code>candidate</code> property is set
-      to an empty string or by <a data-link-for=
-      "RTCPeerConnection">canTrickleIceCandidates</a> being set to
+      to an empty string or by {{RTCPeerConnection/canTrickleIceCandidates}} being set to
       <code>false</code>.</p>
       <p>Some example state transitions are:</p>
       <ul>
-        <li>(<code><a>RTCIceTransport</a></code> first created, as a result of
+        <li>({{RTCIceTransport}} first created, as a result of
         <code>setLocalDescription</code> or <code>setRemoteDescription</code>):
         <code>new</code></li>
         <li>(<code>new</code>, remote candidates received):
@@ -8688,20 +8577,20 @@ interface RTCIceTransport : EventTarget {
         "simple">
           <tbody>
             <tr>
-              <th colspan="2"><code><a>RTCIceRole</a></code> Enumeration description</th>
+              <th colspan="2">{{RTCIceRole}} Enumeration description</th>
             </tr>
             <tr>
-              <td><dfn data-idl><code>unknown</code></dfn></td>
+              <td><dfn data-idl>unknown</dfn></td>
               <td>An agent whose role as defined by [[!ICE]], Section 3,
                 has not yet been determined.
               </td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>controlling</code></dfn></td>
+              <td><dfn data-idl>controlling</dfn></td>
               <td>A controlling agent as defined by [[!ICE]], Section 3.</td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>controlled</code></dfn></td>
+              <td><dfn data-idl>controlled</dfn></td>
               <td>A controlled agent as defined by [[!ICE]], Section 3.</td>
             </tr>
           </tbody>
@@ -8720,22 +8609,22 @@ interface RTCIceTransport : EventTarget {
         class="simple">
           <tbody>
             <tr>
-              <th colspan="2"><code><a>RTCIceComponent</a></code> Enumeration description</th>
+              <th colspan="2">{{RTCIceComponent}} Enumeration description</th>
             </tr>
             <tr>
-              <td><dfn data-idl><code>rtp</code></dfn></td>
+              <td><dfn data-idl>rtp</dfn></td>
               <td>The ICE Transport is used for RTP (or RTCP multiplexing),
               as defined in [[!ICE]], Section 4.1.1.1. Protocols multiplexed
               with RTP (e.g. data channel) share its component ID. This represents
               the <code>component-id</code> value <code>1</code> when encoded
-              in <a>candidate-attribute</a>.</td>
+              in [= candidate-attribute =].</td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>rtcp</code></dfn></td>
+              <td><dfn data-idl>rtcp</dfn></td>
               <td>The ICE Transport is used for RTCP as defined by [[!ICE]],
               Section 4.1.1.1. This represents the <code>component-id</code>
               value <code>2</code> when encoded in
-              <a>candidate-attribute</a>.</td>
+              [= candidate-attribute =].</td>
             </tr>
           </tbody>
         </table>
@@ -8744,8 +8633,8 @@ interface RTCIceTransport : EventTarget {
     </section>
     <section>
       <h3><dfn>RTCTrackEvent</dfn></h3>
-      <p>The <code><a>track</a></code> event uses the
-      <code><a>RTCTrackEvent</a></code> interface.</p>
+      <p>The {{track}} event uses the
+      {{RTCTrackEvent}} interface.</p>
       <div>
         <pre class="idl" data-tests="idlharness.https.window.js"
 >[Exposed=Window]
@@ -8770,36 +8659,36 @@ interface RTCTrackEvent : Event {
           <dl data-link-for="RTCTrackEvent" data-dfn-for="RTCTrackEvent" class=
           "attributes">
             <dt data-tests="RTCPeerConnection-ontrack.https.html,RTCTrackEvent-constructor.html"><code>receiver</code> of type <span class=
-            "idlAttrType"><a>RTCRtpReceiver</a></span>, readonly</dt>
+            "idlAttrType">{{RTCRtpReceiver}}</span>, readonly</dt>
             <dd>
               <p>The <dfn id=
               "dom-trackevent-receiver"><code>receiver</code></dfn> attribute
-              represents the <code><a>RTCRtpReceiver</a></code> object
+              represents the {{RTCRtpReceiver}} object
               associated with the event.</p>
             </dd>
-            <dt data-tests="RTCPeerConnection-ontrack.https.html,RTCTrackEvent-constructor.html"><dfn data-idl><code>track</code></dfn> of type <span class=
-            "idlAttrType"><a>MediaStreamTrack</a></span>, readonly</dt>
+            <dt data-tests="RTCPeerConnection-ontrack.https.html,RTCTrackEvent-constructor.html"><dfn data-idl>track</dfn> of type <span class=
+            "idlAttrType">{{MediaStreamTrack}}</span>, readonly</dt>
             <dd>
               <p>The <code>track</code> attribute represents the
-              <code><a>MediaStreamTrack</a></code> object that is associated
-              with the <code><a>RTCRtpReceiver</a></code> identified by
+              {{MediaStreamTrack}} object that is associated
+              with the {{RTCRtpReceiver}} identified by
               <code>receiver</code>.</p>
             </dd>
             <dt data-tests="RTCPeerConnection-ontrack.https.html,RTCTrackEvent-constructor.html"><code>streams</code> of type <span class=
-            "idlAttrType">FrozenArray&lt;<a>MediaStream</a>&gt;</span>,
+            "idlAttrType">FrozenArray&lt;{{MediaStream}}&gt;</span>,
             readonly</dt>
             <dd>
-              <p>The <dfn data-idl><code>streams</code></dfn> attribute returns an array
-              of <code><a>MediaStream</a></code> objects representing the
-              <code><a>MediaStream</a></code>s that this event's
+              <p>The <dfn data-idl>streams</dfn> attribute returns an array
+              of {{MediaStream}} objects representing the
+              {{MediaStream}}s that this event's
               <code>track</code> is a part of.</p>
             </dd>
             <dt data-tests="RTCPeerConnection-ontrack.https.html,RTCTrackEvent-constructor.html"><code>transceiver</code> of type <span class=
-            "idlAttrType"><a>RTCRtpTransceiver</a></span>, readonly</dt>
+            "idlAttrType">{{RTCRtpTransceiver}}</span>, readonly</dt>
             <dd>
               <p>The <dfn id=
               "dom-trackevent-transceiver"><code>transceiver</code></dfn>
-              attribute represents the <code><a>RTCRtpTransceiver</a></code>
+              attribute represents the {{RTCRtpTransceiver}}
               object associated with the event.</p>
             </dd>
           </dl>
@@ -8817,35 +8706,35 @@ interface RTCTrackEvent : Event {
           <h2>Dictionary <dfn>RTCTrackEventInit</dfn> Members</h2>
           <dl data-link-for="RTCTrackEventInit" data-dfn-for=
           "RTCTrackEventInit" class="dictionary-members">
-            <dt data-tests="RTCTrackEvent-constructor.html"><dfn data-idl><code>receiver</code></dfn> of type <span class=
-            "idlMemberType"><a>RTCRtpReceiver</a></span>, required</dt>
+            <dt data-tests="RTCTrackEvent-constructor.html"><dfn data-idl>receiver</dfn> of type <span class=
+            "idlMemberType">{{RTCRtpReceiver}}</span>, required</dt>
             <dd>
               <p>The <code>receiver</code> attribute represents the
-              <code><a>RTCRtpReceiver</a></code> object associated with the
+              {{RTCRtpReceiver}} object associated with the
               event.</p>
             </dd>
-            <dt data-tests="RTCTrackEvent-constructor.html"><dfn data-idl><code>track</code></dfn> of type <span class=
-            "idlMemberType"><a>MediaStreamTrack</a></span>, required</dt>
+            <dt data-tests="RTCTrackEvent-constructor.html"><dfn data-idl>track</dfn> of type <span class=
+            "idlMemberType">{{MediaStreamTrack}}</span>, required</dt>
             <dd>
               <p>The <code>track</code> attribute represents the
-              <code><a>MediaStreamTrack</a></code> object that is associated
-              with the <code><a>RTCRtpReceiver</a></code> identified by
+              {{MediaStreamTrack}} object that is associated
+              with the {{RTCRtpReceiver}} identified by
               <code>receiver</code>.</p>
             </dd>
-            <dt data-tests="RTCTrackEvent-constructor.html"><dfn data-idl><code>streams</code></dfn> of type <span class=
-            "idlMemberType">sequence&lt;<a>MediaStream</a>&gt;</span>,
+            <dt data-tests="RTCTrackEvent-constructor.html"><dfn data-idl>streams</dfn> of type <span class=
+            "idlMemberType">sequence&lt;{{MediaStream}}&gt;</span>,
             defaulting to <code>[]</code></dt>
             <dd>
               <p>The <code>streams</code> attribute returns an array of
-              <code><a>MediaStream</a></code> objects representing the
-              <code><a>MediaStream</a></code>s that this event's
+              {{MediaStream}} objects representing the
+              {{MediaStream}}s that this event's
               <code>track</code> is a part of.</p>
             </dd>
-            <dt data-tests="RTCTrackEvent-constructor.html"><dfn data-idl><code>transceiver</code></dfn> of type <span class=
-            "idlMemberType"><a>RTCRtpTransceiver</a></span>, required</dt>
+            <dt data-tests="RTCTrackEvent-constructor.html"><dfn data-idl>transceiver</dfn> of type <span class=
+            "idlMemberType">{{RTCRtpTransceiver}}</span>, required</dt>
             <dd>
               <p>The <code>transceiver</code> attribute represents the
-              <code><a>RTCRtpTransceiver</a></code> object associated with the
+              {{RTCRtpTransceiver}} object associated with the
               event.</p>
             </dd>
           </dl>
@@ -8861,7 +8750,7 @@ interface RTCTrackEvent : Event {
     <section>
       <h3>RTCPeerConnection Interface Extensions</h3>
       <p>The Peer-to-peer data API extends the
-      <code><a>RTCPeerConnection</a></code> interface as described below.</p>
+      {{RTCPeerConnection}} interface as described below.</p>
       <div>
         <pre class="idl" data-tests="idlharness.https.window.js" data-cite="HTML"
 >partial interface RTCPeerConnection {
@@ -8874,20 +8763,20 @@ interface RTCTrackEvent : Event {
           <h2>Attributes</h2>
           <dl data-link-for="RTCPeerConnection" data-dfn-for=
           "RTCPeerConnection" class="attributes">
-            <dt data-tests="RTCIceTransport.html"><dfn data-idl><code>sctp</code></dfn> of type <span class=
-            "idlAttrType"><a>RTCSctpTransport</a></span>, readonly,
+            <dt data-tests="RTCIceTransport.html"><dfn data-idl>sctp</dfn> of type <span class=
+            "idlAttrType">{{RTCSctpTransport}}</span>, readonly,
             nullable</dt>
             <dd>
               <p>The SCTP transport over which SCTP data is sent and received.
               If SCTP has not been negotiated, the value is null. This
-              attribute MUST return the <code><a>RTCSctpTransport</a></code>
+              attribute MUST return the {{RTCSctpTransport}}
               object stored in the <a>[[\SctpTransport]]</a>
               internal slot.</p>
             </dd>
-            <dt data-tests="RTCPeerConnection-ondatachannel.html"><dfn data-idl><code>ondatachannel</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-ondatachannel.html"><dfn data-idl>ondatachannel</dfn> of type <span class=
             "idlAttrType">EventHandler</span></dt>
             <dd>The event type of this event handler is
-            <code><a>datachannel</a></code>.</dd>
+            {{datachannel}}.</dd>
           </dl>
         </section>
         <section>
@@ -8896,8 +8785,8 @@ interface RTCTrackEvent : Event {
           "RTCPeerConnection" class="methods">
             <dt><code>createDataChannel</code></dt>
             <dd>
-              <p>Creates a new <code><a>RTCDataChannel</a></code> object with
-              the given label. The <code><a>RTCDataChannelInit</a></code>
+              <p>Creates a new {{RTCDataChannel}} object with
+              the given label. The {{RTCDataChannelInit}}
               dictionary can be used to configure properties of the underlying
               channel such as data reliability.</p>
               <p>When the <dfn id=
@@ -8907,16 +8796,16 @@ interface RTCTrackEvent : Event {
               <ol>
                 <li>
                   <p>Let <var>connection</var> be the
-                  <code><a>RTCPeerConnection</a></code> object on which the
+                  {{RTCPeerConnection}} object on which the
                   method is invoked.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-createDataChannel.html">
                   <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
-                  <code>true</code>, <a>throw</a> an
-                  <code>InvalidStateError</code>.</p>
+                  <code>true</code>, [= exception/throw =] an
+                  {{InvalidStateError}}.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-createDataChannel.html">
-                  <p><a>Create an <code>RTCDataChannel</code></a>,
+                  <p>[= Create an RTCDataChannel =],
                   <var>channel</var>.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-createDataChannel.html">
@@ -8925,8 +8814,8 @@ interface RTCTrackEvent : Event {
                 </li>
                 <li data-tests="RTCPeerConnection-createDataChannel.html">
                   <p>If the UTF-8 representation of <a>[[\DataChannelLabel]]</a>
-                  is longer than 65535 bytes, <a>throw</a> a
-                  <code>TypeError</code>.</p>
+                  is longer than 65535 bytes, [= exception/throw =] a
+                  {{TypeError}}.</p>
                 </li>
                 <li>
                   <p>Let <var>options</var> be the second argument.</p>
@@ -8953,7 +8842,7 @@ interface RTCTrackEvent : Event {
                 <li data-tests="RTCPeerConnection-createDataChannel.html">
                   <p>If the UTF-8 representation of
                   <a>[[\DataChannelProtocol]]</a> is longer than 65535 bytes,
-                  <a>throw</a> a <code>TypeError</code>.</p>
+                  [= exception/throw =] a {{TypeError}}.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-createDataChannel.html">
                   <p>Initialize <var>channel</var>.<a>[[\Negotiated]]</a>
@@ -8975,14 +8864,14 @@ interface RTCTrackEvent : Event {
                 </li>
                 <li>
                   <p>If <a>[[\Negotiated]]</a> is <code>true</code> and
-                  <a>[[\DataChannelId]]</a> is <code>null</code>, <a>throw</a>
-                  a <code>TypeError</code>.</p>
+                  <a>[[\DataChannelId]]</a> is <code>null</code>, [= exception/throw =]
+                  a {{TypeError}}.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-createDataChannel.html">
                   <p>If both <a>[[\MaxPacketLifeTime]]</a> and
                   <a>[[\MaxRetransmits]]</a>
-                  attributes are set (not null), <a>throw</a> a
-                  <code>TypeError</code>.</p>
+                  attributes are set (not null), [= exception/throw =] a
+                  {{TypeError}}.</p>
                 </li>
                 <li class=untestable>
                   <p>If a setting, either <a>[[\MaxPacketLifeTime]]</a> or
@@ -8995,8 +8884,8 @@ interface RTCTrackEvent : Event {
                   <p>If <a>[[\DataChannelId]]</a> is
                   equal to 65535, which is greater than the maximum allowed ID
                   of 65534 but still qualifies as an <span class=
-                  "idlMemberType">unsigned short</span>, <a>throw</a> a
-                  <code>TypeError</code>.</p>
+                  "idlMemberType">unsigned short</span>, [= exception/throw =] a
+                  {{TypeError}}.</p>
                 <li data-tests="RTCPeerConnection-createDataChannel.html,RTCDataChannel-id.html">
                   <p>If the <a>[[\DataChannelId]]</a>
                   slot is <code>null</code> (due to no ID being passed into
@@ -9007,14 +8896,13 @@ interface RTCTrackEvent : Event {
                   user agent, according to [[!RTCWEB-DATA-PROTOCOL]], and skip to
                   the next step. If no available ID could be generated, or if
                   the value of the <a>[[\DataChannelId]]</a> slot
-                  is being used by an existing <code><a>RTCDataChannel</a></code>,
-                  <a>throw</a> an <code>OperationError</code> exception.</p>
+                  is being used by an existing {{RTCDataChannel}},
+                  [= exception/throw =] an {{OperationError}} exception.</p>
                   <div class="note">
                     If the <a>[[\DataChannelId]]</a>
                     slot is <code>null</code> after this step, it will be
                     populated during the
-                    <a href="#sctp-transport-connected">
-                    <code>RTCSctpTransport</code> connected procedure</a>.
+                    [= RTCSctpTransport connected =] procedure.
                   </div>
                 </li>
                 <li>
@@ -9022,22 +8910,22 @@ interface RTCTrackEvent : Event {
                   <p>If the <a>[[\DataChannelId]]</a> slot is not
                   <code>null</code>, <var>transport</var> is in the
                   <code>connected</code> state and <a>[[\DataChannelId]]</a> is
-                  greater or equal to the <var>transport</var>.<a>[[\MaxChannels]]</a>, <a>throw</a> an
-                  <code>OperationError</code>.</p>
+                  greater or equal to the <var>transport</var>.<a>[[\MaxChannels]]</a>, [= exception/throw =] an
+                  {{OperationError}}.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
                   <p>If <var>channel</var> is the first
-                  <code><a>RTCDataChannel</a></code> created on
-                  <var>connection</var>, <a>update the
-                  negotiation-needed flag</a> for <var>connection</var>.</p>
+                  {{RTCDataChannel}} created on
+                  <var>connection</var>, [= update the
+                  negotiation-needed flag =] for <var>connection</var>.</p>
                 </li>
                 <li>
                   <p>Return <var>channel</var> and continue the following steps
                   in parallel.</p>
                 </li>
                 <li>
-                  <p>Create <var>channel</var>'s associated <a>underlying data
-                  transport</a> and configure it according to the relevant
+                  <p>Create <var>channel</var>'s associated [= underlying data
+                  transport =] and configure it according to the relevant
                   properties of <var>channel</var>.</p>
                 </li>
               </ol>
@@ -9047,18 +8935,18 @@ interface RTCTrackEvent : Event {
       </div>
       <section>
         <h3><dfn>RTCSctpTransport</dfn> Interface</h3>
-        <p>The <code><a>RTCSctpTransport</a></code> interface allows an
+        <p>The {{RTCSctpTransport}} interface allows an
         application access to information about the SCTP data channels tied to
         a particular SCTP association.</p>
         <section>
           <h4 id="sctp-transport-create">Create an instance</h4>
-          <p>To <dfn>create an <code><a>RTCSctpTransport</a></code></dfn> with an
+          <p>To <dfn>create an {{RTCSctpTransport}}</dfn> with an
           optional initial state, <var>initialState</var>, run the following
           steps:</p>
           <ol>
             <li data-tests="RTCSctpTransport-constructor.html,RTCSctpTransport-events.html ">
               <p>Let <var>transport</var> be a new <code>
-              <a>RTCSctpTransport</a></code> object.</p>
+              {{RTCSctpTransport}}</code> object.</p>
             </li>
             <li>
               <p>Let <var>transport</var> have a
@@ -9068,8 +8956,8 @@ interface RTCTrackEvent : Event {
             </li>
             <li>
               <p>Let <var>transport</var> have a <dfn>[[\MaxMessageSize]]</dfn>
-              internal slot and run the steps labeled <a>update the data max
-              message size</a> to initialize it.</p>
+              internal slot and run the steps labeled [= update the data max
+              message size =] to initialize it.</p>
             </li>
             <li data-tests="RTCSctpTransport-maxChannels.html">
               <p>Let <var>transport</var> have a <dfn>[[\MaxChannels]]</dfn>
@@ -9084,12 +8972,12 @@ interface RTCTrackEvent : Event {
           <h4 id="sctp-transport-update-mms">Update max message
           size</h4>
           <p>To <dfn>update the data max message size</dfn> of an <code>
-          <a>RTCSctpTransport</a></code> run the following
+          {{RTCSctpTransport}}</code> run the following
           steps:</p>
           <ol>
             <li>
-              <p>Let <var>transport</var> be the <code><a>RTCSctpTransport</a>
-              </code> object to be updated.</p>
+              <p>Let <var>transport</var> be the {{RTCSctpTransport}}
+               object to be updated.</p>
             </li>
             <li data-tests="RTCSctpTransport-maxMessageSize.html">
               <p>Let <var>remoteMaxMessageSize</var> be the value of the
@@ -9120,18 +9008,18 @@ interface RTCTrackEvent : Event {
         </section>
         <section>
           <h4 id="sctp-transport-connected">Connected procedure</h4>
-          <p><dfn data-lt="rtcsctptransport connected">Once an SCTP transport
-          is connected</dfn>, meaning the SCTP association of an <code><a>
-          RTCSctpTransport</a></code> has been established, run the following
+          <p>Once an <dfn data-lt="rtcsctptransport connected">SCTP transport
+          is connected</dfn>, meaning the SCTP association of an {{
+          RTCSctpTransport}} has been established, run the following
           steps:</p>
           <ol>
             <li>
-              <p>Let <var>transport</var> be the <code><a>RTCSctpTransport</a>
-              </code> object.</p>
+              <p>Let <var>transport</var> be the {{RTCSctpTransport}}
+              object.</p>
             </li>
             <li>
               <p>Let <var>connection</var> be the
-              <code><a>RTCPeerConnection</a></code> object associated with
+              {{RTCPeerConnection}} object associated with
               <var>transport</var>.</p>
             </li>
             <li>
@@ -9139,10 +9027,10 @@ interface RTCTrackEvent : Event {
               amount of incoming and outgoing SCTP streams.</p>
             </li>
             <li>
-              <p>For each of <var>connection</var>'s <code><a>RTCDataChannel</a></code>:</p>
+              <p>For each of <var>connection</var>'s {{RTCDataChannel}}:</p>
               <ol>
                 <li>
-                  <p>Let <var>channel</var> be the <code><a>RTCDataChannel</a></code> object.</p>
+                  <p>Let <var>channel</var> be the {{RTCDataChannel}} object.</p>
                 </li>
                 <li>
                   <p>If <var>channel</var>'s <a>[[\DataChannelId]]</a> slot is
@@ -9155,19 +9043,18 @@ interface RTCTrackEvent : Event {
                   <p>If <var>channel</var>'s <a>[[\DataChannelId]]</a> slot is greater or
                     equal to <var>transport</var>'s <a>[[\MaxChannels]]</a> slot,
                     or the previous step failed to assign an id,
-                  <a data-lt="data-channel-failure"> close the <var>channel</var> due to a failure
-                  </a>. Otherwise, <a data-lt="announce the rtcdatachannel as open">announce the
-                  <var>channel</var> as open</a>.</p>
+                   [= unable to create an RTCDataChannel | close =] the <var>channel</var> due to a failure.
+                  Otherwise, [= announce the rtcdatachannel as open | announce the channel as open =].</p>
                 </li>
               </ol>
             </li>
             <li>
-              <p><a>Fire an event</a> named <code><a data-lt="
+              <p>[= Fire an event =] named <code><a data-lt="
               RTCSctpTransport state change">statechange</a></code> at <var>
                   transport</var>.</p>
               <p class="note">This event is fired before the "open" events
-                fired by <a data-lt="announce the rtcdatachannel as open">
-                announcing the <var>channel</var> as open</a>; the "open"
+                fired by [= announce the rtcdatachannel as open |
+                announcing the channel as open =]; the "open"
                 events are fired from a queued task.</p>
             </li>
           </ol>
@@ -9186,33 +9073,32 @@ interface RTCSctpTransport : EventTarget {
             <h2>Attributes</h2>
             <dl data-link-for="RTCSctpTransport" data-dfn-for=
             "RTCSctpTransport" class="attributes">
-              <dt data-tests="RTCIceTransport.html,RTCSctpTransport-constructor.html"><dfn data-idl><code>transport</code></dfn> of type <span class=
-              "idlAttrType"><a>RTCDtlsTransport</a></span>, readonly</dt>
+              <dt data-tests="RTCIceTransport.html,RTCSctpTransport-constructor.html"><dfn data-idl>transport</dfn> of type <span class=
+              "idlAttrType">{{RTCDtlsTransport}}</span>, readonly</dt>
               <dd>
                 <p>The transport over which all SCTP packets for data channels
                 will be sent and received.</p>
               </dd>
-              <dt data-tests="RTCSctpTransport-constructor.html,RTCSctpTransport-events.html"><dfn data-idl><code>state</code></dfn> of type <span class=
-              "idlAttrType"><a>RTCSctpTransportState</a></span>, readonly</dt>
+              <dt data-tests="RTCSctpTransport-constructor.html,RTCSctpTransport-events.html"><dfn data-idl>state</dfn> of type <span class=
+              "idlAttrType">{{RTCSctpTransportState}}</span>, readonly</dt>
               <dd>
                 <p>The current state of the SCTP transport. On getting, this
                 attribute MUST return the value of the
                 <a>[[\SctpTransportState]]</a> slot.</p>
               </dd>
-              <dt data-tests="RTCSctpTransport-constructor.html"><dfn data-idl><code>maxMessageSize</code></dfn> of type <span class=
+              <dt data-tests="RTCSctpTransport-constructor.html"><dfn data-idl>maxMessageSize</dfn> of type <span class=
               "idlAttrType">unrestricted double</span>, readonly</dt>
               <dd>
                 <p>The maximum size of data that can be passed to
-                <code><a>RTCDataChannel</a></code>'s <code><a data-link-for=
-                "RTCDataChannel">send()</a></code> method. The attribute MUST,
+                {{RTCDataChannel}}'s {{RTCDataChannel/send()}} method. The attribute MUST,
                 on getting, return the value of the <a>[[\MaxMessageSize]]</a>
                 slot.</p>
               </dd>
-              <dt data-tests="RTCSctpTransport-maxChannels.html"><dfn data-idl><code>maxChannels</code></dfn> of type
+              <dt data-tests="RTCSctpTransport-maxChannels.html"><dfn data-idl>maxChannels</dfn> of type
               <span class="idlAttrType">unsigned short</span>
               , readonly, nullable</dt>
               <dd>
-                <p>The maximum amount of <code><a>RTCDataChannel</a></code>'s
+                <p>The maximum amount of {{RTCDataChannel}}'s
                 that can be used simultaneously. The attribute MUST, on
                 getting, return the value of the <a>[[\MaxChannels]]</a> slot.
                 </p>
@@ -9221,7 +9107,7 @@ interface RTCSctpTransport : EventTarget {
                 <code>connected</code> state.
                 </div>
               </dd>
-              <dt data-tests="RTCSctpTransport-events.html"><dfn data-idl><code>onstatechange</code></dfn> of type <span class=
+              <dt data-tests="RTCSctpTransport-events.html"><dfn data-idl>onstatechange</dfn> of type <span class=
               "idlAttrType">EventHandler</span></dt>
               <dd>
                 <p>The event type of this event handler is
@@ -9233,7 +9119,7 @@ interface RTCSctpTransport : EventTarget {
       </section>
       <section id="rtcsctptransportstate">
         <h3><dfn>RTCSctpTransportState</dfn> Enum</h3>
-        <p><code>RTCSctpTransportState</code> indicates the state of the SCTP
+        <p>{{RTCSctpTransportState}} indicates the state of the SCTP
         transport.</p>
         <div>
           <pre class="idl"
@@ -9252,10 +9138,10 @@ interface RTCSctpTransport : EventTarget {
                 <td data-tests="RTCSctpTransport-events.html"><dfn data-idl><code id=
                 "idl-def-RTCSctpTransportState.connecting">connecting</code></dfn></td>
                 <td>
-                  <p>The <code><a>RTCSctpTransport</a></code> is in the process of
+                  <p>The {{RTCSctpTransport}} is in the process of
                   negotiating an association. This is the initial state of the
                   [[\SctpTransportState]] slot when an
-                  <code><a>RTCSctpTransport</a></code> is created.</p>
+                  {{RTCSctpTransport}} is created.</p>
                 </td>
               </tr>
               <tr>
@@ -9301,71 +9187,68 @@ interface RTCSctpTransport : EventTarget {
     </section>
     <section>
       <h3><dfn>RTCDataChannel</dfn></h3>
-      <p data-tests="protocol/sctp-format.html">The <code><a>RTCDataChannel</a></code> interface represents a
+      <p data-tests="protocol/sctp-format.html">The {{RTCDataChannel}} interface represents a
       bi-directional data channel between two peers. An
-      <code><a>RTCDataChannel</a></code> is created via a factory method on an
-      <code><a>RTCPeerConnection</a></code> object. The messages sent between
+      {{RTCDataChannel}} is created via a factory method on an
+      {{RTCPeerConnection}} object. The messages sent between
       the browsers are described in [[!RTCWEB-DATA]] and
       [[!RTCWEB-DATA-PROTOCOL]].</p>
       <p>There are two ways to establish a connection with
-      <code><a>RTCDataChannel</a></code>. The first way is to simply create an
-      <code><a>RTCDataChannel</a></code> at one of the peers with the
-      <code><a data-link-for="RTCDataChannelInit">negotiated</a></code>
-      <code><a>RTCDataChannelInit</a></code> dictionary member unset or set to
+      {{RTCDataChannel}}. The first way is to simply create an
+      {{RTCDataChannel}} at one of the peers with the
+      {{RTCDataChannelInit/negotiated}}
+      {{RTCDataChannelInit}} dictionary member unset or set to
       its default value false. This will announce the new channel in-band and
-      trigger an <code><a>RTCDataChannelEvent</a></code> with the corresponding
-      <code><a>RTCDataChannel</a></code> object at the other peer. The second
+      trigger an {{RTCDataChannelEvent}} with the corresponding
+      {{RTCDataChannel}} object at the other peer. The second
       way is to let the application negotiate the
-      <code><a>RTCDataChannel</a></code>. To do this, create an
-      <code><a>RTCDataChannel</a></code> object with the <code><a data-link-for=
-      "RTCDataChannelInit">negotiated</a></code>
-      <code><a>RTCDataChannelInit</a></code> dictionary member set to true, and
+      {{RTCDataChannel}}. To do this, create an
+      {{RTCDataChannel}} object with the {{RTCDataChannelInit/negotiated}}
+      {{RTCDataChannelInit}} dictionary member set to true, and
       signal out-of-band (e.g. via a web server) to the other side that it
-      SHOULD create a corresponding <code><a>RTCDataChannel</a></code> with the
-      <code><a data-link-for="RTCDataChannelInit">negotiated</a></code>
-      <code><a>RTCDataChannelInit</a></code> dictionary member set to true and
-      the same <code><a data-link-for="RTCDataChannel">id</a></code>. This will
-      connect the two separately created <code><a>RTCDataChannel</a></code>
+      SHOULD create a corresponding {{RTCDataChannel}} with the
+      {{RTCDataChannelInit/negotiated}}
+      {{RTCDataChannelInit}} dictionary member set to true and
+      the same {{RTCDataChannel/id}}. This will
+      connect the two separately created {{RTCDataChannel}}
       objects. The second way makes it possible to create channels with
       asymmetric properties and to create channels in a declarative way by
-      specifying matching <code><a data-link-for=
-      "RTCDataChannelInit">id</a></code>s.</p>
-      <p>Each <code><a>RTCDataChannel</a></code> has an associated
+      specifying matching {{RTCDataChannelInit/id}}s.</p>
+      <p>Each {{RTCDataChannel}} has an associated
       <dfn data-lt="data transport">underlying data transport</dfn> that is
       used to transport actual data to the other peer. In the case of SCTP
-      data channels utilizing an <code><a>RTCSctpTransport</a></code> (which
+      data channels utilizing an {{RTCSctpTransport}} (which
       represents the state of the SCTP association), the underlying data
       transport is the SCTP stream pair. The transport properties of
-      the <a>underlying data transport</a>, such as in order delivery
+      the [= underlying data transport =], such as in order delivery
       settings and reliability mode, are configured by the peer as the channel
       is created. The properties of a channel cannot change after the channel
       has been created. The actual wire protocol between the peers is specified
       by the WebRTC DataChannel Protocol specification [[RTCWEB-DATA]].</p>
-      <p>An <code><a>RTCDataChannel</a></code> can be configured to operate in
+      <p>An {{RTCDataChannel}} can be configured to operate in
       different reliability modes. A reliable channel ensures that the data is
       delivered at the other peer through retransmissions. An unreliable
       channel is configured to either limit the number of retransmissions (
-      <code><a data-link-for="RTCDataChannelInit">maxRetransmits</a></code> ) or set
+      {{RTCDataChannelInit/maxRetransmits}} ) or set
       a time during which transmissions (including retransmissions) are allowed
-      ( <code><a data-link-for="RTCDataChannelInit">maxPacketLifeTime</a></code> ).
+      ( {{RTCDataChannelInit/maxPacketLifeTime}} ).
       These properties can not be used simultaneously and an attempt to do so
       will result in an error. Not setting any of these properties results in a
       reliable channel.</p>
-      <p>An <code><a>RTCDataChannel</a></code>, created with <code><a data-link-for=
-      "RTCPeerConnection">createDataChannel</a></code> or dispatched via an
-      <code><a>RTCDataChannelEvent</a></code>, MUST initially be in the
+      <p>An {{RTCDataChannel}}, created with {{RTCPeerConnection/createDataChannel}} or dispatched via an
+      {{RTCDataChannelEvent}}, MUST initially be in the
       <code>connecting</code> state. When the
-      <code><a>RTCDataChannel</a></code> object's <a>underlying data
-      transport</a> is ready, the user agent MUST <a>announce the
-        <code>RTCDataChannel</code> as open</a>.</p>
+      {{RTCDataChannel}} object's [= underlying data
+      transport =] is ready, the user agent MUST [= announce the
+        RTCDataChannel as open =].</p>
       <section>
         <h4>Creating a data channel</h4>
-      <p>To <dfn>create an <code><a>RTCDataChannel</a></code></dfn>, run the
+      <p>To <dfn>create an {{RTCDataChannel}}</dfn>, run the
       following steps:</p>
       <ol>
         <li>
           <p>Let <var>channel</var> be a newly created <code>
-          <a>RTCDataChannel</a></code> object.</p>
+          {{RTCDataChannel}}</code> object.</p>
         </li>
         <li data-tests="RTCPeerConnection-ondatachannel.html">
           <p>Let <var>channel</var> have a <dfn>[[\ReadyState]]</dfn> internal
@@ -9392,16 +9275,16 @@ interface RTCSctpTransport : EventTarget {
 
       <p>When the user agent is to <dfn data-lt=
       "announce the rtcdatachannel as open" id=
-      "announce-datachannel-open">announce an <code>RTCDataChannel</code> as
+      "announce-datachannel-open">announce an {{RTCDataChannel}} as
       open</dfn>, the user agent MUST queue a task to run the following
       steps:</p>
       <ol>
         <li>
-          <p>If the associated <code><a>RTCPeerConnection</a></code> object's
+          <p>If the associated {{RTCPeerConnection}} object's
           <a>[[\IsClosed]]</a> slot is <code>true</code>, abort these steps.</p>
         </li>
         <li>
-          <p>Let <var>channel</var> be the <code><a>RTCDataChannel</a></code>
+          <p>Let <var>channel</var> be the {{RTCDataChannel}}
           object to be announced.</p>
         </li>
         <li>
@@ -9413,36 +9296,35 @@ interface RTCSctpTransport : EventTarget {
           <code>"open"</code>.</p>
         </li>
         <li data-tests="RTCPeerConnection-ondatachannel.html">
-          <p><a>Fire an event</a> named <code><a>open</a></code> at
+          <p>[= Fire an event =] named {{open}} at
           <var>channel</var>.</p>
         </li>
       </ol>
       </section>
       <section>
         <h4>Announcing a data channel instance</h4>
-      <p data-tests="RTCPeerConnection-ondatachannel.html">When an <a>underlying data transport</a> is to be announced (the other
-      peer created a channel with <code><a data-link-for=
-      "RTCDataChannelInit">negotiated</a></code> unset or set to false), the
+      <p data-tests="RTCPeerConnection-ondatachannel.html">When an [= underlying data transport =] is to be announced (the other
+      peer created a channel with {{RTCDataChannelInit/negotiated}} unset or set to false), the
       user agent of the peer that did not initiate the creation process MUST
       queue a task to run the following steps:</p>
       <ol>
         <li>
           <p>Let <var>connection</var> be the
-          <code><a>RTCPeerConnection</a></code> object associated with the
-          <a>underlying data transport</a>.</p>
+          {{RTCPeerConnection}} object associated with the
+          [= underlying data transport =].</p>
         </li>
         <li class="untestable">
           <p>If <var>connection</var>'s <a>[[\IsClosed]]</a> slot is
           <code>true</code>, abort these steps.</p>
         </li>
         <li>
-          <p><a>Create an <code>RTCDataChannel</code></a>,
+          <p>[= Create an RTCDataChannel =],
           <var>channel</var>.</p>
         </li>
         <li data-tests="RTCPeerConnection-ondatachannel.html">
           <p>Let <var>configuration</var> be an information bundle received
           from the other peer as a part of the process to establish the
-          <a>underlying data transport</a> described by the WebRTC DataChannel
+          [= underlying data transport =] described by the WebRTC DataChannel
           Protocol specification [[!RTCWEB-DATA-PROTOCOL]].</p>
         </li>
         <li data-tests="RTCPeerConnection-ondatachannel.html">
@@ -9457,41 +9339,41 @@ interface RTCSctpTransport : EventTarget {
         </li>
         <li data-tests="RTCPeerConnection-ondatachannel.html">
           <p>Set <var>channel</var>.<a>[[\ReadyState]]</a> to
-          <code>"open"</code> (but do not fire the <code><a>open</a></code>
+          <code>"open"</code> (but do not fire the {{open}}
           event, yet).</p>
           <div class="note">This allows to start sending messages inside of the
-          <code><a>datachannel</a></code> event handler prior to the
-          <code><a>open</a></code> event being fired.</div>
+          {{datachannel}} event handler prior to the
+          {{open}} event being fired.</div>
         </li>
         <li data-tests="RTCPeerConnection-ondatachannel.html">
-          <p><a>Fire an event</a> named
-          <code><a>datachannel</a></code> using the
-          <code><a>RTCDataChannelEvent</a></code> interface with
-          the <code><a data-link-for="RTCDataChannelEvent">channel</a></code>
+          <p>[= Fire an event =] named
+          {{datachannel}} using the
+          {{RTCDataChannelEvent}} interface with
+          the {{RTCDataChannelEvent/channel}}
           attribute set to <var>channel</var> at <var>connection</var>.</p>
         </li>
         <li>
-          <p><a data-lt="announce the rtcdatachannel as open">Announce the data channel as
-          open</a>.</p>
+          <p>[= announce the rtcdatachannel as open | Announce the data channel as
+          open =].</p>
         </li>
       </ol>
       </section>
       <section>
         <h4>Closing procedure</h4>
-      <p>An <code><a>RTCDataChannel</a></code> object's <a>underlying data
-      transport</a> may be torn down in a non-abrupt manner by running the
+      <p>An {{RTCDataChannel}} object's [= underlying data
+      transport =] may be torn down in a non-abrupt manner by running the
       <dfn id="data-transport-closing-procedure">closing procedure</dfn>. When
       that happens the user agent MUST queue a task to run the following
       steps:</p>
       <ol>
         <li>
-          <p>Let <var>channel</var> be the <code><a>RTCDataChannel</a></code>
-          object whose <a data-lt="data transport">transport</a> was
+          <p>Let <var>channel</var> be the {{RTCDataChannel}}
+          object whose [= underlying data transport =] was
           closed.</p>
         </li>
         <li>
           <p>Unless the procedure was initiated by the <var>channel</var>'s
-          <code><a data-link-for="RTCDataChannel">close</a></code> method, set
+          {{RTCDataChannel/close}} method, set
           <var>channel</var>.<a>[[\ReadyState]]</a> to
           <code>"closing"</code>.</p>
         </li>
@@ -9503,16 +9385,16 @@ interface RTCSctpTransport : EventTarget {
             </li>
             <li>
               <p>Follow the closing procedure defined for the <var>channel</var>'s
-              underlying <a data-lt="data transport">transport</a>:</p>
+              [= underlying data transport =] :</p>
               <ol>
                 <li>
-                  <p>In the case of an SCTP-based <a data-lt="data transport">
-                  transport</a>, follow [[!RTCWEB-DATA]], section 6.7.</p>
+                  <p>In the case of an SCTP-based [= underlying data transport |
+                  transport =], follow [[!RTCWEB-DATA]], section 6.7.</p>
                 </li>
               </ol>
             </li>
             <li>
-              <p>Render the <var>channel</var>'s <a>data transport</a> <a>closed</a> by following
+              <p>Render the <var>channel</var>'s [= data transport =] {{closed}} by following
               the associated procedure.
             </li>
           </ol>
@@ -9521,13 +9403,13 @@ interface RTCSctpTransport : EventTarget {
       </section>
       <section>
         <h4>Announcing a data channel as closed</h4>
-      <p>When an <code><a>RTCDataChannel</a></code> object's <a>underlying data
-      transport</a> has been <dfn id="data-transport-closed" data-dfn-for="">closed</dfn>, the
+      <p>When an {{RTCDataChannel}} object's [= underlying data
+      transport =] has been <dfn id="data-transport-closed" data-dfn-for="">closed</dfn>, the
       user agent MUST queue a task to run the following steps:</p>
       <ol>
         <li>
-          <p>Let <var>channel</var> be the <code><a>RTCDataChannel</a></code>
-          object whose <a data-lt="data transport">transport</a> was
+          <p>Let <var>channel</var> be the {{RTCDataChannel}}
+          object whose [= underlying data transport =] was
           closed.</p>
         </li>
         <li>
@@ -9535,51 +9417,49 @@ interface RTCSctpTransport : EventTarget {
           <code>"closed"</code>.</p>
         </li>
         <li>
-          <p>If the <a data-lt="data transport">transport</a> was closed
-          <dfn id="data-transport-closed-error">with an error</dfn>, <a>fire
-          an event</a> named <code><a>error</a></code> using the
-          <code><a>RTCErrorEvent</a></code> interface with its
+          <p>If the [= underlying data transport | transport =] was closed
+          <dfn id="data-transport-closed-error">with an error</dfn>, [= fire
+          an event =] named {{error}} using the
+          {{RTCErrorEvent}} interface with its
           <code>errorDetail</code> attribute set to "sctp-failure"
           at <var>channel</var>.</p>
         </li>
         <li>
-          <p><a>Fire an event</a> named <code title=
-          "event-RTCDataChannel-close"><a>close</a></code> at
+          <p>[= Fire an event =] named <code title=
+          "event-RTCDataChannel-close">{{close}}</code> at
           <var>channel</var>.</p>
         </li>
       </ol>
       </section>
       <section>
         <h4>Error on creating data channels</h4>
-      <p>In some cases, the user agent may be <dfn data-lt=
-      "data-channel-failure">unable to create an <code><a>RTCDataChannel</a>
-      </code>'s <a>underlying data transport</a></dfn>.
-      For example, the data channel's <code><a data-link-for=
-      "RTCDataChannel">id</a></code> may be outside the range negotiated by the
+      <p>In some cases, the user agent may be <dfn>
+      unable to create an {{RTCDataChannel}}</dfn>
+      's [= underlying data transport =].
+      For example, the data channel's {{RTCDataChannel/id}} may be outside the range negotiated by the
       [[!RTCWEB-DATA]] implementations in the SCTP handshake. When the user
-      agent determines that an <code><a>RTCDataChannel</a></code>'s
-      <a>underlying data transport</a> cannot be created, the user agent MUST
+      agent determines that an {{RTCDataChannel}}'s
+      [= underlying data transport =] cannot be created, the user agent MUST
       queue a task to run the following steps:</p>
       <ol>
         <li>
-          <p>Let <var>channel</var> be the <code><a>RTCDataChannel</a></code>
-          object for which the user agent could not create an <a>underlying
-          data transport</a>.</p>
+          <p>Let <var>channel</var> be the {{RTCDataChannel}}
+          object for which the user agent could not create an [= underlying
+          data transport =].</p>
         </li>
         <li>
           <p>Set <var>channel</var>.<a>[[\ReadyState]]</a> to
           <code>"closed"</code>.</p>
         </li>
         <li>
-          <p><a>Fire an event</a> named <code><a data-link-for=
-          "RTCDataChannel">error</a></code> using the
-          <code><a>RTCErrorEvent</a></code> interface with the
+          <p>[= Fire an event =] named {{RTCDataChannel/error}} using the
+          {{RTCErrorEvent}} interface with the
           <code>errorDetail</code> attribute set to
           "data-channel-failure" at <var>channel</var>.</p>
         </li>
         <li>
-          <p><a>Fire an event</a> named <code title=
-          "event-RTCDataChannel-close"><a>close</a></code> at
+          <p>[= Fire an event =] named <code title=
+          "event-RTCDataChannel-close">{{close}}</code> at
           <var>channel</var>.</p>
         </li>
       </ol>
@@ -9587,18 +9467,18 @@ interface RTCSctpTransport : EventTarget {
       <section>
         <h4>Receiving messages on a data channel</h4>
       <p>When an <dfn data-lt="receive an rtcdatachannel message">
-      <code><a>RTCDataChannel</a></code> message has been received</dfn> via
-      the <a>underlying data transport</a> with type <var>type</var> and data
+      {{RTCDataChannel}} message has been received</dfn> via
+      the [= underlying data transport =] with type <var>type</var> and data
       <var>rawData</var>, the user agent MUST queue a task to run the following
       steps:</p>
       <ol>
         <li>
-          <p>Let <var>channel</var> be the <code><a>RTCDataChannel</a></code>
+          <p>Let <var>channel</var> be the {{RTCDataChannel}}
           object for which the user agent has received a message.</p>
         </li>
         <li>
           <p>Let <var>connection</var> be the
-          <code><a>RTCPeerConnection</a></code> object associated with
+          {{RTCPeerConnection}} object associated with
           <var>channel</var>.</p>
         </li>
         <li>
@@ -9620,23 +9500,23 @@ interface RTCSctpTransport : EventTarget {
             <li>
               <p>If <var>type</var> indicates that <var>rawData</var> is binary
               and <code>binaryType</code> is <code>"blob"</code>:</p>
-              <p>Let <var>data</var> be a new <code>Blob</code> object
+              <p>Let <var>data</var> be a new {{Blob}} object
               containing <var>rawData</var> as its raw data source.</p>
             </li>
             <li>
               <p>If <var>type</var> indicates that <var>rawData</var> is binary
               and <code>binaryType</code> is <code>"arraybuffer"</code>:</p>
-              <p>Let <var>data</var> be a new <code>ArrayBuffer</code> object
+              <p>Let <var>data</var> be a new {{ArrayBuffer}} object
               containing <var>rawData</var> as its raw data source.</p>
             </li>
           </ul>
         </li>
         <li data-tests="RTCDataChannel-send.html,datachannel-emptystring.html">
-          <p><a>Fire an event</a> named <code><a>message</a></code> using the
-          <code title="event-datachannel-message"><a>MessageEvent</a></code>
+          <p>[= Fire an event =] named {{message}} using the
+          <code title="event-datachannel-message">{{MessageEvent}}</code>
           interface with its <code>origin</code> attribute initialized to the
-          <a href="https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin">
-          serialization</a> of <var>connection</var>'s <a>[[\DocumentOrigin]]</a>,
+          <a data-cite="html">serialization of an origin</a>
+          of <var>connection</var>'s <a>[[\DocumentOrigin]]</a>,
           and the <code>data</code> attribute initialized to <var>data</var> at
           <var>channel</var>.</p>
         </li>
@@ -9678,9 +9558,9 @@ interface RTCDataChannel : EventTarget {
             <dd>
               <p>The <dfn id="dom-datachannel-label"><code>label</code></dfn>
               attribute represents a label that can be used to distinguish this
-              <code><a>RTCDataChannel</a></code> object from other
-              <code><a>RTCDataChannel</a></code> objects. Scripts are allowed
-              to create multiple <code><a>RTCDataChannel</a></code> objects
+              {{RTCDataChannel}} object from other
+              {{RTCDataChannel}} objects. Scripts are allowed
+              to create multiple {{RTCDataChannel}} objects
               with the same label. On getting, the attribute MUST return the
               value of the <a>[[\DataChannelLabel]]</a> slot.</p>
             </dd>
@@ -9689,7 +9569,7 @@ interface RTCDataChannel : EventTarget {
             <dd>
               <p>The <dfn id=
               "dom-datachannel-ordered"><code>ordered</code></dfn> attribute
-              returns true if the <code><a>RTCDataChannel</a></code> is
+              returns true if the {{RTCDataChannel}} is
               ordered, and false if out of order delivery is allowed. On
               getting, the attribute MUST return the value of the <a>[[\Ordered]]</a> slot.</p>
             </dd>
@@ -9721,7 +9601,7 @@ interface RTCDataChannel : EventTarget {
               <p>The <dfn id=
               "dom-datachannel-protocol"><code>protocol</code></dfn> attribute
               returns the name of the sub-protocol used with this
-              <code><a>RTCDataChannel</a></code>. On getting, the attribute MUST
+              {{RTCDataChannel}}. On getting, the attribute MUST
               return the value of the <a>[[\DataChannelProtocol]]</a>
               slot.</p>
             </dd>
@@ -9730,15 +9610,15 @@ interface RTCDataChannel : EventTarget {
             <dd>
               <p>The <dfn id=
               "dom-datachannel-negotiated"><code>negotiated</code></dfn>
-              attribute returns true if this <code><a>RTCDataChannel</a></code>
+              attribute returns true if this {{RTCDataChannel}}
               was negotiated by the application, or false otherwise. On getting,
               the attribute MUST return the value of the <a>[[\Negotiated]]</a> slot.</p>
             </dd>
-            <dt data-tests="RTCDataChannel-id.html, RTCPeerConnection-createDataChannel.html"><dfn data-idl><code>id</code></dfn> of type <span class=
+            <dt data-tests="RTCDataChannel-id.html, RTCPeerConnection-createDataChannel.html"><dfn data-idl>id</dfn> of type <span class=
             "idlAttrType">unsigned short</span>, readonly, nullable</dt>
             <dd>
               <p>The <code>id</code> attribute returns the ID for this
-              <code><a>RTCDataChannel</a></code>. The value is initially null,
+              {{RTCDataChannel}}. The value is initially null,
               which is what will be returned
               if the ID was not provided at channel creation time, and the DTLS
               role of the SCTP transport has not yet been negotiated.
@@ -9749,11 +9629,11 @@ interface RTCDataChannel : EventTarget {
               the value of the <a>[[\DataChannelId]]</a> slot.</p>
             </dd>
             <dt data-tests="RTCDataChannel-send.html, RTCPeerConnection-createDataChannel.html"><code>readyState</code> of type <span class=
-            "idlAttrType"><a>RTCDataChannelState</a></span>, readonly</dt>
+            "idlAttrType">{{RTCDataChannelState}}</span>, readonly</dt>
             <dd>
               <p>The <dfn id=
               "dom-datachannel-readystate"><code>readyState</code></dfn>
-              attribute represents the state of the <code>RTCDataChannel</code>
+              attribute represents the state of the {{RTCDataChannel}}
               object. On getting, the attribute MUST return the value
               of the <a>[[\ReadyState]]</a> slot.</p>
             </dd>
@@ -9766,18 +9646,17 @@ interface RTCDataChannel : EventTarget {
               <a>[[\BufferedAmount]]</a> slot. The attribute exposes the number
               of bytes of application data
               (UTF-8 text and binary data) that have been queued using
-              <code><a data-link-for="RTCDataChannel">send()</a></code>. Even
+              {{RTCDataChannel/send()}}. Even
               though the data transmission can occur in parallel, the returned
               value MUST NOT be decreased before the current task yielded back
               to the event loop to prevent race conditions.
               The value does not include framing overhead incurred by the
               protocol, or buffering done by the operating system or network
               hardware. The value of the <a>[[\BufferedAmount]]</a> slot will
-              only increase with each call to the <code><a data-link-for=
-              "RTCDataChannel">send()</a></code> method as long as the <a>
+              only increase with each call to the {{RTCDataChannel/send()}} method as long as the <a>
               [[\ReadyState]]</a> slot is <code>"open"</code>; however, the
               slot does not reset to zero once the channel closes. When the
-              <a>underlying data transport</a> sends data from its queue, the
+              [= underlying data transport =] sends data from its queue, the
               user agent MUST queue a task that reduces
               <a>[[\BufferedAmount]]</a> with the number of bytes that was
               sent.</p>
@@ -9785,48 +9664,44 @@ interface RTCDataChannel : EventTarget {
             <dt data-tests="RTCDataChannel-bufferedAmount.html"><code>bufferedAmountLowThreshold</code> of type <span class=
             "idlAttrType">unsigned long</span></dt>
             <dd>
-              <p>The <dfn data-idl><code>bufferedAmountLowThreshold</code></dfn>
-              attribute sets the threshold at which the <code><a data-link-for=
-              "RTCDataChannel">bufferedAmount</a></code> is considered to be
-              low. When the <code><a data-link-for=
-              "RTCDataChannel">bufferedAmount</a></code> decreases from above
+              <p>The <dfn data-idl>bufferedAmountLowThreshold</dfn>
+              attribute sets the threshold at which the {{RTCDataChannel/bufferedAmount}} is considered to be
+              low. When the {{RTCDataChannel/bufferedAmount}} decreases from above
               this threshold to equal or below it, the <code title=
-              "event-RTCDataChannel-bufferedamountlow"><a>bufferedamountlow</a></code>
-              event fires. The <code><a data-link-for=
-              "RTCDataChannel">bufferedAmountLowThreshold</a></code> is
-              initially zero on each new <code><a>RTCDataChannel</a></code>,
+              "event-RTCDataChannel-bufferedamountlow">{{bufferedamountlow}}</code>
+              event fires. The {{RTCDataChannel/bufferedAmountLowThreshold}} is
+              initially zero on each new {{RTCDataChannel}},
               but the application may change its value at any time.</p>
             </dd>
-            <dt><dfn data-idl><code>onopen</code></dfn> of type <span class=
+            <dt><dfn data-idl>onopen</dfn> of type <span class=
             "idlAttrType">EventHandler</span></dt>
             <dd>The event type of this event handler is
-            <code><a>open</a></code>.</dd>
-            <dt data-tests="RTCDataChannel-bufferedAmount.html"><dfn data-idl><code>onbufferedamountlow</code></dfn> of type
+            {{open}}.</dd>
+            <dt data-tests="RTCDataChannel-bufferedAmount.html"><dfn data-idl>onbufferedamountlow</dfn> of type
             <span class="idlAttrType">EventHandler</span></dt>
             <dd>The event type of this event handler is
-            <code><a>bufferedamountlow</a></code>.</dd>
-            <dt><dfn data-idl><code>onerror</code></dfn> of type <span class=
+            {{bufferedamountlow}}.</dd>
+            <dt><dfn data-idl>onerror</dfn> of type <span class=
             "idlAttrType">EventHandler</span></dt>
             <dd>
-              <p>The event type of this event handler is <code><a
-              >RTCErrorEvent</a></code>.
+              <p>The event type of this event handler is {{RTCErrorEvent}}.
               <code>errorDetail</code> contains "sctp-failure",
               <code>sctpCauseCode</code> contains the SCTP
               Cause Code value, and <code>message</code>
               contains the SCTP Cause-Specific-Information,
               possibly with additional text.</p></dd>
-            <dt><dfn data-idl><code>onclosing</code></dfn> of type <span class=
+            <dt><dfn data-idl>onclosing</dfn> of type <span class=
             "idlAttrType">EventHandler</span></dt>
             <dd><p>The event type of this event handler is
-            <code><a>Event</a></code>.</p></dd>
-            <dt><dfn data-idl><code>onclose</code></dfn> of type <span class=
+            {{Event}}.</p></dd>
+            <dt><dfn data-idl>onclose</dfn> of type <span class=
             "idlAttrType">EventHandler</span></dt>
             <dd><p>The event type of this event handler is
-            <code><a>Event</a></code>.</p></dd>
-            <dt data-tests="RTCDataChannel-send.html,datachannel-emptystring.html"><dfn data-idl><code>onmessage</code></dfn> of type <span class=
+            {{Event}}.</p></dd>
+            <dt data-tests="RTCDataChannel-send.html,datachannel-emptystring.html"><dfn data-idl>onmessage</dfn> of type <span class=
             "idlAttrType">EventHandler</span></dt>
             <dd><p>The event type of this event handler is
-            <code><a>message</a></code>.</p></dd>
+            {{message}}.</p></dd>
             <dt data-tests="RTCDataChannel-send.html"><code>binaryType</code> of type <span class=
             "idlAttrType">DOMString</span></dt>
             <dd data-cite="html">
@@ -9836,10 +9711,9 @@ interface RTCDataChannel : EventTarget {
               last set. On setting, if the new value is either the string
               <code>"blob"</code> or the string <code>"arraybuffer"</code>,
               then set the IDL attribute to this new value. Otherwise,
-              <a>throw</a> a <code>SyntaxError</code>. <span  data-tests="RTCPeerConnection-createDataChannel.html">When an
-              <code><a>RTCDataChannel</a></code> object is
-              created, the <code><a data-link-for=
-              "RTCDataChannel">binaryType</a></code> attribute MUST be
+              [= exception/throw =] a {{SyntaxError}}. <span  data-tests="RTCPeerConnection-createDataChannel.html">When an
+              {{RTCDataChannel}} object is
+              created, the {{RTCDataChannel/binaryType}} attribute MUST be
               initialized to the string "<code>blob</code>".</span></p>
               <p>This attribute controls how binary data is exposed to scripts.
               See Web Socket's {{WebSocket/binaryType}}.</p>
@@ -9852,16 +9726,16 @@ interface RTCDataChannel : EventTarget {
           class="methods">
             <dt><code>close</code></dt>
             <dd>
-              <p>Closes the <code><a>RTCDataChannel</a></code>. It may be
+              <p>Closes the {{RTCDataChannel}}. It may be
               called regardless of whether the
-              <code><a>RTCDataChannel</a></code> object was created by this
+              {{RTCDataChannel}} object was created by this
               peer or the remote peer.</p>
               <p>When the <dfn>close</dfn> method is called, the user agent
               MUST run the following steps:</p>
               <ol>
                 <li>
                   <p>Let <var>channel</var> be the
-                  <code><a>RTCDataChannel</a></code> object which is about to
+                  {{RTCDataChannel}} object which is about to
                   be closed.</p>
                 </li>
                 <li>
@@ -9874,37 +9748,37 @@ interface RTCDataChannel : EventTarget {
                   <code>"closing"</code>.</p>
                 </li>
                 <li>
-                  <p>If the <code><a>closing procedure</a></code> has not
+                  <p>If the [= closing procedure =] has not
                   started yet, start it.</p>
                 </li>
               </ol>
             </dd>
-            <dt data-tests="RTCDataChannel-send.html"><dfn data-idl><code>send</code></dfn></dt>
+            <dt data-tests="RTCDataChannel-send.html"><dfn data-idl>send</dfn></dt>
             <dd>
-              <p>Run the steps described by the <a><code>send()</code>
-              algorithm</a> with argument type
+              <p>Run the steps described by the [= send()
+              algorithm =] with argument type
               <code>string</code> object.</p>
             </dd>
             <dt data-tests="RTCDataChannel-send.html"><dfn data-lt="send!overload-1" data-lt-nodefault=
             "true"><code>send</code></dfn></dt>
             <dd>
-              <p>Run the steps described by the <a><code>send()</code>
-              algorithm</a> with argument type
-              <code>Blob</code> object.</p>
+              <p>Run the steps described by the [= send()
+              algorithm =] with argument type
+              {{Blob}} object.</p>
             </dd>
             <dt data-tests="RTCDataChannel-send.html"><dfn data-lt="send!overload-2" data-lt-nodefault=
             "true"><code>send</code></dfn></dt>
             <dd>
-              <p>Run the steps described by the <a><code>
-              send()</code> algorithm</a> with argument type
-              <code>ArrayBuffer</code> object.</p>
+              <p>Run the steps described by the [= 
+              send() algorithm =] with argument type
+              {{ArrayBuffer}} object.</p>
             </dd>
             <dt data-tests="RTCDataChannel-send.html"><dfn data-lt="send!overload-3" data-lt-nodefault=
             "true"><code>send</code></dfn></dt>
             <dd>
-              <p>Run the steps described by the <a><code>send()</code>
-              algorithm</a> with argument type
-              <code>ArrayBufferView</code> object.</p>
+              <p>Run the steps described by the [= send()
+              algorithm =] with argument type
+              {{ArrayBufferView}} object.</p>
             </dd>
           </dl>
       <p>The <code>send()</code> method is overloaded to handle
@@ -9912,13 +9786,13 @@ interface RTCDataChannel : EventTarget {
       the user agent MUST <dfn id="datachannel-send" data-lt="send() algorithm" data-lt-nodefault>run the following steps</dfn>:</p>
       <ol>
         <li>
-          <p>Let <var>channel</var> be the <code><a>RTCDataChannel</a></code>
+          <p>Let <var>channel</var> be the {{RTCDataChannel}}
           object on which data is to be sent.</p>
         </li>
         <li data-tests="RTCDataChannel-send.html">
           <p>If <var>channel</var>.<a>[[\ReadyState]]</a> is not
-          <code>"open"</code>, <a>throw</a> an
-          <code>InvalidStateError</code>.</p>
+          <code>"open"</code>, [= exception/throw =] an
+          {{InvalidStateError}}.</p>
         </li>
         <li>
           <p>Execute the sub step that corresponds to the type of the methods
@@ -9930,47 +9804,46 @@ interface RTCDataChannel : EventTarget {
               result of encoding the method's argument as UTF-8.</p>
             </li>
             <li>
-              <p><code>Blob</code> object:</p>
+              <p>{{Blob}} object:</p>
               <p>Let <var>data</var> be the raw data represented by the
-              <code>Blob</code> object.</p>
+              {{Blob}} object.</p>
               <div class="note" data-tests="RTCDataChannel-send-blob-order.html">
-              Although the actual retrieval of <var>data</var> from a <code>Blob</code> object
+              Although the actual retrieval of <var>data</var> from a {{Blob}} object
               can happen asynchronously, the user agent will make sure to queue the data on
-              the <var>channel</var>'s <a>underlying data transport</a> in the same order
+              the <var>channel</var>'s [= underlying data transport =] in the same order
               as the send method is called. The byte size of <var>data</var> needs to be known
               synchronously.</div>
             </li>
             <li>
-              <p><code>ArrayBuffer</code> object:</p>
+              <p>{{ArrayBuffer}} object:</p>
               <p>Let <var>data</var> be the data stored in the buffer described
-              by the <code>ArrayBuffer</code> object.</p>
+              by the {{ArrayBuffer}} object.</p>
             </li>
             <li>
-              <p><code>ArrayBufferView</code> object:</p>
+              <p>{{ArrayBufferView}} object:</p>
               <p>Let <var>data</var> be the data stored in the section of the
-              buffer described by the <code>ArrayBuffer</code> object that the
-              <code>ArrayBufferView</code> object references.</p>
+              buffer described by the {{ArrayBuffer}} object that the
+              {{ArrayBufferView}} object references.</p>
             </li>
           </ul>
           <div class="note">Any data argument type this method has not been
-          overloaded with will result in a <code>TypeError</code>. This includes
+          overloaded with will result in a {{TypeError}}. This includes
           <code>null</code> and <code>undefined</code>.</div>
         </li>
         <li data-tests="RTCDataChannel-send.html">
           <p>If the byte size of <var>data</var> exceeds the value of <code>
-          <a data-link-for="RTCSctpTransport">maxMessageSize</a></code> on
-          <var>channel</var>'s associated <code>RTCSctpTransport</code>,
-          <a>throw</a> a <code>TypeError</code>.</p>
+          {{RTCSctpTransport/maxMessageSize}}</code> on
+          <var>channel</var>'s associated {{RTCSctpTransport}},
+          [= exception/throw =] a {{TypeError}}.</p>
         </li>
         <li data-tests="RTCDataChannel-send.html">
           <p>Queue <var>data</var> for transmission on <var>channel</var>'s
-          <a>underlying data transport</a>. If queuing <var>data</var> is not
-          possible because not enough buffer space is available, <a>throw</a>
-          an <code>OperationError</code>.</p>
+          [= underlying data transport =]. If queuing <var>data</var> is not
+          possible because not enough buffer space is available, [= exception/throw =]
+          an {{OperationError}}.</p>
           <div class="note">The actual transmission of data occurs in
           parallel. If sending data leads to an SCTP-level error, the
-          application will be notified asynchronously through <code><a
-          data-link-for="RTCDataChannel">onerror</a></code>.</div>
+          application will be notified asynchronously through {{RTCDataChannel/onerror}}.</div>
         </li>
         <li data-tests="RTCDataChannel-bufferedAmount.html">
           <p>Increase the value of the <a>[[\BufferedAmount]]</a> slot by
@@ -9994,7 +9867,7 @@ interface RTCDataChannel : EventTarget {
           <h2>Dictionary <dfn>RTCDataChannelInit</dfn> Members</h2>
           <dl data-link-for="RTCDataChannelInit" data-dfn-for=
           "RTCDataChannelInit" class="dictionary-members">
-            <dt data-tests="RTCPeerConnection-createDataChannel.html"><dfn data-idl><code>ordered</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-createDataChannel.html"><dfn data-idl>ordered</dfn> of type <span class=
             "idlMemberType">boolean</span>, defaulting to
             <code>true</code></dt>
             <dd>
@@ -10002,36 +9875,36 @@ interface RTCDataChannel : EventTarget {
               The default value of true, guarantees that data will be delivered
               in order.</p>
             </dd>
-            <dt data-tests="RTCPeerConnection-createDataChannel.html"><dfn data-idl><code>maxPacketLifeTime</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-createDataChannel.html"><dfn data-idl>maxPacketLifeTime</dfn> of type <span class=
             "idlMemberType">unsigned short</span></dt>
             <dd>
               <p>Limits the time (in milliseconds) during which the channel will
               transmit or retransmit data if not acknowledged. This value may be
               clamped if it exceeds the maximum value supported by the user agent.</p>
             </dd>
-            <dt data-tests="RTCPeerConnection-createDataChannel.html"><dfn data-idl><code>maxRetransmits</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-createDataChannel.html"><dfn data-idl>maxRetransmits</dfn> of type <span class=
             "idlMemberType">unsigned short</span></dt>
             <dd>
               <p>Limits the number of times a channel will retransmit data if
               not successfully delivered. This value may be clamped if it
               exceeds the maximum value supported by the user agent.</p>
             </dd>
-            <dt data-tests="RTCPeerConnection-createDataChannel.html"><dfn data-idl><code>protocol</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-createDataChannel.html"><dfn data-idl>protocol</dfn> of type <span class=
             "idlMemberType">USVString</span>, defaulting to
             <code>""</code></dt>
             <dd>
               <p>Subprotocol name used for this channel.</p>
             </dd>
-            <dt data-tests="RTCPeerConnection-createDataChannel.html,RTCPeerConnection-ondatachannel.html"><dfn data-idl><code>negotiated</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-createDataChannel.html,RTCPeerConnection-ondatachannel.html"><dfn data-idl>negotiated</dfn> of type <span class=
             "idlMemberType">boolean</span>, defaulting to
             <code>false</code></dt>
             <dd>
               <p>The default value of false tells the user agent to announce
               the channel in-band and instruct the other peer to dispatch a
-              corresponding <code><a>RTCDataChannel</a></code> object. If set
+              corresponding {{RTCDataChannel}} object. If set
               to true, it is up to the application to negotiate the channel and
-              create an <code><a>RTCDataChannel</a></code> object with the same
-              <code><a data-link-for="RTCDataChannel">id</a></code> at the other
+              create an {{RTCDataChannel}} object with the same
+              {{RTCDataChannel/id}} at the other
               peer.</p>
               <div class="note">If set to true, the application must also take
               care to not send a message until the other peer has created a
@@ -10041,7 +9914,7 @@ interface RTCDataChannel : EventTarget {
               endpoints create their data channel before the first offer/answer
               exchange is complete.</div>
             </dd>
-            <dt data-tests="RTCPeerConnection-createDataChannel.html"><dfn data-idl><code>id</code></dfn> of type <span class=
+            <dt data-tests="RTCPeerConnection-createDataChannel.html"><dfn data-idl>id</dfn> of type <span class=
             "idlMemberType">unsigned short</span></dt>
             <dd>
               <p>Sets the channel ID when "negotiated" is true.
@@ -10065,37 +9938,36 @@ interface RTCDataChannel : EventTarget {
               <th colspan="2"><dfn>RTCDataChannelState</dfn> Enumeration description</th>
             </tr>
             <tr>
-              <td data-tests="RTCPeerConnection-createDataChannel.html"><dfn data-idl><code>connecting</code></dfn></td>
+              <td data-tests="RTCPeerConnection-createDataChannel.html"><dfn data-idl>connecting</dfn></td>
               <td>
-                <p>The user agent is attempting to establish the <a>underlying
-                data transport</a>. This is the initial state of an
-                <code><a>RTCDataChannel</a></code> object, whether created with
-                <code><a data-link-for=
-                  "RTCPeerConnection">createDataChannel</a></code>, or
+                <p>The user agent is attempting to establish the [= underlying
+                data transport =]. This is the initial state of an
+                {{RTCDataChannel}} object, whether created with
+                {{RTCPeerConnection/createDataChannel}}, or
                 dispatched as a part of an
-                <code><a>RTCDataChannelEvent</a></code>.</p>
+                {{RTCDataChannelEvent}}.</p>
               </td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>open</code></dfn></td>
+              <td><dfn data-idl>open</dfn></td>
               <td>
-                <p>The <a>underlying data transport</a> is established and
+                <p>The [= underlying data transport =] is established and
                 communication is possible.</p>
               </td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>closing</code></dfn></td>
+              <td><dfn data-idl>closing</dfn></td>
               <td>
-                <p>The <code><a data-lt=
-                "closing procedure">procedure</a></code> to close down the
-                <a>underlying data transport</a> has started.</p>
+                <p>The [=
+                closing procedure | procedure =] to close down the
+                [= underlying data transport =] has started.</p>
               </td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>closed</code></dfn></td>
+              <td><dfn data-idl>closed</dfn></td>
               <td>
-                <p>The <a>underlying data transport</a> has been
-                <code><a>closed</a></code> or could not be established.</p>
+                <p>The [= underlying data transport =] has been
+                {{closed}} or could not be established.</p>
               </td>
             </tr>
           </tbody>
@@ -10104,8 +9976,8 @@ interface RTCDataChannel : EventTarget {
     </section>
     <section>
       <h3><dfn>RTCDataChannelEvent</dfn></h3>
-      <p data-tests="RTCPeerConnection-ondatachannel.html">The <code><a>datachannel</a></code> event uses the
-      <code><a>RTCDataChannelEvent</a></code> interface.</p>
+      <p data-tests="RTCPeerConnection-ondatachannel.html">The {{datachannel}} event uses the
+      {{RTCDataChannelEvent}} interface.</p>
       <div>
         <pre class="idl" data-tests="idlharness.https.window.js"
 >[Exposed=Window]
@@ -10127,11 +9999,11 @@ interface RTCDataChannelEvent : Event {
           <dl data-link-for="RTCDataChannelEvent" data-dfn-for=
           "RTCDataChannelEvent" class="attributes">
             <dt><code>channel</code> of type <span class=
-            "idlAttrType"><a>RTCDataChannel</a></span>, readonly</dt>
+            "idlAttrType">{{RTCDataChannel}}</span>, readonly</dt>
             <dd>
               <p>The <dfn id=
               "dom-datachannelevent-channel"><code>channel</code></dfn>
-              attribute represents the <code><a>RTCDataChannel</a></code>
+              attribute represents the {{RTCDataChannel}}
               object associated with the event.</p>
             </dd>
           </dl>
@@ -10147,10 +10019,10 @@ interface RTCDataChannelEvent : Event {
           Members</h2>
           <dl data-link-for="RTCDataChannelEventInit" data-dfn-for=
           "RTCDataChannelEventInit" class="dictionary-members">
-            <dt><dfn data-idl><code>channel</code></dfn> of type <span class=
-            "idlMemberType"><a>RTCDataChannel</a></span>, required</dt>
+            <dt><dfn data-idl>channel</dfn> of type <span class=
+            "idlMemberType">{{RTCDataChannel}}</span>, required</dt>
             <dd>
-              <p>The <code><a>RTCDataChannel</a></code> object to be announced
+              <p>The {{RTCDataChannel}} object to be announced
               by the event.</p>
             </dd>
           </dl>
@@ -10159,7 +10031,7 @@ interface RTCDataChannelEvent : Event {
     </section>
     <section>
       <h3>Garbage Collection</h3>
-      <p>An <code><a>RTCDataChannel</a></code> object MUST not be garbage
+      <p>An {{RTCDataChannel}} object MUST not be garbage
       collected if its</p>
       <ul>
         <li>
@@ -10180,7 +10052,7 @@ interface RTCDataChannelEvent : Event {
           for <code>error</code> events, or <code>close</code> events.</p>
         </li>
         <li>
-          <p><a>underlying data transport</a> is established and data is queued
+          <p>[= underlying data transport =] is established and data is queued
           to be transmitted.</p>
         </li>
       </ul>
@@ -10188,13 +10060,13 @@ interface RTCDataChannelEvent : Event {
   </section>
   <section>
     <h3>Peer-to-peer DTMF</h3>
-    <p>This section describes an interface on <code><a>RTCRtpSender</a></code>
+    <p>This section describes an interface on {{RTCRtpSender}}
     to send DTMF (phone keypad) values across an
-    <code><a>RTCPeerConnection</a></code>. Details of how DTMF is sent to the
+    {{RTCPeerConnection}}. Details of how DTMF is sent to the
     other peer are described in [[!RTCWEB-AUDIO]].</p>
     <section>
       <h3>RTCRtpSender Interface Extensions</h3>
-      <p>The Peer-to-peer DTMF API extends the <code><a>RTCRtpSender</a></code>
+      <p>The Peer-to-peer DTMF API extends the {{RTCRtpSender}}
       interface as described below.</p>
       <div>
         <pre class="idl" data-tests="idlharness.https.window.js"
@@ -10206,13 +10078,13 @@ interface RTCDataChannelEvent : Event {
           <dl data-link-for="RTCRtpSender" data-dfn-for="RTCRtpSender" class=
           "attributes">
             <dt><code>dtmf</code> of type <span class=
-            "idlAttrType"><a>RTCDTMFSender</a></span>, readonly, nullable</dt>
+            "idlAttrType">{{RTCDTMFSender}}</span>, readonly, nullable</dt>
             <dd>
               <p>On getting, the <dfn>dtmf</dfn> attribute returns the value
               of the <a>[[\Dtmf]]</a>internal slot, which represents a <code>
-              <a>RTCDTMFSender</a></code> which can be used to send DTMF, or
+              {{RTCDTMFSender}}</code> which can be used to send DTMF, or
               null if unset. The <a>[[\Dtmf]]</a>internal slot is set
-              when the kind of an <code><a>RTCRtpSender</a></code>'s
+              when the kind of an {{RTCRtpSender}}'s
               <a>[[\SenderTrack]]</a> is <code>"audio"</code>.</p>
             </dd>
           </dl>
@@ -10226,7 +10098,7 @@ interface RTCDataChannelEvent : Event {
         <ol>
           <li>
             <p>Let <var>dtmf</var> be a newly created
-            <code><a>RTCDTMFSender</a></code> object.</p>
+            {{RTCDTMFSender}} object.</p>
           </li>
           <li>
             <p>Let <var>dtmf</var> have a <dfn>[[\Duration]]</dfn>
@@ -10254,18 +10126,18 @@ interface RTCDTMFSender : EventTarget {
           <h2>Attributes</h2>
           <dl data-link-for="RTCDTMFSender" data-dfn-for="RTCDTMFSender" class=
           "attributes">
-            <dt data-tests="RTCDTMFSender-ontonechange-long.https.html"><dfn data-idl><code>ontonechange</code></dfn> of type <span class=
+            <dt data-tests="RTCDTMFSender-ontonechange-long.https.html"><dfn data-idl>ontonechange</dfn> of type <span class=
             "idlAttrType">EventHandler</span></dt>
             <dd>
               <p>The event type of this event handler is
-              <code><a>tonechange</a></code>.</p>
+              {{tonechange}}.</p>
             </dd>
-            <dt><dfn data-idl><code>canInsertDTMF</code></dfn> of type <span class=
+            <dt><dfn data-idl>canInsertDTMF</dfn> of type <span class=
             "idlAttrType">boolean</span>, readonly</dt>
             <dd>
-              <p>Whether the <a>RTCDTMFSender</a> <var>dtmfSender</var> is capable of sending
+              <p>Whether the {{RTCDTMFSender}} <var>dtmfSender</var> is capable of sending
               DTMF. On getting, the user agent MUST return the result of running
-              <a>determine if DTMF can be sent</a> for <var>dtmfSender</var>.</p>
+              [= determine if DTMF can be sent =] for <var>dtmfSender</var>.</p>
             </dd>
             <dt><code>toneBuffer</code> of type <span class=
             "idlAttrType">DOMString</span>, readonly</dt>
@@ -10274,7 +10146,7 @@ interface RTCDTMFSender : EventTarget {
               "dom-RTCDTMFSender-tonebuffer"><code>toneBuffer</code></dfn>
               attribute MUST return a list of the tones remaining to be played
               out. For the syntax, content, and interpretation of this list,
-              see <code><a>insertDTMF</a></code>.</p>
+              see {{insertDTMF}}.</p>
             </dd>
           </dl>
         </section>
@@ -10284,7 +10156,7 @@ interface RTCDTMFSender : EventTarget {
           "methods">
             <dt><code>insertDTMF</code></dt>
             <dd>
-              <p>An <code><a>RTCDTMFSender</a></code> object's <dfn id=
+              <p>An {{RTCDTMFSender}} object's <dfn id=
               "dom-RTCDTMFSender-insertDTMF"><code>insertDTMF</code></dfn>
               method is used to send DTMF tones.</p>
               <p data-tests="RTCDTMFSender-insertDTMF.https.html">The tones parameter is treated as a series of characters. The
@@ -10308,23 +10180,23 @@ interface RTCDTMFSender : EventTarget {
               to cause the times that DTMF start and stop to align with the
               boundaries of RTP packets but it MUST not increase either of them
               by more than the duration of a single RTP audio packet.</p>
-              <p>When the <code><a>insertDTMF()</a></code> method is invoked,
+              <p>When the {{insertDTMF()}} method is invoked,
               the user agent MUST run the following steps:</p>
               <ol>
                 <li>Let <var>sender</var> be the
-                <code><a>RTCRtpSender</a></code> used to send DTMF.</li>
+                {{RTCRtpSender}} used to send DTMF.</li>
                 <li>
                   <p>Let <var>transceiver</var> be the
-                  <code><a>RTCRtpTransceiver</a></code> object associated with
+                  {{RTCRtpTransceiver}} object associated with
                   <var>sender</var>.</p>
                 </li>
-                <li>Let <var>dtmf</var> be the <code><a>RTCDTMFSender</a></code>
+                <li>Let <var>dtmf</var> be the {{RTCDTMFSender}}
                 associated with <var>sender</var>.</li>
-                <li>If <a>determine if DTMF can be sent</a> for <var>dtmf</var> returns
-                <code>false</code>, <a>throw</a> an <code>InvalidStateError</code>.</li>
+                <li>If [= determine if DTMF can be sent =] for <var>dtmf</var> returns
+                <code>false</code>, [= exception/throw =] an {{InvalidStateError}}.</li>
                 <li>Let <var>tones</var> be the method's first argument.</li>
-                <li data-tests="RTCDTMFSender-insertDTMF.https.html">If <var>tones</var> contains any <a>unrecognized</a>
-                characters, <a>throw</a> an <code>InvalidCharacterError</code>.
+                <li data-tests="RTCDTMFSender-insertDTMF.https.html">If <var>tones</var> contains any {{unrecognized}}
+                characters, [= exception/throw =] an {{InvalidCharacterError}}.
                 </li>
                 <li>Set the object's <a>[[\ToneBuffer]]</a> slot to
                 <var>tones</var>.</li>
@@ -10350,11 +10222,10 @@ interface RTCDTMFSender : EventTarget {
                     is neither <code>sendrecv</code> nor <code>sendonly</code>,
                     abort these steps.</li>
                     <li>If the <a>[[\ToneBuffer]]</a> slot contains the empty
-                    string, <a>fire an event</a> named <code><a>tonechange</a></code>
-                    using the <code><a>RTCDTMFToneChangeEvent</a></code>
-                    interface with the <code><a data-link-for=
-                    "RTCDTMFToneChangeEvent">tone</a></code> attribute set to
-                    an empty string at the <code><a>RTCDTMFSender</a></code>
+                    string, [= fire an event =] named {{tonechange}}
+                    using the {{RTCDTMFToneChangeEvent}}
+                    interface with the {{RTCDTMFToneChangeEvent/tone}} attribute set to
+                    an empty string at the {{RTCDTMFSender}}
                     object and abort these steps.</li>
                     <li>Remove the first character from the <a>[[\ToneBuffer]]</a>
                     slot and let that character be <var>tone</var>.</li>
@@ -10369,11 +10240,10 @@ interface RTCDTMFSender : EventTarget {
                     queue a task to be executed in <a>[[\Duration]]</a>
                     + <a>[[\InterToneGap]]</a> ms from now that
                     runs the steps labelled <em>Playout task</em>.</li>
-                    <li><a>Fire an event</a> named <code><a>tonechange</a></code>
-                    using the <code><a>RTCDTMFToneChangeEvent</a></code>
-                    interface with the <code><a data-link-for=
-                    "RTCDTMFToneChangeEvent">tone</a></code> attribute set to
-                    <var>tone</var> at the <code><a>RTCDTMFSender</a></code>
+                    <li>[= Fire an event =] named {{tonechange}}
+                    using the {{RTCDTMFToneChangeEvent}}
+                    interface with the {{RTCDTMFToneChangeEvent/tone}} attribute set to
+                    <var>tone</var> at the {{RTCDTMFSender}}
                     object.</li>
                   </ol>
                 </li>
@@ -10383,8 +10253,7 @@ interface RTCDTMFSender : EventTarget {
               it is necessary to call <code>insertDTMF</code> with a
               string containing both the remaining tones (stored in the
               <a>[[\ToneBuffer]]</a> slot) and the new tones appended
-              together. Calling <code><a data-link-for=
-              "RTCDTMFSender">insertDTMF</a></code> with an empty tones
+              together. Calling {{RTCDTMFSender/insertDTMF}} with an empty tones
               parameter can be used to cancel all tones queued to play after
               the currently playing tone.</p>
             </dd>
@@ -10394,16 +10263,16 @@ interface RTCDTMFSender : EventTarget {
     </section>
     <section>
       <h3>canInsertDTMF algorithm</h3>
-      <p>To <dfn>determine if DTMF can be sent</dfn> for an <code><a>RTCDTMFSender</a></code>
+      <p>To <dfn>determine if DTMF can be sent</dfn> for an {{RTCDTMFSender}}
       instance <var>dtmfSender</var>, the user agent MUST queue a task that runs the following steps:</p>
       <ol>
-        <li>Let <var>sender</var> be the <code><a>RTCRtpSender</a></code> associated with
+        <li>Let <var>sender</var> be the {{RTCRtpSender}} associated with
         <var>dtmfSender</var>.</li>
-        <li>Let <var>transceiver</var> be the <code><a>RTCRtpTransceiver</a></code>
+        <li>Let <var>transceiver</var> be the {{RTCRtpTransceiver}}
         associated with <var>sender</var>.</li>
-        <li>Let <var>connection</var> be the <code><a>RTCPeerConnection</a></code> associated with
+        <li>Let <var>connection</var> be the {{RTCPeerConnection}} associated with
         <var>transceiver</var>.</li>
-        <li>If <var>connection</var>'s <code><a>RTCPeerConnectionState</a></code> is not <code>"connected"</code>
+        <li>If <var>connection</var>'s {{RTCPeerConnectionState}} is not <code>"connected"</code>
         return <code>false</code>.</li>
         <li>If <var>sender</var>.<a>[[\SenderTrack]]</a> is <code>null</code>
         return <code>false</code>.</li>
@@ -10418,8 +10287,8 @@ interface RTCDTMFSender : EventTarget {
     </section>
     <section>
       <h3><dfn>RTCDTMFToneChangeEvent</dfn></h3>
-      <p>The <code><a>tonechange</a></code> event uses the
-      <code><a>RTCDTMFToneChangeEvent</a></code> interface.</p>
+      <p>The {{tonechange}} event uses the
+      {{RTCDTMFToneChangeEvent}} interface.</p>
       <div>
         <pre class="idl" data-tests
 >[Exposed=Window]
@@ -10443,10 +10312,9 @@ interface RTCDTMFToneChangeEvent : Event {
             <dt><code>tone</code> of type <span class=
             "idlAttrType">DOMString</span>, readonly</dt>
             <dd>
-              <p>The <dfn data-idl><code>tone</code></dfn> attribute contains the
+              <p>The <dfn data-idl>tone</dfn> attribute contains the
               character for the tone (including ",") that has just
-              begun playout (see <code><a data-link-for=
-              "RTCDTMFSender">insertDTMF</a></code> ). If
+              begun playout (see {{RTCDTMFSender/insertDTMF}} ). If
               the value is the empty string, it indicates that the
               <a>[[\ToneBuffer]]</a> slot is an empty string and that
               the previous tones have completed playback.</p>
@@ -10464,14 +10332,13 @@ interface RTCDTMFToneChangeEvent : Event {
           Members</h2>
           <dl data-link-for="RTCDTMFToneChangeEventInit" data-dfn-for=
           "RTCDTMFToneChangeEventInit" class="dictionary-members">
-            <dt><dfn data-idl><code>tone</code></dfn> of type <span class=
+            <dt><dfn data-idl>tone</dfn> of type <span class=
             "idlMemberType">DOMString</span>, defaulting to
               <code>""</code></dt>
             <dd>
               <p>The <code>tone</code> attribute contains the
               character for the tone (including ",") that has just
-              begun playout (see <code><a data-link-for=
-              "RTCDTMFSender">insertDTMF</a></code> ). If
+              begun playout (see {{RTCDTMFSender/insertDTMF}} ). If
               the value is the empty string, it indicates that the
               <a>[[\ToneBuffer]]</a> slot is an empty string and that
               the previous tones have completed playback.</p>
@@ -10486,30 +10353,28 @@ interface RTCDTMFToneChangeEvent : Event {
     <section>
       <h3>Introduction</h3>
       <p>The basic statistics model is that the browser maintains a set of
-        statistics for <a>monitored object</a>s, in the form of <a>stats object</a>s.
+        statistics for [= monitored object =]s, in the form of [= stats object =]s.
       </p>
       <p>A group of related objects may be
         referenced by a <dfn id="stats-selector">selector</dfn>. The
-      selector may, for example, be a <code>MediaStreamTrack</code>. For a
-      track to be a valid selector, it MUST be a <code>MediaStreamTrack</code>
-      that is sent or received by the <code><a>RTCPeerConnection</a></code>
+      selector may, for example, be a {{MediaStreamTrack}}. For a
+      track to be a valid selector, it MUST be a {{MediaStreamTrack}}
+      that is sent or received by the {{RTCPeerConnection}}
       object on which the stats request was issued. The calling Web application
-      provides the selector to the <code><a data-link-for=
-      "RTCPeerConnection">getStats()</a></code> method and the browser emits
+      provides the selector to the {{RTCPeerConnection/getStats()}} method and the browser emits
       (in the JavaScript) a set of statistics that are relevant to the selector,
-      according to the <a>stats selection algorithm</a>. Note that that
+      according to the [= stats selection algorithm =]. Note that that
       algorithm takes the sender or receiver of a selector.</p>
-      <p>The statistics returned in <a>stats object</a>s are designed in such a
+      <p>The statistics returned in [= stats object =]s are designed in such a
       way that repeated queries can be linked by the
-      <code><a>RTCStats</a></code> <a data-link-for="RTCStats">id</a> dictionary
+      {{RTCStats}} {{RTCStats/id}} dictionary
       member. Thus, a Web application can make measurements over a given time
       period by requesting measurements at the beginning and end of that period.</p>
       <p>
-        With a few exceptions, <a>monitored object</a>s, once created, exist for
-        the duration of their associated <code><a>RTCPeerConnection</a></code>.
+        With a few exceptions, [= monitored object =]s, once created, exist for
+        the duration of their associated {{RTCPeerConnection}}.
         This ensures statistics from them are available in the result from getStats()
-        even past the associated peer connection being <a data-lt="close"
-          href="#dom-rtcpeerconnection-close">close</a>d.
+        even past the associated peer connection being {{RTCPeerConnection/close}}d.
       </p>
       <p>Only a few monitored objects have
       <a data-cite="!WEBRTC-STATS#lifetime-considerations-for-monitored-objects">
@@ -10519,7 +10384,7 @@ interface RTCDTMFToneChangeEvent : Event {
     </section>
     <section>
       <h3>RTCPeerConnection Interface Extensions</h3>
-      <p>The Statistics API extends the <code><a>RTCPeerConnection</a></code>
+      <p>The Statistics API extends the {{RTCPeerConnection}}
       interface as described below.</p>
       <div>
         <pre class="idl" data-tests="idlharness.https.window.js" data-cite="HTML"
@@ -10532,7 +10397,7 @@ interface RTCDTMFToneChangeEvent : Event {
           "RTCPeerConnection" class="methods">
             <dt data-tests="RTCPeerConnection-getStats.https.html,getstats.html"><code>getStats</code></dt>
             <dd>
-              <p>Gathers stats for the given <a>selector</a> and reports the
+              <p>Gathers stats for the given {{selector}} and reports the
               result asynchronously.</p>
               <p>When the <dfn id=
               "widl-RTCPeerConnection-getStats-Promise-RTCStatsReport--MediaStreamTrack-selector">
@@ -10545,7 +10410,7 @@ interface RTCDTMFToneChangeEvent : Event {
                 </li>
                 <li>
                   <p>Let <var>connection</var> be the
-                  <code><a>RTCPeerConnection</a></code> object on which
+                  {{RTCPeerConnection}} object on which
                   the method was invoked.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,getstats.html">
@@ -10553,15 +10418,15 @@ interface RTCDTMFToneChangeEvent : Event {
                   <var>selector</var> be <code>null</code>.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html">
-                  <p>If <var>selectorArg</var> is a <a>MediaStreamTrack</a>
-                  let <var>selector</var> be an <a>RTCRtpSender</a> or
-                  <a>RTCRtpReceiver</a> on <var>connection</var> which
+                  <p>If <var>selectorArg</var> is a {{MediaStreamTrack}}
+                  let <var>selector</var> be an {{RTCRtpSender}} or
+                  {{RTCRtpReceiver}} on <var>connection</var> which
                   <code>track</code> member matches <var>selectorArg</var>.
                   If no such sender or receiver exists, or if more than one
                   sender or receiver fit this criteria, return a promise
-                  <a>rejected</a> with a newly
-                  <a data-link-for="exception" data-lt="create">created</a>
-                  <code>InvalidAccessError</code>.</p>
+                  [= rejected =] with a newly
+                  [= exception/create | created =]
+                  {{InvalidAccessError}}.</p>
                 </li>
                 <li>
                   <p>Let <var>p</var> be a new promise.</p>
@@ -10571,11 +10436,11 @@ interface RTCDTMFToneChangeEvent : Event {
                   <ol>
                     <li>
                       <p>Gather the stats indicated by <var>selector</var>
-                      according to the <a>stats selection algorithm</a>.</p>
+                      according to the [= stats selection algorithm =].</p>
                     </li>
                     <li data-tests="RTCPeerConnection-getStats.https.html,getstats.html">
-                      <p><a>Resolve</a> <var>p</var> with the resulting
-                      <code><a>RTCStatsReport</a></code> object, containing
+                      <p>[= Resolve =] <var>p</var> with the resulting
+                      {{RTCStatsReport}} object, containing
                       the gathered stats.</p>
                     </li>
                   </ol>
@@ -10591,22 +10456,21 @@ interface RTCDTMFToneChangeEvent : Event {
     </section>
     <section>
       <h3><dfn>RTCStatsReport</dfn> Object</h3>
-      <p>The <code><a data-link-for="RTCPeerConnection">getStats()</a></code> method
+      <p>The {{RTCPeerConnection/getStats()}} method
       delivers a successful result in the form of an
-      <code><a>RTCStatsReport</a></code> object. An
-      <code><a>RTCStatsReport</a></code> object is a map between strings that
-      identify the inspected objects (<a data-link-for=
-      "RTCStats">id</a> attribute in <code>RTCStats</code>
-      instances), and their corresponding <code><a>RTCStats</a></code>-derived
+      {{RTCStatsReport}} object. An
+      {{RTCStatsReport}} object is a map between strings that
+      identify the inspected objects ({{RTCStats/id}} attribute in {{RTCStats}}
+      instances), and their corresponding {{RTCStats}}-derived
       dictionaries.</p>
-      <p>An <code><a>RTCStatsReport</a></code> may be composed of several
-      <code><a>RTCStats</a></code>-derived dictionaries, each reporting stats
+      <p>An {{RTCStatsReport}} may be composed of several
+      {{RTCStats}}-derived dictionaries, each reporting stats
       for one underlying object that the implementation thinks is relevant for
-      the <a>selector</a>. One achieves the total for the <a>selector</a> by
+      the {{selector}}. One achieves the total for the {{selector}} by
       summing over all the stats of a certain type; for instance, if an
-      <code>RTCRtpSender</code> uses multiple SSRCs to carry its track over the
-      network, the <code><a>RTCStatsReport</a></code> may contain one
-      <code>RTCStats</code>-derived dictionary per SSRC (which can be
+      {{RTCRtpSender}} uses multiple SSRCs to carry its track over the
+      network, the {{RTCStatsReport}} may contain one
+      {{RTCStats}}-derived dictionary per SSRC (which can be
       distinguished by the value of the "ssrc" stats attribute).</p>
       <div>
         <pre class="idl" data-tests
@@ -10618,20 +10482,19 @@ interface RTCStatsReport {
         "values", @@iterator methods and a "size" getter brought by
         <code>readonly maplike</code>.</p>
         <p>Use these to retrieve the various dictionaries descended from
-        <code><a>RTCStats</a></code> that this stats report is composed of. The
+        {{RTCStats}} that this stats report is composed of. The
         set of supported property names [[!WEBIDL]] is defined as the ids of
-        all the <code><a>RTCStats</a></code>-derived dictionaries that have
+        all the {{RTCStats}}-derived dictionaries that have
         been generated for this stats report.</p>
       </div>
     </section>
     <section>
       <h3><dfn>RTCStats</dfn> Dictionary</h3>
-      <p>An <code>RTCStats</code> dictionary represents the <a>stats object</a>
-      constructed by inspecting a specific <a>monitored object</a>.
-      The <code>RTCStats</code> dictionary is a base type that specifies
-      as set of default attributes, such as <a data-link-for=
-      "RTCStats">timestamp</a> and <a data-link-for="RTCStats">type</a>. Specific
-      stats are added by extending the <code>RTCStats</code>
+      <p>An {{RTCStats}} dictionary represents the [= stats object =]
+      constructed by inspecting a specific [= monitored object =].
+      The {{RTCStats}} dictionary is a base type that specifies
+      as set of default attributes, such as {{RTCStats/timestamp}} and {{RTCStats/type}}. Specific
+      stats are added by extending the {{RTCStats}}
       dictionary.</p>
       <p>Note that while stats names are standardized, any given implementation
       may be using experimental values or values not yet known to the Web
@@ -10643,7 +10506,7 @@ interface RTCStatsReport {
       same interval, so that "average packet size" can be computed as "bytes /
       packets" - if the intervals are different, this will yield errors. Thus
       implementations MUST return synchronized values for all stats in an
-      <code><a>RTCStats</a></code>-derived dictionary.</p>
+      {{RTCStats}}-derived dictionary.</p>
       <div>
         <pre class="idl" data-cite="HR-TIME"
 >dictionary RTCStats {
@@ -10652,38 +10515,38 @@ interface RTCStatsReport {
   required DOMString id;
 };</pre>
         <section>
-          <h2>Dictionary <a class="idlType">RTCStats</a> Members</h2>
+          <h2>Dictionary {{RTCStats}} Members</h2>
           <dl data-link-for="RTCStats" data-dfn-for="RTCStats" class=
           "dictionary-members">
             <dt><code>timestamp</code> of type <span class=
             "idlMemberType">DOMHighResTimeStamp</span></dt>
             <dd>
-              <p>The <dfn data-idl><code>timestamp</code></dfn>, of type
-              <code>DOMHighResTimeStamp</code> [[!hr-time]], associated
+              <p>The <dfn data-idl>timestamp</dfn>, of type
+              {{DOMHighResTimeStamp}}, associated
               with this object. The time is relative to the UNIX epoch (Jan 1,
               1970, UTC). For statistics that came from a remote source (e.g.,
               from received RTCP packets), <code>timestamp</code> represents
               the time at which the information arrived at the local endpoint.
               The remote timestamp can be found in an additional field in an
-              <code><a>RTCStats</a></code>-derived dictionary, if
+              {{RTCStats}}-derived dictionary, if
               applicable.</p>
             </dd>
             <dt data-tests="getstats.html"><code>type</code> of type <span class=
-            "idlMemberType"><a>RTCStatsType</a></span></dt>
+            "idlMemberType">{{RTCStatsType}}</span></dt>
             <dd>
               <p>The type of this object.</p>
-              <p>The <dfn data-idl><code>type</code></dfn> attribute MUST be initialized
+              <p>The <dfn data-idl>type</dfn> attribute MUST be initialized
               to the name of the most specific type this
-              <code><a>RTCStats</a></code> dictionary represents.</p>
+              {{RTCStats}} dictionary represents.</p>
             </dd>
             <dt><code>id</code> of type <span class=
             "idlMemberType">DOMString</span></dt>
             <dd>
-              <p>A unique <dfn data-idl><code>id</code></dfn> that is associated with
+              <p>A unique <dfn data-idl>id</dfn> that is associated with
               the object that was inspected to produce this
-              <code><a>RTCStats</a></code> object. Two
-              <code><a>RTCStats</a></code> objects, extracted from two
-              different <code><a>RTCStatsReport</a></code> objects, MUST have
+              {{RTCStats}} object. Two
+              {{RTCStats}} objects, extracted from two
+              different {{RTCStatsReport}} objects, MUST have
               the same id if they were produced by inspecting the same
               underlying object.</p>
               <p>Stats ids MUST NOT be predictable by an application. This
@@ -10703,7 +10566,7 @@ interface RTCStatsReport {
           </dl>
         </section>
       </div>
-      <p>The set of valid values for <code><a>RTCStatsType</a></code>, and the dictionaries derived
+      <p>The set of valid values for {{RTCStatsType}}, and the dictionaries derived
       from RTCStats that they indicate, are documented in
       [[!WEBRTC-STATS]].</p>
     </section>
@@ -10718,29 +10581,29 @@ interface RTCStatsReport {
           whole <var>connection</var>, add them to <var>result</var>, return
           <var>result</var>, and abort these steps.
         </li>
-        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html">If <var>selector</var> is an <a>RTCRtpSender</a>, gather stats for
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html">If <var>selector</var> is an {{RTCRtpSender}}, gather stats for
           and add the following objects to <var>result</var>:
           <ul>
             <li>
-            All <code>RTCOutboundRTPStreamStats</code> objects representing RTP
+            All {{RTCOutboundRTPStreamStats}} objects representing RTP
             streams being sent by <var>selector</var>.
             </li>
             <li>
             All stats objects referenced directly or indirectly by the
-            <code>RTCOutboundRTPStreamStats</code> objects added.
+            {{RTCOutboundRTPStreamStats}} objects added.
             </li>
           </ul>
         </li>
-        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html">If <var>selector</var> is an <a>RTCRtpReceiver</a>, gather stats
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html">If <var>selector</var> is an {{RTCRtpReceiver}}, gather stats
           for and add the following objects to <var>result</var>:
           <ul>
             <li>
-            All <code>RTCInboundRTPStreamStats</code> objects representing RTP
+            All {{RTCInboundRTPStreamStats}} objects representing RTP
             streams being received by <var>selector</var>.
             </li>
             <li>
             All stats objects referenced directly or indirectly by the
-            <code>RTCInboundRTPStreamStats</code> added.
+            {{RTCInboundRTPStreamStats}} added.
             </li>
           </ul>
         </li>
@@ -10856,80 +10719,78 @@ async function gatherStats() {
     <h2>Media Stream API Extensions for Network Use</h2>
     <section>
       <h3>Introduction</h3>
-      <p>The <code>MediaStreamTrack</code> interface, as defined in the
+      <p>The {{MediaStreamTrack}} interface, as defined in the
       [[!GETUSERMEDIA]] specification, typically represents a stream of data of
-      audio or video. One or more <code>MediaStreamTrack</code>s can be
-      collected in a <code>MediaStream</code> (strictly speaking, a
-      <code>MediaStream</code> as defined in [[!GETUSERMEDIA]] may contain zero
-      or more <code>MediaStreamTrack</code> objects).</p>
-      <p>A <code>MediaStreamTrack</code> may be extended to represent a media
+      audio or video. One or more {{MediaStreamTrack}}s can be
+      collected in a {{MediaStream}} (strictly speaking, a
+      {{MediaStream}} as defined in [[!GETUSERMEDIA]] may contain zero
+      or more {{MediaStreamTrack}} objects).</p>
+      <p>A {{MediaStreamTrack}} may be extended to represent a media
       flow that either comes from or is sent to a remote peer (and not just the
       local camera, for instance). The extensions required to enable this
-      capability on the <code>MediaStreamTrack</code> object will be described
+      capability on the {{MediaStreamTrack}} object will be described
       in this section. How the media is transmitted to the peer is described in
       [[!RTCWEB-RTP]], [[!RTCWEB-AUDIO]], and [[!RTCWEB-TRANSPORT]].</p>
-      <p>A <code>MediaStreamTrack</code> sent to another peer will appear as
-      one and only one <code>MediaStreamTrack</code> to the recipient. A peer
+      <p>A {{MediaStreamTrack}} sent to another peer will appear as
+      one and only one {{MediaStreamTrack}} to the recipient. A peer
       is defined as a user agent that supports this specification. In addition,
-      the sending side application can indicate what <code>MediaStream</code>
-      object(s) the <code>MediaStreamTrack</code> is a member of. The
-      corresponding <code>MediaStream</code> object(s) on the receiver side
+      the sending side application can indicate what {{MediaStream}}
+      object(s) the {{MediaStreamTrack}} is a member of. The
+      corresponding {{MediaStream}} object(s) on the receiver side
       will be created (if not already present) and populated accordingly.</p>
       <p>As also described earlier in this document, the objects
-      <code>RTCRtpSender</code> and <code>RTCRtpReceiver</code> can be used by
+      {{RTCRtpSender}} and {{RTCRtpReceiver}} can be used by
       the application to get more fine grained control over the transmission
-      and reception of <code>MediaStreamTrack</code>s.</p>
+      and reception of {{MediaStreamTrack}}s.</p>
       <p>Channels are the smallest unit considered in the
       <code>MediaStream</code> specification. Channels are intended to be
       encoded together for transmission as, for instance, an RTP payload type.
       All of the channels that a codec needs to encode jointly MUST be in the
-      same <code>MediaStreamTrack</code> and the codecs SHOULD be able to
+      same {{MediaStreamTrack}} and the codecs SHOULD be able to
       encode, or discard, all the channels in the track.</p>
       <p>The concepts of an input and output to a given
-      <code>MediaStreamTrack</code> apply in the case of
-      <code>MediaStreamTrack</code> objects transmitted over the network as
-      well. A <code><a>MediaStreamTrack</a></code> created by an
-      <code><a>RTCPeerConnection</a></code> object (as described previously in
+      {{MediaStreamTrack}} apply in the case of
+      {{MediaStreamTrack}} objects transmitted over the network as
+      well. A {{MediaStreamTrack}} created by an
+      {{RTCPeerConnection}} object (as described previously in
       this document) will take as input the data received from a remote peer.
-      Similarly, a <code>MediaStreamTrack</code> from a local source, for
+      Similarly, a {{MediaStreamTrack}} from a local source, for
       instance a camera via [[!GETUSERMEDIA]], will have an output that
       represents what is transmitted to a remote peer if the object is used
-      with an <code><a>RTCPeerConnection</a></code> object.</p>
-      <p>The concept of duplicating <code>MediaStream</code> and
-      <code>MediaStreamTrack</code> objects as described in [[!GETUSERMEDIA]]
+      with an {{RTCPeerConnection}} object.</p>
+      <p>The concept of duplicating {{MediaStream}} and
+      {{MediaStreamTrack}} objects as described in [[!GETUSERMEDIA]]
       is also applicable here. This feature can be used, for instance, in a
       video-conferencing scenario to display the local video from the user's
       camera and microphone in a local monitor, while only transmitting the
       audio to the remote peer (e.g. in response to the user using a "video
-      mute" feature). Combining different <code>MediaStreamTrack</code> objects
-      into new <code>MediaStream</code> objects is useful in certain
+      mute" feature). Combining different {{MediaStreamTrack}} objects
+      into new {{MediaStream}} objects is useful in certain
       situations.</p>
       <p class="note">In this document, we only specify aspects of the
       following objects that are relevant when used along with an
-      <code><a>RTCPeerConnection</a></code>. Please refer to the original
+      {{RTCPeerConnection}}. Please refer to the original
       definitions of the objects in the [[!GETUSERMEDIA]] document for general
-      information on using <code>MediaStream</code> and
-      <code>MediaStreamTrack</code>.</p>
+      information on using {{MediaStream}} and
+      {{MediaStreamTrack}}.</p>
     </section>
     <section>
       <h3 id="mediastream-network-use">MediaStream</h3>
       <section>
         <h4>id</h4>
-        <p>The <code><a data-cite=
-        "!GETUSERMEDIA#dom-mediastream-id">id</a></code>
-        attribute specified in <code>MediaStream</code> returns an id that is
+        <p>The {{mediastream/id}}
+        attribute specified in {{MediaStream}} returns an id that is
         unique to this stream, so that streams can be recognized at the remote
-        end of the <code><a>RTCPeerConnection</a></code> API.</p>
-        <p>When a <code><a>MediaStream</a></code> is created to represent a
-        stream obtained from a remote peer, the <code><a data-cite=
-        "!GETUSERMEDIA#dom-mediastream-id">id</a></code>
+        end of the {{RTCPeerConnection}} API.</p>
+        <p>When a {{MediaStream}} is created to represent a
+        stream obtained from a remote peer, the {{mediastream/id}}
         attribute is initialized from information provided by the remote
         source.</p>
-        <p class="note">The id of a <code><a>MediaStream</a></code> object is
+        <p class="note">The {{mediastream/id}} of a {{MediaStream}} object is
         unique to the source of the stream, but that does not mean it is not
         possible to end up with duplicates. For example, the tracks of a
         locally generated stream could be sent from one user agent to a remote
-        peer using <code><a>RTCPeerConnection</a></code> and then sent back to
+        peer using {{RTCPeerConnection}} and then sent back to
         the original user agent in the same manner, in which case the original
         user agent will have multiple streams with the same id (the
         locally-generated one and the one received from the remote peer).</p>
@@ -10937,36 +10798,35 @@ async function gatherStats() {
     </section>
     <section>
       <h3 id="mediastreamtrack-network-use">MediaStreamTrack</h3>
-      <p>A <code>MediaStreamTrack</code> object's reference to its
-      <code>MediaStream</code> in the non-local media source case (an RTP
-      source, as is the case for each <code>MediaStreamTrack</code>
+      <p>A {{MediaStreamTrack}} object's reference to its
+      {{MediaStream}} in the non-local media source case (an RTP
+      source, as is the case for each {{MediaStreamTrack}}
       associated with
-      an <code><a>RTCRtpReceiver</a></code>) is always strong.</p>
-      <p data-tests="RTCPeerConnection-remote-track-mute.https.html">Whenever an <code><a>RTCRtpReceiver</a></code> receives data on an RTP
-      source whose corresponding <code><a>MediaStreamTrack</a></code> is muted,
+      an {{RTCRtpReceiver}}) is always strong.</p>
+      <p data-tests="RTCPeerConnection-remote-track-mute.https.html">Whenever an {{RTCRtpReceiver}} receives data on an RTP
+      source whose corresponding {{MediaStreamTrack}} is muted,
       but not ended, and the <a>[[\Receptive]]</a> slot of the
-      <a>RTCRtpTransceiver</a> object the
-      <a>RTCRtpReceiver</a> is a member of is <code>true</code>,
-      it MUST queue a task to <a>set the muted state</a> of the corresponding
-      <code><a>MediaStreamTrack</a></code> to <code>false</code>.
+      {{RTCRtpTransceiver}} object the
+      {{RTCRtpReceiver}} is a member of is <code>true</code>,
+      it MUST queue a task to [= set the muted state =] of the corresponding
+      {{MediaStreamTrack}} to <code>false</code>.
       </p>
       <p>When one of the SSRCs for RTP source media streams received
-      by an <code><a>RTCRtpReceiver</a></code> is removed either
+      by an {{RTCRtpReceiver}} is removed either
       due to reception of a BYE or via timeout, it MUST queue a task to
-      <a>set the muted state</a> of the corresponding
-      <code><a>MediaStreamTrack</a></code> to
-      <code>true</code>. Note that <code><a data-link-for=
-      "RTCPeerConnection">setRemoteDescription</a></code>
-      can also lead to <a data-lt="set the muted state"> the setting
-      of the muted state</a> of the <code>track</code> to the
+      [= set the muted state =] of the corresponding
+      {{MediaStreamTrack}} to
+      <code>true</code>. Note that {{RTCPeerConnection/setRemoteDescription}}
+      can also lead to [= set the muted state | the setting
+      of the muted state =] of the <code>track</code> to the
       value <code>true</code>.</p>
       <p>The procedures
       <dfn data-lt="add the track" id="add-track">add a track</dfn>,
       <dfn data-lt="remove the track" id="remove-track">remove a track</dfn> and
       <dfn data-lt="set the muted state" id="set-track-muted">set a track's
       muted state</dfn> are specified in [[!GETUSERMEDIA]].</p>
-      <p>When a <code><a>MediaStreamTrack</a></code> track produced by
-        an <code><a>RTCRtpReceiver</a></code> <var>receiver</var> has
+      <p>When a {{MediaStreamTrack}} track produced by
+        an {{RTCRtpReceiver}} <var>receiver</var> has
         <code>ended</code> [[!GETUSERMEDIA]] (such as via a call to
         <code><var>receiver</var>.track.stop</code>), the user agent MAY
         choose to free resources allocated for the incoming stream, by
@@ -10975,24 +10835,24 @@ async function gatherStats() {
         <h4>MediaTrackSupportedConstraints, MediaTrackCapabilities,
         MediaTrackConstraints and MediaTrackSettings</h4>
         <p>The concept of constraints and constrainable properties, including
-        <code>MediaTrackConstraints</code>
+        {{MediaTrackConstraints}}
         (<code>MediaStreamTrack.getConstraints()</code>,
         <code>MediaStreamTrack.applyConstraints()</code>), and
-        <code>MediaTrackSettings</code>
+        {{MediaTrackSettings}}
         (<code>MediaStreamTrack.getSettings()</code>) are outlined in
         [[!GETUSERMEDIA]]. However, the constrainable properties of tracks
         sourced from a peer connection are different than those sourced by
         <code>getUserMedia()</code>; the constraints and settings applicable to
-        <code><a>MediaStreamTrack</a></code>s sourced from a <a>remote
-        source</a> are defined here. The settings of a remote track represent
+        {{MediaStreamTrack}}s sourced from a [= remote
+        source =] are defined here. The settings of a remote track represent
         the latest frame received.
         <code>MediaStreamTrack.getCapabilities()</code> MUST always return the
         empty set and <code>MediaStreamTrack.applyConstraints()</code> MUST
         always reject with <code>OverconstrainedError</code> on remote tracks
         for constraints defined here.</p>
         <p>The following constrainable properties are defined to apply to video
-        <code><a>MediaStreamTrack</a></code>s sourced from a <a>remote
-        source</a>:</p>
+        {{MediaStreamTrack}}s sourced from a [= remote
+        source =]:</p>
         <table class="simple">
           <thead>
             <tr>
@@ -11004,25 +10864,25 @@ async function gatherStats() {
           <tbody>
             <tr id="def-constraint-width">
               <td><dfn>width</dfn></td>
-              <td><code>ConstrainULong</code></td>
+              <td>{{ConstrainULong}}</td>
               <td>As a setting, this is the width, in pixels, of the latest
               frame received.</td>
             </tr>
             <tr id="def-constraint-height">
               <td><dfn>height</dfn></td>
-              <td><code>ConstrainULong</code></td>
+              <td>{{ConstrainULong}}</td>
               <td>As a setting, this is the height, in pixels, of the latest
               frame received.</td>
             </tr>
             <tr id="def-constraint-frameRate">
               <td><dfn>frameRate</dfn></td>
-              <td><code>ConstrainDouble</code></td>
+              <td>{{ConstrainDouble}}</td>
               <td>As a setting, this is an estimate of the frame rate based on
               recently received frames.</td>
             </tr>
             <tr id="def-constraint-aspect">
               <td><dfn>aspectRatio</dfn></td>
-              <td><code>ConstrainDouble</code></td>
+              <td>{{ConstrainDouble}}</td>
               <td>As a setting, this is the aspect ratio of the latest frame;
               this is the width in pixels divided by height in pixels as a
               double rounded to the tenth decimal place.</td>
@@ -11030,8 +10890,8 @@ async function gatherStats() {
           </tbody>
         </table>
         <p>This document does not define any constrainable properties to apply
-        to audio <code><a>MediaStreamTrack</a></code>s sourced from a <a>remote
-        source</a>.</p>
+        to audio {{MediaStreamTrack}}s sourced from a [= remote
+        source =].</p>
       </section>
     </section>
   </section>
@@ -11303,9 +11163,9 @@ signaling.onmessage = async (event) =&gt; {
       <h3>Peer-to-peer Data Example</h3>
       <div>
         <p>This example shows how to create an
-        <code><a>RTCDataChannel</a></code> object and perform the offer/answer
+        {{RTCDataChannel}} object and perform the offer/answer
         exchange required to connect the channel to the other peer. The
-        <code><a>RTCDataChannel</a></code> is used in the context of a simple
+        {{RTCDataChannel}} is used in the context of a simple
         chat application and listeners are attached to monitor when the channel
         is ready, messages are received and when the channel is closed.</p>
         <pre class="example highlight">
@@ -11395,7 +11255,7 @@ function setupChat() {
     </section>
     <section>
       <h3>DTMF Example</h3>
-      <p>Examples assume that <var>sender</var> is an <code><a>RTCRtpSender</a></code>.</p>
+      <p>Examples assume that <var>sender</var> is an {{RTCRtpSender}}.</p>
       <p>Sending the DTMF signal "1234" with 500 ms duration per tone:</p>
       <pre class="example highlight">
 if (sender.dtmf.canInsertDTMF) {
@@ -11540,7 +11400,7 @@ signaling.onmessage = async ({data: {description, candidate}}) => {
       <code>setRemoteDescription</code> (with implicit rollback) to avoid
       races with other signaling messages being serviced.</p>
       <p>The <code>ignoredOffer</code> variable is needed, because
-      the <code>RTCPeerConnection</code> object on the impolite side is never
+      the {{RTCPeerConnection}} object on the impolite side is never
       told about ignored offers. We must therefore suppress errors from
       incoming candidates belonging to such offers.</p>
     </section>
@@ -11564,8 +11424,8 @@ signaling.onmessage = async ({data: {description, candidate}}) => {
   </section>
   <section>
     <h2>Error Handling</h2>
-    <p>Some operations throw or fire <code>RTCError</code>. This is an extension
-    of <code><a data-cite="!WEBIDL#idl-DOMException">DOMException</a></code>
+    <p>Some operations throw or fire {{RTCError}}. This is an extension
+    of {{DOMException}}
     that carries additional WebRTC-specific information.</p>
     <section>
       <h3><dfn>RTCError</dfn> Interface</h3>
@@ -11586,7 +11446,7 @@ interface RTCError : DOMException {
         <h2>Constructors</h2>
         <dl data-link-for="RTCError" data-dfn-for="RTCError"
         class="constructors">
-          <dt><dfn data-idl><code>constructor()</code></dfn></dt>
+          <dt><dfn data-idl>constructor()</dfn></dt>
           <dd>
             <p>Run the following steps:</p>
             <ol>
@@ -11598,12 +11458,11 @@ interface RTCError : DOMException {
                 argument.</p>
               </li>
               <li>
-                <p>Let <var>e</var> be a new <code><a>RTCError</a></code>
+                <p>Let <var>e</var> be a new {{RTCError}}
                 object.</p>
               </li>
               <li data-tests="RTCError.html">
-                <p>Invoke the <code><a data-cite="!WEBIDL#idl-DOMException">
-                DOMException</a></code> constructor of <var>e</var> with the
+                <p>Invoke the {{DOMException}} constructor of <var>e</var> with the
                 <code>message</code> argument set to <var>message</var> and the
                 <code>name</code> argument set to <code>"RTCError"</code>.</p>
                 <p class="note">This name does not have a mapping to a legacy
@@ -11611,7 +11470,7 @@ interface RTCError : DOMException {
                 0.</p>
               </li>
               <li data-tests="RTCError.html">
-                <p>Set all <code>RTCError</code> attributes of <var>e</var> to
+                <p>Set all {{RTCError}} attributes of <var>e</var> to
                 the value of the corresponding attribute in <var>init</var> if
                 it is present, otherwise set it to <code>null</code>.</p>
               </li>
@@ -11625,26 +11484,26 @@ interface RTCError : DOMException {
       <section>
         <h2>Attributes</h2>
         <dl data-link-for="RTCError" data-dfn-for="RTCError" class="attributes">
-          <dt data-tests="RTCError.html,RTCPeerConnection-setRemoteDescription-offer.html"><dfn data-idl><code>errorDetail</code></dfn> of type <span
+          <dt data-tests="RTCError.html,RTCPeerConnection-setRemoteDescription-offer.html"><dfn data-idl>errorDetail</dfn> of type <span
           class="idlAttrType">RTCErrorDetailType</span>, readonly</dt>
           <dd>
             <p>The WebRTC-specific error code for the type of error that
             occurred.</p>
           </dd>
-          <dt data-tests="RTCError.html,RTCPeerConnection-setRemoteDescription-offer.html"><dfn data-idl><code>sdpLineNumber</code></dfn> of type <span
+          <dt data-tests="RTCError.html,RTCPeerConnection-setRemoteDescription-offer.html"><dfn data-idl>sdpLineNumber</dfn> of type <span
           class="idlAttrType">long</span>, readonly, nullable</dt>
           <dd>
             <p>If <code>errorDetail</code> is <code>"sdp-syntax-error"</code>
             this is the line number where the error was detected (the first
             line has line number 1).</p>
           </dd>
-          <dt data-tests="RTCError.html"><dfn data-idl><code>sctpCauseCode</code></dfn> of type <span
+          <dt data-tests="RTCError.html"><dfn data-idl>sctpCauseCode</dfn> of type <span
           class="idlAttrType">long</span>, readonly, nullable</dt>
           <dd>
             <p>If <code>errorDetail</code> is <code>"sctp-failure"</code> this
             is the SCTP cause code of the failed SCTP negotiation.</p>
           </dd>
-          <dt data-tests="RTCError.html"><dfn data-idl><code>receivedAlert</code></dfn> of type <span
+          <dt data-tests="RTCError.html"><dfn data-idl>receivedAlert</dfn> of type <span
           class="idlAttrType">unsigned long</span>, readonly,
           nullable</dt>
           <dd>
@@ -11652,7 +11511,7 @@ interface RTCError : DOMException {
             a fatal DTLS alert was received, this is the value of the DTLS
             alert received.</p>
           </dd>
-          <dt data-tests="RTCError.html"><dfn data-idl><code>sentAlert</code></dfn> of type <span
+          <dt data-tests="RTCError.html"><dfn data-idl>sentAlert</dfn> of type <span
           class="idlAttrType">unsigned long</span>, readonly,
           nullable</dt>
           <dd>
@@ -11662,11 +11521,11 @@ interface RTCError : DOMException {
           </dd>
           <dd>
             <div class="issue atrisk">
-              <p>All attributes defined in <a>RTCError</a> are marked at risk due
-              to lack of implementation (<a>errorDetail</a>, <a>sdpLineNumber</a>,
-              <a>httpRequestStatusCode</a>, <a>sctpCauseCode</a>,
-              <a>receivedAlert</a> and <a>sentAlert</a>). This does not include
-              attributes inherited from <code>DOMException</code>.</p>
+              <p>All attributes defined in {{RTCError}} are marked at risk due
+              to lack of implementation ({{errorDetail}}, {{sdpLineNumber}},
+              {{httpRequestStatusCode}}, {{sctpCauseCode}},
+              {{receivedAlert}} and {{sentAlert}}). This does not include
+              attributes inherited from {{DOMException}}.</p>
             </div>
           </dd>
         </dl>
@@ -11682,47 +11541,47 @@ interface RTCError : DOMException {
   unsigned long receivedAlert;
   unsigned long sentAlert;
 };</pre>
-        <p data-dfn-for="RTCErrorInit">The <dfn data-idl>errorDetail</dfn>, <dfn data-idl>sdpLineNumber</dfn>, <dfn data-idl>httpRequestStatusCode</dfn>, <dfn data-idl>sctpCauseCode</dfn>, <dfn data-idl>receivedAlert</dfn> and <dfn data-idl>sentAlert</dfn> members of <code>RTCErrorInit</code> have the same definitions as the attributes of the same name of <a>RTCError</a>.</p>
+        <p data-dfn-for="RTCErrorInit">The <dfn data-idl>errorDetail</dfn>, <dfn data-idl>sdpLineNumber</dfn>, <dfn data-idl>httpRequestStatusCode</dfn>, <dfn data-idl>sctpCauseCode</dfn>, <dfn data-idl>receivedAlert</dfn> and <dfn data-idl>sentAlert</dfn> members of {{RTCErrorInit}} have the same definitions as the attributes of the same name of {{RTCError}}.</p>
       </div>
       <section>
-        <h2>Dictionary <a>RTCError</a> Members</h2>
+        <h2>Dictionary {{RTCError}} Members</h2>
         <dl data-link-for="RTCError" data-dfn-for="RTCError"
         class="dictionary-members">
           <dt><code>errorDetail</code> of type <span
           class="idlMemberType">RTCErrorDetailType</span>,
           required</dt>
           <dd>
-            <p>See <code><a>RTCError</a></code>'s
+            <p>See {{RTCError}}'s
             <code>errorDetail</code>.</p>
           </dd>
           <dt><code>sdpLineNumber</code> of type <span
           class="idlMemberType">long</span></dt>
           <dd>
-            <p>See <code><a>RTCError</a></code>'s
+            <p>See {{RTCError}}'s
             <code>sdpLineNumber</code>.</p>
           </dd>
           <dt><code>httpRequestStatusCode</code> of type
           <span class="idlMemberType">long</span></dt>
           <dd>
-            <p>See <code><a>RTCError</a></code>'s
+            <p>See {{RTCError}}'s
             <code>httpRequestStatusCode</code>.</p>
           </dd>
           <dt><code>sctpCauseCode</code> of type <span
           class="idlMemberType">long</span></dt>
           <dd>
-            <p>See <code><a>RTCError</a></code>'s
+            <p>See {{RTCError}}'s
             <code>sctpCauseCode</code>.</p>
           </dd>
           <dt><code>receivedAlert</code> of type <span
           class="idlMemberType">unsigned long</span></dt>
           <dd>
-            <p>See <code><a>RTCError</a></code>'s
+            <p>See {{RTCError}}'s
             <code>receivedAlert</code>.</p>
           </dd>
           <dt><code>sentAlert</code> of type <span
           class="idlMemberType">unsigned long</span></dt>
           <dd>
-            <p>See <code><a>RTCError</a></code>'s
+            <p>See {{RTCError}}'s
             <code>sentAlert</code>.</p>
           </dd>
         </dl>
@@ -11748,11 +11607,11 @@ interface RTCError : DOMException {
               <th colspan="2">Enumeration description</th>
             </tr>
             <tr>
-              <td><dfn data-idl><code>data-channel-failure</code></dfn></td>
+              <td><dfn data-idl>data-channel-failure</dfn></td>
               <td>The data channel has failed.</td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>dtls-failure</code></dfn></td>
+              <td><dfn data-idl>dtls-failure</dfn></td>
               <td>The DTLS negotiation has failed or the connection
               has been terminated with a fatal error. The
               <code>message</code> contains information relating to
@@ -11763,8 +11622,8 @@ interface RTCError : DOMException {
               the value of the DTLS alert sent.</td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>fingerprint-failure</code></dfn></td>
-              <td>The <code><a>RTCDtlsTransport</a></code>'s
+              <td><dfn data-idl>fingerprint-failure</dfn></td>
+              <td>The {{RTCDtlsTransport}}'s
               remote certificate did not match any of the fingerprints
               provided in the SDP. If the remote peer cannot match
               the local certificate against the provided fingerprints,
@@ -11773,25 +11632,25 @@ interface RTCError : DOMException {
               resulting in a "dtls-failure".</td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>sctp-failure</code></dfn></td>
+              <td><dfn data-idl>sctp-failure</dfn></td>
               <td>The SCTP negotiation has failed or the connection
               has been terminated with a fatal error. The
               <code>sctpCauseCode</code> attribute is set to the
               SCTP cause code.</td>
             </tr>
             <tr>
-              <td data-tests="RTCPeerConnection-setRemoteDescription-offer.html"><dfn data-idl><code>sdp-syntax-error</code></dfn></td>
+              <td data-tests="RTCPeerConnection-setRemoteDescription-offer.html"><dfn data-idl>sdp-syntax-error</dfn></td>
               <td>The SDP syntax is not valid. The <code>sdpLineNumber</code>
               attribute is set to the line number in the SDP where the syntax
               error was detected.</td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>hardware-encoder-not-available</code></dfn></td>
+              <td><dfn data-idl>hardware-encoder-not-available</dfn></td>
               <td>The hardware encoder resources required for the requested
               operation are not available.</td>
             </tr>
             <tr>
-              <td><dfn data-idl><code>hardware-encoder-error</code></dfn></td>
+              <td><dfn data-idl>hardware-encoder-error</dfn></td>
               <td>The hardware encoder does not support the provided
               parameters.</td>
             </tr>
@@ -11801,8 +11660,8 @@ interface RTCError : DOMException {
     </section>
     <section>
       <h3><dfn>RTCErrorEvent</dfn> Interface</h3>
-      <p>The <code>RTCErrorEvent</code> interface is defined for cases when an
-      <code><a>RTCError</a></code> is raised as an event:</p>
+      <p>The {{RTCErrorEvent}} interface is defined for cases when an
+      {{RTCError}} is raised as an event:</p>
       <div>
         <pre class="idl" data-tests="idlharness.https.window.js"
 >[Exposed=Window]
@@ -11815,10 +11674,10 @@ interface RTCErrorEvent : Event {
         <h2>Constructors</h2>
         <dl data-link-for="RTCErrorEvent" data-dfn-for=
         "RTCErrorEvent" class="constructors">
-          <dt data-tests="idlharness.https.window.js"><dfn data-idl><code>constructor()</code></dfn></dt>
+          <dt data-tests="idlharness.https.window.js"><dfn data-idl>constructor()</dfn></dt>
           <dd>
             <p>Constructs a new
-            <code><a>RTCErrorEvent</a></code>.</p>
+            {{RTCErrorEvent}}.</p>
           </dd>
         </dl>
       </section>
@@ -11826,11 +11685,11 @@ interface RTCErrorEvent : Event {
         <h2>Attributes</h2>
         <dl data-link-for="RTCErrorEvent" data-dfn-for=
         "RTCErrorEvent" class="attributes">
-          <dt><dfn data-idl><code>error</code></dfn> of type <span class=
-          "idlAttrType"><a>RTCError</a></span>, readonly,
+          <dt><dfn data-idl>error</dfn> of type <span class=
+          "idlAttrType">{{RTCError}}</span>, readonly,
           nullable</dt>
           <dd>
-            <p>The <code><a>RTCError</a></code> describing the error that
+            <p>The {{RTCError}} describing the error that
             triggered the event.</p>
           </dd>
         </dl>
@@ -11848,11 +11707,11 @@ interface RTCErrorEvent : Event {
         <h2>Dictionary RTCErrorEventInit Members</h2>
         <dl data-link-for="RTCErrorEventInit" data-dfn-for=
         "RTCErrorEventInit" class="dictionary-members">
-          <dt><dfn data-idl><code>error</code></dfn> of type <span class=
-          "idlMemberType"><a>RTCError</a></span>, nullable,
+          <dt><dfn data-idl>error</dfn> of type <span class=
+          "idlMemberType">{{RTCError}}</span>, nullable,
           defaulting to <code>null</code></dt>
           <dd>
-            <p>The <code><a>RTCError</a></code> describing the error
+            <p>The {{RTCError}} describing the error
             associated with the event (if any).</p>
           </dd>
         </dl>
@@ -11861,7 +11720,7 @@ interface RTCErrorEvent : Event {
   </section>
   <section class="informative">
     <h2>Event summary</h2>
-    <p>The following events fire on <code><a>RTCDataChannel</a></code>
+    <p>The following events fire on {{RTCDataChannel}}
     objects:</p>
     <table>
       <tbody>
@@ -11874,10 +11733,10 @@ interface RTCErrorEvent : Event {
       <tbody>
         <tr>
           <td><dfn id="event-datachannel-open"><code>open</code></dfn></td>
-          <td><code><a>Event</a></code></td>
+          <td>{{Event}}</td>
           <td>
-            The <code><a>RTCDataChannel</a></code> object's <a>underlying data
-            transport</a> has been established (or re-established).
+            The {{RTCDataChannel}} object's [= underlying data
+            transport =] has been established (or re-established).
           </td>
         </tr>
         <tr>
@@ -11889,38 +11748,36 @@ interface RTCErrorEvent : Event {
         <tr>
           <td><dfn id=
           "event-datachannel-bufferedamountlow"><code>bufferedamountlow</code></dfn></td>
-          <td><code><a>Event</a></code></td>
-          <td>The <code><a>RTCDataChannel</a></code> object's
-          <code><a data-link-for="RTCDataChannel">bufferedAmount</a></code>
-          decreases from above its <code><a data-link-for=
-          "RTCDataChannel">bufferedAmountLowThreshold</a></code> to less than
-          or equal to its <code><a data-link-for=
-          "RTCDataChannel">bufferedAmountLowThreshold</a></code>.</td>
+          <td>{{Event}}</td>
+          <td>The {{RTCDataChannel}} object's
+          {{RTCDataChannel/bufferedAmount}}
+          decreases from above its {{RTCDataChannel/bufferedAmountLowThreshold}} to less than
+          or equal to its {{RTCDataChannel/bufferedAmountLowThreshold}}.</td>
         </tr>
         <tr>
           <td><dfn><code id="event-datachannel-error">error</code></dfn></td>
-          <td><code><a>RTCErrorEvent</a></code></td>
+          <td>{{RTCErrorEvent}}</td>
           <td>An error occurred on the data channel.</td>
         </tr>
         <tr>
           <td><dfn><code id="event-datachannel-closing">closing</code></dfn></td>
-          <td><code><a>Event</a></code></td>
+          <td>{{Event}}</td>
           <td>
-            The <code><a>RTCDataChannel</a></code> object transitions to the
+            The {{RTCDataChannel}} object transitions to the
             "closing" state
           </td>
         </tr>
         <tr>
           <td><dfn><code id="event-datachannel-close">close</code></dfn></td>
-          <td><code><a>Event</a></code></td>
+          <td>{{Event}}</td>
           <td>
-            The <code><a>RTCDataChannel</a></code> object's <a>underlying data
-            transport</a> has been closed.
+            The {{RTCDataChannel}} object's [= underlying data
+            transport =] has been closed.
           </td>
         </tr>
       </tbody>
     </table>
-    <p>The following events fire on <code><a>RTCPeerConnection</a></code>
+    <p>The following events fire on {{RTCPeerConnection}}
     objects:</p>
     <table>
       <tbody>
@@ -11960,17 +11817,17 @@ interface RTCErrorEvent : Event {
         -->
         <tr>
           <td><dfn id="event-track"><code>track</code></dfn></td>
-          <td><code><a>RTCTrackEvent</a></code></td>
+          <td>{{RTCTrackEvent}}</td>
           <td>New incoming media has been negotiated for a specific
-            <code><a>RTCRtpReceiver</a></code>, and that receiver's
+            {{RTCRtpReceiver}}, and that receiver's
             <code>track</code> has been added to any associated remote
-            <code>MediaStream</code>s.
+            {{MediaStream}}s.
           </td>
         </tr>
         <tr>
           <td><dfn id=
           "event-negotiation"><code>negotiationneeded</code></dfn></td>
-          <td><code><a>Event</a></code></td>
+          <td>{{Event}}</td>
           <td>The browser wishes to inform the application that session
           negotiation needs to be done (i.e. a createOffer call followed by
           setLocalDescription).</td>
@@ -11978,63 +11835,60 @@ interface RTCErrorEvent : Event {
         <tr>
           <td><dfn id=
           "event-signalingstatechange"><code>signalingstatechange</code></dfn></td>
-          <td><code><a>Event</a></code></td>
+          <td>{{Event}}</td>
           <td>
-            The <a>signaling state</a> has changed. This state change is the
-            result of either <code><a data-link-for=
-            "RTCPeerConnection">setLocalDescription</a></code> or
-            <code><a data-link-for=
-            "RTCPeerConnection">setRemoteDescription</a></code> being invoked.
+            The [= signaling state =] has changed. This state change is the
+            result of either {{RTCPeerConnection/setLocalDescription}} or
+            {{RTCPeerConnection/setRemoteDescription}} being invoked.
           </td>
         </tr>
         <tr>
           <td><dfn id=
           "event-iceconnectionstatechange"><code>iceconnectionstatechange</code></dfn></td>
-          <td><code><a>Event</a></code></td>
+          <td>{{Event}}</td>
           <td>
-            The <code>RTCPeerConnection</code>'s <a>ICE connection state</a>
+            The {{RTCPeerConnection}}'s [= ICE connection state =]
             has changed.
           </td>
         </tr>
         <tr>
           <td><dfn id=
           "event-icegatheringstatechange"><code>icegatheringstatechange</code></dfn></td>
-          <td><code><a>Event</a></code></td>
+          <td>{{Event}}</td>
           <td>
-            The <code>RTCPeerConnection</code>'s <a>ICE gathering state</a> has
+            The {{RTCPeerConnection}}'s [= ICE gathering state =] has
             changed.
           </td>
         </tr>
         <tr>
           <td><dfn id="event-icecandidate"><code>icecandidate</code></dfn></td>
-          <td><code><a>RTCPeerConnectionIceEvent</a></code></td>
-          <td>A new <code><a>RTCIceCandidate</a></code> is made available to
+          <td>{{RTCPeerConnectionIceEvent}}</td>
+          <td>A new {{RTCIceCandidate}} is made available to
           the script.</td>
         </tr>
         <tr>
           <td><dfn id=
           "event-connectionstatechange"><code>connectionstatechange</code></dfn></td>
-          <td><code><a>Event</a></code></td>
+          <td>{{Event}}</td>
           <td>
-            The <code>RTCPeerConnection</code> <a
-            data-link-for="RTCPeerConnection">connectionState</a> has changed.
+            The {{RTCPeerConnection}}.{{RTCPeerConnection/connectionState}} has changed.
           </td>
         </tr>
         <tr>
           <td><dfn id=
           "event-icecandidateerror"><code>icecandidateerror</code></dfn></td>
-          <td><code><a>RTCPeerConnectionIceErrorEvent</a></code></td>
+          <td>{{RTCPeerConnectionIceErrorEvent}}</td>
           <td>A failure occured when gathering ICE candidates.</td>
         </tr>
         <tr>
           <td><dfn id="event-datachannel"><code>datachannel</code></dfn></td>
-          <td><code><a>RTCDataChannelEvent</a></code></td>
-          <td>A new <code><a>RTCDataChannel</a></code> is dispatched to the
+          <td>{{RTCDataChannelEvent}}</td>
+          <td>A new {{RTCDataChannel}} is dispatched to the
           script in response to the other peer creating a channel.</td>
         </tr>
       </tbody>
     </table>
-    <p>The following events fire on <code><a>RTCDTMFSender</a></code>
+    <p>The following events fire on {{RTCDTMFSender}}
     objects:</p>
     <table>
       <tbody>
@@ -12048,19 +11902,18 @@ interface RTCErrorEvent : Event {
         <tr>
           <td><dfn id=
           "event-RTCDTMFSender-tonechange"><code>tonechange</code></dfn></td>
-          <td><code><a>RTCDTMFToneChangeEvent</a></code></td>
-          <td data-tests="RTCDTMFSender-ontonechange-long.https.html">The <code><a>RTCDTMFSender</a></code> object has either just
-          begun playout of a tone (returned as the <code><a data-link-for=
-          "RTCDTMFToneChangeEvent">tone</a></code> attribute) or just ended
+          <td>{{RTCDTMFToneChangeEvent}}</td>
+          <td data-tests="RTCDTMFSender-ontonechange-long.https.html">The {{RTCDTMFSender}} object has either just
+          begun playout of a tone (returned as the {{RTCDTMFToneChangeEvent/tone}} attribute) or just ended
           the playout of tones in the
-          <code><a data-link-for="RTCDTMFSender">toneBuffer</a></code>
+          {{RTCDTMFSender/toneBuffer}}
           (returned as an empty value in the
-          <code><a data-link-for="RTCDTMFToneChangeEvent">tone</a></code>
+          {{RTCDTMFToneChangeEvent/tone}}
           attribute).</td>
         </tr>
       </tbody>
     </table>
-    <p>The following events fire on <code><a>RTCIceTransport</a></code>
+    <p>The following events fire on {{RTCIceTransport}}
     objects:</p>
     <table>
       <tbody>
@@ -12074,26 +11927,26 @@ interface RTCErrorEvent : Event {
         <tr>
           <td><dfn id="event-icetransport-statechange" data-lt=
           "RTCIceTransport state change"><code>statechange</code></dfn></td>
-          <td><code><a>Event</a></code></td>
-          <td>The <code><a>RTCIceTransport</a></code> state changes.</td>
+          <td>{{Event}}</td>
+          <td>The {{RTCIceTransport}} state changes.</td>
         </tr>
         <tr>
           <td><dfn id=
           "event-icetransport-gatheringstatechange"><code>gatheringstatechange</code></dfn></td>
-          <td><code><a>Event</a></code></td>
-          <td>The <code><a>RTCIceTransport</a></code> gathering state
+          <td>{{Event}}</td>
+          <td>The {{RTCIceTransport}} gathering state
           changes.</td>
         </tr>
         <tr>
           <td><dfn id=
           "event-icetransport-selectedcandidatepairchange"><code>selectedcandidatepairchange</code></dfn></td>
-          <td><code><a>Event</a></code></td>
-          <td>The <code><a>RTCIceTransport</a></code>'s selected candidate pair
+          <td>{{Event}}</td>
+          <td>The {{RTCIceTransport}}'s selected candidate pair
           changes.</td>
         </tr>
       </tbody>
     </table>
-    <p>The following events fire on <code><a>RTCDtlsTransport</a></code>
+    <p>The following events fire on {{RTCDtlsTransport}}
     objects:</p>
     <table>
       <tbody>
@@ -12108,18 +11961,18 @@ interface RTCErrorEvent : Event {
           <td><dfn id="event-dtlstransport-statechange" data-lt=
           "RTCDtlsTransport state change" data-lt-nodefault=
           ""><code>statechange</code></dfn></td>
-          <td><code><a>Event</a></code></td>
-          <td>The <code><a>RTCDtlsTransport</a></code> state changes.</td>
+          <td>{{Event}}</td>
+          <td>The {{RTCDtlsTransport}} state changes.</td>
         </tr>
         <tr>
-          <td><code>error</code></td>
-          <td><code><a>RTCErrorEvent</a></code></td>
-          <td>An error occurred on the <code><a>RTCDtlsTransport</a></code>
+          <td><dfn data-lt="RTCDtlsTransport error" data-lt-noDefault><code>error</code></dfn></td>
+          <td>{{RTCErrorEvent}}</td>
+          <td>An error occurred on the {{RTCDtlsTransport}}
           (either "dtls-error" or "fingerprint-failure").</td>
         </tr>
       </tbody>
     </table>
-    <p>The following events fire on <code><a>RTCSctpTransport</a></code>
+    <p>The following events fire on {{RTCSctpTransport}}
     objects:</p>
     <table>
       <tbody>
@@ -12134,8 +11987,8 @@ interface RTCErrorEvent : Event {
           <td><dfn id="event-sctptransport-statechange" data-lt=
           "RTCSctpTransport state change" data-lt-nodefault=
           ""><code>statechange</code></dfn></td>
-          <td><code><a>Event</a></code></td>
-          <td>The <code><a>RTCSctpTransport</a></code> state changes.</td>
+          <td>{{Event}}</td>
+          <td>The {{RTCSctpTransport}} state changes.</td>
         </tr>
       </tbody>
     </table>
@@ -12182,7 +12035,7 @@ interface RTCErrorEvent : Event {
       <p>A connection will always reveal the IP addresses proposed for
       communication to the corresponding party. The application can limit this
       exposure by choosing not to use certain addresses using the settings
-      exposed by the <a>RTCIceTransportPolicy</a> dictionary, and by using
+      exposed by the {{RTCIceTransportPolicy}} dictionary, and by using
       relays (for instance TURN servers) rather than direct connections between
       participants. One will normally assume that the IP address of TURN
       servers is not sensitive information. These choices can for instance be
@@ -12228,7 +12081,7 @@ interface RTCErrorEvent : Event {
       <code>postMessage</code> in anticipation of future needs. User agents are
       strongly encouraged to isolate the private keying material these objects
       hold a handle to, from the processes that have access to the
-      <code>RTCCertificate</code> objects, to reduce memory attack surface.</p>
+      {{RTCCertificate}} objects, to reduce memory attack surface.</p>
     </section>
     <section>
       <h2>Persistent information exposed by WebRTC</h2>

--- a/webrtc.html
+++ b/webrtc.html
@@ -254,7 +254,7 @@
         <div>
           <pre class="idl"
 >enum RTCIceCredentialType {
-  "password",
+  "password"
 };</pre>
           <table data-link-for="RTCIceCredentialType" data-dfn-for=
           "RTCIceCredentialType" class="simple">
@@ -300,12 +300,12 @@
               <dd>
                 <p>If this {{RTCIceServer}} object represents a
                 TURN server, and <code>credentialType</code> is
-                <code>"password"</code>, then this attribute specifies the
+                {{RTCIceCredentialType/"password"}}, then this attribute specifies the
                 username to use with that TURN server.</p>
               </dd>
               <dt><dfn data-idl>credentialType</dfn> of type <span class=
               "idlMemberType">{{RTCIceCredentialType}}</span>, defaulting to
-              <code>"password"</code></dt>
+              {{RTCIceCredentialType/"password"}}</dt>
               <dd>
                 <p>If this {{RTCIceServer}} object represents a
                 TURN server, then this attribute specifies how
@@ -545,24 +545,24 @@
               </tr>
               <tr>
                 <td data-tests="RTCPeerConnection-createOffer.html, RTCPeerConnection-setLocalDescription-offer.html,RTCPeerConnection-setLocalDescription.html,RTCPeerConnection-setRemoteDescription.html"><dfn data-idl>have-local-offer</dfn></td>
-                <td>A local description, of type <code>"offer"</code>, has been successfully
+                <td>A local description, of type {{RTCSdpType/"offer"}}, has been successfully
                 applied.</td>
               </tr>
               <tr>
                 <td data-tests="RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setRemoteDescription-offer.html,RTCPeerConnection-setRemoteDescription-rollback.html,RTCPeerConnection-setRemoteDescription.html"><dfn data-idl>have-remote-offer</dfn></td>
-                <td>A remote description, of type <code>"offer"</code>, has been
+                <td>A remote description, of type {{RTCSdpType/"offer"}}, has been
                 successfully applied.</td>
               </tr>
               <tr>
                 <td><dfn data-idl>have-local-pranswer</dfn></td>
-                <td>A remote description of type <code>"offer"</code> has been successfully
-                applied and a local description of type <code>"pranswer"</code> has been
+                <td>A remote description of type {{RTCSdpType/"offer"}} has been successfully
+                applied and a local description of type {{RTCSdpType/"pranswer"}} has been
                 successfully applied.</td>
               </tr>
               <tr>
                 <td data-tests="RTCPeerConnection-setRemoteDescription-pranswer.html,RTCPeerConnection-setRemoteDescription.html"><dfn data-idl>have-remote-pranswer</dfn></td>
-                <td>A local description of type <code>"offer"</code> has been successfully
-                applied and a remote description of type <code>"pranswer"</code> has been
+                <td>A local description of type {{RTCSdpType/"offer"}} has been successfully
+                applied and a remote description of type {{RTCSdpType/"pranswer"}} has been
                 successfully applied.</td>
               </tr>
               <tr>
@@ -585,19 +585,19 @@
           <dt>Caller transition:</dt>
           <dd>
             <ul>
-              <li>new RTCPeerConnection(): <code>stable</code></li>
-              <li>setLocalDescription(offer): <code>have-local-offer</code></li>
-              <li>setRemoteDescription(pranswer): <code>have-remote-pranswer</code></li>
-              <li>setRemoteDescription(answer): <code>stable</code></li>
+              <li>new RTCPeerConnection(): {{RTCSignalingState/"stable"}}</li>
+              <li>setLocalDescription(offer): {{RTCSignalingState/"have-local-offer"}}</li>
+              <li>setRemoteDescription(pranswer): {{RTCSignalingState/"have-remote-pranswer"}}</li>
+              <li>setRemoteDescription(answer): {{RTCSignalingState/"stable"}}</li>
             </ul>
           </dd>
           <dt>Callee transition:</dt>
           <dd>
             <ul>
-              <li>new RTCPeerConnection(): <code>stable</code></li>
-              <li>setRemoteDescription(offer): <code>have-remote-offer</code></li>
-              <li>setLocalDescription(pranswer): <code>have-local-pranswer</code></li>
-              <li>setLocalDescription(answer): <code>stable</code></li>
+              <li>new RTCPeerConnection(): {{RTCSignalingState/"stable"}}</li>
+              <li>setRemoteDescription(offer): {{RTCSignalingState/"have-remote-offer"}}</li>
+              <li>setLocalDescription(pranswer): {{RTCSignalingState/"have-local-pranswer"}}</li>
+              <li>setLocalDescription(answer): {{RTCSignalingState/"stable"}}</li>
             </ul>
           </dd>
         </dl>
@@ -620,20 +620,20 @@
               <tr>
                 <td data-tests="RTCPeerConnection-iceGatheringState.html"><dfn data-idl>new</dfn></td>
                 <td>Any of the {{RTCIceTransport}}s are in the
-                <code>"new"</code> gathering state and none of the transports are
-                in the <code>"gathering"</code> state, or there are no
+                {{RTCIceGathererState/"new"}} gathering state and none of the transports are
+                in the {{RTCIceGathererState/"gathering"}} state, or there are no
                 transports.</td>
               </tr>
               <tr>
                 <td data-tests="RTCPeerConnection-iceGatheringState.html"><dfn data-idl>gathering</dfn></td>
                 <td>Any of the {{RTCIceTransport}}s are in the
-                <code>"gathering"</code> state.</td>
+                {{RTCIceGathererState/"gathering"}} state.</td>
               </tr>
               <tr>
                 <td data-tests="RTCPeerConnection-iceGatheringState.html,protocol/candidate-exchange.https.html "><dfn data-idl>complete</dfn></td>
                 <td>At least one {{RTCIceTransport}} exists,
                 and all {{RTCIceTransport}}s are in the
-                <code>"completed"</code> gathering state.</td>
+                {{RTCIceGathererState/"complete"}} gathering state.</td>
               </tr>
             </tbody>
           </table>
@@ -735,39 +735,39 @@
                 <td data-tests="RTCPeerConnection-iceConnectionState-disconnected.https.html,protocol/ice-state.https.html"><dfn data-idl>failed</dfn></td>
                 <td>The previous state doesn't apply and any
                 {{RTCIceTransport}}s are in the
-                <code>"failed"</code> state.</td>
+                {{RTCIceTransportState/"failed"}} state.</td>
               </tr>
               <tr>
                 <td data-tests="RTCPeerConnection-iceConnectionState-disconnected.https.html,protocol/ice-state.https.html"><dfn data-idl>disconnected</dfn></td>
                 <td>None of the previous states apply and any
                 {{RTCIceTransport}}s are in the
-                <code>"disconnected"</code> state.</td>
+                {{RTCIceTransportState/"disconnected"}} state.</td>
               </tr>
               <tr>
                 <td data-tests="RTCPeerConnection-iceConnectionState.https.html,no-media-call.html"><dfn data-idl>new</dfn></td>
                 <td>None of the previous states apply and all
                 {{RTCIceTransport}}s are in the
-                <code>"new"</code> or <code>"closed"</code> state,
+                {{RTCIceTransportState/"new"}} or {{RTCIceTransportState/"closed"}} state,
                 or there are no transports.</td>
               </tr>
               <tr>
                 <td data-tests="RTCPeerConnection-iceConnectionState.https.html,no-media-call.html"><dfn data-idl>checking</dfn></td>
                 <td>None of the previous states apply and any
                 {{RTCIceTransport}}s are in the
-                <code>"new"</code> or <code>"checking"</code> state.</td>
+                {{RTCIceTransportState/"new"}} or {{RTCIceTransportState/"checking"}} state.</td>
               </tr>
               <tr>
                 <td data-tests="RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl>completed</dfn></td>
                 <td>None of the previous states apply and all
                 {{RTCIceTransport}}s are in the
-                <code>"completed"</code> or <code>"closed"</code> state.</td>
+                {{RTCIceTransportState/"completed"}} or {{RTCIceTransportState/"closed"}} state.</td>
               </tr>
               <tr>
                 <td data-tests="RTCPeerConnection-iceConnectionState.https.html,protocol/ice-state.https.html,RTCIceConnectionState-candidate-pair.https.html"><dfn data-idl>connected</dfn></td>
                 <td>None of the previous states apply and all
                 {{RTCIceTransport}}s are in the
-                <code>"connected"</code>, <code>"completed"</code> or
-                <code>"closed"</code> state.</td>
+                {{RTCIceTransportState/"connected"}}, {{RTCIceTransportState/"completed"}} or
+                {{RTCIceTransportState/"closed"}} state.</td>
               </tr>
             </tbody>
           </table>
@@ -882,15 +882,15 @@
           </li>
           <li>
             <p>If the value of <code><var>configuration</var>.{{RTCConfiguration/iceTransportPolicy}}</code> is
-            <code>undefined</code>, set it to <code>"all"</code>.</p>
+            <code>undefined</code>, set it to {{RTCIceTransportPolicy/"all"}}.</p>
           </li>
           <li>
             <p>If the value of <code><var>configuration</var>.{{RTCConfiguration/bundlePolicy}}</code> is
-            <code>undefined</code>, set it to <code>"balanced"</code>.</p>
+            <code>undefined</code>, set it to {{RTCBundlePolicy/"balanced"}}.</p>
           </li>
           <li>
             <p>If the value of <code><var>configuration</var>.{{RTCConfiguration/rtcpMuxPolicy}}</code> is
-            <code>undefined</code>, set it to <code>"require"</code>.</p>
+            <code>undefined</code>, set it to {{RTCRtcpMuxPolicy/"require"}}.</p>
           </li>
           <li>
             <p>Let <var>connection</var> have a <dfn>[[\Configuration]]</dfn>
@@ -928,19 +928,19 @@
           </li>
           <li data-tests="RTCPeerConnection-constructor.html">
             <p>Set <var>connection</var>'s [= signaling state =] to
-            <code>"stable"</code>.</p>
+            {{RTCSignalingState/"stable"}}.</p>
           </li>
           <li data-tests="RTCPeerConnection-constructor.html">
             <p>Set <var>connection</var>'s [= ICE connection state =] to
-            <code>"new"</code>.</p>
+            {{RTCIceConnectionState/"new"}}.</p>
           </li>
           <li data-tests="RTCPeerConnection-constructor.html">
             <p>Set <var>connection</var>'s [= ICE gathering state =] to
-            <code>"new"</code>.</p>
+            {{RTCIceGatheringState/"new"}}.</p>
           </li>
           <li data-tests="RTCPeerConnection-constructor.html">
             <p>Set <var>connection</var>'s [= connection state =] to
-            <code>"new"</code>.</p>
+            {{RTCPeerConnectionState/"new"}}.</p>
           </li>
           <li data-tests="RTCPeerConnection-constructor.html">
             <p>Let <var>connection</var> have a
@@ -1116,7 +1116,7 @@
             <var>connection</var>.</p>
           </li>
           <li>
-            <p>If <var>newState</var> is <code>"completed"</code>,
+            <p>If <var>newState</var> is {{RTCIceGatheringState/"complete"}},
             [= fire an event =] named {{icecandidate}}
             using the {{RTCPeerConnectionIceEvent}}
             interface with the candidate attribute set to
@@ -1149,9 +1149,9 @@
         <ol>
           <li data-tests="RTCPeerConnection-setLocalDescription-rollback.html,RTCPeerConnection-setRemoteDescription-rollback.html">
             <p>If <code><var>description</var>.type</code> is
-            <code>"rollback"</code> and <var>connection</var>'s [= signaling state =] is either
-            <code>"stable"</code>, <code>"have-local-pranswer"</code>, or
-            <code>"have-remote-pranswer"</code>, then [= reject =] <var>p</var>
+            {{RTCSdpType/"rollback"}} and <var>connection</var>'s [= signaling state =] is either
+            {{RTCSignalingState/"stable"}}, {{RTCSignalingState/"have-local-pranswer"}}, or
+            {{RTCSignalingState/"have-remote-pranswer"}}, then [= reject =] <var>p</var>
             with a newly [= exception/create | created =]
             {{InvalidStateError}} and abort these steps.</p>
           </li>
@@ -1234,9 +1234,9 @@
                     <code>true</code>, then abort these steps.</p>
                   </li>
                   <li>
-                    <p>If <var>description</var> is of type <code>"offer"</code>
+                    <p>If <var>description</var> is of type {{RTCSdpType/"offer"}}
                     and the [= signaling state =] of <var>connection</var> is
-                    <code>"stable"</code> then for each <var>transceiver</var>
+                    {{RTCSignalingState/"stable"}} then for each <var>transceiver</var>
                     in <var>connection</var>'s [= set
                     of transceivers =], run the following steps:</p>
                     <ol>
@@ -1264,17 +1264,17 @@
                     <ol>
                       <!-- A) transition stable to haveLocalOffer -->
                       <li data-tests="RTCPeerConnection-setLocalDescription-offer.html,RTCPeerConnection-setLocalDescription.html">
-                        <p>If <var>description</var> is of type <code>"offer"</code>, set
+                        <p>If <var>description</var> is of type {{RTCSdpType/"offer"}}, set
                         <var>connection</var>.<a>[[\PendingLocalDescription]]</a>
                         to a new {{RTCSessionDescription}} object
                         constructed from <var>description</var>, set
-                        <var>connection</var>'s [= signaling state =] to <code>"have-local-offer"</code>,
+                        <var>connection</var>'s [= signaling state =] to {{RTCSignalingState/"have-local-offer"}},
                         and [= release early candidates =].</p>
                       </li>
                       <!-- C) transition haveRemoteOffer or haveLocalProvAnswer to
                       stable -->
                       <li data-tests="RTCPeerConnection-setLocalDescription-answer.html">
-                        <p>If <var>description</var> is of type <code>"answer"</code>, then
+                        <p>If <var>description</var> is of type {{RTCSdpType/"answer"}}, then
                         this completes an offer answer negotiation. Set
                         <var>connection</var>.<a>[[\CurrentLocalDescription]]</a>
                         to a new {{RTCSessionDescription}} object
@@ -1287,7 +1287,7 @@
                         <var>connection</var>.<a>[[\LastCreatedOffer]]</a> and
                         <var>connection</var>.<a>[[\LastCreatedAnswer]]</a> to
                         <code>""</code>, set <var>connection</var>'s
-                        [= signaling state =] to <code>"stable"</code>, and
+                        [= signaling state =] to {{RTCSignalingState/"stable"}}, and
                         [= release early candidates =]. Finally, if none of the
                         ICE credentials in
                         <var>connection</var>.[[\LocalIceCredentialsToReplace]] are
@@ -1297,11 +1297,11 @@
                       </li>
                       <!-- G) transition haveRemoteOffer to haveLocalProvAnswer -->
                       <li data-tests="RTCPeerConnection-setLocalDescription-pranswer.html">
-                        <p>If <var>description</var> is of type <code>"pranswer"</code>,
+                        <p>If <var>description</var> is of type {{RTCSdpType/"pranswer"}},
                         then set <var>connection</var>.<a>[[\PendingLocalDescription]]</a>
                         to a new {{RTCSessionDescription}} object
                         constructed from <var>description</var>, set <var>connection</var>'s
-                        [= signaling state =] to <code>"have-local-pranswer"</code>,
+                        [= signaling state =] to {{RTCSignalingState/"have-local-pranswer"}},
                         and [= release early candidates =].</p>
                       </li>
                     </ol>
@@ -1312,16 +1312,16 @@
                     <ol>
                       <!-- D) transition stable to haveRemoteOffer -->
                       <li data-tests="RTCPeerConnection-setRemoteDescription-offer.html">
-                        <p>If <var>description</var> is of type <code>"offer"</code>, set
+                        <p>If <var>description</var> is of type {{RTCSdpType/"offer"}}, set
                         <var>connection</var>.<a>[[\PendingRemoteDescription]]</a>
                         attribute to a new {{RTCSessionDescription}}
                         object constructed from <var>description</var>, and set <var>connection</var>'s
-                        [= signaling state =] to <code>"have-remote-offer"</code>.</p>
+                        [= signaling state =] to {{RTCSignalingState/"have-remote-offer"}}.</p>
                       </li>
                       <!-- F) transition haveRemoteOffer or haveLocalProvAnswer to
                       stable -->
                       <li data-tests="RTCPeerConnection-setRemoteDescription-answer.html">
-                        <p>If <var>description</var> is of type <code>"answer"</code>, then
+                        <p>If <var>description</var> is of type {{RTCSdpType/"answer"}}, then
                         this completes an offer answer negotiation. Set
                         <var>connection</var>.<a>[[\CurrentRemoteDescription]]</a>
                         to a new {{RTCSessionDescription}} object
@@ -1334,7 +1334,7 @@
                         <var>connection</var>.<a>[[\LastCreatedOffer]]</a> and
                         <var>connection</var>.<a>[[\LastCreatedAnswer]]</a> to
                         <code>""</code>, and set <var>connection</var>'s
-                        [= signaling state =] to <code>"stable"</code>.
+                        [= signaling state =] to {{RTCSignalingState/"stable"}}.
                         Finally, if none of the ICE credentials in
                         <var>connection</var>.[[\LocalIceCredentialsToReplace]]
                         are present in the newly set
@@ -1344,16 +1344,16 @@
                       </li>
                       <!-- H) transition haveRemoteOffer to haveLocalProvAnswer -->
                       <li data-tests="RTCPeerConnection-setRemoteDescription-pranswer.html">
-                        <p>If <var>description</var> is of type <code>"pranswer"</code>,
+                        <p>If <var>description</var> is of type {{RTCSdpType/"pranswer"}},
                         then set <var>connection</var>.<a>[[\PendingRemoteDescription]]</a>
                         to a new {{RTCSessionDescription}} object
                         constructed from <var>description</var> and set <var>connection</var>'s
-                        [= signaling state =] to <code>"have-remote-pranswer"</code>.</p>
+                        [= signaling state =] to {{RTCSignalingState/"have-remote-pranswer"}}.</p>
                       </li>
                     </ol>
                   </li>
                   <li>
-                    <p>If <var>description</var> is of type <code>"answer"</code>, and it
+                    <p>If <var>description</var> is of type {{RTCSdpType/"answer"}}, and it
                     initiates the closure of an existing SCTP association, as
                     defined in [[!SCTP-SDP]], Sections 10.3 and 10.4, set the
                     value of <var>connection</var>.<a>[[\SctpTransport]]</a> to
@@ -1365,15 +1365,15 @@
                     <var>errorList</var> be empty lists.</p>
                   </li>
                   <li>
-                    <p>If <var>description</var> is of type <code>"answer"</code> or
-                      <code>"pranswer"</code>, then run the following steps:</p>
+                    <p>If <var>description</var> is of type {{RTCSdpType/"answer"}} or
+                      {{RTCSdpType/"pranswer"}}, then run the following steps:</p>
                     <ol>
                       <li data-tests="RTCPeerConnection-createDataChannel.html,RTCSctpTransport-constructor.html">
                         <p>If <var>description</var> initiates the
                         establishment of a new SCTP association, as defined in
                         [[!SCTP-SDP]], Sections 10.3 and 10.4, [= create an
                         RTCSctpTransport =] with an initial state of
-                        <code>"connecting"</code> and assign the result to the
+                        {{RTCSctpTransportState/"connecting"}} and assign the result to the
                         <a>[[\SctpTransport]]</a> slot. Otherwise, if an SCTP
                         association is established,
                         but the "max-message-size" SDP attribute is updated,
@@ -1393,7 +1393,7 @@
                             according to [[!RTCWEB-DATA-PROTOCOL]]. If no
                             available ID could be generated, set
                             <var>channel</var>.<a>[[\ReadyState]]</a> to
-                            <code>"closed"</code>, and add <var>channnel</var>
+                            {{RTCDataChannelState/"closed"}}, and add <var>channnel</var>
                             to <var>errorList</var>.
                           </li>
                         </ol>
@@ -1406,7 +1406,7 @@
                     lists.</p>
                   </li>
                   <li>
-                    <p>If <var>description</var> is not of type <code>"rollback"</code>, then
+                    <p>If <var>description</var> is not of type {{RTCSdpType/"rollback"}}, then
                     run the following steps:</p>
                     <ol>
                       <li>
@@ -1481,8 +1481,8 @@
                             description =].</p>
                           </li>
                           <li>
-                            <p>If <var>direction</var> is <code>"sendrecv"</code> or
-                            <code>"recvonly"</code>,
+                            <p>If <var>direction</var> is {{RTCRtpTransceiverDirection/"sendrecv"}} or
+                            {{RTCRtpTransceiverDirection/"recvonly"}},
                             set <var>transceiver</var>.<a>[[\Receptive]]</a>
                             to <code>true</code>, otherwise set it to <code>false</code>.</p>
                           </li>
@@ -1494,14 +1494,14 @@
                               agent is currently prepared to receive.</p>
                             <p class='note'>
                               If the <var>direction</var> is
-                              <code>"sendonly"</code> or <code>"inactive"</code>,
+                              {{RTCRtpTransceiverDirection/"sendonly"}} or {{RTCRtpTransceiverDirection/"inactive"}},
                               the receiver is not prepared to receive
                               anything, and the list will be empty.
                             </p>
                           </li>
                           <li>
                             <p>If <var>description</var> is of type
-                            <code>"answer"</code> or <code>"pranswer"</code>,
+                            {{RTCSdpType/"answer"}} or {{RTCSdpType/"pranswer"}},
                             then run the following steps:</p>
                             <ol>
                               <li>
@@ -1515,9 +1515,9 @@
                               </li>
                               <li>
                                 <p>If <var>direction</var> is
-                                <code>"sendonly"</code> or <code>"inactive"</code>,
+                                {{RTCRtpTransceiverDirection/"sendonly"}} or {{RTCRtpTransceiverDirection/"inactive"}},
                                 and <var>transceiver</var>.<a>[[\FiredDirection]]</a> is either
-                                <code>"sendrecv"</code> or <code>"recvonly"</code>,
+                                {{RTCRtpTransceiverDirection/"sendrecv"}} or {{RTCRtpTransceiverDirection/"recvonly"}},
                                 then run the following steps:</p>
                                 <ol>
                                   <li>
@@ -1549,7 +1549,7 @@
                         in <var>description</var>:</p>
                         <ol>
                           <li>
-                            <p>If the <var>description</var> is of type <code>"offer"</code>
+                            <p>If the <var>description</var> is of type {{RTCSdpType/"offer"}}
                             and contains a request to receive simulcast, use the order
                             of the rid values specified in the simulcast attribute to create
                             an {{RTCRtpEncodingParameters}} dictionary for
@@ -1597,7 +1597,7 @@
                                 <p>[= Create an RTCRtpTransceiver =] with
                                 <var>sender</var>, <var>receiver</var> and
                                 an {{RTCRtpTransceiverDirection}}
-                                value of <code>"recvonly"</code>, and let
+                                value of {{RTCRtpTransceiverDirection/"recvonly"}}, and let
                                 <var>transceiver</var> be the result.</p>
                               </li>
                               <li data-tests="RTCPeerConnection-setDescription-transceiver.html">
@@ -1609,8 +1609,8 @@
                             </ol>
                           </li>
                           <li>
-                            <p>If <var>description</var> is of type <code>"answer"</code>
-                            or <code>"pranswer"</code>, and <var>transceiver</var>.
+                            <p>If <var>description</var> is of type {{RTCSdpType/"answer"}}
+                            or {{RTCSdpType/"pranswer"}}, and <var>transceiver</var>.
                             <a>[[\Sender]]</a>.<a>[[\SendEncodings]]</a> .length is
                             greater than <code>1</code>, then run the following steps:</p>
                             <ol>
@@ -1650,12 +1650,12 @@
                             description =], but with the send and receive
                             directions reversed to represent this peer's point
                             of view. If the [= media description =] is rejected,
-                            set <var>direction</var> to <code>"inactive"</code>.
+                            set <var>direction</var> to {{RTCRtpTransceiverDirection/"inactive"}}.
                             </p>
                           </li>
                           <li data-tests="RTCPeerConnection-ontrack.https.html,RTCTrackEvent-fire.html">
-                            <p>If <var>direction</var> is <code>"sendrecv"</code>
-                            or <code>"recvonly"</code>, let <var>msids</var> be a
+                            <p>If <var>direction</var> is {{RTCRtpTransceiverDirection/"sendrecv"}}
+                            or {{RTCRtpTransceiverDirection/"recvonly"}}, let <var>msids</var> be a
                             list of the MSIDs that the media description indicates
                             <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\ReceiverTrack]]</a>
                             is to be associated with. Otherwise, let
@@ -1679,7 +1679,7 @@
                           </li>
                           <li>
                             <p>If <var>description</var> is of type
-                            <code>"answer"</code> or <code>"pranswer"</code>, then run
+                            {{RTCSdpType/"answer"}} or {{RTCSdpType/"pranswer"}}, then run
                             the following steps:</p>
                             <ol>
                               <li>
@@ -1744,7 +1744,7 @@
                     </ol>
                   </li>
                   <li>
-                    <p>Otherwise, (if <var>description</var> is of type <code>"rollback"</code>)
+                    <p>Otherwise, (if <var>description</var> is of type {{RTCSdpType/"rollback"}})
                     run the following steps:</p>
                     <ol>
                       <li>
@@ -1774,7 +1774,7 @@
                           </li>
                           <li>
                             <p>If the <a>signaling state</a> of <var>connection</var>
-                            is <code>"have-remote-offer"</code>, run the following
+                            is {{RTCSignalingState/"have-remote-offer"}}, run the following
                             sub steps:</p>
                             <ol>
                               <li>
@@ -1805,12 +1805,12 @@
                         <p>Set <var>connection</var>.<a>[[\PendingLocalDescription]]</a>
                         and <var>connection</var>.<a>[[\PendingRemoteDescription]]</a>
                         to <code>null</code>, and set <var>connection</var>'s
-                        [= signaling state =] to <code>"stable"</code>.</p>
+                        [= signaling state =] to {{RTCSignalingState/"stable"}}.</p>
                       </li>
                     </ol>
                   </li>
                   <li>
-                    <p>If <var>description</var> is of type <code>"answer"</code>, then run
+                    <p>If <var>description</var> is of type {{RTCSdpType/"answer"}}, then run
                     the following steps:</p>
                     <ol>
                       <li>
@@ -1832,7 +1832,7 @@
                   </li>
                   <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
                     <p>If <var>connection</var>'s [= signaling state =] is now
-                    <code>"stable"</code>, [= update the negotiation-needed
+                    {{RTCSignalingState/"stable"}}, [= update the negotiation-needed
                     flag =]. If <var>connection</var>.<a>[[\NegotiationNeeded]]</a>
                     was <code>true</code> both before and after this update,
                     <p>[= Chain =] a step to
@@ -2046,7 +2046,7 @@
                       <p>If <var>scheme name</var> is <code>turn</code> or
                       <code>turns</code>, and
                       <code><var>server</var>.credentialType</code> is
-                      <code>"password"</code>, and
+                      {{RTCIceCredentialType/"password"}}, and
                       <code><var>server</var>.credential</code> is not a
                       <span class="idlMemberType">DOMString</span>, then
                       [= exception/throw =] an {{InvalidAccessError}}.</p>
@@ -2392,8 +2392,8 @@ interface RTCPeerConnection : EventTarget  {
                 <ol>
                   <li data-tests="RTCPeerConnection-setRemoteDescription-offer.html">
                     <p>If <var>connection</var>'s [= signaling state =] is
-                    neither <code>"stable"</code> nor
-                    <code>"have-local-offer"</code>, return a promise
+                    neither {{RTCSignalingState/"stable"}} nor
+                    {{RTCSignalingState/"have-local-offer"}}, return a promise
                     [= rejected =] with a newly [= exception/create | created =]
                     {{InvalidStateError}}.</p>
                   </li>
@@ -2484,20 +2484,20 @@ interface RTCPeerConnection : EventTarget  {
                         <ol>
                           <li>
                             <p>If the {{RTCRtpTransceiver/direction}} is
-                            <code>"sendrecv"</code>, exclude any codecs not
+                            {{RTCRtpTransceiverDirection/"sendrecv"}}, exclude any codecs not
                             included in the intersection of
                             <code>RTCRtpSender.getCapabilities(kind).codecs</code>
                             and <code>RTCRtpReceiver.getCapabilities(kind).codecs</code>.
                           </li>
                           <li>
                             <p>If the {{RTCRtpTransceiver/direction}} is
-                            <code>"sendonly"</code>, exclude any codecs not
+                            {{RTCRtpTransceiverDirection/"sendonly"}}, exclude any codecs not
                             included in
                             <code>RTCRtpSender.getCapabilities(kind).codecs</code>.
                           </li>
                           <li>
                             <p>If the {{RTCRtpTransceiver/direction}} is
-                            <code>"recvonly"</code>, exclude any codecs not
+                            {{RTCRtpTransceiverDirection/"recvonly"}}, exclude any codecs not
                             included in
                             <code>RTCRtpReceiver.getCapabilities(kind).codecs</code>.
                           </li>
@@ -2532,7 +2532,7 @@ interface RTCPeerConnection : EventTarget  {
                     <p>Let <var>offer</var> be a newly created
                     {{RTCSessionDescriptionInit}} dictionary
                     with its <code>type</code> member initialized to the string
-                    <code>"offer"</code> and its <code>sdp</code> member
+                    {{RTCSdpType/"offer"}} and its <code>sdp</code> member
                     initialized to <var>sdpString</var>.</p>
                   </li>
                   <li><p>Set the <a>[[\LastCreatedOffer]]</a> internal slot to
@@ -2581,7 +2581,7 @@ interface RTCPeerConnection : EventTarget  {
                 <p>An answer can be marked as provisional, as described in
                 <span data-jsep="use-of-provisional-answer">[[!JSEP]]</span>,
                 by setting the {{RTCSessionDescription/type}} to
-                <code>"pranswer"</code>.</p>
+                {{RTCSdpType/"pranswer"}}.</p>
                 <p>When the method is called, the user agent MUST run the
                 following steps:</p>
                 <ol>
@@ -2610,8 +2610,8 @@ interface RTCPeerConnection : EventTarget  {
                   RTCPeerConnection-setLocalDescription-answer.html,
                   RTCPeerConnection-setLocalDescription-pranswer.html">
                     <p>If <var>connection</var>'s [= signaling state =]
-                    is neither <code>"have-remote-offer"</code> nor
-                    <code>"have-local-pranswer"</code>, return a promise
+                    is neither {{RTCSignalingState/"have-remote-offer"}} nor
+                    {{RTCSignalingState/"have-local-pranswer"}}, return a promise
                     [= rejected =] with a newly [= exception/create | created =]
                     {{InvalidStateError}}.</p>
                   </li>
@@ -2671,9 +2671,9 @@ interface RTCPeerConnection : EventTarget  {
                       This may be necessary if, for example,
                       <code>createAnswer</code> was called when an
                       {{RTCRtpTransceiver}}'s direction was
-                      <code>"recvonly"</code>, but while performing the
+                      {{RTCRtpTransceiverDirection/"recvonly"}}, but while performing the
                       [= in-parallel steps to create an answer =], the
-                      direction was changed to <code>"sendrecv"</code>,
+                      direction was changed to {{RTCRtpTransceiverDirection/"sendrecv"}},
                       requiring additional inspection of video encoding
                       resources.
                     </div>
@@ -2694,20 +2694,20 @@ interface RTCPeerConnection : EventTarget  {
                         <ol>
                           <li>
                             <p>If the {{RTCRtpTransceiver/direction}} is
-                            <code>"sendrecv"</code>, exclude any codecs not
+                            {{RTCRtpTransceiverDirection/"sendrecv"}}, exclude any codecs not
                             included in the intersection of
                             <code>RTCRtpSender.getCapabilities(kind).codecs</code>
                             and <code>RTCRtpReceiver.getCapabilities(kind).codecs</code>.
                           </li>
                           <li>
                             <p>If the {{RTCRtpTransceiver/direction}} is
-                            <code>"sendonly"</code>, exclude any codecs not
+                            {{RTCRtpTransceiverDirection/"sendonly"}}, exclude any codecs not
                             included in
                             <code>RTCRtpSender.getCapabilities(kind).codecs</code>.
                           </li>
                           <li>
                             <p>If the {{RTCRtpTransceiver/direction}} is
-                            <code>"recvonly"</code>, exclude any codecs not
+                            {{RTCRtpTransceiverDirection/"recvonly"}}, exclude any codecs not
                             included in
                             <code>RTCRtpReceiver.getCapabilities(kind).codecs</code>.
                           </li>
@@ -2734,7 +2734,7 @@ interface RTCPeerConnection : EventTarget  {
                     <p>Let <var>answer</var> be a newly created
                     {{RTCSessionDescriptionInit}} dictionary
                     with its <code>type</code> member initialized to the string
-                    <code>"answer"</code> and its <code>sdp</code> member
+                    {{RTCSdpType/"answer"}} and its <code>sdp</code> member
                     initialized to <var>sdpString</var>.</p>
                   </li>
                   <li><p>Set the <a>[[\LastCreatedAnswer]]</a> internal slot to
@@ -2792,14 +2792,14 @@ interface RTCPeerConnection : EventTarget  {
                       <li>
                         <p>Let <var>type</var> be
                         <code><var>description</var>.type</code> if present, or
-                        <code>"offer"</code> if not present and
+                        {{RTCSdpType/"offer"}} if not present and
                         <var>connection</var>'s [= signaling state =] is either
-                        <code>"stable"</code>, <code>"have-local-offer"</code>,
-                        or <code>"have-remote-pranswer"</code>; otherwise
-                        <code>"answer"</code>.</p>
+                        {{RTCSignalingState/"stable"}}, {{RTCSignalingState/"have-local-offer"}},
+                        or {{RTCSignalingState/"have-remote-pranswer"}}; otherwise
+                        {{RTCSdpType/"answer"}}.</p>
                       </li>
                       <li data-tests="RTCPeerConnection-setLocalDescription-offer.html">
-                        <p>If <var>type</var> is <code>"offer"</code>, and
+                        <p>If <var>type</var> is {{RTCSdpType/"offer"}}, and
                         <var>sdp</var> is not the empty string and not equal to
                         <var>connection</var>.<a>[[\LastCreatedOffer]]</a>,
                         then return a promise [= rejected =] with a newly
@@ -2808,8 +2808,8 @@ interface RTCPeerConnection : EventTarget  {
                         steps.</p>
                       </li>
                       <li data-tests="RTCPeerConnection-setLocalDescription-offer.html">
-                        <p>If <var>type</var> is <code>"answer"</code> or
-                        <code>"pranswer"</code>, and <var>sdp</var> is not the
+                        <p>If <var>type</var> is {{RTCSdpType/"answer"}} or
+                        {{RTCSdpType/"pranswer"}}, and <var>sdp</var> is not the
                         empty string and not equal to <var>connection</var>.<a>[[\LastCreatedAnswer]]</a>, then return a
                         promise [= rejected =] with a newly
                         [= exception/create | created =]
@@ -2818,7 +2818,7 @@ interface RTCPeerConnection : EventTarget  {
                       </li>
                       <li>
                         <p>If <var>sdp</var> is the empty string, and
-                          <var>type</var> is <code>"offer"</code>, then run the
+                          <var>type</var> is {{RTCSdpType/"offer"}}, then run the
                           following sub steps:</p>
                         <ol>
                           <li data-tests="RTCPeerConnection-setLocalDescription-offer.html">
@@ -2841,8 +2841,8 @@ interface RTCPeerConnection : EventTarget  {
                       </li>
                       <li>
                         <p>If <var>sdp</var> is the empty string, and
-                          <var>type</var> is <code>"answer"</code> or
-                          <code>"pranswer"</code>, then run the following sub
+                          <var>type</var> is {{RTCSdpType/"answer"}} or
+                          {{RTCSdpType/"pranswer"}}, then run the following sub
                           steps:</p>
                         <ol>
                           <li data-tests="RTCPeerConnection-setLocalDescription-offer.html">
@@ -2916,7 +2916,7 @@ interface RTCPeerConnection : EventTarget  {
                     <ol>
                       <li>
                         <p>If the <var>description</var>'s {{RTCSessionDescriptionInit/type}} is
-                        <code>"offer"</code> and is invalid for the
+                        {{RTCSdpType/"offer"}} and is invalid for the
                         current [= signaling state =] of <var>connection</var>
                         as described in <span data-jsep=
                         "processing-a-local-desc processing-a-remote-desc">[[!JSEP]]</span>,
@@ -3194,7 +3194,7 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>Set <var>connection</var>'s [= signaling state =] to
-                    <code>"closed"</code>.</p>
+                    {{RTCSignalingState/"closed"}}.</p>
                   </li>
                   <li data-tests="RTCPeerConnection-transceivers.https.html">
                     <p>Let <var>transceivers</var> be the result of executing the
@@ -3215,7 +3215,7 @@ interface RTCPeerConnection : EventTarget  {
                   <li>
                     <p>Set the <a>[[\ReadyState]]</a> slot of each of
                     <var>connection</var>'s {{RTCDataChannel}}s
-                    to <code>"{{RTCDataChannelState/closed}}"</code></p>
+                    to {{RTCDataChannelState/"closed"}}</p>
                     <div class="note">The {{RTCDataChannel}}s
                     will be closed abruptly and the closing procedure
                     will not be invoked.</div>
@@ -3224,12 +3224,12 @@ interface RTCPeerConnection : EventTarget  {
                     <p>If the <var>connection</var>.<a>[[\SctpTransport]]</a>
                     is not <code>null</code>, tear down the underlying SCTP
                     association by sending an SCTP ABORT chunk and set the
-                    <a>[[\SctpTransportState]]</a> to <code>"{{RTCSctpTransportState/closed}}"</code>.</p>
+                    <a>[[\SctpTransportState]]</a> to {{RTCSctpTransportState/"closed"}}.</p>
                   </li>
                   <li>
                     <p>Set the <a>[[\DtlsTransportState]]</a> slot of each of
                     <var>connection</var>'s {{RTCDtlsTransport}}s
-                    to <code>"{{RTCDtlsTransportState/closed}}"</code>.</p>
+                    to {{RTCDtlsTransportState/"closed"}}.</p>
                   </li>
                   <li>
                     <p>Destroy <var>connection</var>'s [= ICE Agent =],
@@ -3240,16 +3240,16 @@ interface RTCPeerConnection : EventTarget  {
                   <li>
                     <p>Set the <a>[[\IceTransportState]]</a> slot of each of
                     <var>connection</var>'s {{RTCIceTransport}}s
-                    to <code>"{{RTCIceTransportState/closed}}"</code>.</p>
+                    to {{RTCIceTransportState/"closed"}}.</p>
                   </li>
                   <li>
                     <p>Set <var>connection</var>'s [= ICE connection state =] to
-                      <code>"closed"</code>. This does not fire any event.
+                      {{RTCIceConnectionState/"closed"}}. This does not fire any event.
                     </p>
                   </li>
                   <li>
                     <p>Set <var>connection</var>'s [= connection state =] to
-                    <code>"closed"</code>.</p>
+                    {{RTCPeerConnectionState/"closed"}}.</p>
                   </li>
                 </ol>
               </dd>
@@ -3690,7 +3690,7 @@ interface RTCPeerConnection : EventTarget  {
               <tr>
                 <td data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-setLocalDescription-rollback.html"><dfn data-idl>rollback</dfn></td>
                 <td>
-                  <p>An <code>RTCSdpType</code> of <code>rollback</code>
+                  <p>An <code>RTCSdpType</code> of {{RTCSdpType/"rollback"}}
                   indicates that a description MUST be treated as canceling the
                   current SDP negotiation and moving the SDP [[!SDP]] offer
                   back to what it was in the previous stable state. Note
@@ -3784,7 +3784,7 @@ interface RTCSessionDescription {
               <dt data-tests="RTCPeerConnection-setLocalDescription-rollback.html"><dfn data-idl>sdp</dfn> of type <span class=
               "idlMemberType">DOMString</span></dt>
               <dd>The string representation of the SDP [[!SDP]]; if
-              <code>type</code> is <code>"rollback"</code>, this member is unused.
+              <code>type</code> is {{RTCSdpType/"rollback"}}, this member is unused.
               </dd>
             </dl>
           </section>
@@ -3846,7 +3846,7 @@ interface RTCSessionDescription {
           </li>
           <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
             <p>If <var>connection</var>'s [= signaling state =] is not
-            <code>"stable"</code>, abort these steps.</p>
+            {{RTCSignalingState/"stable"}}, abort these steps.</p>
 
             <p class="note">The negotiation-needed flag will be
             updated once the state transitions to "stable", as part of the steps
@@ -3934,7 +3934,7 @@ interface RTCSessionDescription {
                 <ol>
                   <li>
                     <p>If <var>transceiver</var>.<a>[[\Direction]]</a> is
-                    <code>"sendrecv"</code> or <code>"sendonly"</code>,
+                    {{RTCRtpTransceiverDirection/"sendrecv"}} or {{RTCRtpTransceiverDirection/"sendonly"}},
                     and the [= associated =] m= section in <var>description</var>
                     either doesn't contain a single "a=msid" line, or the number
                     of MSIDs from the "a=msid" lines in this m= section,
@@ -3944,7 +3944,7 @@ interface RTCSessionDescription {
                     </p>
                   </li>
                   <li>
-                    <p>If <var>description</var> is of type <code>"offer"</code>,
+                    <p>If <var>description</var> is of type {{RTCSdpType/"offer"}},
                     and the direction of the [= associated =] m=
                     section in neither
                     <var>connection</var>.<a>[[\CurrentLocalDescription]]</a> nor
@@ -3957,7 +3957,7 @@ interface RTCSessionDescription {
                     view.</p>
                   </li>
                   <li>
-                    <p>If <var>description</var> is of type <code>"answer"</code>,
+                    <p>If <var>description</var> is of type {{RTCSdpType/"answer"}},
                     and the direction of the [= associated =] m=
                     section in the <var>description</var> does not match
                     <var>transceiver</var>.<a>[[\Direction]]</a>
@@ -4435,14 +4435,14 @@ interface RTCIceCandidate {
               <p>All {{RTCIceTransport}}s have finished
               gathering candidates, and the {{RTCPeerConnection}}'s
               {{RTCIceGatheringState}} has transitioned to
-              <code>"{{RTCIceGatheringState/complete}}"</code>.
+              {{RTCIceGatheringState/"complete"}}.
               This is indicated by the
               {{RTCPeerConnectionIceEvent/candidate}}
               member of the event being set to <code>null</code>. This only
               exists for backwards compatibility, and this event does not need
               to be signaled to the remote peer. It's equivalent to an
               <code>"{{icegatheringstatechange}}"</code> event with the
-              <code>"{{RTCIceGatheringState/complete}}"</code>
+              {{RTCIceGatheringState/"complete"}}
               state.</p>
             </li>
           </ul>
@@ -5534,7 +5534,7 @@ interface RTCCertificate {
           "RTCRtpTransceiverInit" class="dictionary-members">
             <dt data-tests="RTCPeerConnection-addTransceiver.https.html, RTCRtpTransceiver-direction.html"><dfn data-idl>direction</dfn> of type <span class=
             "idlMemberType">{{RTCRtpTransceiverDirection}}</span>,
-            defaulting to <code>"sendrecv"</code></dt>
+            defaulting to {{RTCRtpTransceiverDirection/"sendrecv"}}</dt>
             <dd>The direction of the {{RTCRtpTransceiver}}.</dd>
             <dt><dfn data-idl>streams</dfn> of type <span class=
             "idlMemberType">sequence&lt;{{MediaStream}}&gt;</span></dt>
@@ -5619,8 +5619,8 @@ interface RTCCertificate {
       <section>
         <h4>Processing Remote MediaStreamTracks</h4>
         <p>An application can reject incoming media descriptions by setting
-        the transceiver's direction to either <code>"inactive"</code> to turn
-        off both directions temporarily, or to <code>"sendonly"</code> to reject
+        the transceiver's direction to either {{RTCRtpTransceiverDirection/"inactive"}} to turn
+        off both directions temporarily, or to {{RTCRtpTransceiverDirection/"sendonly"}} to reject
         only the incoming side. To permanently reject an m-line in a manner that
         makes it available for reuse, the application would need to call
         <code>RTCRtpTransceiver.{{RTCRtpTransceiver/stop}}()</code>
@@ -5637,23 +5637,23 @@ interface RTCCertificate {
             <var>addList</var>, and <var>removeList</var>.</p>
           </li>
           <li data-tests="RTCPeerConnection-ontrack.https.html,RTCPeerConnection-setRemoteDescription-tracks.https.html,RTCPeerConnection-transceivers.https.html">
-            <p>If <var>direction</var> is <code>"sendrecv"</code> or
-            <code>"recvonly"</code> and <var>transceiver</var>.<a>[[\FiredDirection]]</a>
-            is neither <code>"sendrecv"</code> nor <code>"recvonly"</code>,
+            <p>If <var>direction</var> is {{RTCRtpTransceiverDirection/"sendrecv"}} or
+            {{RTCRtpTransceiverDirection/"recvonly"}} and <var>transceiver</var>.<a>[[\FiredDirection]]</a>
+            is neither {{RTCRtpTransceiverDirection/"sendrecv"}} nor {{RTCRtpTransceiverDirection/"recvonly"}},
             or the previous step increased the length of <var>addList</var>,
             <a>process the addition of a remote track</a> with <var>transceiver</var>
             and <var>trackEventInits</var>.</p>
           </li>
           <li>
-            <p>If <var>direction</var> is <code>"sendonly"</code> or
-            <code>"inactive"</code>, set <var>transceiver</var>.<a>[[\Receptive]]</a>
+            <p>If <var>direction</var> is {{RTCRtpTransceiverDirection/"sendonly"}} or
+            {{RTCRtpTransceiverDirection/"inactive"}}, set <var>transceiver</var>.<a>[[\Receptive]]</a>
             to <code>false</code>.</p>
           </li>
           <li data-tests="RTCPeerConnection-remote-track-mute.https.html">
-            <p>If <var>direction</var> is <code>"sendonly"</code> or
-            <code>"inactive"</code>, and
+            <p>If <var>direction</var> is {{RTCRtpTransceiverDirection/"sendonly"}} or
+            {{RTCRtpTransceiverDirection/"inactive"}}, and
             <var>transceiver</var>.<a>[[\FiredDirection]]</a>
-            is either <code>"sendrecv"</code> or <code>"recvonly"</code>,
+            is either {{RTCRtpTransceiverDirection/"sendrecv"}} or {{RTCRtpTransceiverDirection/"recvonly"}},
             <a>process the removal of a remote track</a> for
             the <a>media description</a>, with <var>transceiver</var>
             and <var>muteTracks</var>.</p>
@@ -6168,7 +6168,7 @@ async function updateParameters() {
                     <li>
                       <p>Let <var>sending</var> be <code>true</code> if the
                       <var>transceiver</var>.<a>[[\CurrentDirection]]</a>
-                      is <code>"sendrecv"</code> or <code>"sendonly"</code>,
+                      is {{RTCRtpTransceiverDirection/"sendrecv"}} or {{RTCRtpTransceiverDirection/"sendonly"}},
                       and <code>false</code> otherwise.</p>
                     </li>
                     <li>
@@ -7227,7 +7227,7 @@ interface RTCRtpTransceiver {
                 </li>
                 <li>
                   <p>If <var>transceiver</var>.<a>[[\Stopping]]</a> is
-                  <code>true</code>, return <code>"stopped"</code>.</p>
+                  <code>true</code>, return {{RTCRtpTransceiverDirection/"stopped"}}.</p>
                 </li>
                 <li>
                   <p>Otherwise, return the value of the <a>[[\Direction]]</a>
@@ -7263,7 +7263,7 @@ interface RTCRtpTransceiver {
                 </li>
                 <li data-tests="RTCRtpTransceiver-direction.html">
                   <p>If <var>newDirection</var> is equal to
-                  <code>"stopped"</code>, [= exception/throw =] a {{TypeError}}.
+                  {{RTCRtpTransceiverDirection/"stopped"}}, [= exception/throw =] a {{TypeError}}.
                   </p>
                 </li>
                 <li>
@@ -7289,7 +7289,7 @@ interface RTCRtpTransceiver {
               deduced from the other. If this transceiver has never been
               represented in an offer/answer exchange, the value is
               <code>null</code>. If the transceiver is
-              {{stopped}}, the value is <code>"stopped"</code>.
+              {{stopped}}, the value is {{RTCRtpTransceiverDirection/"stopped"}}.
               </p>
               <p>On getting, the user agent MUST run the following steps:</p>
               <ol>
@@ -7300,7 +7300,7 @@ interface RTCRtpTransceiver {
                 </li>
                 <li>
                   <p>If <var>transceiver</var>.<a>[[\Stopped]]</a> is
-                  <code>true</code>, return <code>"stopped"</code>.</p>
+                  <code>true</code>, return {{RTCRtpTransceiverDirection/"stopped"}}.</p>
                 </li>
                 <li>
                   <p>Otherwise, return the value of the
@@ -8306,8 +8306,8 @@ interface RTCIceTransport : EventTarget {
             <dd>
               <p>Returns the selected candidate pair on which packets are sent. This
               method MUST return the value of the <a>[[\SelectedCandidatePair]]</a>
-              slot. When <code>{{RTCIceTransport}}.state</code> is <code>"new"</code> or
-              <code>"closed"</code> <code>getSelectedCandidatePair</code> returns
+              slot. When <code>{{RTCIceTransport}}.state</code> is {{RTCIceTransportState/"new"}} or
+              {{RTCIceTransportState/"closed"}} <code>getSelectedCandidatePair</code> returns
               <code>null</code>.</p>
             </dd>
             <dt data-tests="RTCIceTransport.html"><dfn data-idl>getLocalParameters</dfn></dt>
@@ -8518,18 +8518,18 @@ interface RTCIceTransport : EventTarget {
         checking -> connected -> completed, but under specific circumstances
         (only the last checked candidate succeeds, and gathering and the
         no-more candidates indication both occur prior to success), the
-        state can transition directly from "checking" to "completed".
+        state can transition directly from {{RTCIceTransportState/"checking"}} to {{RTCIceTransportState/"completed"}}.
       </p>
       <p>An ICE restart causes candidate gathering and connectity checks to
-      begin anew, causing a transition to <code>connected</code> if begun in the
-      <code>completed</code> state. If begun in the transient
-      <code>disconnected</code> state, it causes a transition to
-      <code>checking</code>, effectively forgetting that connectivity was
+      begin anew, causing a transition to {{RTCIceTransportState/"connected"}} if begun in the
+      {{RTCIceTransportState/"completed"}} state. If begun in the transient
+      {{RTCIceTransportState/"disconnected"}} state, it causes a transition to
+      {{RTCIceTransportState/"checking"}}, effectively forgetting that connectivity was
       previously lost.</p>
-      <p>The <code>failed</code> and <code>completed</code> states require an
+      <p>The {{RTCIceTransportState/"failed"}} and {{RTCIceTransportState/"completed"}} states require an
       indication that there are no additional remote candidates. This can be
       indicated by calling {{RTCPeerConnection/addIceCandidate}} with
-      a candidate value whose <code>candidate</code> property is set
+      a candidate value whose {{RTCIceCandidate/candidate}} property is set
       to an empty string or by {{RTCPeerConnection/canTrickleIceCandidates}} being set to
       <code>false</code>.</p>
       <p>Some example state transitions are:</p>
@@ -9150,7 +9150,7 @@ interface RTCSctpTransport : EventTarget {
                 <td>
                   <p>When the negotiation of an association is completed, a task is
                   queued to update the [[\SctpTransportState]] slot to
-                  <code>"connected"</code>.</p>
+                  {{RTCSctpTransportState/"connected"}}.</p>
                 </td>
               </tr>
               <tr>
@@ -9158,7 +9158,7 @@ interface RTCSctpTransport : EventTarget {
                 "idl-def-RTCSctpTransportState.closed">closed</code></dfn></td>
                 <td>
                   <p>A task is queued to update the [[\SctpTransportState]]
-                    slot to <code>"closed"</code> when:
+                    slot to {{RTCSctpTransportState/"closed"}} when:
                     </p>
                   <ul>
                     <li>a SHUTDOWN or ABORT chunk
@@ -9252,7 +9252,7 @@ interface RTCSctpTransport : EventTarget {
         </li>
         <li data-tests="RTCPeerConnection-ondatachannel.html">
           <p>Let <var>channel</var> have a <dfn>[[\ReadyState]]</dfn> internal
-          slot initialized to <code>"connecting"</code>.</p>
+          slot initialized to {{RTCDataChannelState/"connecting"}}.</p>
         </li>
         <li>
           <p>Let <var>channel</var> have a <dfn>[[\BufferedAmount]]</dfn>
@@ -9288,12 +9288,12 @@ interface RTCSctpTransport : EventTarget {
           object to be announced.</p>
         </li>
         <li>
-          <p>If <var>channel</var>.<a>[[\ReadyState]]</a> is <code>"closing"</code> or
-          <code>"closed"</code>, abort these steps.</p>
+          <p>If <var>channel</var>.<a>[[\ReadyState]]</a> is {{RTCDataChannelState/"closing"}} or
+          {{RTCDataChannelState/"closed"}}, abort these steps.</p>
         </li>
         <li>
           <p>Set <var>channel</var>.<a>[[\ReadyState]]</a> to
-          <code>"open"</code>.</p>
+          {{RTCDataChannelState/"open"}}.</p>
         </li>
         <li data-tests="RTCPeerConnection-ondatachannel.html">
           <p>[= Fire an event =] named {{open}} at
@@ -9339,7 +9339,7 @@ interface RTCSctpTransport : EventTarget {
         </li>
         <li data-tests="RTCPeerConnection-ondatachannel.html">
           <p>Set <var>channel</var>.<a>[[\ReadyState]]</a> to
-          <code>"open"</code> (but do not fire the {{open}}
+          {{RTCDataChannelState/"open"}} (but do not fire the {{open}}
           event, yet).</p>
           <div class="note">This allows to start sending messages inside of the
           {{datachannel}} event handler prior to the
@@ -9375,7 +9375,7 @@ interface RTCSctpTransport : EventTarget {
           <p>Unless the procedure was initiated by the <var>channel</var>'s
           {{RTCDataChannel/close}} method, set
           <var>channel</var>.<a>[[\ReadyState]]</a> to
-          <code>"closing"</code>.</p>
+          {{RTCDataChannelState/"closing"}}.</p>
         </li>
         <li>
           <p>Run the following steps in parallel:</p>
@@ -9414,7 +9414,7 @@ interface RTCSctpTransport : EventTarget {
         </li>
         <li>
           <p>Set <var>channel</var>.<a>[[\ReadyState]]</a> to
-          <code>"closed"</code>.</p>
+          {{RTCDataChannelState/"closed"}}.</p>
         </li>
         <li>
           <p>If the [= underlying data transport | transport =] was closed
@@ -9449,7 +9449,7 @@ interface RTCSctpTransport : EventTarget {
         </li>
         <li>
           <p>Set <var>channel</var>.<a>[[\ReadyState]]</a> to
-          <code>"closed"</code>.</p>
+          {{RTCDataChannelState/"closed"}}.</p>
         </li>
         <li>
           <p>[= Fire an event =] named {{RTCDataChannel/error}} using the
@@ -9483,7 +9483,7 @@ interface RTCSctpTransport : EventTarget {
         </li>
         <li>
           <p>If <var>channel</var>.<a>[[\ReadyState]]</a> is not
-          <code>"open"</code>, abort these steps and discard <var>rawData</var>.
+          {{RTCDataChannelState/"open"}}, abort these steps and discard <var>rawData</var>.
           </p>
         </li>
         <li data-tests="RTCDataChannel-bufferedAmount.html,RTCDataChannel-send.html">
@@ -9654,7 +9654,7 @@ interface RTCDataChannel : EventTarget {
               protocol, or buffering done by the operating system or network
               hardware. The value of the <a>[[\BufferedAmount]]</a> slot will
               only increase with each call to the {{RTCDataChannel/send()}} method as long as the <a>
-              [[\ReadyState]]</a> slot is <code>"open"</code>; however, the
+              [[\ReadyState]]</a> slot is {{RTCDataChannelState/"open"}}; however, the
               slot does not reset to zero once the channel closes. When the
               [= underlying data transport =] sends data from its queue, the
               user agent MUST queue a task that reduces
@@ -9740,12 +9740,12 @@ interface RTCDataChannel : EventTarget {
                 </li>
                 <li>
                   <p>If <var>channel</var>.<a>[[\ReadyState]]</a> is
-                  <code>"closing"</code> or <code>"closed"</code>, then abort these
+                  {{RTCDataChannelState/"closing"}} or {{RTCDataChannelState/"closed"}}, then abort these
                   steps.</p>
                 </li>
                 <li>
                   <p>Set <var>channel</var>.<a>[[\ReadyState]]</a> to
-                  <code>"closing"</code>.</p>
+                  {{RTCDataChannelState/"closing"}}.</p>
                 </li>
                 <li>
                   <p>If the [= closing procedure =] has not
@@ -9791,7 +9791,7 @@ interface RTCDataChannel : EventTarget {
         </li>
         <li data-tests="RTCDataChannel-send.html">
           <p>If <var>channel</var>.<a>[[\ReadyState]]</a> is not
-          <code>"open"</code>, [= exception/throw =] an
+          {{RTCDataChannelState/"open"}}, [= exception/throw =] an
           {{InvalidStateError}}.</p>
         </li>
         <li>
@@ -10036,19 +10036,19 @@ interface RTCDataChannelEvent : Event {
       <ul>
         <li>
           <p><a>[[\ReadyState]]</a> slot is
-          <code>"connecting"</code> and at least one event listener is registered
+          {{RTCDataChannelState/"connecting"}} and at least one event listener is registered
           for <code>open</code> events, <code>message</code> events,
           <code>error</code> events, or <code>close</code> events.</p>
         </li>
         <li>
           <p><a>[[\ReadyState]]</a> slot is
-          <code>"open"</code> and at least one event listener is registered for
+          {{RTCDataChannelState/"open"}} and at least one event listener is registered for
           <code>message</code> events, <code>error</code> events, or
           <code>close</code> events.</p>
         </li>
         <li>
           <p><a>[[\ReadyState]]</a> slot is
-          <code>"closing"</code> and at least one event listener is registered
+          {{RTCDataChannelState/"closing"}} and at least one event listener is registered
           for <code>error</code> events, or <code>close</code> events.</p>
         </li>
         <li>
@@ -10272,12 +10272,12 @@ interface RTCDTMFSender : EventTarget {
         associated with <var>sender</var>.</li>
         <li>Let <var>connection</var> be the {{RTCPeerConnection}} associated with
         <var>transceiver</var>.</li>
-        <li>If <var>connection</var>'s {{RTCPeerConnectionState}} is not <code>"connected"</code>
+        <li>If <var>connection</var>'s {{RTCPeerConnectionState}} is not {{RTCPeerConnectionState/"connected"}}
         return <code>false</code>.</li>
         <li>If <var>sender</var>.<a>[[\SenderTrack]]</a> is <code>null</code>
         return <code>false</code>.</li>
-        <li>If <var>transceiver</var>.<a>[[\CurrentDirection]]</a> is neither <code>"sendrecv"</code>
-        nor <code>"sendonly"</code> return <code>false</code>.</li>
+        <li>If <var>transceiver</var>.<a>[[\CurrentDirection]]</a> is neither {{RTCRtpTransceiverDirection/"sendrecv"}}
+        nor {{RTCRtpTransceiverDirection/"sendonly"}} return <code>false</code>.</li>
         <li>If <var>sender</var>.<a>[[\SendEncodings]]</a><code>[0].active</code> is
         <code>false</code> return <code>false</code>.</li>
         <li>If no codec with mimetype <code>"audio/telephone-event"</code> has been
@@ -11336,7 +11336,7 @@ if (sender.dtmf.canInsertDTMF) {
       application. This pattern has advantages over other patterns, like one
       side always being the offerer, as it lets applications operate on both
       peer connection objects simultaneously without risk of glare (an offer
-      coming in outside of <code>"stable"</code> state). The rest of the
+      coming in outside of {{RTCSignalingState/"stable"}} state). The rest of the
       application may use any and all modification methods and attributes,
       without worrying about signaling state races.
       </p>
@@ -11493,21 +11493,21 @@ interface RTCError : DOMException {
           <dt data-tests="RTCError.html,RTCPeerConnection-setRemoteDescription-offer.html"><dfn data-idl>sdpLineNumber</dfn> of type <span
           class="idlAttrType">long</span>, readonly, nullable</dt>
           <dd>
-            <p>If <code>errorDetail</code> is <code>"sdp-syntax-error"</code>
+            <p>If <code>errorDetail</code> is {{RTCErrorDetailType/"sdp-syntax-error"}}
             this is the line number where the error was detected (the first
             line has line number 1).</p>
           </dd>
           <dt data-tests="RTCError.html"><dfn data-idl>sctpCauseCode</dfn> of type <span
           class="idlAttrType">long</span>, readonly, nullable</dt>
           <dd>
-            <p>If <code>errorDetail</code> is <code>"sctp-failure"</code> this
+            <p>If <code>errorDetail</code> is {{RTCErrorDetailType/"sctp-failure"}} this
             is the SCTP cause code of the failed SCTP negotiation.</p>
           </dd>
           <dt data-tests="RTCError.html"><dfn data-idl>receivedAlert</dfn> of type <span
           class="idlAttrType">unsigned long</span>, readonly,
           nullable</dt>
           <dd>
-            <p>If <code>errorDetail</code> is <code>"dtls-failure"</code> and
+            <p>If <code>errorDetail</code> is {{RTCErrorDetailType/"dtls-failure"}} and
             a fatal DTLS alert was received, this is the value of the DTLS
             alert received.</p>
           </dd>
@@ -11515,7 +11515,7 @@ interface RTCError : DOMException {
           class="idlAttrType">unsigned long</span>, readonly,
           nullable</dt>
           <dd>
-            <p>If <code>errorDetail</code> is <code>"dtls-failure"</code> and
+            <p>If <code>errorDetail</code> is {{RTCErrorDetailType/"dtls-failure"}} and
             a fatal DTLS alert was sent, this is the value of the DTLS alert
             sent.</p>
           </dd>

--- a/webrtc.html
+++ b/webrtc.html
@@ -61,7 +61,7 @@
 
     <p>The following features are marked as at risk:</p>
     <ul>
-      <li>All attributes defined in {{RTCError}}: <code>errorDetail</code>, <code>sdpLineNumber</code>, <code>httpRequestStatusCode</code>, <code>sctpCauseCode</code>, <code>receivedAlert</code> and <code>sentAlert</code>.</li>
+      <li>All attributes defined in {{RTCError}}: {{RTCError/errorDetail}}, {{RTCError/sdpLineNumber}}, {{RTCError/httpRequestStatusCode}}, {{RTCError/sctpCauseCode}}, {{RTCError/receivedAlert}} and {{RTCError/sentAlert}}.</li>
     </ul>
   </section>
   <section class="informative" id="intro">
@@ -162,7 +162,7 @@
       exchange of control messages (called a signaling protocol) over a
       signaling channel which is provided by unspecified means, but generally
       by a script in the page via the server, e.g. using
-      <code>XMLHttpRequest</code> [[?xhr]] or <a data-cite="html">Web Sockets</a>.</p>
+      <code class=example>XMLHttpRequest</code> [[?xhr]] or <a data-cite="html">Web Sockets</a>.</p>
     </section>
     <section>
       <h3>Configuration</h3>
@@ -299,7 +299,7 @@
               "idlMemberType">DOMString</span></dt>
               <dd>
                 <p>If this {{RTCIceServer}} object represents a
-                TURN server, and <code>credentialType</code> is
+                TURN server, and {{credentialType}} is
                 {{RTCIceCredentialType/"password"}}, then this attribute specifies the
                 username to use with that TURN server.</p>
               </dd>
@@ -316,7 +316,7 @@
           </section>
         </div>
         <p>An example array of RTCIceServer objects is:</p>
-        <pre class="example highlight"><code>
+        <pre class="example highlight">
 [
   {urls: 'stun:stun1.example.net'},
   {urls: ['turns:turn.example.org', 'turn:turn.example.net'],
@@ -324,7 +324,7 @@
     credential: 'myPassword',
     credentialType: 'password'},
 ];
-        </code></pre>
+        </pre>
       </section>
       <section data-tests="RTCConfiguration-iceTransportPolicy.html">
         <h4><dfn>RTCIceTransportPolicy</dfn> Enum</h4>
@@ -511,7 +511,7 @@
           </section>
         </div>
         <div>
-          <p>The <dfn>RTCAnswerOptions</dfn> dictionary describe options specific to session description of type <code>answer</code> (none in this version of the specification).</p>
+          <p>The <dfn>RTCAnswerOptions</dfn> dictionary describe options specific to session description of type {{RTCSdpType/"answer"}} (none in this version of the specification).</p>
           <pre class="idl"
 >dictionary RTCAnswerOptions : RTCOfferAnswerOptions {};</pre>
         </div>
@@ -669,21 +669,21 @@
                 <td>The previous state doesn't apply and any
                 {{RTCIceTransport}}s or
                 {{RTCDtlsTransport}}s are in the
-                <code>"failed"</code> state.</td>
+                <code class=fixme>"failed"</code> state.</td>
               </tr>
               <tr>
                 <td><dfn data-idl>disconnected</dfn></td>
                 <td>None of the previous states apply and any
                 {{RTCIceTransport}}s or
                 {{RTCDtlsTransport}}s are in the
-                <code>"disconnected"</code> state.</td>
+                <code class=fixme>"disconnected"</code> state.</td>
               </tr>
               <tr>
                 <td><dfn data-idl>new</dfn></td>
                 <td>None of the previous states apply and all
                 {{RTCIceTransport}}s and
                 {{RTCDtlsTransport}}s are in the
-                <code>"new"</code> or <code>"closed"</code> state, or there are
+                <code class=fixme>"new"</code> or <code class=fixme>"closed"</code> state, or there are
                 no transports.</td>
               </tr>
               <tr>
@@ -691,15 +691,15 @@
                 <td>None of the previous states apply and all
                 {{RTCIceTransport}}s or
                 {{RTCDtlsTransport}}s are in the
-                <code>"new"</code>, <code>"connecting"</code> or <code>"checking"</code> state.</td>
+                <code class=fixme>"new"</code>, <code class=fixme>"connecting"</code> or <code class=fixme>"checking"</code> state.</td>
               </tr>
               <tr>
                 <td data-tests="RTCPeerConnection-connectionState.https.html"><dfn data-idl>connected</dfn></td>
                 <td>None of the previous states apply and all
                 {{RTCIceTransport}}s and
                 {{RTCDtlsTransport}}s are in the
-                <code>"connected"</code>, <code>"completed"</code> or
-                <code>"closed"</code> state.</td>
+                <code class=fixme>"connected"</code>, <code class=fixme>"completed"</code> or
+                <code class=fixme>"closed"</code> state.</td>
               </tr>
             </tbody>
           </table>
@@ -787,7 +787,7 @@
         <h4>Operation</h4>
         <p>Calling <code>new {{RTCPeerConnection}}(<var>configuration</var>)
         </code> creates an {{RTCPeerConnection}} object.</p>
-        <p><code><var>configuration</var>.servers</code> contains information
+        <p><var>configuration</var>.{{RTCConfiguration/iceServers}} contains information
         used to find and access the servers used by ICE. The application can
         supply multiple servers of each type, and any TURN server MAY also be
         used as a STUN server for the purposes of gathering server reflexive
@@ -830,7 +830,7 @@
         <section>
         <h4>Constructor</h4>
         <p>When the <dfn id=
-        "dom-peerconnection"><code>RTCPeerConnection.constructor()</code></dfn>
+        "dom-peerconnection">RTCPeerConnection.constructor()</dfn>
         is invoked, the user agent MUST run the following steps:</p>
         <ol>
           <li>
@@ -849,12 +849,12 @@
             origin</a>.</p>
           </li>
           <li data-tests="RTCCertificate.html">
-            <p id="certificate-validation">If the <code>certificates</code> value in
+            <p id="certificate-validation">If the {{RTCConfiguration/certificates}} value in
             <var>configuration</var> is non-empty, run the following steps for
             each <var>certificate</var> in certificates:
             <ol>
               <li>
-                <p>If the value of <var>certificate</var>.<code>expires</code>
+                <p>If the value of <var>certificate</var>.{{RTCCertificate/expires}}
                 is less than the current time, [= exception/throw =] an
                 {{InvalidAccessError}}.</p> </li>
               <li>
@@ -870,7 +870,7 @@
           <li>
             <p>Else, generate one or more new {{RTCCertificate}} instances
             with this {{RTCPeerConnection}} instance and store them. This MAY happen
-            asynchronously and the value of <code>certificates</code> remains
+            asynchronously and the value of {{RTCConfiguration/certificates}} remains
             <code>undefined</code> for the subsequent steps. As noted in Section 4.3.2.3 of
             [[RTCWEB-SECURITY]], WebRTC utilizes self-signed rather than
             Public Key Infrastructure (PKI) certificates, so that the expiration
@@ -881,15 +881,15 @@
             <p>Initialize <var>connection</var>'s [= ICE Agent =].</p>
           </li>
           <li>
-            <p>If the value of <code><var>configuration</var>.{{RTCConfiguration/iceTransportPolicy}}</code> is
+            <p>If the value of <var>configuration</var>.{{RTCConfiguration/iceTransportPolicy}} is
             <code>undefined</code>, set it to {{RTCIceTransportPolicy/"all"}}.</p>
           </li>
           <li>
-            <p>If the value of <code><var>configuration</var>.{{RTCConfiguration/bundlePolicy}}</code> is
+            <p>If the value of <var>configuration</var>.{{RTCConfiguration/bundlePolicy}} is
             <code>undefined</code>, set it to {{RTCBundlePolicy/"balanced"}}.</p>
           </li>
           <li>
-            <p>If the value of <code><var>configuration</var>.{{RTCConfiguration/rtcpMuxPolicy}}</code> is
+            <p>If the value of <var>configuration</var>.{{RTCConfiguration/rtcpMuxPolicy}} is
             <code>undefined</code>, set it to {{RTCRtcpMuxPolicy/"require"}}.</p>
           </li>
           <li>
@@ -1123,8 +1123,8 @@
             <code>null</code> at <var>connection</var>.</p>
             <div class="note">The null candidate event is fired to ensure
             legacy compatibility. New code should monitor the gathering state
-            of {{RTCIceTransport}} and/or <code>
-            {{RTCPeerConnection}}</code>.</div>
+            of {{RTCIceTransport}} and/or
+            {{RTCPeerConnection}}.</div>
           </li>
         </ol>
         </section>
@@ -1148,7 +1148,7 @@
         following steps:</p>
         <ol>
           <li data-tests="RTCPeerConnection-setLocalDescription-rollback.html,RTCPeerConnection-setRemoteDescription-rollback.html">
-            <p>If <code><var>description</var>.type</code> is
+            <p>If <var>description</var>.{{RTCSessionDescription/type}} is
             {{RTCSdpType/"rollback"}} and <var>connection</var>'s [= signaling state =] is either
             {{RTCSignalingState/"stable"}}, {{RTCSignalingState/"have-local-pranswer"}}, or
             {{RTCSignalingState/"have-remote-pranswer"}}, then [= reject =] <var>p</var>
@@ -1193,8 +1193,8 @@
                   <li data-tests="RTCPeerConnection-setRemoteDescription-offer.html,RTCPeerConnection-setRemoteDescription.html,protocol/missing-fields.html">
                     <p>If the content of <var>description</var> is not
                     valid SDP syntax, then [= reject =] <var>p</var> with an
-                    {{RTCError}} (with <code>errorDetail</code>
-                    set to "sdp-syntax-error" and the <code>sdpLineNumber</code>
+                    {{RTCError}} (with {{RTCError/errorDetail}}
+                    set to "sdp-syntax-error" and the {{RTCError/sdpLineNumber}}
                     attribute set to the line number in the SDP where
                     the syntax error was detected) and abort these steps.</p>
                   </li>
@@ -1420,8 +1420,8 @@
                             the following steps:</p>
                             <ol>
                               <li data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-transceivers.https.html">
-                                <p>Let <var>transceiver</var> be the <code>
-                                {{RTCRtpTransceiver}}</code> used to create the
+                                <p>Let <var>transceiver</var> be the
+                                {{RTCRtpTransceiver}} used to create the
                                 [= media description =].</p>
                               </li>
                               <li data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html">
@@ -1466,8 +1466,8 @@
                             </ol>
                           </li>
                           <li>
-                            <p>Let <var>transceiver</var> be the <code>
-                            {{RTCRtpTransceiver}}</code> {{associated}} with the
+                            <p>Let <var>transceiver</var> be the
+                            {{RTCRtpTransceiver}} {{associated}} with the
                             [= media description =].</p>
                           </li>
                           <li data-tests="RTCRtpTransceiver.https.html">
@@ -1475,8 +1475,8 @@
                             is <code>true</code>, abort these sub steps.</p>
                           </li>
                           <li>
-                            <p>Let <var>direction</var> be an <code>
-                            {{RTCRtpTransceiverDirection}}</code> value
+                            <p>Let <var>direction</var> be an
+                            {{RTCRtpTransceiverDirection}} value
                             representing the direction from the [= media
                             description =].</p>
                           </li>
@@ -1553,7 +1553,7 @@
                             and contains a request to receive simulcast, use the order
                             of the rid values specified in the simulcast attribute to create
                             an {{RTCRtpEncodingParameters}} dictionary for
-                            each of the simulcast layers, populating the <code>rid</code> member
+                            each of the simulcast layers, populating the  {{RTCRtpCodingParameters/rid}} member
                             according to the corresponding rid value, and let <var>sendEncodings</var>
                             be the list containing the created dictionaries. Otherwise,
                             let <var>sendEncodings</var> be an empty list.</p>
@@ -1644,8 +1644,8 @@
                             <span data-jsep="applying-a-remote-desc">[[!JSEP]]</span>.</p>
                           </li>
                           <li>
-                            <p>Let <var>direction</var> be an <code>
-                            {{RTCRtpTransceiverDirection}}</code> value
+                            <p>Let <var>direction</var> be an
+                            {{RTCRtpTransceiverDirection}} value
                             representing the direction from the [= media
                             description =], but with the send and receive
                             directions reversed to represent this peer's point
@@ -1778,7 +1778,7 @@
                             sub steps:</p>
                             <ol>
                               <li>
-                                <p>Let <var>msids</var> be a list of the <code>id</code>s
+                                <p>Let <var>msids</var> be a list of the <code class=gum>id</code>s
                                 of all {{MediaStream}} objects in
                                 <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\LastStableStateAssociatedRemoteMediaStreams]]</a>,
                                 or an empty list if there are none.</p>
@@ -1793,7 +1793,7 @@
                           </li>
                           <li data-tests="RTCPeerConnection-setDescription-transceiver.html">
                             <p>If the <var>transceiver</var> was created by applying the
-                            <code><a>RTCSessionDescription</a></code> that is
+                            {{RTCSessionDescription}} that is
                             being rolled back, and a track has never been attached to
                             it via {{RTCPeerConnection/addTrack()}}, then <a>stop the RTCRtpTransceiver</a>
                             <var>transceiver</var>, and remove it from <var>connection</var>'s
@@ -1863,7 +1863,7 @@
                     <p>For each <var>channel</var> in <var>errorList</var>,
                     [= fire an event =] named {{RTCDataChannel/error}} using the
                     {{RTCErrorEvent}} interface with the
-                    <code>errorDetail</code> attribute set to
+                    {{RTCError/errorDetail}} attribute set to
                     "data-channel-failure" at <var>channel</var>.</p>
                   </li>
                   <li id="remote-mute" data-tests="RTCPeerConnection-remote-track-mute.https.html">
@@ -1883,17 +1883,16 @@
                   </li>
                   <li data-tests="RTCPeerConnection-ontrack.https.html,RTCPeerConnection-setRemoteDescription-tracks.https.html,RTCTrackEvent-fire.html">
                     <p>For each entry <var>entry</var> in <var>trackEventInits</var>,
-                    [= fire an event =] named <code title=
-                    "event-track">{{track}}</code> using the
+                    [= fire an event =] named {{track}} using the
                     {{RTCTrackEvent}} interface with its
-                    <code>receiver</code> attribute initialized to
-                    <var>entry</var>.<code>receiver</code>, its
-                    <code>track</code> attribute initialized to
-                    <var>entry</var>.<code>track</code>, its
-                    <code>streams</code> attribute initialized to
-                    <var>entry</var>.<code>streams</code> and its
-                    <code>transceiver</code> attribute initialized to
-                    <var>entry</var>.<code>transceiver</code>
+                    {{RTCTrackEvent/receiver}} attribute initialized to
+                    <var>entry</var>.{{RTCTrackEventInit/receiver}}, its
+                    {{RTCTrackEvent/track}} attribute initialized to
+                    <var>entry</var>.{{RTCTrackEventInit/track}}, its
+                    {{RTCTrackEvent/streams}} attribute initialized to
+                    <var>entry</var>.{{RTCTrackEventInit/streams}} and its
+                    {{RTCTrackEvent/transceiver}} attribute initialized to
+                    <var>entry</var>.{{RTCTrackEventInit/transceiver}}
                     at the <var>connection</var> object.</p>
                   </li>
                   <li data-tests="RTCPeerConnection-setLocalDescription.html">
@@ -1920,13 +1919,13 @@
             <li><p>Let <var>connection</var> be the target
             {{RTCPeerConnection}} object.</p></li>
             <li data-tests="RTCCertificate.html">
-              <p id="setconfig-certificate">If <code><var>configuration</var>.certificates</code> is
+              <p id="setconfig-certificate">If <var>configuration</var>.{{RTCConfiguration/certificates}} is
               set, run the following steps:</p>
               <ol>
                 <li>
-                  <p>If the length of <code><var>configuration</var>.certificates</code>
+                  <p>If the length of <var>configuration</var>.{{RTCConfiguration/certificates}}
                   is different from the length of
-                  <code><var>connection</var>.[[\Configuration]].certificates</code>,
+                  <var>connection</var>.<a>[[\Configuration]]</a>.{{RTCConfiguration/certificates}},
                   [= exception/throw =] an {{InvalidModificationError}}.</p>
                 </li>
                 <li>
@@ -1934,7 +1933,7 @@
                 </li>
                 <li>
                   <p>Let <var>size</var> be initialized to the length of
-                  <code><var>configuration</var>.certificates</code>.</p>
+                  <var>configuration</var>.{{RTCConfiguration/certificates}}.</p>
                 </li>
                 <li>
                   <p>While <var>index</var> is less than <var>size</var>,
@@ -1942,10 +1941,10 @@
                   <ol>
                     <li>
                       <p>If the ECMAScript object represented by the value of
-                      <code><var>configuration</var>.certificates</code> at
+                      <var>configuration</var>.{{RTCConfiguration/certificates}} at
                       <var>index</var> is not the same as the ECMAScript
                       object represented by the value of
-                      <code><var>connection</var>.[[\Configuration]].certificates</code>
+                      <var>connection</var>.<a>[[\Configuration]]</a>.{{RTCConfiguration/certificates}}
                       at <var>index</var>, [= exception/throw =] an
                       {{InvalidModificationError}}.</p>
                     </li>
@@ -1956,21 +1955,21 @@
                 </li>
               </ol>
             </li>
-            <li><p id="config-bundle" data-tests="RTCConfiguration-bundlePolicy.html">If the value of <code><var>configuration</var>.{{RTCConfiguration/bundlePolicy}}</code> is set and its value
+            <li><p id="config-bundle" data-tests="RTCConfiguration-bundlePolicy.html">If the value of <var>configuration</var>.{{RTCConfiguration/bundlePolicy}} is set and its value
             differs from the <var>connection</var>'s bundle policy, [= exception/throw =]
             an {{InvalidModificationError}}.</p></li>
-            <li><p id="config-rtcpmux" data-tests="RTCConfiguration-rtcpMuxPolicy.html">If the value of <code><var>configuration</var>.{{RTCConfiguration/rtcpMuxPolicy}}</code> is set and its value
+            <li><p id="config-rtcpmux" data-tests="RTCConfiguration-rtcpMuxPolicy.html">If the value of <var>configuration</var>.{{RTCConfiguration/rtcpMuxPolicy}} is set and its value
             differs from the <var>connection</var>'s rtcpMux policy, [= exception/throw =] an
             {{InvalidModificationError}}.</p></li>
-            <li><p  id="config-icepool" data-tests="RTCConfiguration-iceCandidatePoolSize.html">If the value of <code><var>configuration</var>.{{RTCConfiguration/iceCandidatePoolSize}}</code> is set and its
+            <li><p  id="config-icepool" data-tests="RTCConfiguration-iceCandidatePoolSize.html">If the value of <var>configuration</var>.{{RTCConfiguration/iceCandidatePoolSize}} is set and its
             value differs from the <var>connection</var>'s previously set
-            <code>iceCandidatePoolSize</code>, and {{RTCPeerConnection/setLocalDescription}} has
+            {{RTCConfiguration/iceCandidatePoolSize}}, and {{RTCPeerConnection/setLocalDescription}} has
             already been called, [= exception/throw =] an
             {{InvalidModificationError}}.</p></li>
             <li data-tests="RTCConfiguration-iceTransportPolicy.html">
               <p id="config-icetransportpolicy" >Set the [= ICE Agent =]'s <dfn id=
               "ice-transports-setting">ICE transports setting</dfn> to
-              the value of <code><var>configuration</var>.{{RTCConfiguration/iceTransportPolicy}}</code>. As defined
+              the value of <var>configuration</var>.{{RTCConfiguration/iceTransportPolicy}}. As defined
               in <span data-jsep="setconfiguration">[[!JSEP]]</span>, if
               the new [= ICE transports setting =] changes the existing
               setting, no action will be taken until the next gathering
@@ -1981,7 +1980,7 @@
               <p>Set the [= ICE Agent =]'s prefetched <dfn>ICE candidate
               pool size</dfn> as defined in <span data-jsep=
               "ice-candidate-pool constructor">[[!JSEP]]</span> to the
-              value of <code><var>configuration</var>.{{RTCConfiguration/iceCandidatePoolSize}}</code>. If the
+              value of <var>configuration</var>.{{RTCConfiguration/iceCandidatePoolSize}}. If the
               new [= ICE candidate pool size =] changes the existing
               setting, this may result in immediate gathering of new
               pooled candidates, or discarding of existing pooled
@@ -1992,7 +1991,7 @@
               <p>Let <var>validatedServers</var> be an empty list.</p>
             </li>
             <li data-tests="RTCConfiguration-iceServers.html">
-              <p id="config-iceservers">If <code><var>configuration</var>.{{RTCConfiguration/iceServers}}</code> is defined, then
+              <p id="config-iceservers">If <var>configuration</var>.{{RTCConfiguration/iceServers}} is defined, then
               run the following steps for each element:</p>
               <ol>
                 <li>
@@ -2000,7 +1999,7 @@
                   element.</p>
                 </li>
                 <li>
-                  <p>Let <var>urls</var> be <code><var>server</var>.urls</code>.</p>
+                  <p>Let <var>urls</var> be <var>server</var>.{{RTCIceServer/urls}}.</p>
                 </li>
                 <li>
                   <p>If <var>urls</var> is a string, set <var>urls</var> to a
@@ -2024,30 +2023,30 @@
                       the <var>scheme name</var> is not implemented
                       by the browser [= exception/throw =] a
                       {{NotSupportedError}}. If
-                      <var>scheme name</var> is <code>turn</code> or
-                      <code>turns</code>, and parsing the
+                      <var>scheme name</var> is <code class=scheme>turn</code> or
+                      <code class=scheme>turns</code>, and parsing the
                       <var>url</var> using the syntax defined in
                       [[!RFC7064]] fails, [= exception/throw =] a
                       {{SyntaxError}}. If <var>scheme
-                      name</var> is <code>stun</code> or
-                      <code>stuns</code>, and parsing the
+                      name</var> is <code class=scheme>stun</code> or
+                      <code class=scheme>stuns</code>, and parsing the
                       <var>url</var> using the syntax defined in
                       [[!RFC7065]] fails, [= exception/throw =] a
                       {{SyntaxError}}. </p>
                     </li>
                     <li>
-                      <p>If <var>scheme name</var> is <code>turn</code> or
-                      <code>turns</code>, and either of
-                      <code><var>server</var>.username</code> or
-                      <code><var>server</var>.credential</code> are omitted,
+                      <p>If <var>scheme name</var> is <code class=scheme>turn</code> or
+                      <code class=scheme>turns</code>, and either of
+                      <var>server</var>.{{RTCIceServer/username}} or
+                      <var>server</var>.<code class=fixme>credential</code> are omitted,
                       then [= exception/throw =] an {{InvalidAccessError}}.</p>
                     </li>
                     <li>
-                      <p>If <var>scheme name</var> is <code>turn</code> or
-                      <code>turns</code>, and
-                      <code><var>server</var>.credentialType</code> is
+                      <p>If <var>scheme name</var> is <code class=scheme>turn</code> or
+                      <code class=scheme>turns</code>, and
+                      <var>server</var>.{{RTCIceServer/credentialType}} is
                       {{RTCIceCredentialType/"password"}}, and
-                      <code><var>server</var>.credential</code> is not a
+                      <var>server</var>.<code class=fixme>credential</code> is not a
                       <span class="idlMemberType">DOMString</span>, then
                       [= exception/throw =] an {{InvalidAccessError}}.</p>
                     </li>
@@ -2143,12 +2142,12 @@ interface RTCPeerConnection : EventTarget  {
             <h2>Attributes</h2>
             <dl data-link-for="RTCPeerConnection" data-dfn-for=
             "RTCPeerConnection" class="attributes">
-              <dt><code>localDescription</code> of type <span class=
+              <dt><dfn id=
+                "dom-peerconnection-localdescription">localDescription</dfn> of type <span class=
               "idlAttrType">{{RTCSessionDescription}}</span>, readonly,
               nullable</dt>
               <dd>
-                <p>The <dfn id=
-                "dom-peerconnection-localdescription"><code>localDescription</code></dfn>
+                <p>The {{localDescription}}
                 attribute MUST return <a>[[\PendingLocalDescription]]</a> if it is
                 not null and otherwise it MUST return
                 <a>[[\CurrentLocalDescription]]</a>.</p>
@@ -2160,12 +2159,12 @@ interface RTCPeerConnection : EventTarget  {
                 may be parsed and reformatted, and ICE candidates may be
                 added).</p>
               </dd>
-              <dt><code>currentLocalDescription</code> of type <span class=
+              <dt><dfn id=
+                "dom-peerconnection-currentlocaldesc">currentLocalDescription</dfn> of type <span class=
               "idlAttrType">{{RTCSessionDescription}}</span>, readonly,
               nullable</dt>
               <dd>
-                <p>The <dfn id=
-                "dom-peerconnection-currentlocaldesc"><code>currentLocalDescription</code></dfn>
+                <p>The {{currentLocalDescription}}
                 attribute MUST return <a>[[\CurrentLocalDescription]]</a>.</p>
                 <p>It represents the local description that was successfully
                 negotiated the last time the {{RTCPeerConnection}}
@@ -2173,12 +2172,12 @@ interface RTCPeerConnection : EventTarget  {
                 that have been generated by the [= ICE Agent =] since the offer
                 or answer was created.</p>
               </dd>
-              <dt><code>pendingLocalDescription</code> of type <span class=
+              <dt><dfn id=
+                "dom-peerconnection-pendinglocaldesc">pendingLocalDescription</dfn> of type <span class=
               "idlAttrType">{{RTCSessionDescription}}</span>, readonly,
               nullable</dt>
               <dd>
-                <p>The <dfn id=
-                "dom-peerconnection-pendinglocaldesc"><code>pendingLocalDescription</code></dfn>
+                <p>The {{pendingLocalDescription}}
                 attribute MUST return <a>[[\PendingLocalDescription]]</a>.</p>
                 <p>It represents a local description that is in the
                 process of being negotiated plus any local candidates that have
@@ -2186,12 +2185,12 @@ interface RTCPeerConnection : EventTarget  {
                 answer was created. If the {{RTCPeerConnection}} is in
                 the stable state, the value is <code>null</code>.</p>
               </dd>
-              <dt data-tests="RTCPeerConnection-setRemoteDescription-answer.html,RTCPeerConnection-setRemoteDescription-offer.html"><code>remoteDescription</code> of type <span class=
+              <dt data-tests="RTCPeerConnection-setRemoteDescription-answer.html,RTCPeerConnection-setRemoteDescription-offer.html"><dfn id=
+                "dom-peerconnection-remotedescription">remoteDescription</dfn> of type <span class=
               "idlAttrType">{{RTCSessionDescription}}</span>, readonly,
               nullable</dt>
               <dd>
-                <p>The <dfn id=
-                "dom-peerconnection-remotedescription"><code>remoteDescription</code></dfn>
+                <p>The {{remoteDescription}}
                 attribute MUST return <a>[[\PendingRemoteDescription]]</a> if it
                 is not <code>null</code> and otherwise it MUST return
                 <a>[[\CurrentRemoteDescription]]</a>.</p>
@@ -2203,12 +2202,12 @@ interface RTCPeerConnection : EventTarget  {
                 may be parsed and reformatted, and ICE candidates may be
                 added).</p>
               </dd>
-              <dt data-tests="RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setRemoteDescription-answer.html,RTCPeerConnection-setRemoteDescription-offer.html"><code>currentRemoteDescription</code> of type <span class=
+              <dt data-tests="RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setRemoteDescription-answer.html,RTCPeerConnection-setRemoteDescription-offer.html"><dfn id=
+                "dom-peerconnection-currentremotedesc">currentRemoteDescription</dfn> of type <span class=
               "idlAttrType">{{RTCSessionDescription}}</span>, readonly,
               nullable</dt>
               <dd>
-                <p>The <dfn id=
-                "dom-peerconnection-currentremotedesc"><code>currentRemoteDescription</code></dfn>
+                <p>The {{currentRemoteDescription}}
                 attribute MUST return <a>[[\CurrentRemoteDescription]]</a>.</p>
                 <p>It represents the last remote description that was successfully
                 negotiated the last time the {{RTCPeerConnection}}
@@ -2216,12 +2215,12 @@ interface RTCPeerConnection : EventTarget  {
                 that have been supplied via {{RTCPeerConnection/addIceCandidate()}} since the
                 offer or answer was created.</p>
               </dd>
-              <dt data-tests="RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setRemoteDescription-answer.html,RTCPeerConnection-setRemoteDescription-offer.html"><code>pendingRemoteDescription</code> of type <span class=
+              <dt data-tests="RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setRemoteDescription-answer.html,RTCPeerConnection-setRemoteDescription-offer.html"><dfn id=
+                "dom-peerconnection-pendingremotedesc">pendingRemoteDescription</dfn> of type <span class=
               "idlAttrType">{{RTCSessionDescription}}</span>, readonly,
               nullable</dt>
               <dd>
-                <p>The <dfn id=
-                "dom-peerconnection-pendingremotedesc"><code>pendingRemoteDescription</code></dfn>
+                <p>The {{pendingRemoteDescription}}
                 attribute MUST return <a>[[\PendingRemoteDescription]]</a>.</p>
                 <p>It  represents a remote description that is in the
                 process of being negotiated, complete with any remote
@@ -2230,42 +2229,40 @@ interface RTCPeerConnection : EventTarget  {
                 {{RTCPeerConnection}} is in the stable state, the
                 value is <code>null</code>.</p>
               </dd>
-              <dt><code>signalingState</code> of type <span class=
+              <dt><dfn id=
+                "dom-peerconnection-signaling-state">signalingState</dfn> of type <span class=
               "idlAttrType">{{RTCSignalingState}}</span>, readonly</dt>
               <dd>
-                <p>The <dfn id=
-                "dom-peerconnection-signaling-state"><code>signalingState</code></dfn>
+                <p>The {{signalingState}}
                 attribute MUST return the {{RTCPeerConnection/RTCPeerConnection}} object's
                 [= signaling state =].</p>
               </dd>
-              <dt data-tests="RTCPeerConnection-iceGatheringState.html,protocol/candidate-exchange.https.html"><code>iceGatheringState</code> of type <span class=
+              <dt data-tests="RTCPeerConnection-iceGatheringState.html,protocol/candidate-exchange.https.html"><dfn id=
+                "dom-peerconnection-ice-gathering-state">iceGatheringState</dfn> of type <span class=
               "idlAttrType">{{RTCIceGatheringState}}</span>, readonly</dt>
               <dd>
-                <p>The <dfn id=
-                "dom-peerconnection-ice-gathering-state"><code>iceGatheringState</code></dfn>
-                attribute MUST return the [= ICE gathering state =] of the
-                {{RTCPeerConnection}} instance.</p>
+                <p>The {{iceGatheringState}} attribute MUST return the [= ICE gathering state =] of the {{RTCPeerConnection}} instance.</p>
               </dd>
-              <dt data-tests="RTCPeerConnection-iceConnectionState.https.html,no-media-call.html,RTCPeerConnection-iceConnectionState-disconnected.https.html,protocol/ice-state.https.html"><code>iceConnectionState</code> of type <span class=
+              <dt data-tests="RTCPeerConnection-iceConnectionState.https.html,no-media-call.html,RTCPeerConnection-iceConnectionState-disconnected.https.html,protocol/ice-state.https.html"><dfn id=
+                "dom-peerconnection-ice-connection-state">iceConnectionState</dfn> of type <span class=
               "idlAttrType">{{RTCIceConnectionState}}</span>, readonly</dt>
               <dd>
-                <p>The <dfn id=
-                "dom-peerconnection-ice-connection-state"><code>iceConnectionState</code></dfn>
+                <p>The {{iceConnectionState}}
                 attribute MUST return the [= ICE connection state =] of the
                 {{RTCPeerConnection}} instance.</p>
               </dd>
-              <dt data-tests="RTCPeerConnection-connectionState.https.html"><code>connectionState</code> of type <span class=
+              <dt data-tests="RTCPeerConnection-connectionState.https.html"><dfn id=
+                "dom-peerconnection-connection-state">connectionState</dfn> of type <span class=
               "idlAttrType">{{RTCPeerConnectionState}}</span>, readonly</dt>
               <dd>
-                <p>The <dfn id=
-                "dom-peerconnection-connection-state"><code>connectionState</code></dfn>
+                <p>The {{connectionState}}
                 attribute MUST return the [= connection state =] of the
                 {{RTCPeerConnection}} instance.</p>
               </dd>
-              <dt data-tests="RTCPeerConnection-canTrickleIceCandidates.html, RTCPeerConnection-constructor.html"><code>canTrickleIceCandidates</code> of type <span class=
+              <dt data-tests="RTCPeerConnection-canTrickleIceCandidates.html, RTCPeerConnection-constructor.html"><dfn data-idl>canTrickleIceCandidates</dfn> of type <span class=
               "idlAttrType">boolean</span>, readonly, nullable</dt>
               <dd>
-                <p>The <dfn data-idl>canTrickleIceCandidates</dfn>
+                <p>The {{canTrickleIceCandidates}}
                 attribute indicates whether the remote peer is able to accept
                 trickled ICE candidates [[TRICKLE-ICE]]. The value is
                 determined based on whether a remote description indicates
@@ -2310,21 +2307,21 @@ interface RTCPeerConnection : EventTarget  {
             "RTCPeerConnection" class="methods">
               <dt data-tests="RTCPeerConnection-createOffer.html,promises-call.html"><dfn data-idl>createOffer</dfn></dt>
               <dd>
-                <p>The <code>createOffer</code> method generates a blob of SDP that contains
+                <p>The {{createOffer}} method generates a blob of SDP that contains
                 an RFC 3264 offer with the supported configurations for the
                 session, including descriptions of the local
                 {{MediaStreamTrack}}s attached to this
                 {{RTCPeerConnection}}, the codec/RTP/RTCP capabilities
                 supported by this implementation, and parameters of the [= ICE
-                agent =] and the DTLS connection. The <code>options</code>
+                agent =] and the DTLS connection. The <var>options</var>
                 parameter may be supplied to provide additional control over
                 the offer generated.</p>
                 <p>If a system has limited resources (e.g. a finite number of
-                decoders), <code>createOffer</code> needs to return an offer
+                decoders), {{createOffer}} needs to return an offer
                 that reflects the current state of the system, so that
-                <code>setLocalDescription</code> will succeed when it attempts
+                {{setLocalDescription}} will succeed when it attempts
                 to acquire those resources. The session descriptions MUST
-                remain usable by <code>setLocalDescription</code> without
+                remain usable by {{setLocalDescription}} without
                 causing an error until at least the end of the [= fulfillment =]
                 callback of the returned promise.</p>
                 <p data-tests="RTCRtpTransceiver-stop.html,protocol/jsep-initial-offer.https.html">Creating the SDP
@@ -2338,8 +2335,8 @@ interface RTCPeerConnection : EventTarget  {
                 codec/RTP/RTCP capabilities supported or preferred by the session (as
                 opposed to an answer, which will include only a specific
                 negotiated subset to use). In the event
-                <code>createOffer</code> is called after the session is
-                established, <code>createOffer</code> will generate an offer
+                {{createOffer}} is called after the session is
+                established, {{createOffer}} will generate an offer
                 that is compatible with the current session, incorporating any
                 changes that have been made to the session since the last
                 complete offer-answer exchange, such as addition or removal of
@@ -2352,7 +2349,7 @@ interface RTCPeerConnection : EventTarget  {
                 {{RTCIceParameters/password}} and
                 ICE options (as defined in [[!ICE]], Section 14) and may also contain
                 any local candidates that have been gathered by the agent.</p>
-                <p>The <code>certificates</code> value in <var>configuration</var>
+                <p>The {{RTCConfiguration/certificates}} value in <var>configuration</var>
                 for the {{RTCPeerConnection}} provides the
                 certificates configured by the application for the
                 {{RTCPeerConnection}}.  These certificates,
@@ -2449,7 +2446,7 @@ interface RTCPeerConnection : EventTarget  {
                     steps.</p>
                     <div class="note">
                       This may be necessary if, for example,
-                      <code>createOffer</code> was called when only an audio
+                      {{createOffer}} was called when only an audio
                       {{RTCRtpTransceiver}} was added to
                       <var>connection</var>, but while performing the
                       [= in-parallel steps to create an offer =], a video
@@ -2486,20 +2483,20 @@ interface RTCPeerConnection : EventTarget  {
                             <p>If the {{RTCRtpTransceiver/direction}} is
                             {{RTCRtpTransceiverDirection/"sendrecv"}}, exclude any codecs not
                             included in the intersection of
-                            <code>RTCRtpSender.getCapabilities(kind).codecs</code>
-                            and <code>RTCRtpReceiver.getCapabilities(kind).codecs</code>.
+                            {{RTCRtpSender}}.{{RTCRtpSender/getCapabilities}}(kind).{{RTCRtpCapabilities/codecs}}
+                            and {{RTCRtpReceiver}}.{{RTCRtpReceiver/getCapabilities}}(kind).{{RTCRtpCapabilities/codecs}}.
                           </li>
                           <li>
                             <p>If the {{RTCRtpTransceiver/direction}} is
                             {{RTCRtpTransceiverDirection/"sendonly"}}, exclude any codecs not
                             included in
-                            <code>RTCRtpSender.getCapabilities(kind).codecs</code>.
+                            {{RTCRtpSender}}.{{RTCRtpSender/getCapabilities}}(kind).{{RTCRtpCapabilities/codecs}}.
                           </li>
                           <li>
                             <p>If the {{RTCRtpTransceiver/direction}} is
                             {{RTCRtpTransceiverDirection/"recvonly"}}, exclude any codecs not
                             included in
-                            <code>RTCRtpReceiver.getCapabilities(kind).codecs</code>.
+                            {{RTCRtpReceiver}}.{{RTCRtpReceiver/getCapabilities}}(kind).{{RTCRtpCapabilities/codecs}}.
                           </li>
                         </ol>
                         <p>The filtering MUST NOT change the order of the codec
@@ -2531,8 +2528,8 @@ interface RTCPeerConnection : EventTarget  {
                   <li data-tests="RTCPeerConnection-createOffer.html">
                     <p>Let <var>offer</var> be a newly created
                     {{RTCSessionDescriptionInit}} dictionary
-                    with its <code>type</code> member initialized to the string
-                    {{RTCSdpType/"offer"}} and its <code>sdp</code> member
+                    with its {{RTCSessionDescriptionInit/type}} member initialized to the string
+                    {{RTCSdpType/"offer"}} and its {{RTCSessionDescriptionInit/sdp}} member
                     initialized to <var>sdpString</var>.</p>
                   </li>
                   <li><p>Set the <a>[[\LastCreatedOffer]]</a> internal slot to
@@ -2545,20 +2542,20 @@ interface RTCPeerConnection : EventTarget  {
               </dd>
               <dt data-tests="RTCPeerConnection-createAnswer.html,promises-call.html"><dfn data-idl>createAnswer</dfn></dt>
               <dd>
-                <p>The <code>createAnswer</code> method generates an [[!SDP]]
+                <p>The {{createAnswer}} method generates an [[!SDP]]
                 answer with the supported configuration for the session that is
                 compatible with the parameters in the remote configuration.
-                Like <code>createOffer</code>, the returned blob of SDP contains
+                Like {{createOffer}}, the returned blob of SDP contains
                 descriptions of the local {{MediaStreamTrack}}s
                 attached to this {{RTCPeerConnection}}, the
                 codec/RTP/RTCP options negotiated for this session, and any
                 candidates that have been gathered by the [= ICE Agent =]. The
-                <code>options</code> parameter may be supplied to provide
+                <var>options</var> parameter may be supplied to provide
                 additional control over the generated answer.</p>
-                <p>Like <code>createOffer</code>, the
+                <p>Like {{createOffer}}, the
                 returned description SHOULD reflect the current state of the
                 system. The session descriptions MUST remain usable by
-                <code>setLocalDescription</code> without causing an error until
+                {{setLocalDescription}} without causing an error until
                 at least the end of the [= fulfillment =] callback of the returned
                 promise.</p>
                 <p>As an answer, the generated SDP will contain a specific
@@ -2571,7 +2568,7 @@ interface RTCPeerConnection : EventTarget  {
                 {{RTCIceParameters/password}} and
                 ICE options (as defined in [[!ICE]], Section 14) and may also contain
                 any local candidates that have been gathered by the agent.</p>
-                <p>The <code>certificates</code> value in <var>configuration</var>
+                <p>The {{RTCConfiguration/certificates}} value in <var>configuration</var>
                 for the {{RTCPeerConnection}} provides the
                 certificates configured by the application for the
                 {{RTCPeerConnection}}.  These certificates,
@@ -2669,7 +2666,7 @@ interface RTCPeerConnection : EventTarget  {
                     steps.</p>
                     <div class="note">
                       This may be necessary if, for example,
-                      <code>createAnswer</code> was called when an
+                      {{createAnswer}} was called when an
                       {{RTCRtpTransceiver}}'s direction was
                       {{RTCRtpTransceiverDirection/"recvonly"}}, but while performing the
                       [= in-parallel steps to create an answer =], the
@@ -2696,20 +2693,20 @@ interface RTCPeerConnection : EventTarget  {
                             <p>If the {{RTCRtpTransceiver/direction}} is
                             {{RTCRtpTransceiverDirection/"sendrecv"}}, exclude any codecs not
                             included in the intersection of
-                            <code>RTCRtpSender.getCapabilities(kind).codecs</code>
-                            and <code>RTCRtpReceiver.getCapabilities(kind).codecs</code>.
+                            {{RTCRtpSender}}.{{RTCRtpSender/getCapabilities}}(kind).{{RTCRtpCapabilities/codecs}}
+                            and {{RTCRtpReceiver}}.{{RTCRtpReceiver/getCapabilities}}(kind).{{RTCRtpCapabilities/codecs}}.
                           </li>
                           <li>
                             <p>If the {{RTCRtpTransceiver/direction}} is
                             {{RTCRtpTransceiverDirection/"sendonly"}}, exclude any codecs not
                             included in
-                            <code>RTCRtpSender.getCapabilities(kind).codecs</code>.
+                            {{RTCRtpSender}}.{{RTCRtpSender/getCapabilities}}(kind).{{RTCRtpCapabilities/codecs}}.
                           </li>
                           <li>
                             <p>If the {{RTCRtpTransceiver/direction}} is
                             {{RTCRtpTransceiverDirection/"recvonly"}}, exclude any codecs not
                             included in
-                            <code>RTCRtpReceiver.getCapabilities(kind).codecs</code>.
+                            {{RTCRtpReceiver}}.{{RTCRtpReceiver/getCapabilities}}(kind).{{RTCRtpCapabilities/codecs}}.
                           </li>
                         </ol>
                         <p>The filtering MUST NOT change the order of the codec
@@ -2733,8 +2730,8 @@ interface RTCPeerConnection : EventTarget  {
                   <li data-tests="RTCPeerConnection-createAnswer.html">
                     <p>Let <var>answer</var> be a newly created
                     {{RTCSessionDescriptionInit}} dictionary
-                    with its <code>type</code> member initialized to the string
-                    {{RTCSdpType/"answer"}} and its <code>sdp</code> member
+                    with its {{RTCSessionDescriptionInit/type}} member initialized to the string
+                    {{RTCSdpType/"answer"}} and its {{RTCSessionDescriptionInit/sdp}} member
                     initialized to <var>sdpString</var>.</p>
                   </li>
                   <li><p>Set the <a>[[\LastCreatedAnswer]]</a> internal slot to
@@ -2745,10 +2742,10 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                 </ol>
               </dd>
-              <dt data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setLocalDescription-offer.html,promises-call.html"><code>setLocalDescription</code></dt>
+              <dt data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setLocalDescription-offer.html,promises-call.html"><dfn id=
+                "dom-peerconnection-setlocaldescription">setLocalDescription</dfn></dt>
               <dd>
-                <p>The <dfn id=
-                "dom-peerconnection-setlocaldescription"><code>setLocalDescription</code></dfn>
+                <p>The {{setLocalDescription}}
                 method instructs the {{RTCPeerConnection}} to
                 apply the supplied {{RTCSessionDescriptionInit}}
                 as the local description.</p>
@@ -2763,12 +2760,12 @@ interface RTCPeerConnection : EventTarget  {
                 adopt the pending local description, or rollback to the current
                 description if the remote side rejected the change.</p>
                 <p>Passing in a description is optional. If left out, then
-                <code>setLocalDescription</code> will implicitly
+                {{setLocalDescription}} will implicitly
                 [= create an offer =] or [= create an answer =], as needed.
                 As noted in <span data-jsep="modifying-sdp">[[!JSEP]]</span>,
                 if a description with SDP is passed in, that SDP is not allowed
                 to have changed from when it was returned from either
-                <code>createOffer</code> or <code>createAnswer</code>.</p>
+                {{createOffer}} or {{createAnswer}}.</p>
                 <p>When the method is invoked, the user agent MUST run the
                 following steps:</p>
                 <ol>
@@ -2783,7 +2780,7 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>Let <var>sdp</var> be
-                    <code><var>description</var>.sdp</code>.</p>
+                    <var>description</var>.{{RTCSessionDescription/sdp}}.</p>
                   </li>
                   <li>
                     <p>Return the result of [= chaining =] the following steps to
@@ -2791,7 +2788,7 @@ interface RTCPeerConnection : EventTarget  {
                     <ol>
                       <li>
                         <p>Let <var>type</var> be
-                        <code><var>description</var>.type</code> if present, or
+                        <var>description</var>.{{RTCSessionDescription/type}} if present, or
                         {{RTCSdpType/"offer"}} if not present and
                         <var>connection</var>'s [= signaling state =] is either
                         {{RTCSignalingState/"stable"}}, {{RTCSignalingState/"have-local-offer"}},
@@ -2867,7 +2864,7 @@ interface RTCPeerConnection : EventTarget  {
                               <li>
                                 <p>Return the result of [= setting the local RTCSessionDescription =]
                                 indicated by
-                                <code>{<var>type</var>, <var>answer</var>.sdp}</code>.
+                                <code class=param>{<var>type</var>, <var>answer</var>.{{RTCSessionDescription/sdp}}}</code>.
                                 </p>
                               </li>
                             </ol>
@@ -2877,7 +2874,7 @@ interface RTCPeerConnection : EventTarget  {
                       <li>
                         <p>Return the result of [= setting the local RTCSessionDescription =]
                         indicated by
-                        <code>{<var>type</var>, <var>sdp</var>}</code>.</p>
+                        <code class=param>{<var>type</var>, <var>sdp</var>}</code>.</p>
                       </li>
                     </ol>
                   </li>
@@ -2888,10 +2885,10 @@ interface RTCPeerConnection : EventTarget  {
                   by the [= ICE Agent =].</p>
                 </div>
               </dd>
-              <dt data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-setLocalDescription-answer.html,promises-call.html,simplecall-no-ssrcs.https.html,simplecall.https.html"><code>setRemoteDescription</code></dt>
+              <dt data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-setLocalDescription-answer.html,promises-call.html,simplecall-no-ssrcs.https.html,simplecall.https.html"><dfn id=
+                "dom-peerconnection-setremotedescription">setRemoteDescription</dfn></dt>
               <dd>
-                <p>The <dfn id=
-                "dom-peerconnection-setremotedescription"><code>setRemoteDescription</code></dfn>
+                <p>The {{setRemoteDescription}}
                 method instructs the {{RTCPeerConnection}} to
                 apply the supplied
                 {{RTCSessionDescriptionInit}} as the remote
@@ -2924,7 +2921,7 @@ interface RTCPeerConnection : EventTarget  {
                         <ol>
                           <li>
                             <p>Let <var>p</var> be the result of [= setting the local RTCSessionDescription =]
-                            indicated by <code>{type: "rollback"}</code>.</p>
+                            indicated by <code class=param>{type: {{RTCSdpType/"rollback"}}}</code>.</p>
                           </li>
                           <li>
                             <p>Return the result of
@@ -2943,10 +2940,10 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                 </ol>
               </dd>
-              <dt data-tests="RTCPeerConnection-addIceCandidate.html,promises-call.html"><code>addIceCandidate</code></dt>
+              <dt data-tests="RTCPeerConnection-addIceCandidate.html,promises-call.html"><dfn id=
+                "dom-peerconnection-addicecandidate">addIceCandidate</dfn></dt>
               <dd>
-                <p>The <dfn id=
-                "dom-peerconnection-addicecandidate"><code>addIceCandidate</code></dfn>
+                <p>The {{addIceCandidate}}
                 method provides a remote candidate to the [= ICE Agent =].
                 This method can also be used to indicate the end of remote
                 candidates when called with an empty string for the {{RTCIceCandidate/candidate}} member. The only
@@ -3025,7 +3022,7 @@ interface RTCPeerConnection : EventTarget  {
                         </p>
                       </li>
                       <li data-tests="RTCPeerConnection-addIceCandidate.html">
-                        <p>If <code><var>candidate</var>.usernameFragment</code>
+                        <p>If <var>candidate</var>.{{RTCIceCandidate/usernameFragment}}
                         is not <code>null</code>, and is not
                         equal to any username fragment present in the corresponding
                         [= media description =] of an applied remote
@@ -3038,11 +3035,11 @@ interface RTCPeerConnection : EventTarget  {
                         <p>In parallel, add the ICE candidate
                         <var>candidate</var> as described in <span data-jsep=
                         "addicecandidate">[[!JSEP]]</span>. Use
-                        <code><var>candidate</var>.usernameFragment</code> to identify the
-                        ICE [= generation =]; if <code>usernameFragment</code> is null, process the
+                        <var>candidate</var>.{{RTCIceCandidate/usernameFragment}} to identify the
+                        ICE [= generation =]; if {{RTCIceCandidate/usernameFragment}} is null, process the
                         <var>candidate</var> for the most recent ICE
                         [= generation =]. If
-                        <code><var>candidate</var>.candidate</code> is an empty
+                        <var>candidate</var>.{{RTCIceCandidate/candidate}} is an empty
                         string, process <var>candidate</var> as an
                         end-of-candidates indication for the corresponding
                         [= media description =] and ICE candidate
@@ -3110,9 +3107,9 @@ interface RTCPeerConnection : EventTarget  {
               </dd>
               <dt data-tests="RTCPeerConnection-restartIce.https.html"><dfn data-idl>restartIce</dfn></dt>
               <dd>
-                <p>The <code>restartIce</code> method tells the
+                <p>The {{restartIce}} method tells the
                 {{RTCPeerConnection}} that ICE should be
-                restarted. Subsequent calls to <code>createOffer</code> will
+                restarted. Subsequent calls to {{createOffer}} will
                 create descriptions that will restart ICE, as described in
                 section 9.1.1.1 of [[!ICE]].</p>
                 <p>When this method is invoked, the user agent MUST run the
@@ -3146,16 +3143,16 @@ interface RTCPeerConnection : EventTarget  {
                 {{RTCConfiguration}} object stored in the
                 <a>[[\Configuration]]</a> internal slot.</p>
               </dd>
-              <dt><code>setConfiguration</code></dt>
+              <dt><dfn data-idl>setConfiguration</dfn></dt>
               <dd>
-                <p>The <code>setConfiguration</code> method updates the
+                <p>The {{setConfiguration}} method updates the
                 configuration of this {{RTCPeerConnection}}
                 object. This includes changing the configuration of the [= ICE
                 Agent =]. As noted in <span data-jsep=
                 "ice-gather-overview">[[!JSEP]]</span>, when the ICE
                 configuration changes in a way that requires a new gathering
                 phase, an ICE restart is required.</p>
-                <p>When the <dfn data-idl>setConfiguration</dfn> method is
+                <p>When the {{setConfiguration}} method is
                 invoked, the user agent MUST run the following steps:</p>
                 <ol>
                   <li>
@@ -3174,9 +3171,9 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                 </ol>
               </dd>
-              <dt data-tests="RTCPeerConnection-transceivers.https.html"><code>close</code></dt>
+              <dt data-tests="RTCPeerConnection-transceivers.https.html"><dfn data-idl>close</dfn></dt>
               <dd>
-                <p>When the <dfn data-idl>close</dfn> method is invoked,
+                <p>When the {{close}} method is invoked,
                 the user agent MUST run the following steps:</p>
                 <ol>
                   <li>
@@ -3259,7 +3256,7 @@ interface RTCPeerConnection : EventTarget  {
       </section>
       <section>
         <h3>Legacy Interface Extensions</h3>
-          <div class="note">The IDL definition of these methods are <a href="#dom-rtcpeerconnection-createoffer!overload-1">documented in the main definition of the <code>RTCPeerConnection</code> interface</a> since overladed functions are not allowed to be defined in partial interfaces.</div>
+          <div class="note">The IDL definition of these methods are <a href="#dom-rtcpeerconnection-createoffer!overload-1">documented in the main definition of the {{RTCPeerConnection}} interface</a> since overloaded functions are not allowed to be defined in partial interfaces.</div>
           <p>Supporting the methods in this section is optional. However,
           if these methods are supported it is mandatory to implement
           according to what is specified here.</p>
@@ -3278,9 +3275,9 @@ interface RTCPeerConnection : EventTarget  {
             <dl data-link-for="RTCPeerConnection" data-dfn-for=
             "RTCPeerConnection" class="methods">
               <dt data-tests="legacy/RTCPeerConnection-createOffer-offerToReceive.html"><dfn data-lt="createOffer!overload-1" data-lt-nodefault=
-              "true"><code>createOffer</code></dfn></dt>
+              "true">createOffer</dfn></dt>
               <dd>
-                <p>When the <code>createOffer</code> method is called, the user
+                <p>When the <code class=overload>createOffer</code> method is called, the user
                 agent MUST run the following steps:</p>
                 <ol>
                   <li>
@@ -3319,9 +3316,9 @@ interface RTCPeerConnection : EventTarget  {
               </dd>
               <dt><dfn data-lt="setLocalDescription!overload-1"
               data-lt-nodefault=
-              "true"><code>setLocalDescription</code></dfn></dt>
+              "true">setLocalDescription</dfn></dt>
               <dd>
-                <p>When the <code>setLocalDescription</code> method is called,
+                <p>When the <code class=overload>setLocalDescription</code> method is called,
                 the user agent MUST run the following steps:</p>
                 <ol>
                   <li>
@@ -3359,14 +3356,14 @@ interface RTCPeerConnection : EventTarget  {
                 </ol>
               </dd>
               <dt><dfn data-lt="createAnswer!overload-1" data-lt-nodefault=
-              "true"><code>createAnswer</code></dfn></dt>
+              "true">createAnswer</dfn></dt>
               <dd>
-                <div class="note">The legacy <code>createAnswer</code> method
+                <div class="note">The legacy <code class=overload>createAnswer</code> method
                 does not take an {{RTCAnswerOptions}}
-                parameter, since no known legacy <code>createAnswer</code>
+                parameter, since no known legacy <code class=overload>createAnswer</code>
                 implementation ever supported it.</div>
 
-                <p>When the <code>createAnswer</code> method is called, the
+                <p>When the <code class=overload>createAnswer</code> method is called, the
                 user agent MUST run the following steps:</p>
                 <ol>
                   <li>
@@ -3401,9 +3398,9 @@ interface RTCPeerConnection : EventTarget  {
               </dd>
               <dt><dfn data-lt="setRemoteDescription!overload-1"
               data-lt-nodefault=
-              "true"><code>setRemoteDescription</code></dfn></dt>
+              "true">setRemoteDescription</dfn></dt>
               <dd>
-                <p>When the <code>setRemoteDescription</code> method is called,
+                <p>When the <code class=overload>setRemoteDescription</code> method is called,
                 the user agent MUST run the following steps:</p>
                 <ol>
                   <li>
@@ -3440,9 +3437,9 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                 </ol>
               </dd>
-              <dt><code>addIceCandidate</code></dt>
+              <dt><dfn data-lt="addIceCandidate!overload-1" data-lt-nodefault="true">addIceCandidate</dfn></dt>
               <dd>
-                <p>When the <dfn data-lt="addIceCandidate!overload-1" data-lt-nodefault="true"><code>addIceCandidate</code></dfn> method is called, the
+                <p>When the <code class=overload>addIceCandidate</code> method is called, the
                 user agent MUST run the following steps:</p>
                 <ol>
                   <li>
@@ -3492,7 +3489,7 @@ interface RTCPeerConnection : EventTarget  {
                   Parameters</h2>
                   <dl data-link-for="RTCPeerConnectionErrorCallback" data-dfn-for=
                   "RTCPeerConnectionErrorCallback" class="callback-members">
-                    <dt><code>error</code> of type
+                    <dt><code class=param>error</code> of type
                     {{DOMException}}</dt>
                     <dd>An error object encapsulating information about what went
                     wrong.</dd>
@@ -3510,7 +3507,7 @@ interface RTCPeerConnection : EventTarget  {
                   Parameters</h2>
                   <dl data-link-for="RTCSessionDescriptionCallback" data-dfn-for=
                   "RTCSessionDescriptionCallback" class="callback-members">
-                    <dt><code>description</code> of type <span class=
+                    <dt>description of type <span class=
                     "idlMemberType">{{RTCSessionDescriptionInit}}</span></dt>
                     <dd>The object containing the SDP [[!SDP]].</dd>
                   </dl>
@@ -3535,8 +3532,8 @@ interface RTCPeerConnection : EventTarget  {
             <p>Let <var>options</var> be the methods first argument.</p>
           </li>
           <li>
-            <p>Let <var>connection</var> be the current <code>
-            {{RTCPeerConnection}}</code> object.</p>
+            <p>Let <var>connection</var> be the current
+            {{RTCPeerConnection}} object.</p>
           </li>
           <li>
             <p>For each "offerToReceive&lt;Kind&gt;" member in <var>options</var> with
@@ -3568,7 +3565,7 @@ interface RTCPeerConnection : EventTarget  {
               <li>
                 <p>Let <var>transceiver</var> be the result of invoking the
                 equivalent of
-                <code>connection.addTransceiver(kind)</code>, except
+                <var>connection</var>.{{RTCPeerConnection/addTransceiver}}(<var>kind</var>), except
                 that this operation MUST NOT [= update the
                 negotiation-needed flag =].</p>
               </li>
@@ -3662,24 +3659,24 @@ interface RTCPeerConnection : EventTarget  {
               <tr>
                 <td data-tests="RTCPeerConnection-setLocalDescription-offer.html"><dfn data-idl>offer</dfn></td>
                 <td>
-                  <p>An <code>RTCSdpType</code> of <code>offer</code> indicates
+                  <p>An {{RTCSdpType}} of {{RTCSdpType/"offer"}} indicates
                   that a description MUST be treated as an [[!SDP]] offer.</p>
                 </td>
               </tr>
               <tr>
                 <td data-tests="RTCPeerConnection-setLocalDescription-pranswer.html"><dfn data-idl>pranswer</dfn></td>
                 <td>
-                  <p>An <code>RTCSdpType</code> of <code>pranswer</code>
+                  <p>An {{RTCSdpType}} of {{RTCSdpType/"pranswer"}}
                   indicates that a description MUST be treated as an [[!SDP]]
                   answer, but not a final answer. A description used as an SDP
-                  <code>pranswer</code> may be applied as a response to an SDP
+                  pranswer may be applied as a response to an SDP
                   offer, or an update to a previously sent SDP pranswer.</p>
                 </td>
               </tr>
               <tr data-tests="RTCPeerConnection-setLocalDescription-answer.html">
                 <td><dfn data-idl>answer</dfn></td>
                 <td>
-                  <p>An <code>RTCSdpType</code> of <code>answer</code>
+                  <p>An {{RTCSdpType}} of {{RTCSdpType/"answer"}}
                   indicates that a description MUST be treated as an [[!SDP]]
                   final answer, and the offer-answer exchange MUST be
                   considered complete. A description used as an SDP answer may
@@ -3690,14 +3687,14 @@ interface RTCPeerConnection : EventTarget  {
               <tr>
                 <td data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-setLocalDescription-rollback.html"><dfn data-idl>rollback</dfn></td>
                 <td>
-                  <p>An <code>RTCSdpType</code> of {{RTCSdpType/"rollback"}}
+                  <p>An {{RTCSdpType}} of {{RTCSdpType/"rollback"}}
                   indicates that a description MUST be treated as canceling the
                   current SDP negotiation and moving the SDP [[!SDP]] offer
                   back to what it was in the previous stable state. Note
                   the local or remote SDP descriptions in the previous stable
                   state could be null if there has not yet been a successful
-                  offer-answer negotiation. An <code>answer</code> or
-                  <code>pranswer</code> cannot be rolled back.</p>
+                  offer-answer negotiation. An {{RTCSdpType/"answer"}} or
+                  {{RTCSdpType/"pranswer"}} cannot be rolled back.</p>
                 </td>
               </tr>
             </tbody>
@@ -3722,17 +3719,17 @@ interface RTCSessionDescription {
             <h2>Constructors</h2>
             <dl data-link-for="RTCSessionDescription" data-dfn-for=
             "RTCSessionDescription" class="constructors">
-              <dt><dfn><code>constructor()</code></dfn></dt>
+              <dt><dfn>constructor()</dfn></dt>
               <dd>
                 The <dfn id=
-                "dom-sessiondescription"><code>RTCSessionDescription()</code></dfn>
+                "dom-sessiondescription"><code class=constructor>RTCSessionDescription()</code></dfn>
                 constructor takes a dictionary argument,
                 <var>description</var>, whose content is used to
                 initialize the new {{RTCSessionDescription}}
                 object. This constructor is deprecated; it exists for
                 legacy compatibility reasons only. The constructor MUST
                 [= exception/throw =] a {{TypeError}} if
-                <var>description</var>.<code>type</code> is not present.
+                <var>description</var>.{{type}} is not present.
               </dd>
             </dl>
           </section>
@@ -3752,7 +3749,7 @@ interface RTCSessionDescription {
             <h2>Methods</h2>
             <dl data-link-for="RTCSessionDescription" data-dfn-for=
             "RTCSessionDescription" class="methods">
-              <dt><dfn><code>toJSON()</code></dfn></dt>
+              <dt><dfn>toJSON()</dfn></dt>
               <dd>
                 When called, run [[!WEBIDL]]'s [= default toJSON operation =].
               </dd>
@@ -3784,7 +3781,7 @@ interface RTCSessionDescription {
               <dt data-tests="RTCPeerConnection-setLocalDescription-rollback.html"><dfn data-idl>sdp</dfn> of type <span class=
               "idlMemberType">DOMString</span></dt>
               <dd>The string representation of the SDP [[!SDP]]; if
-              <code>type</code> is {{RTCSdpType/"rollback"}}, this member is unused.
+              {{RTCSessionDescription/type}} is {{RTCSdpType/"rollback"}}, this member is unused.
               </dd>
             </dl>
           </section>
@@ -3797,7 +3794,7 @@ interface RTCSessionDescription {
       require communication with the remote side via the signaling channel, in
       order to have the desired effect. The app can be kept informed as to when
       it needs to do signaling, by listening to the
-      <code>negotiationneeded</code> event. This event is fired according to
+      <code class=event>negotiationneeded</code> event. This event is fired according to
       the state of the connection's <dfn>negotiation-needed flag</dfn>,
       represented by a <a>[[\NegotiationNeeded]]</a> internal slot.</p>
       <section class="informative">
@@ -3991,10 +3988,10 @@ interface RTCSessionDescription {
         <h4><dfn>RTCIceCandidate</dfn> Interface</h4>
         <p>This interface describes an ICE candidate, described in
         [[!ICE]] Section 2. Other than
-        <code>candidate</code>, <code>sdpMid</code>,
-        <code>sdpMLineIndex</code>, and <code>usernameFragment</code>,
+        {{RTCIceCandidateInit/candidate}}, {{RTCIceCandidateInit/sdpMid}},
+        {{RTCIceCandidateInit/sdpMLineIndex}}, and {{RTCIceCandidateInit/usernameFragment}},
         the remaining attributes are derived from parsing the
-        <code>candidate</code> member in <var>candidateInitDict</var>,
+        {{RTCIceCandidateInit/candidate}} member in <var>candidateInitDict</var>,
         if it is well formed.</p>
 
         <div>
@@ -4022,9 +4019,9 @@ interface RTCIceCandidate {
             <h2>Constructor</h2>
             <dl data-link-for="RTCIceCandidate" data-dfn-for="RTCIceCandidate"
             class="constructors">
-              <dt><dfn><code>constructor()</code></dfn></dt>
+              <dt><dfn>constructor()</dfn></dt>
               <dd>
-                <p>The <dfn><code>RTCIceCandidate()</code></dfn> constructor takes
+                <p>The <dfn><code class=constructor>RTCIceCandidate()</code></dfn> constructor takes
                 a dictionary argument, <var>candidateInitDict</var>, whose
                 content is used to initialize the new {{RTCIceCandidate}} object.</p>
                 <p>When invoked, run the following steps:</p>
@@ -4055,8 +4052,8 @@ interface RTCIceCandidate {
                     <var>candidateInitDict</var>: {{candidate}},
                     {{sdpMid}}, {{sdpMLineIndex}},
                     {{usernameFragment}}.</li>
-                  <li>Let <var>candidate</var> be the <code>
-                    {{RTCIceCandidateInit/candidate}}</code>
+                  <li>Let <var>candidate</var> be the
+                    {{RTCIceCandidateInit/candidate}}
                   dictionary member of <var>candidateInitDict</var>. If
                   <var>candidate</var> is not an empty string, run the following steps:
                   <ol data-tests="RTCIceCandidate-constructor.html">
@@ -4076,8 +4073,8 @@ interface RTCIceCandidate {
                   <p>The constructor for {{RTCIceCandidate}} only does basic
                   parsing and type checking for the dictionary members in
                   <var>candidateInitDict</var>. Detailed validation on the well-formedness
-                  of <code>candidate</code>, <code>sdpMid</code>, <code>sdpMLineIndex</code>,
-                  <code>usernameFragment</code> with the corresponding session description is done
+                  of {{RTCIceCandidateInit/candidate}}, {{RTCIceCandidateInit/sdpMid}}, {{RTCIceCandidateInit/sdpMLineIndex}},
+                  {{RTCIceCandidateInit/usernameFragment}} with the corresponding session description is done
                   when passing the {{RTCIceCandidate}} object to
                   {{RTCPeerConnection/addIceCandidate()}}.</p>
 
@@ -4101,11 +4098,11 @@ interface RTCIceCandidate {
               <dd>This carries the [= candidate-attribute =] as defined
               in section 15.1 of [[!ICE]]. If this {{RTCIceCandidate}}
               represents an end-of-candidates indication or a peer reflexive remote
-              candidate, <code>candidate</code> is an empty string.</dd>
+              candidate, {{candidate}} is an empty string.</dd>
               <dt><dfn data-idl>sdpMid</dfn> of type <span class=
               "idlAttrType">DOMString</span>, readonly, nullable</dt>
-              <dd>If not <code>null</code>, this contains the media stream
-              "identification-tag" defined in [[!RFC5888]] for the
+              <dd>If not <code>null</code>, this contains the <dfn>media stream
+              "identification-tag"</dfn> defined in [[!RFC5888]] for the
               media component this candidate is associated with.</dd>
               <dt><dfn data-idl>sdpMLineIndex</dfn> of type <span class=
               "idlAttrType">unsigned short</span>, readonly,
@@ -4123,8 +4120,8 @@ interface RTCIceCandidate {
               <dt><dfn data-idl>component</dfn> of type <span class=
               "idlAttrType">{{RTCIceComponent}}</span>, readonly, nullable</dt>
               <dd>The assigned network component of the candidate
-              (<code>rtp</code> or <code>rtcp</code>). This corresponds to the
-              <code>component-id</code> field in [= candidate-attribute =],
+              ({{RTCIceComponent/"rtp"}} or {{RTCIceComponent/"rtcp"}}). This corresponds to the
+              <code class=ice>component-id</code> field in [= candidate-attribute =],
               decoded to the string representation as defined in
               {{RTCIceComponent}}.</dd>
               <dt><dfn data-idl>priority</dfn> of type <span class=
@@ -4135,10 +4132,10 @@ interface RTCIceCandidate {
               <dd>
                 <p>The address of the candidate, allowing for IPv4 addresses,
                 IPv6 addresses, and fully qualified domain names (FQDNs). This
-                corresponds to the <code>connection-address</code> field in
+                corresponds to the <code class=ice>connection-address</code> field in
                 [= candidate-attribute =].</p>
                 <p>Remote candidates may be exposed, for instance
-                via <code><a>[[\SelectedCandidatePair]]</a>.remote</code>.
+                via <a>[[\SelectedCandidatePair]]</a>.{{RTCIceCandidatePair/remote}}.
                 By default, the user agent MUST leave the 'address' member
                 as null for any exposed remote candidate.
                 Once a RTCPeerConnection instance learns on an address
@@ -4164,7 +4161,7 @@ interface RTCIceCandidate {
                   <p>Applications can avoid exposing addresses to the
                   communicating party, either temporarily or permanently, by
                   forcing the [= ICE Agent =] to report only relay candidates
-                  via the <code>iceTransportPolicy</code> member of
+                  via the {{RTCConfiguration/iceTransportPolicy}} member of
                   {{RTCConfiguration}}.</p>
                   <p>To limit the addresses exposed to the application
                   itself, browsers can offer their users different policies
@@ -4175,41 +4172,41 @@ interface RTCIceCandidate {
               <dt><dfn data-idl>protocol</dfn> of type <span class=
               "idlAttrType">{{RTCIceProtocol}}</span>, readonly, nullable</dt>
               <dd>The protocol of the candidate
-              (<code>udp</code>/<code>tcp</code>). This corresponds to the
-              <code>transport</code> field in [= candidate-attribute =].</dd>
+              ({{RTCIceProtocol/"udp"}}/{{RTCIceProtocol/"tcp"}}). This corresponds to the
+              <code class=ice>transport</code> field in [= candidate-attribute =].</dd>
               <dt><dfn data-idl>port</dfn> of type <span class=
               "idlAttrType">unsigned short</span>, readonly, nullable</dt>
               <dd>The port of the candidate.</dd>
               <dt><dfn data-idl>type</dfn> of type <span class=
               "idlAttrType">{{RTCIceCandidateType}}</span>, readonly, nullable</dt>
               <dd>The type of the candidate. This corresponds to the
-              <code>candidate-types</code> field in [= candidate-attribute =].</dd>
+              <code class=ice>candidate-types</code> field in [= candidate-attribute =].</dd>
               <dt><dfn data-idl>tcpType</dfn> of type <span class=
               "idlAttrType">{{RTCIceTcpCandidateType}}</span>, readonly,
                nullable</dt>
-              <dd>If <code>protocol</code> is <code>tcp</code>,
-              <code>tcpType</code> represents the type of TCP candidate.
-              Otherwise, <code>tcpType</code> is <code>null</code>. This corresponds
-              to the <code>tcp-type</code> field in [= candidate-attribute =].</dd>
-              <dt><code>relatedAddress</code> of type <span class=
+              <dd>If {{protocol}} is {{RTCIceProtocol/"tcp"}},
+              {{tcpType}} represents the type of TCP candidate.
+              Otherwise, {{tcpType}} is <code>null</code>. This corresponds
+              to the <code class=ice>tcp-type</code> field in [= candidate-attribute =].</dd>
+              <dt><dfn>relatedAddress</dfn> of type <span class=
               "idlAttrType">DOMString</span>, readonly, nullable</dt>
               <dd>For a candidate that is derived from another, such as a relay
-              or reflexive candidate, the <dfn>relatedAddress</dfn> is the IP
+              or reflexive candidate, the {{relatedAddress}} is the IP
               address of the candidate that it is derived from. For host
-              candidates, the <code>relatedAddress</code> is
-              <code>null</code>. This corresponds to the <code>rel-address</code>
+              candidates, the {{relatedAddress}} is
+              <code>null</code>. This corresponds to the <code class=ice>rel-address</code>
               field in [= candidate-attribute =].</dd>
-              <dt><code>relatedPort</code> of type <span class=
+              <dt><dfn>relatedPort</dfn> of type <span class=
               "idlAttrType">unsigned short</span>, readonly,
               nullable</dt>
               <dd>For a candidate that is derived from another, such as a relay
-              or reflexive candidate, the <dfn>relatedPort</dfn> is the port of
+              or reflexive candidate, the {{relatedPort}} is the port of
               the candidate that it is derived from. For host candidates, the
-              <code>relatedPort</code> is <code>null</code>. This corresponds to
-              the <code>rel-port</code> field in [= candidate-attribute =].</dd>
-              <dt><code><dfn>usernameFragment</dfn></code> of type <span class=
+              {{relatedPort}} is <code>null</code>. This corresponds to
+              the <code class=ice>rel-port</code> field in [= candidate-attribute =].</dd>
+              <dt><dfn>usernameFragment</dfn> of type <span class=
               "idlAttrType">DOMString</span>, readonly, nullable</dt>
-              <dd>This carries the <code>ufrag</code> as defined in section
+              <dd>This carries the <code class=ice>ufrag</code> as defined in section
               15.4 of [[!ICE]].</dd>
             </dl>
           </section>
@@ -4218,7 +4215,7 @@ interface RTCIceCandidate {
             <dl data-link-for="RTCIceCandidate" data-dfn-for="RTCIceCandidate"
             class="methods">
               <dt><dfn data-idl>toJSON()</dfn></dt>
-              <dd>To invoke the <code>toJSON()</code> operation of the {{RTCIceCandidate}} interface, run the following steps:
+              <dd>To invoke the {{toJSON()}} operation of the {{RTCIceCandidate}} interface, run the following steps:
                 <ol>
                   <li>Let <var>json</var> be a new {{RTCIceCandidateInit}} dictionary.</li>
                   <li>For each attribute identifier <var>attr</var> in «"candidate", "sdpMid", "sdpMLineIndex", "usernameFragment"»:
@@ -4249,9 +4246,9 @@ interface RTCIceCandidate {
               <dt><dfn data-idl>candidate</dfn> of type <span class=
               "idlMemberType">DOMString</span>, defaulting to
               <code>""</code></dt>
-              <dd>This carries the <code>candidate-attribute</code> as defined
+              <dd>This carries the [= candidate-attribute =] as defined
               in section 15.1 of [[!ICE]]. If this represents an
-              end-of-candidates indication, <code>candidate</code>
+              end-of-candidates indication, {{candidate}}
               is an empty string.</dd>
               <dt><dfn data-idl>sdpMid</dfn> of type <span class=
               "idlMemberType">DOMString</span>, nullable, defaulting to
@@ -4268,23 +4265,23 @@ interface RTCIceCandidate {
               <dt><dfn data-idl>usernameFragment</dfn> of type <span class=
               "idlMemberType">DOMString</span>, nullable,
               defaulting to <code>null</code></dt>
-              <dd>If not <code>null</code>, this carries the <code>ufrag</code>
+              <dd>If not <code>null</code>, this carries the <code class=ice>ufrag</code>
               as defined in section 15.4 of [[!ICE]].</dd>
             </dl>
           </section>
         </div>
         <section>
-          <h4><dfn data-idl>candidate-attribute</dfn> Grammar</h4>
-          <p>The <code>candidate-attribute</code> grammar is used to parse
+          <h4><dfn><code class=ice>candidate-attribute</code></dfn> Grammar</h4>
+          <p>The [= candidate-attribute =] grammar is used to parse
           the {{RTCIceCandidateInit/candidate}}
           member of <var>candidateInitDict</var>
           in the {{RTCIceCandidate()}} constructor.</p>
-          <p>The primary grammar for <code>candidate-attribute</code>
+          <p>The primary grammar for [= candidate-attribute =]
           is defined in section 15.1 of [[!ICE]]. In addition, the browser
           MUST support the grammar extension for ICE TCP as defined in
           section 4.5 of [[!RFC6544]].</p>
           <p>The browser MAY support other grammar extensions for
-          <code>candidate-attribute</code> as defined in other RFCs.</p>
+          [= candidate-attribute =] as defined in other RFCs.</p>
         </section>
         <section>
           <h4><dfn>RTCIceProtocol</dfn> Enum</h4>
@@ -4333,26 +4330,26 @@ interface RTCIceCandidate {
                 </tr>
                 <tr>
                   <td><dfn data-idl>active</dfn></td>
-                  <td>An <code>active</code> TCP candidate is one for which the
+                  <td>An {{RTCIceTcpCandidateType/"active"}} TCP candidate is one for which the
                   transport will attempt to open an outbound connection but
                   will not receive incoming connection requests.</td>
                 </tr>
                 <tr>
                   <td><dfn data-idl>passive</dfn></td>
-                  <td>A <code>passive</code> TCP candidate is one for which the
+                  <td>A {{RTCIceTcpCandidateType/"passive"}} TCP candidate is one for which the
                   transport will receive incoming connection attempts but not
                   attempt a connection.</td>
                 </tr>
                 <tr>
                   <td><dfn data-idl>so</dfn></td>
-                  <td>An <code>so</code> candidate is one for which the
+                  <td>An {{RTCIceTcpCandidateType/"so"}} candidate is one for which the
                   transport will attempt to open a connection simultaneously
                   with its peer.</td>
                 </tr>
               </tbody>
             </table>
           </div>
-          <p class="note">The user agent will typically only gather <code>active</code>
+          <p class="note">The user agent will typically only gather {{RTCIceTcpCandidateType/active}}
           ICE TCP candidates.</p>
         </section>
         <section>
@@ -4400,13 +4397,13 @@ interface RTCIceCandidate {
       </section>
       <section>
         <h4><dfn>RTCPeerConnectionIceEvent</dfn></h4>
-        <p>The <code>icecandidate</code> event of the RTCPeerConnection uses
+        <p>The <code class=event>icecandidate</code> event of the RTCPeerConnection uses
         the {{RTCPeerConnectionIceEvent}} interface.</p>
         <p data-tests="RTCPeerConnectionIceEvent-constructor.html">When firing an {{RTCPeerConnectionIceEvent}} event
         that contains an {{RTCIceCandidate}} object, it MUST
         include values for both {{RTCIceCandidate/sdpMid}} and {{RTCIceCandidate/sdpMLineIndex}}. If the
-        {{RTCIceCandidate}} is of type <code>srflx</code> or
-        type <code>relay</code>, the <code>url</code> property of the event
+        {{RTCIceCandidate}} is of type {{RTCIceCandidateType/"srflx"}} or
+        type {{RTCIceCandidateType/"relay"}}, the {{RTCPeerConnectionIceEvent/url}} property of the event
         MUST be set to the URL of the ICE server from which the candidate was
         obtained.</p>
 
@@ -4424,8 +4421,8 @@ interface RTCIceCandidate {
               <p>An {{RTCIceTransport}} has finished gathering a
               [= generation =] of candidates, and is providing an end-of-candidates
               indication as defined by Section 8.2 of [[TRICKLE-ICE]]. This is
-              indicated by <code>{{RTCPeerConnectionIceEvent/candidate}}.{{RTCIceCandidate/candidate}}</code> being set to an
-              empty string. The <code>{{RTCPeerConnectionIceEvent/candidate}}</code> object
+              indicated by {{RTCPeerConnectionIceEvent/candidate}}.{{RTCIceCandidate/candidate}} being set to an
+              empty string. The {{RTCPeerConnectionIceEvent/candidate}} object
               should be signaled to the remote peer and passed into
               {{RTCPeerConnection/addIceCandidate}}
               like a typical ICE candidate, in order to provide the
@@ -4441,7 +4438,7 @@ interface RTCIceCandidate {
               member of the event being set to <code>null</code>. This only
               exists for backwards compatibility, and this event does not need
               to be signaled to the remote peer. It's equivalent to an
-              <code>"{{icegatheringstatechange}}"</code> event with the
+              {{icegatheringstatechange}} event with the
               {{RTCIceGatheringState/"complete"}}
               state.</p>
             </li>
@@ -4459,7 +4456,7 @@ interface RTCPeerConnectionIceEvent : Event {
             <h2>Constructors</h2>
             <dl data-link-for="RTCPeerConnectionIceEvent" data-dfn-for=
             "RTCPeerConnectionIceEvent" class="constructors">
-              <dt data-tests="RTCPeerConnectionIceEvent-constructor.html"><dfn><code>RTCPeerConnectionIceEvent.constructor()</code></dfn></dt>
+              <dt data-tests="RTCPeerConnectionIceEvent-constructor.html"><dfn>RTCPeerConnectionIceEvent.constructor()</dfn></dt>
               <dd>
               </dd>
             </dl>
@@ -4472,7 +4469,7 @@ interface RTCPeerConnectionIceEvent : Event {
               "idlAttrType">{{RTCIceCandidate}}</span>, readonly,
               nullable</dt>
               <dd>
-                <p>The <code>candidate</code> attribute is the
+                <p>The {{candidate}} attribute is the
                 {{RTCIceCandidate}} object with the new ICE
                 candidate that caused the event.</p>
                 <p>This attribute is set to <code>null</code> when an event is
@@ -4484,7 +4481,7 @@ interface RTCPeerConnectionIceEvent : Event {
               <dt data-tests="RTCPeerConnectionIceEvent-constructor.html"><dfn data-idl>url</dfn> of type <span class=
               "idlAttrType">DOMString</span>, readonly, nullable</dt>
               <dd>
-                <p>The <code>url</code> attribute is the STUN or TURN URL that
+                <p>The {{url}} attribute is the STUN or TURN URL that
                 identifies the STUN or TURN server used to gather this
                 candidate. If the candidate was not gathered from a STUN or
                 TURN server, this parameter will be set to
@@ -4513,7 +4510,7 @@ interface RTCPeerConnectionIceEvent : Event {
               </dd>
               <dt data-tests="RTCPeerConnectionIceEvent-constructor.html"><dfn data-idl>url</dfn> of type <span class=
               "idlMemberType">DOMString</span>, nullable</dt>
-              <dd>The <code>url</code> attribute is the STUN or TURN URL that
+              <dd>The {{url}} attribute is the STUN or TURN URL that
               identifies the STUN or TURN server used to gather this
               candidate.</dd>
             </dl>
@@ -4522,7 +4519,7 @@ interface RTCPeerConnectionIceEvent : Event {
       </section>
       <section>
         <h4><dfn>RTCPeerConnectionIceErrorEvent</dfn></h4>
-        <p>The <code>icecandidateerror</code> event of the RTCPeerConnection
+        <p>The <code class=event>icecandidateerror</code> event of the RTCPeerConnection
         uses the {{RTCPeerConnectionIceErrorEvent}}
         interface.</p>
         <div>
@@ -4540,7 +4537,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             <h2>Constructors</h2>
             <dl data-link-for="RTCPeerConnectionIceErrorEvent" data-dfn-for=
             "RTCPeerConnectionIceErrorEvent" class="constructors">
-              <dt><dfn><code>RTCPeerConnectionIceErrorEvent.constructor()</code></dfn></dt>
+              <dt><dfn>RTCPeerConnectionIceErrorEvent.constructor()</dfn></dt>
               <dd>
               </dd>
             </dl>
@@ -4552,39 +4549,39 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <dt><dfn data-idl>address</dfn> of type <span class=
               "idlAttrType">DOMString</span>, readonly</dt>
               <dd>
-                <p>The <code>address</code> attribute is the local IP
+                <p>The {{address}} attribute is the local IP
                 address used to communicate with the STUN or TURN
                 server.</p>
                 <p>On a multihomed system, multiple interfaces may be used to
                 contact the server, and this attribute allows the application
                 to figure out on which one the failure occurred.</p>
                 <p>If the local IP address value is not already exposed
-                as part of a local candidate, the <code>address</code>
+                as part of a local candidate, the {{address}}
                 attribute will be set to <code>null</code>.</p>
               </dd>
               <dt><dfn data-idl>port</dfn> of type <span class=
               "idlAttrType">unsigned short</span>, readonly</dt>
               <dd>
-                <p>The <code>port</code> attribute is the port used to
+                <p>The {{port}} attribute is the port used to
                 communicate with the STUN or TURN server.</p>
-                <p>If the <code>address</code> attribute is <code>null</code>,
-                 the <code>port</code> attribute is also set to <code>null</code>.</p>
+                <p>If the {{address}} attribute is <code>null</code>,
+                 the {{port}} attribute is also set to <code>null</code>.</p>
               </dd>
               <dt><dfn data-idl>url</dfn> of type <span class=
               "idlAttrType">DOMString</span>, readonly</dt>
               <dd>
-                <p>The <code>url</code> attribute is the STUN or TURN URL that
+                <p>The {{url}} attribute is the STUN or TURN URL that
                 identifies the STUN or TURN server for which the failure
                 occurred.</p>
               </dd>
               <dt><dfn data-idl>errorCode</dfn> of type <span class=
               "idlAttrType">unsigned short</span>, readonly</dt>
               <dd>
-                <p>The <code>errorCode</code> attribute is the numeric STUN
+                <p>The {{errorCode}} attribute is the numeric STUN
                 error code returned by the STUN or TURN server
                 [[STUN-PARAMETERS]].</p>
                 <p>If no host candidate can reach the server,
-                <code>errorCode</code> will be set to the value 701 which is
+                {{errorCode}} will be set to the value 701 which is
                 outside the STUN error code range. This error is only fired
                 once per server URL while in the
                 {{RTCIceGatheringState}} of "gathering".</p>
@@ -4592,9 +4589,9 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <dt><dfn data-idl>errorText</dfn> of type <span class=
               "idlAttrType">USVString</span>, readonly</dt>
               <dd>
-                <p>The <code>errorText</code> attribute is the STUN reason text
+                <p>The {{errorText}} attribute is the STUN reason text
                 returned by the STUN or TURN server [[STUN-PARAMETERS]].</p>
-                <p>If the server could not be reached, <code>errorText</code>
+                <p>If the server could not be reached, {{errorText}}
                 will be set to an implementation-specific value providing
                 details about the error.</p>
               </dd>
@@ -4654,7 +4651,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
       constructing a new {{RTCPeerConnection}} instance.</p>
       <p>The explicit certificate management functions provided here are
       optional. If an application does not provide the
-      <code>certificates</code> configuration option when constructing an
+      {{RTCConfiguration/certificates}} configuration option when constructing an
       {{RTCPeerConnection}} a new set of certificates MUST be
       generated by the <a>user agent</a>. That set MUST include an ECDSA
       certificate with a private key on the P-256 curve and a signature with a
@@ -4671,7 +4668,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           "RTCPeerConnection" class="methods">
             <dt data-tests="RTCPeerConnection-generateCertificate.html"><dfn data-idl>generateCertificate</dfn>, static</dt>
             <dd>
-              <p>The <code>generateCertificate</code> function causes the
+              <p>The {{generateCertificate}} function causes the
               <a>user agent</a> to create an X.509 certificate
               [[!X509V3]] and corresponding private key. A handle to
               information is provided in the form of the
@@ -4713,14 +4710,14 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               <ol>
                 <li>
                   <p>Let <var>keygenAlgorithm</var> be the first argument to
-                  <code>generateCertificate</code>.</p>
+                  {{generateCertificate}}.</p>
                 </li>
                 <li>
                   <p>Let <var>expires</var> be a {{DOMTimeStamp}} value
                   of 2592000000.</p>
                   <div class="note">
                     <p>This means the certificate will by default expire in 30 days
-                    from the time of the <code>generateCertificate</code> call.</p>
+                    from the time of the {{generateCertificate}} call.</p>
                   </div>
                 </li>
                 <li>
@@ -4737,15 +4734,15 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                       return a promise that is [= rejected =] with <var>error</var>.</p>
                     </li>
                     <li>
-                      <p>If <var>certificateExpiration</var>.<code>expires</code>
+                      <p>If <var>certificateExpiration</var>.{{RTCCertificateExpiration/expires}}
                       is not <code>undefined</code>, set <var>expires</var> to
-                      <var>certificateExpiration</var>.<code>expires</code>.</p>
+                      <var>certificateExpiration</var>.{{RTCCertificateExpiration/expires}}.</p>
                     </li>
                     <li>
                       <p>If <var>expires</var> is greater than 31536000000, set <var>expires</var> to 31536000000.</p>
                       <div class="note">
                         <p>This means the certificate cannot be valid for longer than 365 days
-                        from the time of the <code>generateCertificate</code> call.</p>
+                        from the time of the {{generateCertificate}} call.</p>
                       </div>
                       <p>A <a>user agent</a> MAY further cap the value of <var>expires</var>.</p>
                     </li>
@@ -4754,7 +4751,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 <li>
                   <p>Let <var>normalizedKeygenAlgorithm</var> be the result of
                   <a data-cite="!WebCryptoAPI#dfn-normalize-an-algorithm">normalizing an algorithm</a>
-                  with an operation name of <code>generateKey</code> and a
+                  with an operation name of <code class=ext><a data-cite="WebCryptoAPI#SubtleCrypto-method-generateKey">generateKey</a></code> and a
                   <a data-cite="!WebCryptoAPI#dfn-supportedAlgorithms">supportedAlgorithms</a>
                   value specific to production of certificates for
                   {{RTCPeerConnection}}.</p>
@@ -4841,7 +4838,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
         "RTCCertificateExpiration" class="methods">
           <dt data-tests="RTCPeerConnection-generateCertificate.html"><dfn>expires</dfn></dt>
           <dd>
-            <p>An optional <code>expires</code> attribute MAY be added to the
+            <p>An optional {{expires}} attribute MAY be added to the
             definition of the algorithm that is passed to {{RTCPeerConnection/generateCertificate}}. If this
             parameter is present it indicates the maximum time that the
             {{RTCCertificate}} is valid for relative to the
@@ -4879,7 +4876,7 @@ interface RTCCertificate {
                 After this time, attempts to construct an
                 {{RTCPeerConnection}} using this certificate fail.</p>
                 <p>Note that this value might not be reflected in a
-                <code>notAfter</code> parameter in the certificate itself.</p>
+                <code class=ext>notAfter</code> parameter in the certificate itself.</p>
               </dd>
             </dl>
           </section>
@@ -4913,7 +4910,7 @@ interface RTCCertificate {
 
         <ol>
           <li>Set <var>serialized</var>.[[\Expires]] to the value of
-          <var>value</var>'s <code>expires</code> attribute.</li>
+          <var>value</var>'s {{RTCCertificate/expires}} attribute.</li>
 
           <li>Set <var>serialized</var>.[[\Certificate]] to
           a copy of the unstructured binary data in
@@ -4933,7 +4930,7 @@ interface RTCCertificate {
         <var>value</var>, are:</p>
 
         <ol>
-          <li>Initialize <var>value</var>'s <code>expires</code> attribute to
+          <li>Initialize <var>value</var>'s {{RTCCertificate/expires}} attribute to
           contain <var>serialized</var>.[[\Expires]].</li>
 
           <li>Set <var>value</var>.<a>[[\Certificate]]</a> to a copy of
@@ -5027,7 +5024,7 @@ interface RTCCertificate {
       application attaches a {{MediaStreamTrack}} to an
       {{RTCPeerConnection}} via the {{RTCPeerConnection/addTrack()}}
       method, or explicitly when the application uses the
-      <code>addTransceiver</code> method. They are also created when a remote
+      {{RTCPeerConnection/addTransceiver}} method. They are also created when a remote
       description is applied that includes a new media description.
       Additionally, when a remote description is applied that indicates the
       remote endpoint has media to send, the relevant
@@ -5066,14 +5063,14 @@ interface RTCCertificate {
           <h2>Methods</h2>
           <dl data-link-for="RTCPeerConnection" data-dfn-for=
           "RTCPeerConnection" class="methods">
-            <dt data-tests="RTCPeerConnection-getTransceivers.html,RTCPeerConnection-transceivers.https.html"><code>getSenders</code></dt>
+            <dt data-tests="RTCPeerConnection-getTransceivers.html,RTCPeerConnection-transceivers.https.html"><dfn id=
+              "dom-peerconnection-getsenders">getSenders</dfn></dt>
             <dd>
               <p>Returns a sequence of {{RTCRtpSender}} objects
               representing the RTP senders that belong to non-stopped
               {{RTCRtpTransceiver}} objects currently attached
               to this {{RTCPeerConnection}} object.</p>
-              <p>When the <dfn id=
-              "dom-peerconnection-getsenders"><code>getSenders</code></dfn>
+              <p>When the {{getSenders}}
               method is invoked, the user agent MUST return the result of
               executing the {{CollectSenders}} algorithm.</p>
              <p>We define the <dfn>CollectSenders</dfn> algorithm as follows:</p>
@@ -5092,14 +5089,14 @@ interface RTCCertificate {
                 <li>Return <var>senders</var>.</li>
               </ol>
             </dd>
-            <dt data-tests="RTCPeerConnection-addTransceiver.https.html,RTCPeerConnection-getTransceivers.html,RTCPeerConnection-transceivers.https.html"><code>getReceivers</code></dt>
+            <dt data-tests="RTCPeerConnection-addTransceiver.https.html,RTCPeerConnection-getTransceivers.html,RTCPeerConnection-transceivers.https.html"><dfn id=
+              "dom-peerconnection-getreceivers">getReceivers</dfn></dt>
             <dd>
               <p>Returns a sequence of {{RTCRtpReceiver}} objects
               representing the RTP receivers that belong to non-stopped
               {{RTCRtpTransceiver}} objects currently attached
               to this {{RTCPeerConnection}} object.</p>
-              <p>When the <dfn id=
-              "dom-peerconnection-getreceivers"><code>getReceivers</code></dfn>
+              <p>When the {{getReceivers}}
               method is invoked, the user agent MUST run the following steps:</p>
               <ol>
                 <li>Let <var>transceivers</var> be the result of executing the
@@ -5116,14 +5113,14 @@ interface RTCCertificate {
                 <li>Return <var>receivers</var>.</li>
               </ol>
             </dd>
-            <dt data-tests="RTCPeerConnection-getTransceivers.html,RTCPeerConnection-transceivers.https.html"><code>getTransceivers</code></dt>
+            <dt data-tests="RTCPeerConnection-getTransceivers.html,RTCPeerConnection-transceivers.https.html"><dfn id=
+              "dom-peerconnection-gettranseceivers">getTransceivers</dfn></dt>
             <dd>
               <p>Returns a sequence of {{RTCRtpTransceiver}}
               objects representing the RTP transceivers that are currently
               attached to this {{RTCPeerConnection}}
               object.</p>
-              <p>The <dfn id=
-              "dom-peerconnection-gettranseceivers"><code>getTransceivers</code></dfn>
+              <p>The {{getTransceivers}}
               method MUST return the result of executing the
               {{CollectTransceivers}} algorithm.</p>
 
@@ -5138,12 +5135,12 @@ interface RTCCertificate {
                 <li>Return <var>transceivers</var>.</li>
               </ol>
             </dd>
-            <dt data-tests="RTCPeerConnection-add-track-no-deadlock.https.html"><code>addTrack</code></dt>
+            <dt data-tests="RTCPeerConnection-add-track-no-deadlock.https.html"><dfn data-idl>addTrack</dfn></dt>
             <dd>
               <p>Adds a new track to the {{RTCPeerConnection}},
               and indicates that it is contained in the specified
               {{MediaStream}}s.</p>
-              <p>When the <dfn data-idl>addTrack</dfn> method is invoked,
+              <p>When the {{addTrack}} method is invoked,
               the user agent MUST run the following steps:</p>
               <ol>
                 <li>
@@ -5180,9 +5177,9 @@ interface RTCCertificate {
                 <li data-tests="RTCPeerConnection-addTrack.https.html,RTCPeerConnection-transceivers.https.html">
                   <p>The steps below describe how to determine if an existing
                   sender can be reused. Doing so will cause future calls to
-                  <code>createOffer</code> and <code>createAnswer</code> to
+                  {{RTCPeerConnection/createOffer}} and {{RTCPeerConnection/createAnswer}} to
                   mark the corresponding [= media description =] as
-                  <code>sendrecv</code> or <code>sendonly</code> and add the
+                  <code class=sdp>sendrecv</code> or <code class=sdp>sendonly</code> and add the
                   MSID of the sender's streams, as defined in <span data-jsep=
                   "subsequent-offers subsequent-answers">[[!JSEP]]</span>.</p>
                   <p>If any {{RTCRtpSender}} object in
@@ -5207,8 +5204,8 @@ interface RTCCertificate {
                       <p>The sender has never been used to send. More
                       precisely, the <a>[[\CurrentDirection]]</a> slot of the
                       {{RTCRtpTransceiver}} associated with the
-                      sender has never had a value of <code>sendrecv</code> or
-                      <code>sendonly</code>.</p>
+                      sender has never had a value of {{RTCRtpTransceiverDirection/"sendrecv"}} or
+                      {{RTCRtpTransceiverDirection/"sendonly"}}.</p>
                     </li>
                   </ul>
                 </li>
@@ -5238,11 +5235,11 @@ interface RTCCertificate {
                     </li>
                     <li>
                       <p>If <var>transceiver</var>.<a>[[\Direction]]</a> is
-                      <code>recvonly</code>, set <var>transceiver</var>.<a>[[\Direction]]</a> to <code>sendrecv</code>.</p>
+                      {{RTCRtpTransceiverDirection/"recvonly"}}, set <var>transceiver</var>.<a>[[\Direction]]</a> to {{RTCRtpTransceiverDirection/"sendrecv"}}.</p>
                     </li>
                     <li>
                       <p>If <var>transceiver</var>.<a>[[\Direction]]</a>
-                      is <code>inactive</code>, set <var>transceiver</var>.<a>[[\Direction]]</a> to <code>sendonly</code>.</p>
+                      is {{RTCRtpTransceiverDirection/"inactive"}}, set <var>transceiver</var>.<a>[[\Direction]]</a> to {{RTCRtpTransceiverDirection/"sendonly"}}.</p>
                     </li>
                   </ol>
                 </li>
@@ -5263,7 +5260,7 @@ interface RTCCertificate {
                       <p><a>Create an RTCRtpTransceiver</a> with
                       <var>sender</var>, <var>receiver</var> and
                       an {{RTCRtpTransceiverDirection}} value
-                      of <code>sendrecv</code>, and let <var>transceiver</var>
+                      of {{RTCRtpTransceiverDirection/"sendrecv"}}, and let <var>transceiver</var>
                       be the result.</p>
                     </li>
                     <li>
@@ -5293,35 +5290,35 @@ interface RTCCertificate {
                 </li>
               </ol>
             </dd>
-            <dt data-tests="RTCPeerConnection-removeTrack.https.html"><code>removeTrack</code></dt>
+            <dt data-tests="RTCPeerConnection-removeTrack.https.html"><dfn data-idl>removeTrack</dfn></dt>
             <dd>
               <p>Stops sending media from <var>sender</var>. The
               {{RTCRtpSender}} will still appear
-              in <code>getSenders</code>. Doing so will cause future
-              calls to <code>createOffer</code> to mark the
+              in {{getSenders}}. Doing so will cause future
+              calls to {{createOffer}} to mark the
               [= media description =] for the corresponding transceiver
-              as <code>recvonly</code> or <code>inactive</code>,
+              as {{RTCRtpTransceiverDirection/"recvonly"}} or {{RTCRtpTransceiverDirection/"inactive"}},
               as defined in <span data-jsep="subsequent-offers">
               [[!JSEP]]</span>. <!-- onended --></p>
               <p>When the other peer stops sending a track in this manner, the
               track is removed from any remote {{MediaStream}}s
-              that were initially revealed in the <code>track</code> event, and
+              that were initially revealed in the <code class=event>track</code> event, and
               if the {{MediaStreamTrack}} is not already muted,
-              a <code title="event-MediaStreamTrack-mute">mute</code> event is
+              a <code class=event>mute</code> event is
               fired at the track.</p>
-              <div class="note">The same effect as <code>removeTrack()</code>
+              <div class="note">The same effect as {{removeTrack()}}
               can be achieved by setting the
-              <code>RTCRtpTransceiver.direction</code> attribute of the
+              {{RTCRtpTransceiver}}.{{RTCRtpTransceiver/direction}} attribute of the
               corresponding transceiver and invoking
-              <code>RTCRtpSender.replaceTrack(null)</code> on the sender. One
-              minor difference is that <code>replaceTrack()</code> is
-              asynchronous and <code>removeTrack()</code> is synchronous.</div>
-              <p>When the <dfn data-idl>removeTrack</dfn> method is
+              {{RTCRtpSender}}.{{RTCRtpSender/replaceTrack}}(null) on the sender. One
+              minor difference is that {{RTCRtpSender/replaceTrack()}} is
+              asynchronous and {{removeTrack()}} is synchronous.</div>
+              <p>When the {{removeTrack}} method is
               invoked, the user agent MUST run the following steps:</p>
               <ol>
                 <li>
                   <p>Let <var>sender</var> be the argument to
-                  <code>removeTrack</code>.</p>
+                  {{removeTrack}}.</p>
                 </li>
                 <li>
                   <p>Let <var>connection</var> be the
@@ -5362,11 +5359,11 @@ interface RTCCertificate {
                 </li>
                 <li data-tests="RTCPeerConnection-removeTrack.https.html">
                   <p>If <var>transceiver</var>.<a>[[\Direction]]</a> is
-                  <code>sendrecv</code>, set <var>transceiver</var>.<a>[[\Direction]]</a> to <code>recvonly</code>.</p>
+                  {{RTCRtpTransceiverDirection/"sendrecv"}}, set <var>transceiver</var>.<a>[[\Direction]]</a> to {{RTCRtpTransceiverDirection/"recvonly"}}.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-removeTrack.https.html">
                   <p>If <var>transceiver</var>.<a>[[\Direction]]</a>
-                  is <code>sendonly</code>, set <var>transceiver</var>.<a>[[\Direction]]</a> to <code>inactive</code>.</p>
+                  is {{RTCRtpTransceiverDirection/"sendonly"}}, set <var>transceiver</var>.<a>[[\Direction]]</a> to {{RTCRtpTransceiverDirection/"inactive"}}.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
                   <p>[= Update the
@@ -5379,14 +5376,14 @@ interface RTCCertificate {
               <p>Create a new {{RTCRtpTransceiver}} and add it
               to the [= set of transceivers =].</p>
               <p>Adding a transceiver will cause future calls to
-              <code>createOffer</code> to add a [= media description =] for
+              {{createOffer}} to add a [= media description =] for
               the corresponding transceiver, as defined in <span data-jsep=
               "subsequent-offers">[[!JSEP]]</span>.</p>
               <p data-tests="RTCPeerConnection-addTransceiver.https.html">The initial value of {{RTCRtpTransceiver/mid}} is null. Setting a new
               {{RTCSessionDescription}} may change it to a
               non-null value, as defined in <span data-jsep=
               "processing-a-local-desc processing-a-remote-desc">[[!JSEP]]</span>.</p>
-              <p data-tests="protocol/simulcast-offer.html">The <code>sendEncodings</code> argument can be used to
+              <p data-tests="protocol/simulcast-offer.html">The {{RTCRtpTransceiverInit/sendEncodings}} argument can be used to
               specify the number of offered simulcast encodings, and
               optionally their RIDs and encoding parameters.</p>
               <p>When this method is invoked, the user agent MUST run the
@@ -5397,15 +5394,15 @@ interface RTCCertificate {
                 </li>
                 <li>
                   <p>Let <var>streams</var> be <var>init</var>'s
-                  <code>streams</code> member.</p>
+                  {{RTCRtpTransceiverInit/streams}} member.</p>
                 </li>
                 <li>
                   <p>Let <var>sendEncodings</var> be <var>init</var>'s
-                  <code>sendEncodings</code> member.</p>
+                  {{RTCRtpTransceiverInit/sendEncodings}} member.</p>
                 </li>
                 <li>
                   <p>Let <var>direction</var> be <var>init</var>'s
-                  <code>direction</code> member.</p>
+                  {{RTCRtpTransceiverInit/direction}} member.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-addTransceiver.https.html,RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html">
                   <p>If the first argument is a string, let it be
@@ -5413,7 +5410,7 @@ interface RTCCertificate {
                   <ol>
                     <li>
                       <p>If <var>kind</var> is not a legal
-                      {{MediaStreamTrack}} <code>kind</code>,
+                      {{MediaStreamTrack}} <code class=ext>kind</code>,
                       [= exception/throw =] a {{TypeError}}.</p>
                     </li>
                     <li>
@@ -5450,7 +5447,7 @@ interface RTCCertificate {
                   <li data-tests="RTCRtpParameters-encodings.html">
                     <p>Verify that each {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
                     value in <var>sendEncodings</var> is greater than or equal to 1.0. If
-                    one of the <code>scaleResolutionDownBy</code> values does not meet
+                    one of the {{RTCRtpEncodingParameters/scaleResolutionDownBy}} values does not meet
                     this requirement, [= exception/throw =] a {{RangeError}}.</p>
                   </li>
                   <li>
@@ -5483,16 +5480,16 @@ interface RTCCertificate {
                   <var>kind</var>, <var>streams</var> and <var>sendEncodings</var>
                   and let <var>sender</var> be the result.</p>
                   <p>If <var>sendEncodings</var> is set, then subsequent calls
-                  to <code>createOffer</code> will be configured to send
+                  to {{createOffer}} will be configured to send
                   multiple RTP encodings as defined in <span data-jsep=
                   "subsequent-offers initial-offers">[[!JSEP]]</span>. When
-                  <code>setRemoteDescription</code> is called with a
+                  {{RTCPeerConnection/setRemoteDescription}} is called with a
                   corresponding remote description that is able to receive
                   multiple RTP encodings as defined in <span data-jsep=
                   "simulcast">[[!JSEP]]</span>, the
                   {{RTCRtpSender}} may send multiple RTP
                   encodings and the parameters retrieved via the transceiver's
-                  <code>sender.getParameters()</code> will reflect the
+                  {{RTCRtpTransceiver/sender}}.{{RTCRtpSender/getParameters()}} will reflect the
                   encodings negotiated.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-addTransceiver.https.html,RTCRtpTransceiver.https.html">
@@ -5572,7 +5569,7 @@ interface RTCCertificate {
               <td>The {{RTCRtpTransceiver}}'s
               {{RTCRtpSender}} <var>sender</var> will offer to
               send RTP, and will send RTP if the remote peer accepts and
-              <code><var>sender.getParameters().encodings[i].active</var></code>
+              <var>sender</var>.{{RTCRtpSender/getParameters()}}.{{RTCRtpSendParameters/encodings}}[<var>i</var>].{{RTCRtpEncodingParameters/active}}
               is <code>true</code> for any value of <var>i</var>. The
               {{RTCRtpTransceiver}}'s
               {{RTCRtpReceiver}} will offer to receive RTP, and
@@ -5583,7 +5580,7 @@ interface RTCCertificate {
               <td>The {{RTCRtpTransceiver}}'s
               {{RTCRtpSender}} <var>sender</var> will offer to
               send RTP, and will send RTP if the remote peer accepts and
-              <code><var>sender.getParameters().encodings[i].active</var></code>
+              <var>sender</var>.{{RTCRtpSender/getParameters()}}.{{RTCRtpSendParameters/encodings}}[<var>i</var>].{{RTCRtpEncodingParameters/active}}
               is <code>true</code> for any value of <var>i</var>. The
               {{RTCRtpTransceiver}}'s
               {{RTCRtpReceiver}} will not offer to receive RTP,
@@ -5623,7 +5620,7 @@ interface RTCCertificate {
         off both directions temporarily, or to {{RTCRtpTransceiverDirection/"sendonly"}} to reject
         only the incoming side. To permanently reject an m-line in a manner that
         makes it available for reuse, the application would need to call
-        <code>RTCRtpTransceiver.{{RTCRtpTransceiver/stop}}()</code>
+        {{RTCRtpTransceiver}}.{{RTCRtpTransceiver/stop()}}
         and subsequently initiate negotiation from its end.</p>
         <p>To <dfn id="process-remote-tracks">
         process remote tracks</dfn> given an {{RTCRtpTransceiver}}
@@ -5717,14 +5714,14 @@ interface RTCCertificate {
           <li data-tests="RTCPeerConnection-ontrack.https.html,protocol/msid-parse.html">
             <p>For each MSID in <var>msids</var>, unless a
             {{MediaStream}} object has previously been created
-            with that <code>id</code> for this <var>connection</var>, create a
+            with that <code class=gum>id</code> for this <var>connection</var>, create a
             {{MediaStream}} object with that
-            <code>id</code>.</p>
+            <code class=gum>id</code>.</p>
           </li>
           <li>
             <p>Let <var>streams</var> be a list of the
             {{MediaStream}} objects created for this
-            <var>connection</var> with the <code>id</code>s corresponding to
+            <var>connection</var> with the <code class=gum>id</code>s corresponding to
             <var>msids</var>.</p>
           </li>
           <li>
@@ -5754,7 +5751,7 @@ interface RTCCertificate {
       <h3><dfn>RTCRtpSender</dfn> Interface</h3>
       <p>The {{RTCRtpSender}} interface allows an
       application to control how a given {{MediaStreamTrack}} is
-      encoded and transmitted to a remote peer. When <code>setParameters</code>
+      encoded and transmitted to a remote peer. When {{RTCRtpSender/setParameters}}
       is called on an {{RTCRtpSender}} object, the encoding is
       changed appropriately.</p>
 
@@ -5788,7 +5785,7 @@ interface RTCCertificate {
         </li>
         <li>
           <p>If <var>kind</var> is <code>"audio"</code> then
-          <a>create an <code>RTCDTMFSender</code></a> <var>dtmf</var> and set
+          <a>create an RTCDTMFSender</a> <var>dtmf</var> and set
           the <a>[[\Dtmf]]</a> internal slot to <var>dtmf</var>.
         </li>
         <li>
@@ -5820,7 +5817,7 @@ interface RTCCertificate {
           and is non-empty, set the <a>[[\SendEncodings]]</a> slot to
           <var>sendEncodings</var>. Otherwise, set it to a list containing a
           single {{RTCRtpEncodingParameters}} with
-          <code>active</code> set to <code>true</code>.</p>
+          {{RTCRtpEncodingParameters/active}} set to <code>true</code>.</p>
         </li>
         <li>
           <p>Let <var>sender</var> have a <dfn>[[\SendCodecs]]</dfn>
@@ -5859,14 +5856,14 @@ interface RTCRtpSender {
             "idlAttrType">{{MediaStreamTrack}}</span>, readonly,
             nullable</dt>
             <dd>
-              <p>The <code>track</code> attribute is the track that is
+              <p>The {{track}} attribute is the track that is
               associated with this {{RTCRtpSender}} object. If
-              <code>track</code> is ended, or if the track's output is disabled,
-              i.e. the track is disabled and/or muted, the <code>
-              {{RTCRtpSender}}</code> MUST send black frames (video) and
+              {{track}} is ended, or if the track's output is disabled,
+              i.e. the track is disabled and/or muted, the
+              {{RTCRtpSender}} MUST send black frames (video) and
               MUST NOT send (audio).  In the case of video,
               the {{RTCRtpSender}} SHOULD send one
-              black frame per second. If <code>track</code> is null then
+              black frame per second. If {{track}} is null then
               the {{RTCRtpSender}} does not send. On getting, the
               attribute MUST return the value of the <a>[[\SenderTrack]]</a>
               slot.</p>
@@ -5875,13 +5872,13 @@ interface RTCRtpSender {
             "idlAttrType">{{RTCDtlsTransport}}</span>, readonly,
             nullable</dt>
             <dd>
-              <p>The <code>transport</code> attribute is the transport over
-              which media from <code>track</code> is sent in the form of RTP
+              <p>The {{transport}} attribute is the transport over
+              which media from {{track}} is sent in the form of RTP
               packets. Prior to construction of the
               {{RTCDtlsTransport}} object, the
-              <code>transport</code> attribute will be null. When bundling is
+              {{transport}} attribute will be null. When bundling is
               used, multiple {{RTCRtpSender}} objects will
-              share one <code>transport</code> and will all send RTP and RTCP
+              share one {{transport}} and will all send RTP and RTCP
               over the same transport.</p>
               <p>On getting, the attribute MUST return the value of the
               <a>[[\SenderTransport]]</a> slot.</p>
@@ -5892,9 +5889,9 @@ interface RTCRtpSender {
           <h2>Methods</h2>
           <dl data-link-for="RTCRtpSender" data-dfn-for="RTCRtpSender" class=
           "methods">
-            <dt data-tests="RTCRtpSender-getCapabilities.html"><code>getCapabilities</code>, static</dt>
+            <dt data-tests="RTCRtpSender-getCapabilities.html"><dfn data-idl>getCapabilities</dfn>, static</dt>
             <dd>
-              <p data-tests="RTCRtpSender-getCapabilities.html">The <dfn data-idl>getCapabilities()</dfn>
+              <p data-tests="RTCRtpSender-getCapabilities.html">The {{getCapabilities()}}
               method returns the most optimistic view of the capabilities of the
               system for sending media of the given kind. It does not reserve
               any resources, ports, or other state but is meant to provide a
@@ -5903,7 +5900,7 @@ interface RTCRtpSender {
               MUST support <var>kind</var> values of <code>"audio"</code>
               and <code>"video"</code>. If the system has no capabilities
               corresponding to the value of the <var>kind</var>
-              argument, <code>getCapabilities</code> returns <code>null</code>.</p>
+              argument, {{getCapabilities}} returns <code>null</code>.</p>
               <p class="fingerprint">These capabilities provide generally
               persistent cross-origin information on the device and thus
               increases the fingerprinting surface of the application. In
@@ -5912,17 +5909,17 @@ interface RTCRtpSender {
             </dd>
             <dt data-tests="RTCRtpParameters-codecs.html,RTCRtpSender-setParameters.html"><dfn data-idl>setParameters</dfn></dt>
             <dd>
-              <p>The <code>setParameters</code> method updates how
-              <code>track</code> is encoded and transmitted to a remote
+              <p>The {{setParameters}} method updates how
+              {{track}} is encoded and transmitted to a remote
               peer.</p>
-              <p>When the <code>setParameters</code> method is called, the user
+              <p>When the {{setParameters}} method is called, the user
               agent MUST run the following steps:</p>
               <ol>
                 <li>Let <var>parameters</var> be the method's first argument.
                 </li>
                 <li>Let <var>sender</var> be the
                 {{RTCRtpSender}} object on which
-                <code>setParameters</code> is invoked.</li>
+                {{setParameters}} is invoked.</li>
                 <li>Let <var>transceiver</var> be the
                 {{RTCRtpTransceiver}} object associated
                 with <var>sender</var> (i.e. <var>sender</var> is
@@ -5939,10 +5936,10 @@ interface RTCRtpSender {
                 <li>Validate <var>parameters</var> by running the following steps:
                 <ol>
                  <li>
-                   Let <var>encodings</var> be <code><var>parameters</var>.encodings</code>.
+                   Let <var>encodings</var> be <var>parameters</var>.{{RTCRtpSendParameters/encodings}}.
                  </li>
                  <li>
-                   Let <var>codecs</var> be <code><var>parameters</var>.codecs</code>.
+                   Let <var>codecs</var> be <var>parameters</var>.{{RTCRtpParameters/codecs}}.
                  </li>
                  <li>
                    Let <var>N</var> be the number of
@@ -5973,7 +5970,7 @@ interface RTCRtpSender {
                  <li data-tests="RTCRtpParameters-encodings.html">
                    <p>Verify that each {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
                    value in <var>encodings</var> is greater than or equal to 1.0. If
-                   one of the <code>scaleResolutionDownBy</code> values does not meet
+                   one of the {{RTCRtpEncodingParameters/scaleResolutionDownBy}} values does not meet
                    this requirement, return a promise [= rejected =] with a newly
                    [= exception/create | created =]
                    {{RangeError}}.</p>
@@ -5991,8 +5988,8 @@ interface RTCRtpSender {
                       <ol>
                         <li data-tests="RTCRtpParameters-degradationPreference.html">Set <var>sender</var>.<a>[[\LastReturnedParameters]]</a> to
                         <code>null</code>.</li>
-                        <li>Set <var>sender</var>.<a>[[\SendEncodings]]</a> to <code>
-                        <var>parameters</var>.encodings</code>.</li>
+                        <li>Set <var>sender</var>.<a>[[\SendEncodings]]</a> to 
+                        <var>parameters</var>.{{RTCRtpSendParameters/encodings}}.</li>
                         <li>[= Resolve =] <var>p</var> with <code>undefined</code>.
                       </ol>
                     </li>
@@ -6002,12 +5999,12 @@ interface RTCRtpSender {
                         <li>If an error occurred due to hardware resources not
                         being available, [= reject =] <var>p</var> with a newly
                         created {{RTCError}} whose
-                        <code>errorDetail</code> is set to
+                        {{RTCError/errorDetail}} is set to
                         "hardware-encoder-not-available" and abort these steps.</li>
                         <li>If an error occurred due to a hardware encoder not
                         supporting <var>parameters</var>, [= reject =]
-                        <var>p</var> with a newly created <code>
-                        {{RTCError}}</code> whose <code>errorDetail</code>
+                        <var>p</var> with a newly created
+                        {{RTCError}} whose {{RTCError/errorDetail}}
                         is set to "hardware-encoder-error" and abort these
                         steps.</li>
                         <li>For all other errors, [= reject =] <var>p</var>
@@ -6019,27 +6016,27 @@ interface RTCRtpSender {
                 </li>
                 <li>Return <var>p</var>.</li>
               </ol>
-              <p><code>setParameters</code> does not cause SDP renegotiation
+              <p>{{setParameters}} does not cause SDP renegotiation
               and can only be used to change what the media stack is sending or
               receiving within the envelope negotiated by Offer/Answer. The
               attributes in the {{RTCRtpSendParameters}} dictionary
               are designed to not enable this, so attributes like
-              <code>cname</code> that cannot be changed are read-only. Other
+              {{RTCRtcpParameters/cname}} that cannot be changed are read-only. Other
               things, like bitrate, are controlled using limits such as
-              <code>maxBitrate</code>, where the user agent needs to ensure it
+              {{RTCRtpEncodingParameters/maxBitrate}}, where the user agent needs to ensure it
               does not exceed the maximum bitrate specified by
-              <code>maxBitrate</code>, while at the same time making sure it
+              {{RTCRtpEncodingParameters/maxBitrate}}, while at the same time making sure it
               satisfies constraints on bitrate specified in other places such
               as the SDP.</p>
             </dd>
-            <dt data-tests="RTCRtpParameters-codecs.html,protocol/video-codecs.https.html"><code>getParameters</code></dt>
+            <dt data-tests="RTCRtpParameters-codecs.html,protocol/video-codecs.https.html"><dfn data-idl>getParameters</dfn></dt>
             <dd>
-              <p>The <dfn data-idl>getParameters()</dfn> method
+              <p>The {{getParameters()}} method
               returns the {{RTCRtpSender}} object's current
-              parameters for how <code>track</code> is encoded and transmitted
+              parameters for how {{track}} is encoded and transmitted
               to a remote {{RTCRtpReceiver}}.</p>
 
-              <p>When <code>getParameters</code> is called, the user agent MUST
+              <p>When {{getParameters}} is called, the user agent MUST
               run the following steps:</p>
               <ol>
                 <li>
@@ -6076,10 +6073,10 @@ interface RTCRtpSender {
                       is set to the value of the <a>[[\SendCodecs]]</a> internal slot.
                     </li>
                     <li data-tests="RTCRtpParameters-encodings.html">
-                      <code>{{RTCRtpParameters/rtcp}}.cname</code>
+                      {{RTCRtpParameters/rtcp}}.{{RTCRtcpParameters/cname}}
                       is set to the CNAME of the associated
                       {{RTCPeerConnection}}.
-                      <code>{{RTCRtpParameters/rtcp}}.reducedSize</code>
+                      {{RTCRtpParameters/rtcp}}.{{RTCRtcpParameters/reducedSize}}
                       is set to <code>true</code> if reduced-size RTCP has been negotiated
                       for sending, and <code>false</code> otherwise.
                     </li>
@@ -6098,8 +6095,8 @@ interface RTCRtpSender {
                   <p>Return <var>result</var>.</p>
                 </li>
               </ol>
-              <p><code>getParameters</code> may be used with
-              <code>setParameters</code> to change the parameters in the
+              <p>{{getParameters}} may be used with
+              {{setParameters}} to change the parameters in the
               following way:</p>
               <pre class="example highlight">
 async function updateParameters() {
@@ -6113,22 +6110,22 @@ async function updateParameters() {
   }
 }
               </pre>
-              <p>After a completed call to <code>setParameters</code>,
-              subsequent calls to <code>getParameters</code> will return the
+              <p>After a completed call to {{setParameters}},
+              subsequent calls to {{getParameters}} will return the
               modified set of parameters.</p>
             </dd>
-            <dt data-tests="RTCPeerConnection-setRemoteDescription-replaceTrack.https.html,RTCRtpSender-replaceTrack.https.html"><code>replaceTrack</code></dt>
+            <dt data-tests="RTCPeerConnection-setRemoteDescription-replaceTrack.https.html,RTCRtpSender-replaceTrack.https.html"><dfn data-idl>replaceTrack</dfn></dt>
             <dd>
               <p>Attempts to replace the {{RTCRtpSender}}'s
-              current <code>track</code> with another track provided (or
+              current {{track}} with another track provided (or
               with a null track), without renegotiation.</p>
-              <p>When the <dfn data-idl>replaceTrack</dfn> method is
+              <p>When the {{replaceTrack}} method is
               invoked, the user agent MUST run the following steps:</p>
               <ol>
                 <li>
                   <p>Let <var>sender</var> be the
                   {{RTCRtpSender}} object on which
-                  <code>replaceTrack</code> is invoked.</p>
+                  {{replaceTrack}} is invoked.</p>
                 </li>
                 <li>
                   <p>Let <var>transceiver</var> be the
@@ -6145,7 +6142,7 @@ async function updateParameters() {
                   method.</p>
                 </li>
                 <li data-tests="RTCRtpSender-replaceTrack.https.html">
-                  <p>If <code><var>withTrack</var></code> is non-null and
+                  <p>If <var>withTrack</var> is non-null and
                   <code><var>withTrack</var>.kind</code> differs from the
                   <a>transceiver kind</a> of <var>transceiver</var>, return a
                   promise [= rejected =] with a newly
@@ -6241,11 +6238,11 @@ async function updateParameters() {
                 </ol>
               </div>
             </dd>
-            <dt data-tests="RTCRtpSender-setStreams.https.html,RTCPeerConnection-onnegotiationneeded.html"><code>setStreams</code></dt>
+            <dt data-tests="RTCRtpSender-setStreams.https.html,RTCPeerConnection-onnegotiationneeded.html"><dfn data-idl>setStreams</dfn></dt>
             <dd>
               <p>Sets the {{MediaStream}}s to be associated with this
               sender's track.</p>
-              <p>When the <dfn data-idl>setStreams</dfn> method is invoked,
+              <p>When the {{setStreams}} method is invoked,
               the user agent MUST run the following steps:</p>
               <ol>
                 <li>
@@ -6286,13 +6283,13 @@ async function updateParameters() {
                 </li>
               </ol>
             </dd>
-            <dt data-tests="RTCPeerConnection-getStats.https.html,RTCRtpSender-getStats.https.html"><code>getStats</code></dt>
+            <dt data-tests="RTCPeerConnection-getStats.https.html,RTCRtpSender-getStats.https.html"><dfn data-idl id=
+              "widl-RTCRtpSender-getStats-Promise-RTCStatsReport">getStats</dfn></dt>
             <dd>
               <p>Gathers stats for this sender only and reports the result
               asynchronously.</p>
-              <p>When the <dfn data-idl id=
-              "widl-RTCRtpSender-getStats-Promise-RTCStatsReport">
-              <code>getStats()</code></dfn> method is invoked, the user
+              <p>When the 
+              {{getStats()}} method is invoked, the user
               agent MUST run the following steps:</p>
               <ol data-tests="RTCRtpSender-getStats.https.html">
                 <li>
@@ -6356,9 +6353,9 @@ async function updateParameters() {
               {{RTCRtpSender}} will choose from, as well as
               entries for RTX, RED and FEC mechanisms. Corresponding to each
               media codec where retransmission via RTX is enabled, there will
-              be an entry in <code>codecs[]</code> with a <code>mimeType</code>
+              be an entry in {{codecs}} with a {{RTCRtpCodecParameters/mimeType}}
               attribute indicating retransmission via "audio/rtx" or
-              "video/rtx", and an <code>sdpFmtpLine</code> attribute (providing
+              "video/rtx", and an {{RTCRtpCodecParameters/sdpFmtpLine}} attribute (providing
               the "apt" and "rtx-time" parameters). <a>Read-only parameter</a>.</p>
             </dd>
           </dl>
@@ -6421,8 +6418,8 @@ async function updateParameters() {
               <p>If set, this RTP encoding will be sent with the RID header
               extension as defined by <span data-jsep=
               "initial-offers">[[!JSEP]]</span>. The RID is not modifiable via
-              <code>setParameters</code>. It can only be set or modified in
-              <code>addTransceiver</code> on the sending side.
+              {{RTCRtpSender/setParameters}}. It can only be set or modified in
+              {{RTCPeerConnection/addTransceiver}} on the sending side.
               <a>Read-only parameter</a>.</p>
             </dd>
           </dl>
@@ -6465,7 +6462,7 @@ async function updateParameters() {
             <dd>
               <p>When present, indicates the maximum bitrate that can be used to send this
               encoding. The user agent is free to allocate bandwidth between the encodings,
-              as long as the <code>maxBitrate</code> value is not exceeded.
+              as long as the {{maxBitrate}} value is not exceeded.
               The encoding may also be further constrained by other
               limits (such as per-transport or per-session
               bandwidth limits) below the maximum specified here. maxBitrate is
@@ -6486,7 +6483,7 @@ async function updateParameters() {
             <dt data-tests="RTCRtpParameters-encodings.html"><dfn data-idl>scaleResolutionDownBy</dfn> of type
             <span class="idlMemberType">double</span></dt>
             <dd>
-              <p>This member is only present if the sender's <code>kind</code>
+              <p>This member is only present if the sender's <code class=gum>kind</code>
               is <code>"video"</code>. The video's
               resolution will be scaled down in each dimension by the given
               value before sending. For example, if the value is 2.0, the video
@@ -6494,7 +6491,7 @@ async function updateParameters() {
               in sending a video of one quarter the size. If the value is 1.0,
               the video will not be affected. The value must be greater than or
               equal to 1.0. By default, the sender will not apply any scaling,
-              (i.e., <code>scaleResolutionDownBy</code> will be 1.0).</p>
+              (i.e., {{RTCRtpEncodingParameters/scaleResolutionDownBy}} will be 1.0).</p>
             </dd>
           </dl>
         </section>
@@ -6575,15 +6572,15 @@ async function updateParameters() {
       without having to parse SDP:</p>
       <ol>
         <li>sendonly: The header extension is only included in
-        <code><var>transceiver</var>.sender.getParameters().headerExtensions</code>.</li>
+        <var>transceiver</var>.{{RTCRtpTransceiver/sender}}.{{RTCRtpSender/getParameters()}}.{{RTCRtpParameters/headerExtensions}}.</li>
         <li>recvonly: The header extension is only included in
-        <code><var>transceiver</var>.receiver.getParameters().headerExtensions</code>.</li>
+        <var>transceiver</var>.{{RTCRtpTransceiver/receiver}}.{{RTCRtpReceiver/getParameters()}}.{{RTCRtpParameters/headerExtensions}}.</li>
         <li>sendrecv: The header extension is included in both
-        <code><var>transceiver</var>.sender.getParameters().headerExtensions</code> and
-        <code><var>transceiver</var>.receiver.getParameters().headerExtensions</code>.</li>
+        <var>transceiver</var>.{{RTCRtpTransceiver/sender}}.{{RTCRtpSender/getParameters()}}.{{RTCRtpParameters/headerExtensions}} and
+        <var>transceiver</var>.{{RTCRtpTransceiver/receiver}}.{{RTCRtpReceiver/getParameters()}}.{{RTCRtpParameters/headerExtensions}}.</li>
         <li>inactive: The header extension is included in neither
-        <code><var>transceiver</var>.sender.getParameters().headerExtensions</code> nor
-        <code><var>transceiver</var>.receiver.getParameters().headerExtensions</code>.</li>
+        <var>transceiver</var>.{{RTCRtpTransceiver/sender}}.{{RTCRtpSender/getParameters()}}.{{RTCRtpParameters/headerExtensions}} nor
+        <var>transceiver</var>.{{RTCRtpTransceiver/receiver}}.{{RTCRtpReceiver/getParameters()}}.{{RTCRtpParameters/headerExtensions}}.</li>
       </ol>
       </div>
       </section>
@@ -6659,8 +6656,8 @@ async function updateParameters() {
             <dd>
               <p>Supported media codecs as well as entries for RTX, RED and FEC
               mechanisms. There will only be a single entry in
-              <code>codecs[]</code> for retransmission via RTX, with
-              <code>sdpFmtpLine</code> not present.</p>
+              {{codecs}} for retransmission via RTX, with
+              {{RTCRtpCodecCapability/sdpFmtpLine}} not present.</p>
             </dd>
             <dt data-tests="RTCRtpReceiver-getCapabilities.html"><dfn data-idl>headerExtensions</dfn> of type <span class=
             "idlMemberType">sequence&lt;{{RTCRtpHeaderExtensionCapability}}&gt;</span>, required</dt>
@@ -6765,15 +6762,15 @@ async function updateParameters() {
         </li>
         <li data-tests="RTCPeerConnection-addTransceiver.https.html">
           <p>Initialize <var>track.label</var> to the result of concatenating
-          the string <code>"remote "</code> with <var>kind</var>.</p>
+          the string <code>"remote"</code> with <var>kind</var>.</p>
         </li>
         <li data-tests="RTCPeerConnection-addTransceiver.https.html">
-          <p>Initialize <var>track.readyState</var> to <code>live</code>.</p>
+          <p>Initialize <var>track.readyState</var> to <code class=gum>live</code>.</p>
         </li>
         <li data-tests="RTCPeerConnection-addTransceiver.https.html,RTCPeerConnection-transceivers.https.html">
           <p>Initialize <var>track.muted</var> to <code>true</code>. See the
           <a href="#mediastreamtrack-network-use">MediaStreamTrack</a> section
-          about how the <code>muted</code> attribute reflects if a
+          about how the <code class=gum>muted</code> attribute reflects if a
           {{MediaStreamTrack}} is receiving media data or
           not.</p>
         </li>
@@ -6833,31 +6830,31 @@ interface RTCRtpReceiver {
           <h2>Attributes</h2>
           <dl data-link-for="RTCRtpReceiver" data-dfn-for="RTCRtpReceiver"
           class="attributes">
-            <dt><dfn data-idl>track</dfn> of type <span class=
+            <dt><dfn data-idl id="dom-rtpreceiver-track">track</dfn> of type <span class=
             "idlAttrType">{{MediaStreamTrack}}</span>, readonly</dt>
             <dd>
-              <p>The <code id="dom-rtpreceiver-track">track</code>
+              <p>The {{track}}
               attribute is the track that is associated with this
               {{RTCRtpReceiver}} object <var>receiver</var>.
               </p>
-              <p>Note that <code>track.stop()</code> is final, although
+              <p>Note that {{track}}.<code class=gum>stop()</code> is final, although
               clones are not affected. Since
-              <code><var>receiver</var>.track.stop()</code>
+              <var>receiver</var>.{{track}}.<code class=gum>stop()</code>
               does not implicitly stop <var>receiver</var>, Receiver
               Reports continue to be sent. On getting, the attribute MUST
               return the value of the <a>[[\ReceiverTrack]]</a> slot.</p>
             </dd>
-            <dt><code>transport</code> of type <span class=
+            <dt><dfn data-idl>transport</dfn> of type <span class=
             "idlAttrType">{{RTCDtlsTransport}}</span>, readonly,
             nullable</dt>
             <dd>
-              <p>The <dfn data-idl>transport</dfn> attribute is the
-              transport over which media for the receiver's <code>track</code>
+              <p>The {{transport}} attribute is the
+              transport over which media for the receiver's {{RTCRtpReceiver/track}}
               is received in the form of RTP packets. Prior to construction of
               the {{RTCDtlsTransport}} object, the
-              <code>transport</code> attribute will be null. When bundling is
+              {{transport}} attribute will be <code>null</code>. When bundling is
               used, multiple {{RTCRtpReceiver}} objects will
-              share one <code>transport</code> and will all receive RTP and
+              share one {{transport}} and will all receive RTP and
               RTCP over the same transport.</p>
               <p>On getting, the attribute MUST return the value of the
               <a>[[\ReceiverTransport]]</a> slot.</p>
@@ -6868,9 +6865,9 @@ interface RTCRtpReceiver {
           <h2>Methods</h2>
           <dl data-link-for="RTCRtpReceiver" data-dfn-for="RTCRtpReceiver"
           class="methods">
-            <dt data-tests="RTCRtpReceiver-getCapabilities.html"><code>getCapabilities</code>, static</dt>
+            <dt data-tests="RTCRtpReceiver-getCapabilities.html"><dfn data-idl>getCapabilities</dfn>, static</dt>
             <dd>
-              <p data-tests="RTCRtpReceiver-getCapabilities.html">The <dfn data-idl>getCapabilities()</dfn>
+              <p data-tests="RTCRtpReceiver-getCapabilities.html">The {{getCapabilities()}}
               method returns the most optimistic view of the capabilities of
               the system for receiving media of the given kind. It does not
               reserve any resources, ports, or other state but is meant to
@@ -6879,20 +6876,20 @@ interface RTCRtpReceiver {
               MUST support <var>kind</var> values of <code>"audio"</code>
               and <code>"video"</code>. If the system has no capabilities
               corresponding to the value of the <var>kind</var> argument,
-              <code>getCapabilities</code> returns <code>null</code>.</p>
+              {{getCapabilities}} returns <code>null</code>.</p>
               <p class="fingerprint">These capabilities provide generally
               persistent cross-origin information on the device and thus
               increases the fingerprinting surface of the application. In
               privacy-sensitive contexts, browsers can consider mitigations
               such as reporting only a common subset of the capabilities.</p>
             </dd>
-            <dt data-tests="RTCRtpReceiver-getParameters.html"><code>getParameters</code></dt>
+            <dt data-tests="RTCRtpReceiver-getParameters.html"><dfn data-idl>getParameters</dfn></dt>
             <dd>
-              <p>The <dfn data-idl>getParameters()</dfn> method returns the
+              <p>The {{getParameters()}} method returns the
               {{RTCRtpReceiver}} object's current parameters for how
-              <code>track</code> is decoded.</p>
+              {{track}} is decoded.</p>
 
-              <p>When <code>getParameters</code> is called, the
+              <p>When {{getParameters}} is called, the
               {{RTCRtpReceiveParameters}} dictionary is
               constructed as follows:</p>
               <ul>
@@ -6909,16 +6906,16 @@ interface RTCRtpReceiver {
                   affect this list of codecs. For example, if three codecs are
                   offered, the receiver will be prepared to receive each of
                   them and will return them all from
-                  <code>getParameters</code>. But if the remote endpoint only
+                  {{getParameters}}. But if the remote endpoint only
                   answers with two, the absent codec will no longer be returned
-                  by <code>getParameters</code> as the receiver no longer needs
+                  by {{getParameters}} as the receiver no longer needs
                   to be prepared to receive it.</div>
                 </li>
                 <li data-tests="RTCRtpReceiver-getParameters.html">
-                  <code>{{RTCRtpParameters/rtcp}}.reducedSize</code>
+                  {{RTCRtpParameters/rtcp}}.{{RTCRtcpParameters/reducedSize}}
                   is set to <code>true</code> if the receiver is currently prepared to
                   receive reduced-size RTCP packets, and <code>false</code> otherwise.
-                  <code>{{RTCRtpParameters/rtcp}}.cname</code> is
+                  {{RTCRtpParameters/rtcp}}.{{RTCRtcpParameters/cname}} is
                   left out.
                 </li>
               </ul>
@@ -6926,24 +6923,23 @@ interface RTCRtpReceiver {
             <dt data-tests="RTCRtpReceiver-getContributingSources.https.html"><dfn data-idl>getContributingSources</dfn></dt>
             <dd>
               <p>Returns an {{RTCRtpContributingSource}} for
-              each unique CSRC identifier received by this RTCRtpReceiver in
-              the last 10 seconds, in descending <code>timestamp</code> order.
+              each unique CSRC identifier received by this {{RTCRtpReceiver}} in
+              the last 10 seconds, in descending {{RTCRtpContributingSource/timestamp}} order.
               </p>
             </dd>
             <dt data-tests="RTCRtpReceiver-getSynchronizationSources.https.html"><dfn data-idl>getSynchronizationSources</dfn></dt>
             <dd>
               <p>Returns an {{RTCRtpSynchronizationSource}} for
-              each unique SSRC identifier received by this RTCRtpReceiver in
-              the last 10 seconds, in descending <code>timestamp</code> order.
+              each unique SSRC identifier received by this {{RTCRtpReceiver}} in
+              the last 10 seconds, in descending {{RTCRtpContributingSource/timestamp}} order.
               </p>
             </dd>
-            <dt data-tests="RTCRtpReceiver-getStats.https.html"><code>getStats</code></dt>
+            <dt data-tests="RTCRtpReceiver-getStats.https.html"><dfn data-idl id=
+              "widl-RTCRtpReceiver-getStats-Promise-RTCStatsReport">getStats</dfn></dt>
             <dd>
               <p>Gathers stats for this receiver only and reports the result
               asynchronously.</p>
-              <p>When the <dfn data-idl id=
-              "widl-RTCRtpReceiver-getStats-Promise-RTCStatsReport">
-              <code>getStats()</code></dfn> method is invoked, the user
+              <p>When the {{getStats()}} method is invoked, the user
               agent MUST run the following steps:</p>
               <ol data-tests="RTCRtpReceiver-getStats.https.html">
                 <li>
@@ -6993,8 +6989,8 @@ interface RTCRtpReceiver {
       from RTP packets delivered to the {{RTCRtpReceiver}}'s
       {{MediaStreamTrack}} in the previous 10 seconds.</p>
       <div class="note">Even if the {{MediaStreamTrack}} is not attached to
-      any sink for playout, <code>getSynchronizationSources</code> and
-      <code>getContributingSources</code> returns up-to-date information as long
+      any sink for playout, {{RTCRtpReceiver/getSynchronizationSources}} and
+      {{RTCRtpReceiver/getContributingSources}} returns up-to-date information as long
       as the track is not ended; sinks are not a prerequisite for decoding RTP
       packets.</div>
       <div class="note">As stated in the <a href="#conformance">conformance
@@ -7020,10 +7016,10 @@ interface RTCRtpReceiver {
           "RTCRtpContributingSource" class="dictionary-members">
             <dt data-tests="RTCRtpReceiver-getSynchronizationSources.https.html"><dfn data-idl>timestamp</dfn> of type {{DOMHighResTimeStamp}}, required</dt>
             <dd>
-              <p>The <code>timestamp</code> indicating the most recent time a
+              <p>The {{timestamp}} indicating the most recent time a
               frame from an RTP packet, originating from this source, was
               delivered to the {{RTCRtpReceiver}}'s
-              {{MediaStreamTrack}}. The <code>timestamp</code>
+              {{MediaStreamTrack}}. The {{timestamp}}
               is defined as {{Performance.timeOrigin}} +
               {{Performance.now()}} at that time.</p>
             </dd>
@@ -7055,7 +7051,7 @@ interface RTCRtpReceiver {
               and 127 represents silence.</p>
               <p>To convert these values to the linear 0..1 range, a value of
               127 is converted to 0, and all other values are converted using
-              the equation: <code>10^(-rfc_level/20)</code>.</p>
+              the equation: <code class=math>10^(-rfc_level/20)</code>.</p>
             </dd>
             <dt data-tests="RTCRtpReceiver-getSynchronizationSources.https.html"><dfn data-idl>rtpTimestamp</dfn> of type
                 <span class="idlMemberType">unsigned long</span>, required</dt>
@@ -7083,7 +7079,7 @@ interface RTCRtpReceiver {
               (false). If the RFC 6464 extension header was not present, or if
               the peer has signaled that it is not using the V bit by setting the
               "vad" extension attribute to "off", as described in [[!RFC6464]],
-              Section 4, <code>voiceActivityFlag</code> will be absent.</p>
+              Section 4, {{voiceActivityFlag}} will be absent.</p>
             </dd>
           </dl>
         </section>
@@ -7094,7 +7090,7 @@ interface RTCRtpReceiver {
       <p>The {{RTCRtpTransceiver}} interface represents a
       combination of an {{RTCRtpSender}} and an
       {{RTCRtpReceiver}} that share a common
-      <code>mid</code>. As defined in <span data-jsep="rtptransceivers">[[!JSEP]]</span>,
+      [= media stream "identification-tag" =]. As defined in <span data-jsep="rtptransceivers">[[!JSEP]]</span>,
       an {{RTCRtpTransceiver}} is said to be <dfn>associated</dfn> with
       a [= media description =] if its {{RTCRtpTransceiver/mid}}
       property is non-null; otherwise it is said to be disassociated. Conceptually, an
@@ -7175,21 +7171,21 @@ interface RTCRtpTransceiver {
           <h2>Attributes</h2>
           <dl data-link-for="RTCRtpTransceiver" data-dfn-for=
           "RTCRtpTransceiver" class="attributes">
-            <dt data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html"><code>mid</code> of type <span class=
+            <dt data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html"><dfn id="dom-rtptransceiver-mid">mid</dfn> of type <span class=
             "idlAttrType">DOMString</span>, readonly, nullable</dt>
             <dd>
-              <p>The <dfn id="dom-rtptransceiver-mid"><code>mid</code></dfn>
-              attribute is the <code>mid</code> negotatiated and present in the
+              <p>The {{mid}}
+              attribute is the [= media stream "identification-tag" =] negotiated and present in the
               local and remote descriptions as defined in <span data-jsep=
               "initial-offers initial-answers">[[!JSEP]]</span>. Before
-              negotiation is complete, the <code>mid</code> value may be null.
+              negotiation is complete, the {{mid}} value may be null.
               After rollbacks, the value may change from a non-null value
               to null.</p>
             </dd>
             <dt data-tests="RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html"><dfn data-idl>sender</dfn> of type <span class=
             "idlAttrType">{{RTCRtpSender}}</span>, readonly</dt>
             <dd>
-              <p>The <code>sender</code> attribute exposes the
+              <p>The {{sender}} attribute exposes the
               {{RTCRtpSender}} corresponding to the RTP media
               that may be sent with mid = {{mid}}. On getting,
               the attribute MUST return the value of the <a>[[\Sender]]</a>
@@ -7198,7 +7194,7 @@ interface RTCRtpTransceiver {
             <dt data-tests="RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html"><dfn data-idl>receiver</dfn> of type <span class=
             "idlAttrType">{{RTCRtpReceiver}}</span>, readonly</dt>
             <dd>
-              <p>The <code>receiver</code> attribute is the
+              <p>The {{receiver}} attribute is the
               {{RTCRtpReceiver}} corresponding to the RTP media
               that may be received with mid = {{mid}}. On
               getting the attribute MUST return the value of the
@@ -7212,10 +7208,10 @@ interface RTCRtpTransceiver {
               <var>direction</var> attribute indicates the preferred direction
               of this transceiver, which will be used in calls to {{RTCPeerConnection/createOffer}} and {{RTCPeerConnection/createAnswer}}. An update
               of directionality does not take effect immediately. Instead,
-              future calls to <code>createOffer</code>
-              and <code>createAnswer</code> mark the corresponding media
-              description as <code>sendrecv</code>, <code>sendonly</code>,
-              <code>recvonly</code> or <code>inactive</code> as defined in
+              future calls to {{RTCPeerConnection/createOffer}}
+              and {{RTCPeerConnection/createAnswer}} mark the corresponding [= media
+              description =] as <code class=sdp>sendrecv</code>, <code class=sdp>sendonly</code>,
+               <code class=sdp>recvonly</code> or <code class=sdp>inactive</code> as defined in
               <span data-jsep=
               "subsequent-offers subsequent-answers">[[!JSEP]]</span></p>
               <p>On getting, the user agent MUST run the following steps:</p>
@@ -7285,7 +7281,7 @@ interface RTCRtpTransceiver {
               <var>currentDirection</var> attribute indicates the current
               direction negotiated for this transceiver. The value of
               <var>currentDirection</var> is independent of the value of
-              <code>RTCRtpEncodingParameters.{{RTCRtpEncodingParameters/active}}</code> since one cannot be
+              {{RTCRtpEncodingParameters}}.{{RTCRtpEncodingParameters/active}} since one cannot be
               deduced from the other. If this transceiver has never been
               represented in an offer/answer exchange, the value is
               <code>null</code>. If the transceiver is
@@ -7314,38 +7310,38 @@ interface RTCRtpTransceiver {
           <h2>Methods</h2>
           <dl data-link-for="RTCRtpTransceiver" data-dfn-for=
           "RTCRtpTransceiver" class="methods">
-            <dt data-tests="RTCRtpTransceiver-stop.html"><code>stop</code></dt>
+            <dt data-tests="RTCRtpTransceiver-stop.html"><dfn data-idl>stop</dfn></dt>
             <dd>
               <p>Irreversibly marks the transceiver as {{stopping}}, unless
               it is already {{stopped}}. This will immediately cause the
               transceiver's sender to no longer send, and its receiver to no
-              longer receive. Calling <code>stop()</code> also [=
+              longer receive. Calling {{stop()}} also [=
               update the negotiation-needed flag | updates the
               negotiation-needed flag =] for the
               {{RTCRtpTransceiver}}'s associated
               {{RTCPeerConnection}}.</p>
               <p>A <dfn>stopping</dfn> transceiver will cause future calls to
-              <code>createOffer</code> to generate a zero port in the
+              {{RTCPeerConnection/createOffer}} to generate a zero port in the
               [= media description =] for the corresponding transceiver, as
               defined in <span data-jsep="stop">[[!JSEP]]</span> (The user agent
               MUST treat a {{stopping}} transceiver as {{stopped}} for the
               purposes of JSEP only in this case). However, to avoid problems
               with [[!BUNDLE]], a transceiver that is {{stopping}}, but not
-              {{stopped}}, will not affect <code>createAnswer</code>.</p>
+              {{stopped}}, will not affect {{RTCPeerConnection/createAnswer}}.</p>
               <p>A <dfn>stopped</dfn> transceiver will cause future calls to
-              <code>createOffer</code> or <code>createAnswer</code> to generate
+              {{RTCPeerConnection/createOffer}} or {{RTCPeerConnection/createAnswer}} to generate
               a zero port in the [= media description =] for the corresponding
               transceiver, as defined in
               <span data-jsep="stop">[[!JSEP]]</span>.</p>
               <p>The transceiver will remain in the {{stopping}} state,
-              unless it becomes {{stopped}} by <code>setRemoteDescription</code>
+              unless it becomes {{stopped}} by {{RTCPeerConnection/setRemoteDescription}}
               processing a rejected m-line in a remote offer or answer.</p>
               <p class="note">A transceiver that is {{stopping}} but not
               {{stopped}} will always need negotiation. In practice, this
-              means that calling <code>stop()</code> on a transceiver will cause
+              means that calling {{stop()}} on a transceiver will cause
               the transceiver to become {{stopped}} eventually, provided
               negotiation is allowed to complete on both ends.</p>
-              <p>When the <dfn data-idl>stop</dfn> method is
+              <p>When the {{stop}} method is
               invoked, the user agent MUST run the following steps:</p>
               <ol>
                 <li>
@@ -7400,7 +7396,7 @@ interface RTCRtpTransceiver {
                 </li>
                 <li>
                   <p>Set <var>transceiver</var>.<a>[[\Direction]]</a>
-                  to <code>inactive</code>.</p>
+                  to {{RTCRtpTransceiverDirection/"inactive"}}.</p>
                 </li>
                 <li>
                   <p>Set <var>transceiver</var>.<a>[[\Stopping]]</a>
@@ -7431,10 +7427,10 @@ interface RTCRtpTransceiver {
             </dd>
             <dt data-tests="RTCRtpTransceiver-setCodecPreferences.html"><dfn data-idl>setCodecPreferences</dfn></dt>
             <dd>
-              <p>The <code>setCodecPreferences</code> method overrides the
+              <p>The {{setCodecPreferences}} method overrides the
               default codec preferences used by the <a>user agent</a>. When
               generating a session description using either
-              <code>createOffer</code> or <code>createAnswer</code>, the
+              {{RTCPeerConnection/createOffer}} or {{RTCPeerConnection/createAnswer}}, the
               <a>user agent</a> MUST use the indicated codecs, in the order
               specified in the <var>codecs</var> argument, for the media
               section corresponding to this {{RTCRtpTransceiver}}.
@@ -7444,30 +7440,30 @@ interface RTCRtpTransceiver {
               application to cause a remote peer to prefer the codec that
               appears first in the list for sending.</p>
               <p>Codec preferences remain in effect for all calls to
-              <code>createOffer</code> and <code>createAnswer</code> that
+              {{RTCPeerConnection/createOffer}} and {{RTCPeerConnection/createAnswer}} that
               include this {{RTCRtpTransceiver}} until this method is
               called again. Setting <var>codecs</var> to an empty sequence
               resets codec preferences to any default value.</p>
-              <p>The <code>codecs</code> sequence passed into
-              <code>setCodecPreferences</code> can only contain codecs that are
-              returned by <code>RTCRtpSender.getCapabilities(kind)</code> or
-              <code>RTCRtpReceiver.getCapabilities(kind)</code>, where
-              <code>kind</code> is the kind of the
+              <p>The <var>codecs</var> sequence passed into
+              {{setCodecPreferences}} can only contain codecs that are
+              returned by {{RTCRtpSender}}.{{RTCRtpSender/getCapabilities}}(<var>kind</var>) or
+              {{RTCRtpReceiver}}.{{RTCRtpReceiver/getCapabilities}}(<var>kind</var>), where
+              <var>kind</var> is the kind of the
               {{RTCRtpTransceiver}} on which the method is called.
               Additionally, the {{RTCRtpCodecCapability}} dictionary
-              members cannot be modified. If <code>codecs</code> does not
+              members cannot be modified. If <var>codecs</var> does not
               fulfill these requirements, the user agent MUST [= exception/throw =] an
               {{InvalidModificationError}}.</p>
               <p class="note">
               Due to a recommendation in [[!SDP]], calls to
-              <code>createAnswer</code> SHOULD use only the common subset of
+              {{RTCPeerConnection/createAnswer}} SHOULD use only the common subset of
               the codec preferences and the codecs that appear in the offer.
               For example, if codec preferences are "C, B, A", but only codecs
               "A, B" were offered, the answer should only contain codecs "B,
               A". However, <span data-jsep="initial-answers">[[!JSEP]]</span>
               allows adding codecs that were not in the offer, so
               implementations can behave differently.</p>
-              <p>When <code>setCodecPreferences()</code> in invoked, the <a>user agent</a>
+              <p>When {{setCodecPreferences()}} in invoked, the <a>user agent</a>
               MUST run the following steps:</p>
               <ol>
                 <li>
@@ -7492,17 +7488,17 @@ interface RTCRtpTransceiver {
                 </li>
                 <li data-tests="RTCRtpTransceiver-setCodecPreferences.html">
                   <p>If the intersection between <var>codecs</var> and
-                  <code>RTCRtpSender.getCapabilities(kind).codecs</code> or the intersection
+                  {{RTCRtpSender}}.{{RTCRtpSender/getCapabilities}}(<var>kind</var>).{{RTCRtpParameters/codecs}} or the intersection
                   between <var>codecs</var> and
-                  <code>RTCRtpReceiver.getCapabilities(kind).codecs</code> only contains RTX, RED
+                  {{RTCRtpReceiver}}.{{RTCRtpReceiver/getCapabilities}}(<var>kind</var>).{{RTCRtpParameters/codecs}} only contains RTX, RED
                   or FEC codecs or is an empty set,
                   throw {{InvalidModificationError}}. This ensures that we always have
-                  something to offer, regardless of <code><var>transceiver</var>.{{RTCRtpTransceiver/direction}}</code>.</p>
+                  something to offer, regardless of <var>transceiver</var>.{{RTCRtpTransceiver/direction}}.</p>
                 </li>
                 <li>
                   <p>Let <var>codecCapabilities</var> be the union of
-                  <code>RTCRtpSender.getCapabilities(kind).codecs</code> and
-                  <code>RTCRtpReceiver.getCapabilities(kind).codecs</code>.</p>
+                  {{RTCRtpSender}}.{{RTCRtpSender/getCapabilities}}(<var>kind</var>).{{RTCRtpParameters/codecs}} and
+                  {{RTCRtpReceiver}}.{{RTCRtpReceiver/getCapabilities}}(<var>kind</var>).{{RTCRtpParameters/codecs}}.</p>
                 </li>
                 <li>
                   <p>For each <var>codec</var> in <var>codecs</var>,</p>
@@ -7529,28 +7525,28 @@ interface RTCRtpTransceiver {
       </div>
       <section>
         <h3>Simulcast functionality</h3>
-        <p>Simulcast functionality is provided via the <code>addTransceiver</code> method of the
-        {{RTCPeerConnection}} object and the <code>setParameters</code> method of the
+        <p>Simulcast functionality is provided via the {{RTCPeerConnection/addTransceiver}} method of the
+        {{RTCPeerConnection}} object and the {{RTCRtpSender/setParameters}} method of the
         {{RTCRtpSender}} object.</p>
-        <p>The <code>addTransceiver</code> method establishes the <dfn>simulcast envelope</dfn> which
+        <p>The {{RTCPeerConnection/addTransceiver}} method establishes the <dfn>simulcast envelope</dfn> which
         includes the maximum number of simulcast streams that can be sent, as well as the ordering of the
-        <code>encodings</code>. While characteristics of individual simulcast streams can be modified using
-        the <code>setParameters</code> method, the [= simulcast envelope =] cannot be changed. One of the
+        {{RTCRtpSendParameters/encodings}}. While characteristics of individual simulcast streams can be modified using
+        the {{RTCRtpSender/setParameters}} method, the [= simulcast envelope =] cannot be changed. One of the
         implications of this model is that the {{RTCPeerConnection/addTrack()}} method cannot provide simulcast
-        functionality since it does not take <code>sendEncodings</code> as an argument, and therefore cannot
+        functionality since it does not take {{RTCRtpTransceiverInit/sendEncodings}} as an argument, and therefore cannot
         configure an {{RTCRtpTransceiver}} to send simulcast.</p>
         <p>Another implication is that the answerer cannot set the [= simulcast envelope =] directly.
-        Upon calling the <code>setRemoteDescription</code> method of the {{RTCPeerConnection}}
+        Upon calling the {{RTCPeerConnection/setRemoteDescription}} method of the {{RTCPeerConnection}}
         object, the [= simulcast envelope =] is configured on the {{RTCRtpTransceiver}}
         to contain the layers described by the specified {{RTCSessionDescription}}.
         Once the envelope is determined, layers cannot be removed. They can be marked as inactive by setting
-        the <code>active</code> attribute to <code>false</code> effectively disabling the layer.</p>
-        <p>While <code>setParameters</code> cannot modify the [= simulcast envelope =], it is still possible
+        the {{RTCRtpEncodingParameters/active}} member to <code>false</code> effectively disabling the layer.</p>
+        <p>While {{RTCRtpSender/setParameters}} cannot modify the [= simulcast envelope =], it is still possible
         to control the number of streams that are sent and the characteristics of those streams. Using
-        <code>setParameters</code>, simulcast streams can be made inactive by setting the <code>active</code>
-        attribute to <code>false</code>, or can be reactivated by setting the <code>active</code>
-        attribute to <code>true</code>.  Using <code>setParameters</code>, stream characteristics can be
-        changed by modifying attributes such as <code>maxBitrate</code>.</p>
+        {{RTCRtpSender/setParameters}}, simulcast streams can be made inactive by setting the {{RTCRtpEncodingParameters/active}}
+        member to <code>false</code>, or can be reactivated by setting the {{RTCRtpEncodingParameters/active}}
+        member to <code>true</code>.  Using {{RTCRtpSender/setParameters}}, stream characteristics can be
+        changed by modifying attributes such as {{RTCRtpEncodingParameters/maxBitrate}}.</p>
         <p class="note">
           Simulcast is frequently used to send multiple encodings to
           an SFU, which will then forward one of the simulcast streams to the
@@ -7565,11 +7561,11 @@ interface RTCRtpTransceiver {
         <p>As defined in <span data-jsep="simulcast">[[!JSEP]]</span>, an offer from a user-agent will
         only contain a "send" description and no "recv" description on the "a=simulcast" line.
         Alternatives and restrictions (described in [[MMUSIC-SIMULCAST]]) are not supported.</p>
-        <p>This specification does not define how to configure <code>createOffer</code> to receive multiple
-        RTP encodings. However when <code>setRemoteDescription</code> is called with a corresponding remote
+        <p>This specification does not define how to configure {{RTCPeerConnection/createOffer}} to receive multiple
+        RTP encodings. However when {{RTCPeerConnection/setRemoteDescription}} is called with a corresponding remote
         description that is able to send multiple RTP encodings as defined in [[!JSEP]], the
         {{RTCRtpReceiver}} may receive multiple RTP encodings and the parameters retrieved
-        via the transceiver's <code>receiver.getParameters()</code> will reflect the encodings negotiated.</p>
+        via the transceiver's {{RTCRtpTransceiver/receiver}}.{{RTCRtpReceiver/getParameters()}} will reflect the encodings negotiated.</p>
         <p class="note">An {{RTCRtpReceiver}} can receive multiple RTP streams in a scenario
         where a Selective Forwarding Unit (SFU) switches between simulcast streams it receives from user agents.
         If the SFU does not rewrite RTP headers so as to arrange the switched streams into a single RTP
@@ -7677,8 +7673,8 @@ async function onOffHold() {
       {{RTCDtlsTransport}} interface allows access to information
       about the underlying transport and the security added.
       {{RTCDtlsTransport}} objects are constructed as a result
-      of calls to <code>setLocalDescription()</code> and
-      <code>setRemoteDescription()</code>. Each
+      of calls to {{RTCPeerConnection/setLocalDescription()}} and
+      {{RTCPeerConnection/setRemoteDescription()}}. Each
       {{RTCDtlsTransport}} object represents the DTLS transport
       layer for the RTP or RTCP {{RTCIceTransport/component}}
       of a specific {{RTCRtpTransceiver}}, or a group of
@@ -7691,8 +7687,8 @@ async function onOffHold() {
       as opposed to being represented by a new object.</div>
 
       <p data-tests="RTCDtlsTransport-getRemoteCertificates.html">An {{RTCDtlsTransport}} has a
-      <dfn>[[\DtlsTransportState]]</dfn> internal slot initialized to <code>
-      {{RTCDtlsTransportState/new}}</code> and a
+      <dfn>[[\DtlsTransportState]]</dfn> internal slot initialized to
+      {{RTCDtlsTransportState/"new"}} and a
       <dfn>[[\RemoteCertificates]]</dfn> slot initialized to an empty list.</p>
       <p>When the underlying DTLS transport experiences an error, such as
         a certificate validation failure, or a fatal alert (see [[RFC5246]]
@@ -7701,23 +7697,23 @@ async function onOffHold() {
       </p>
       <ol>
         <li>
-          <p>Let <var>transport</var> be the <code>
-              {{RTCDtlsTransport}}</code> object to receive the state update
+          <p>Let <var>transport</var> be the
+              {{RTCDtlsTransport}} object to receive the state update
             and error notification.</p>
         </li>
         <li>
           <p>If the state of <var>transport</var> is
-          already <code>failed</code>, abort these steps.
+          already {{RTCDtlsTransportState/"failed"}}, abort these steps.
           </p>
         </li>
         <li data-tests="protocol/dtls-fingerprint-validation.html">
           <p>Set <var>transport</var>.<a>[[\DtlsTransportState]]</a>
-            to <code>failed</code>.</p>
+            to {{RTCDtlsTransportState/"failed"}}.</p>
         </li>
         <li>
           <p>
             [= Fire an event =] named
-            <code><a data-lt="RTCDtlsTransport error">error</a></code>
+            <code class=event><a data-lt="RTCDtlsTransport error">error</a></code>
             using the {{RTCErrorEvent}} interface with its
             errorDetail attribute set to either "dtls-failure" or
             "fingerprint-failure", as appropriate, and other fields
@@ -7727,7 +7723,7 @@ async function onOffHold() {
         </li>
         <li>
           <p>[= Fire an event =]
-          named <code><a data-lt="RTCDtlsTransport state
+          named <code class=event><a data-lt="RTCDtlsTransport state
           change">statechange</a></code> at <var>transport</var>.</p>
         </li>
       </ol>
@@ -7737,8 +7733,8 @@ async function onOffHold() {
         MUST queue a task that runs the following steps:</p>
       <ol>
         <li>
-          <p>Let <var>transport</var> be the <code>
-          {{RTCDtlsTransport}}</code> object to receive the state update.</p>
+          <p>Let <var>transport</var> be the
+          {{RTCDtlsTransport}} object to receive the state update.</p>
         </li>
         <li>
           <p>Let <var>newState</var> be the new state.</p>
@@ -7757,7 +7753,7 @@ async function onOffHold() {
           <var>newRemoteCertificates</var>.</p>
         </li>
         <li data-tests="RTCDtlsTransport-state.html">
-          <p>[= Fire an event =] named <code><a data-lt="RTCDtlsTransport state change">statechange</a></code>
+          <p>[= Fire an event =] named <code class=event><a data-lt="RTCDtlsTransport state change">statechange</a></code>
           at <var>transport</var>.</p>
         </li>
       </ol>
@@ -7779,7 +7775,7 @@ interface RTCDtlsTransport : EventTarget {
                 ><dfn data-idl>iceTransport</dfn> of type <span class=
             "idlAttrType">{{RTCIceTransport}}</span>, readonly</dt>
             <dd>
-              <p>The <code>iceTransport</code> attribute is the underlying
+              <p>The {{iceTransport}} attribute is the underlying
               transport that is used to send and receive packets. The
               underlying transport may not be shared between multiple active
               {{RTCDtlsTransport}} objects.</p>
@@ -7787,13 +7783,13 @@ interface RTCDtlsTransport : EventTarget {
             <dt data-tests="RTCDtlsTransport-state.html,RTCPeerConnection-connectionState.https.html"><dfn data-idl>state</dfn> of type <span class=
             "idlAttrType">{{RTCDtlsTransportState}}</span>, readonly</dt>
             <dd>
-              <p>The <code>state</code> attribute MUST, on getting, return the
+              <p>The {{state}} attribute MUST, on getting, return the
               value of the <a>[[\DtlsTransportState]]</a> slot.</p>
             </dd>
             <dt data-tests="RTCDtlsTransport-state.html"><dfn data-idl>onstatechange</dfn> of type <span class=
             "idlAttrType">EventHandler</span></dt>
             <dd>
-              The event type of this event handler is <code>
+              The event type of this event handler is <code class=event>
               <a data-lt="RTCDtlsTransport state change">statechange</a></code>.
             </dd>
             <dt><dfn data-idl>onerror</dfn> of type
@@ -7846,7 +7842,7 @@ interface RTCDtlsTransport : EventTarget {
             <tr>
               <td data-tests="RTCDtlsTransport-state.html"><dfn data-idl>closed</dfn></td>
               <td>The transport has been closed intentionally as the result of
-              receipt of a close_notify alert, or calling <code>close()</code>.</td>
+              receipt of a close_notify alert, or calling {{RTCPeerConnection/close()}}.</td>
             </tr>
             <tr>
               <td data-tests="protocol/dtls-fingerprint-validation.html"><dfn data-idl>failed</dfn></td>
@@ -7897,8 +7893,8 @@ interface RTCDtlsTransport : EventTarget {
       packets are sent and received. In particular, ICE manages peer-to-peer
       connections which involve state which the application may want to access.
       {{RTCIceTransport}} objects are constructed as a result
-      of calls to <code>setLocalDescription()</code> and
-      <code>setRemoteDescription()</code>. The underlying ICE state is managed
+      of calls to {{RTCPeerConnection/setLocalDescription()}} and
+      {{RTCPeerConnection/setRemoteDescription()}}. The underlying ICE state is managed
       by the <a>ICE agent</a>; as such, the state of an
       {{RTCIceTransport}} changes when the [= ICE Agent =]
       provides indications to the user agent as described below. Each
@@ -8196,14 +8192,14 @@ interface RTCDtlsTransport : EventTarget {
       </ol>
       <p>An {{RTCIceTransport}} object has the following internal slots:</p>
       <ul>
-        <li><dfn>[[\IceTransportState]]</dfn> initialized to <code>
-        {{RTCIceTransportState/new}}</code></li>
-        <li><dfn>[[\IceGathererState]]</dfn> initialized to <code>
-        {{RTCIceGatheringState/new}}</code></li>
+        <li><dfn>[[\IceTransportState]]</dfn> initialized to
+        {{RTCIceTransportState/"new"}}</li>
+        <li><dfn>[[\IceGathererState]]</dfn> initialized to
+        {{RTCIceGatheringState/"new"}}</li>
         <li data-tests="RTCIceTransport.html"><dfn>[[\SelectedCandidatePair]]</dfn> initialized to
           <code>null</code></li>
-        <li><dfn>[[\IceRole]]</dfn> initialized to <code>
-            {{RTCIceRole/unknown}}</code>
+        <li><dfn>[[\IceRole]]</dfn> initialized to
+            {{RTCIceRole/"unknown"}}
         </li>
       </ul>
       <div>
@@ -8227,35 +8223,35 @@ interface RTCIceTransport : EventTarget {
           <h2>Attributes</h2>
           <dl data-link-for="RTCIceTransport" data-dfn-for="RTCIceTransport"
           class="attributes">
-            <dt><code>role</code> of type <span class=
+            <dt><dfn id="dom-icetransport-role">role</dfn> of type <span class=
             "idlAttrType">{{RTCIceRole}}</span>, readonly</dt>
             <dd>
-              <p>The <dfn id="dom-icetransport-role"><code>role</code></dfn>
+              <p>The {{role}}
                 attribute MUST, on getting, return the value of the [[\IceRole]]
                 internal slot.</p>
             </dd>
-            <dt><code>component</code> of type <span class=
+            <dt><dfn id=
+              "dom-icetransport-component">component</dfn> of type <span class=
             "idlAttrType">{{RTCIceComponent}}</span>, readonly</dt>
             <dd>
-              <p>The <dfn id=
-              "dom-icetransport-component"><code>component</code></dfn>
+              <p>The {{component}}
               attribute MUST return the ICE component of the transport. When
               RTCP mux is used, a single
               {{RTCIceTransport}} transports both RTP and RTCP
-              and <code>component</code> is set to "RTP".</p>
+              and {{component}} is set to "RTP".</p>
             </dd>
-            <dt><code>state</code> of type <span class=
+            <dt><dfn id="dom-icetransport-state">state</dfn> of type <span class=
             "idlAttrType">{{RTCIceTransportState}}</span>, readonly</dt>
             <dd>
-              <p>The <dfn id="dom-icetransport-state"><code>state</code></dfn>
+              <p>The {{state}}
               attribute MUST, on getting, return the value of the
               <a>[[\IceTransportState]]</a> slot.</p>
             </dd>
-            <dt><dfn data-idl>gatheringState</dfn> of type <span class=
+            <dt><dfn  id="dom-icetransport-gatheringstate" data-idl>gatheringState</dfn> of type <span class=
             "idlAttrType">{{RTCIceGathererState}}</span>, readonly</dt>
             <dd>
-              <p>The <dfn id="dom-icetransport-gatheringstate"><code>gathering
-              state</code></dfn> attribute MUST, on getting, return the value
+              <p>The {{gatheringState}}
+              attribute MUST, on getting, return the value
               of the <a>[[\IceGathererState]]</a> slot.</p>
             </dd>
             <dt><dfn data-idl>onstatechange</dfn> of type <span class=
@@ -8271,7 +8267,7 @@ interface RTCIceTransport : EventTarget {
             <dd>
               This event handler, of event handler event type
               {{gatheringstatechange}}, MUST be fired any time
-              the {{RTCIceTransport}} [= gathering state =]
+              the {{RTCIceTransport}} [= ICE gathering state =]
               changes.
             </dd>
             <dt><dfn data-idl>onselectedcandidatepairchange</dfn> of type
@@ -8298,7 +8294,7 @@ interface RTCIceTransport : EventTarget {
               received by this {{RTCIceTransport}} via
               {{RTCPeerConnection/addIceCandidate()}}</p>
               <div class="note">
-                <code>getRemoteCandidates</code> will not expose peer reflexive
+                {{getRemoteCandidates}} will not expose peer reflexive
                 candidates since they are not received via {{RTCPeerConnection/addIceCandidate()}}.
               </div>
             </dd>
@@ -8306,8 +8302,8 @@ interface RTCIceTransport : EventTarget {
             <dd>
               <p>Returns the selected candidate pair on which packets are sent. This
               method MUST return the value of the <a>[[\SelectedCandidatePair]]</a>
-              slot. When <code>{{RTCIceTransport}}.state</code> is {{RTCIceTransportState/"new"}} or
-              {{RTCIceTransportState/"closed"}} <code>getSelectedCandidatePair</code> returns
+              slot. When {{RTCIceTransport}}.{{RTCIceTransport/state}} is {{RTCIceTransportState/"new"}} or
+              {{RTCIceTransportState/"closed"}} {{getSelectedCandidatePair}} returns
               <code>null</code>.</p>
             </dd>
             <dt data-tests="RTCIceTransport.html"><dfn data-idl>getLocalParameters</dfn></dt>
@@ -8501,7 +8497,7 @@ interface RTCIceTransport : EventTarget {
               have either failed connectivity checks or have lost consent.
               This is a terminal state until ICE is restarted. Since an ICE
               restart may cause connectivity to resume, entering the
-              <code>failed</code> state does not cause DTLS transports, SCTP
+              {{RTCIceTransportState/"failed"}} state does not cause DTLS transports, SCTP
               associations or the data channels that run over them to close, or
               tracks to mute.</td>
             </tr>
@@ -8535,26 +8531,26 @@ interface RTCIceTransport : EventTarget {
       <p>Some example state transitions are:</p>
       <ul>
         <li>({{RTCIceTransport}} first created, as a result of
-        <code>setLocalDescription</code> or <code>setRemoteDescription</code>):
-        <code>new</code></li>
-        <li>(<code>new</code>, remote candidates received):
-        <code>checking</code></li>
-        <li>(<code>checking</code>, found usable connection):
-        <code>connected</code></li>
-        <li>(<code>checking</code>, checks fail but gathering still in
-        progress): <code>disconnected</code></li>
-        <li>(<code>checking</code>, gave up): <code>failed</code></li>
-        <li>(<code>disconnected</code>, new local candidates):
-        <code>checking</code></li>
-        <li>(<code>connected</code>, finished all checks):
-        <code>completed</code></li>
-        <li>(<code>completed</code>, lost connectivity):
-        <code>disconnected</code></li>
-        <li>(<code>disconnected</code> or <code>failed</code>, ICE restart occurs):
-        <code>checking</code></li>
-        <li>(<code>completed</code>, ICE restart occurs):
-        <code>connected</code></li>
-        <li><code>RTCPeerConnection.close()</code>: <code>closed</code></li>
+        {{RTCPeerConnection/setLocalDescription}} or {{RTCPeerConnection/setRemoteDescription}}):
+        {{RTCIceTransportState/"new"}}</li>
+        <li>({{RTCIceTransportState/"new"}}, remote candidates received):
+        {{RTCIceTransportState/"checking"}}</li>
+        <li>({{RTCIceTransportState/"checking"}}, found usable connection):
+        {{RTCIceTransportState/"connected"}}</li>
+        <li>({{RTCIceTransportState/"checking"}}, checks fail but gathering still in
+        progress): {{RTCIceTransportState/"disconnected"}}</li>
+        <li>({{RTCIceTransportState/"checking"}}, gave up): {{RTCIceTransportState/"failed"}}</li>
+        <li>({{RTCIceTransportState/"disconnected"}}, new local candidates):
+        {{RTCIceTransportState/"checking"}}</li>
+        <li>({{RTCIceTransportState/"connected"}}, finished all checks):
+        {{RTCIceTransportState/"completed"}}</li>
+        <li>({{RTCIceTransportState/"completed"}}, lost connectivity):
+        {{RTCIceTransportState/"disconnected"}}</li>
+        <li>({{RTCIceTransportState/"disconnected"}} or {{RTCIceTransportState/"failed"}}, ICE restart occurs):
+        {{RTCIceTransportState/"checking"}}</li>
+        <li>({{RTCIceTransportState/"completed"}}, ICE restart occurs):
+        {{RTCIceTransportState/"connected"}}</li>
+        <li>{{RTCPeerConnection}}.{{RTCPeerConnection/close()}}: {{RTCIceTransportState/"closed"}}</li>
       </ul>
       <figure>
         <img alt="ICE transport state transition diagram" src=
@@ -8616,13 +8612,13 @@ interface RTCIceTransport : EventTarget {
               <td>The ICE Transport is used for RTP (or RTCP multiplexing),
               as defined in [[!ICE]], Section 4.1.1.1. Protocols multiplexed
               with RTP (e.g. data channel) share its component ID. This represents
-              the <code>component-id</code> value <code>1</code> when encoded
+              the <code class=ice>component-id</code> value <code>1</code> when encoded
               in [= candidate-attribute =].</td>
             </tr>
             <tr>
               <td><dfn data-idl>rtcp</dfn></td>
               <td>The ICE Transport is used for RTCP as defined by [[!ICE]],
-              Section 4.1.1.1. This represents the <code>component-id</code>
+              Section 4.1.1.1. This represents the <code class=ice>component-id</code>
               value <code>2</code> when encoded in
               [= candidate-attribute =].</td>
             </tr>
@@ -8649,7 +8645,7 @@ interface RTCTrackEvent : Event {
           <h2>Constructors</h2>
           <dl data-link-for="RTCTrackEvent" data-dfn-for="RTCTrackEvent" class=
           "constructors">
-            <dt data-tests="RTCTrackEvent-constructor.html"><dfn><code>RTCTrackEvent.constructor()</code></dfn></dt>
+            <dt data-tests="RTCTrackEvent-constructor.html"><dfn>RTCTrackEvent.constructor()</dfn></dt>
             <dd>
             </dd>
           </dl>
@@ -8658,36 +8654,36 @@ interface RTCTrackEvent : Event {
           <h2>Attributes</h2>
           <dl data-link-for="RTCTrackEvent" data-dfn-for="RTCTrackEvent" class=
           "attributes">
-            <dt data-tests="RTCPeerConnection-ontrack.https.html,RTCTrackEvent-constructor.html"><code>receiver</code> of type <span class=
+            <dt data-tests="RTCPeerConnection-ontrack.https.html,RTCTrackEvent-constructor.html"><dfn id=
+              "dom-trackevent-receiver">receiver</dfn> of type <span class=
             "idlAttrType">{{RTCRtpReceiver}}</span>, readonly</dt>
             <dd>
-              <p>The <dfn id=
-              "dom-trackevent-receiver"><code>receiver</code></dfn> attribute
+              <p>The {{receiver}} attribute
               represents the {{RTCRtpReceiver}} object
               associated with the event.</p>
             </dd>
             <dt data-tests="RTCPeerConnection-ontrack.https.html,RTCTrackEvent-constructor.html"><dfn data-idl>track</dfn> of type <span class=
             "idlAttrType">{{MediaStreamTrack}}</span>, readonly</dt>
             <dd>
-              <p>The <code>track</code> attribute represents the
+              <p>The {{track}} attribute represents the
               {{MediaStreamTrack}} object that is associated
               with the {{RTCRtpReceiver}} identified by
-              <code>receiver</code>.</p>
+              {{receiver}}.</p>
             </dd>
-            <dt data-tests="RTCPeerConnection-ontrack.https.html,RTCTrackEvent-constructor.html"><code>streams</code> of type <span class=
+            <dt data-tests="RTCPeerConnection-ontrack.https.html,RTCTrackEvent-constructor.html"><dfn data-idl>streams</dfn> of type <span class=
             "idlAttrType">FrozenArray&lt;{{MediaStream}}&gt;</span>,
             readonly</dt>
             <dd>
-              <p>The <dfn data-idl>streams</dfn> attribute returns an array
+              <p>The {{streams}} attribute returns an array
               of {{MediaStream}} objects representing the
               {{MediaStream}}s that this event's
-              <code>track</code> is a part of.</p>
+              {{track}} is a part of.</p>
             </dd>
-            <dt data-tests="RTCPeerConnection-ontrack.https.html,RTCTrackEvent-constructor.html"><code>transceiver</code> of type <span class=
+            <dt data-tests="RTCPeerConnection-ontrack.https.html,RTCTrackEvent-constructor.html"><dfn id=
+              "dom-trackevent-transceiver">transceiver</dfn> of type <span class=
             "idlAttrType">{{RTCRtpTransceiver}}</span>, readonly</dt>
             <dd>
-              <p>The <dfn id=
-              "dom-trackevent-transceiver"><code>transceiver</code></dfn>
+              <p>The {{transceiver}}
               attribute represents the {{RTCRtpTransceiver}}
               object associated with the event.</p>
             </dd>
@@ -8709,31 +8705,31 @@ interface RTCTrackEvent : Event {
             <dt data-tests="RTCTrackEvent-constructor.html"><dfn data-idl>receiver</dfn> of type <span class=
             "idlMemberType">{{RTCRtpReceiver}}</span>, required</dt>
             <dd>
-              <p>The <code>receiver</code> attribute represents the
+              <p>The {{receiver}} member represents the
               {{RTCRtpReceiver}} object associated with the
               event.</p>
             </dd>
             <dt data-tests="RTCTrackEvent-constructor.html"><dfn data-idl>track</dfn> of type <span class=
             "idlMemberType">{{MediaStreamTrack}}</span>, required</dt>
             <dd>
-              <p>The <code>track</code> attribute represents the
+              <p>The {{track}} member represents the
               {{MediaStreamTrack}} object that is associated
               with the {{RTCRtpReceiver}} identified by
-              <code>receiver</code>.</p>
+              {{RTCTrackEventInit/receiver}}.</p>
             </dd>
             <dt data-tests="RTCTrackEvent-constructor.html"><dfn data-idl>streams</dfn> of type <span class=
             "idlMemberType">sequence&lt;{{MediaStream}}&gt;</span>,
             defaulting to <code>[]</code></dt>
             <dd>
-              <p>The <code>streams</code> attribute returns an array of
+              <p>The {{streams}} member is an array of
               {{MediaStream}} objects representing the
               {{MediaStream}}s that this event's
-              <code>track</code> is a part of.</p>
+              {{track}} is a part of.</p>
             </dd>
             <dt data-tests="RTCTrackEvent-constructor.html"><dfn data-idl>transceiver</dfn> of type <span class=
             "idlMemberType">{{RTCRtpTransceiver}}</span>, required</dt>
             <dd>
-              <p>The <code>transceiver</code> attribute represents the
+              <p>The {{transceiver}} attribute represents the
               {{RTCRtpTransceiver}} object associated with the
               event.</p>
             </dd>
@@ -8783,14 +8779,14 @@ interface RTCTrackEvent : Event {
           <h2>Methods</h2>
           <dl data-link-for="RTCPeerConnection" data-dfn-for=
           "RTCPeerConnection" class="methods">
-            <dt><code>createDataChannel</code></dt>
+            <dt><dfn id=
+              "dom-peerconnection-createdatachannel">createDataChannel</dfn></dt>
             <dd>
               <p>Creates a new {{RTCDataChannel}} object with
               the given label. The {{RTCDataChannelInit}}
               dictionary can be used to configure properties of the underlying
               channel such as data reliability.</p>
-              <p>When the <dfn id=
-              "dom-peerconnection-createdatachannel"><code>createDataChannel</code></dfn>
+              <p>When the {{createDataChannel}}
               method is invoked, the user agent MUST run the following
               steps.</p>
               <ol>
@@ -8823,21 +8819,21 @@ interface RTCTrackEvent : Event {
                 <li data-tests="RTCPeerConnection-createDataChannel.html">
                   <p>Initialize <var>channel</var>.<a>[[\MaxPacketLifeTime]]</a>
                   to <var>option</var>'s
-                  <code>maxPacketLifeTime</code> member, if present, otherwise
+                  {{RTCDataChannelInit/maxPacketLifeTime}} member, if present, otherwise
                   <code>null</code>.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-createDataChannel.html">
                   <p>Initialize <var>channel</var>.<a>[[\MaxRetransmits]]</a>
-                  to <var>option</var>'s <code>maxRetransmits</code>
+                  to <var>option</var>'s {{RTCDataChannelInit/maxRetransmits}}
                   member, if present, otherwise <code>null</code>.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-createDataChannel.html">
                   <p>Initialize <var>channel</var>.<a>[[\Ordered]]</a>
-                  to <var>option</var>'s <code>ordered</code> member.</p>
+                  to <var>option</var>'s {{RTCDataChannelInit/ordered}} member.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-createDataChannel.html">
                   <p>Initialize <var>channel</var>.<a>[[\DataChannelProtocol]]</a> to <var>option</var>'s
-                  <code>protocol</code> member.</p>
+                  {{RTCDataChannelInit/protocol}} member.</p>
                 </li>
                 <li data-tests="RTCPeerConnection-createDataChannel.html">
                   <p>If the UTF-8 representation of
@@ -8846,16 +8842,16 @@ interface RTCTrackEvent : Event {
                 </li>
                 <li data-tests="RTCPeerConnection-createDataChannel.html">
                   <p>Initialize <var>channel</var>.<a>[[\Negotiated]]</a>
-                  to <var>option</var>'s <code>negotiated</code> member.</p>
+                  to <var>option</var>'s {{RTCDataChannelInit/negotiated}} member.</p>
                 </li>
                 <li>
                   <p>Initialize <var>channel</var>.<a>[[\DataChannelId]]</a>
                   to the value of <var>option</var>'s
-                  <code>id</code> member, if it is present and
+                  {{RTCDataChannelInit/id}} member, if it is present and
                   <a>[[\Negotiated]]</a> is true, otherwise
                   <code>null</code>.</p>
                   <div class="note">
-                    This means the <code>id</code> member will be ignored if
+                    This means the {{RTCDataChannelInit/id}} member will be ignored if
                     the data channel is negotiated in-band; this is
                     intentional. Data channels negotiated in-band should have
                     IDs selected based on the DTLS role, as specified in
@@ -8889,7 +8885,7 @@ interface RTCTrackEvent : Event {
                 <li data-tests="RTCPeerConnection-createDataChannel.html,RTCDataChannel-id.html">
                   <p>If the <a>[[\DataChannelId]]</a>
                   slot is <code>null</code> (due to no ID being passed into
-                  <code>createDataChannel</code>, or <a>[[\Negotiated]]</a> being false),
+                  {{createDataChannel}}, or <a>[[\Negotiated]]</a> being false),
                   and the DTLS role of the SCTP transport has already been
                   negotiated, then initialize <a>[[\DataChannelId]]</a>
                   to a value generated by the
@@ -8909,7 +8905,7 @@ interface RTCTrackEvent : Event {
                   <p>Let <var>transport</var> be the <var>connection</var>.<a>[[\SctpTransport]]</a>.</p>
                   <p>If the <a>[[\DataChannelId]]</a> slot is not
                   <code>null</code>, <var>transport</var> is in the
-                  <code>connected</code> state and <a>[[\DataChannelId]]</a> is
+                  {{RTCSctpTransportState/"connected"}} state and <a>[[\DataChannelId]]</a> is
                   greater or equal to the <var>transport</var>.<a>[[\MaxChannels]]</a>, [= exception/throw =] an
                   {{OperationError}}.</p>
                 </li>
@@ -8945,14 +8941,14 @@ interface RTCTrackEvent : Event {
           steps:</p>
           <ol>
             <li data-tests="RTCSctpTransport-constructor.html,RTCSctpTransport-events.html ">
-              <p>Let <var>transport</var> be a new <code>
-              {{RTCSctpTransport}}</code> object.</p>
+              <p>Let <var>transport</var> be a new
+              {{RTCSctpTransport}} object.</p>
             </li>
             <li>
               <p>Let <var>transport</var> have a
               <dfn>[[\SctpTransportState]]</dfn> internal slot initialized to
               <var>initialState</var>, if provided, otherwise
-              <code>"new"</code>.</p>
+              <code class=fixme>"new"</code>.</p>
             </li>
             <li>
               <p>Let <var>transport</var> have a <dfn>[[\MaxMessageSize]]</dfn>
@@ -8971,8 +8967,8 @@ interface RTCTrackEvent : Event {
         <section>
           <h4 id="sctp-transport-update-mms">Update max message
           size</h4>
-          <p>To <dfn>update the data max message size</dfn> of an <code>
-          {{RTCSctpTransport}}</code> run the following
+          <p>To <dfn>update the data max message size</dfn> of an
+          {{RTCSctpTransport}} run the following
           steps:</p>
           <ol>
             <li>
@@ -9049,7 +9045,7 @@ interface RTCTrackEvent : Event {
               </ol>
             </li>
             <li>
-              <p>[= Fire an event =] named <code><a data-lt="
+              <p>[= Fire an event =] named <code class=event><a data-lt="
               RTCSctpTransport state change">statechange</a></code> at <var>
                   transport</var>.</p>
               <p class="note">This event is fired before the "open" events
@@ -9104,14 +9100,14 @@ interface RTCSctpTransport : EventTarget {
                 </p>
                 <div class="note">This attribute's value will be
                 <code>null</code> until the SCTP transport goes into the
-                <code>connected</code> state.
+                {{RTCSctpTransportState/"connected"}} state.
                 </div>
               </dd>
               <dt data-tests="RTCSctpTransport-events.html"><dfn data-idl>onstatechange</dfn> of type <span class=
               "idlAttrType">EventHandler</span></dt>
               <dd>
                 <p>The event type of this event handler is
-                <code><a data-lt="RTCSctpTransport state change">statechange</a></code>.</p>
+                <code class=event><a data-lt="RTCSctpTransport state change">statechange</a></code>.</p>
               </dd>
             </dl>
           </section>
@@ -9135,8 +9131,8 @@ interface RTCSctpTransport : EventTarget {
                 <th colspan="2">Enumeration description</th>
               </tr>
               <tr>
-                <td data-tests="RTCSctpTransport-events.html"><dfn data-idl><code id=
-                "idl-def-RTCSctpTransportState.connecting">connecting</code></dfn></td>
+                <td data-tests="RTCSctpTransport-events.html"><dfn data-idl id=
+                "idl-def-RTCSctpTransportState.connecting">connecting</dfn></td>
                 <td>
                   <p>The {{RTCSctpTransport}} is in the process of
                   negotiating an association. This is the initial state of the
@@ -9145,8 +9141,8 @@ interface RTCSctpTransport : EventTarget {
                 </td>
               </tr>
               <tr>
-                <td data-tests="RTCSctpTransport-events.html"><dfn data-idl><code id=
-                "idl-def-RTCSctpTransportState.connected">connected</code></dfn></td>
+                <td data-tests="RTCSctpTransport-events.html"><dfn data-idl id=
+                "idl-def-RTCSctpTransportState.connected">connected</dfn></td>
                 <td>
                   <p>When the negotiation of an association is completed, a task is
                   queued to update the [[\SctpTransportState]] slot to
@@ -9154,8 +9150,8 @@ interface RTCSctpTransport : EventTarget {
                 </td>
               </tr>
               <tr>
-                <td data-tests="RTCSctpTransport-events.html"><dfn data-idl><code id=
-                "idl-def-RTCSctpTransportState.closed">closed</code></dfn></td>
+                <td data-tests="RTCSctpTransport-events.html"><dfn data-idl id=
+                "idl-def-RTCSctpTransportState.closed">closed</dfn></td>
                 <td>
                   <p>A task is queued to update the [[\SctpTransportState]]
                     slot to {{RTCSctpTransportState/"closed"}} when:
@@ -9237,7 +9233,7 @@ interface RTCSctpTransport : EventTarget {
       reliable channel.</p>
       <p>An {{RTCDataChannel}}, created with {{RTCPeerConnection/createDataChannel}} or dispatched via an
       {{RTCDataChannelEvent}}, MUST initially be in the
-      <code>connecting</code> state. When the
+      {{RTCDataChannelState/"connecting"}} state. When the
       {{RTCDataChannel}} object's [= underlying data
       transport =] is ready, the user agent MUST [= announce the
         RTCDataChannel as open =].</p>
@@ -9247,8 +9243,8 @@ interface RTCSctpTransport : EventTarget {
       following steps:</p>
       <ol>
         <li>
-          <p>Let <var>channel</var> be a newly created <code>
-          {{RTCDataChannel}}</code> object.</p>
+          <p>Let <var>channel</var> be a newly created
+          {{RTCDataChannel}} object.</p>
         </li>
         <li data-tests="RTCPeerConnection-ondatachannel.html">
           <p>Let <var>channel</var> have a <dfn>[[\ReadyState]]</dfn> internal
@@ -9421,12 +9417,11 @@ interface RTCSctpTransport : EventTarget {
           <dfn id="data-transport-closed-error">with an error</dfn>, [= fire
           an event =] named {{error}} using the
           {{RTCErrorEvent}} interface with its
-          <code>errorDetail</code> attribute set to "sctp-failure"
+          {{RTCError/errorDetail}} attribute set to "sctp-failure"
           at <var>channel</var>.</p>
         </li>
         <li>
-          <p>[= Fire an event =] named <code title=
-          "event-RTCDataChannel-close">{{close}}</code> at
+          <p>[= Fire an event =] named {{close}} at
           <var>channel</var>.</p>
         </li>
       </ol>
@@ -9454,12 +9449,11 @@ interface RTCSctpTransport : EventTarget {
         <li>
           <p>[= Fire an event =] named {{RTCDataChannel/error}} using the
           {{RTCErrorEvent}} interface with the
-          <code>errorDetail</code> attribute set to
+          {{RTCError/errorDetail}} attribute set to
           "data-channel-failure" at <var>channel</var>.</p>
         </li>
         <li>
-          <p>[= Fire an event =] named <code title=
-          "event-RTCDataChannel-close">{{close}}</code> at
+          <p>[= Fire an event =] named {{close}} at
           <var>channel</var>.</p>
         </li>
       </ol>
@@ -9488,24 +9482,24 @@ interface RTCSctpTransport : EventTarget {
         </li>
         <li data-tests="RTCDataChannel-bufferedAmount.html,RTCDataChannel-send.html">
           <p>Execute the sub step by switching on <var>type</var> and the
-          <var>channel</var>'s <code>binaryType</code>:</p>
+          <var>channel</var>'s {{RTCDataChannel/binaryType}}:</p>
           <ul>
             <li data-tests="datachannel-emptystring.html">
               <p>If <var>type</var> indicates that <var>rawData</var> is a
-              <code>string</code>:</p>
+              <code class=param>string</code>:</p>
               <p>Let <var>data</var> be a <span class=
               "idlMemberType">DOMString</span> that represents the
               result of decoding <var>rawData</var> as UTF-8.</p>
             </li>
             <li>
               <p>If <var>type</var> indicates that <var>rawData</var> is binary
-              and <code>binaryType</code> is <code>"blob"</code>:</p>
+              and {{RTCDataChannel/binaryType}} is <code class=html>"blob"</code>:</p>
               <p>Let <var>data</var> be a new {{Blob}} object
               containing <var>rawData</var> as its raw data source.</p>
             </li>
             <li>
               <p>If <var>type</var> indicates that <var>rawData</var> is binary
-              and <code>binaryType</code> is <code>"arraybuffer"</code>:</p>
+              and {{RTCDataChannel/binaryType}} is <code class=html>"arraybuffer"</code>:</p>
               <p>Let <var>data</var> be a new {{ArrayBuffer}} object
               containing <var>rawData</var> as its raw data source.</p>
             </li>
@@ -9513,11 +9507,11 @@ interface RTCSctpTransport : EventTarget {
         </li>
         <li data-tests="RTCDataChannel-send.html,datachannel-emptystring.html">
           <p>[= Fire an event =] named {{message}} using the
-          <code title="event-datachannel-message">{{MessageEvent}}</code>
-          interface with its <code>origin</code> attribute initialized to the
+          {{MessageEvent}}
+          interface with its <code class=html>origin</code> attribute initialized to the
           <a data-cite="html">serialization of an origin</a>
           of <var>connection</var>'s <a>[[\DocumentOrigin]]</a>,
-          and the <code>data</code> attribute initialized to <var>data</var> at
+          and the <code class=html>data</code> attribute initialized to <var>data</var> at
           <var>channel</var>.</p>
         </li>
       </ol>
@@ -9553,10 +9547,10 @@ interface RTCDataChannel : EventTarget {
           <h2>Attributes</h2>
           <dl data-link-for="RTCDataChannel" data-dfn-for="RTCDataChannel"
           class="attributes">
-            <dt data-tests="RTCPeerConnection-createDataChannel.html"><code>label</code> of type <span class=
+            <dt data-tests="RTCPeerConnection-createDataChannel.html"><dfn id="dom-datachannel-label">label</dfn> of type <span class=
             "idlAttrType">USVString</span>, readonly</dt>
             <dd>
-              <p>The <dfn id="dom-datachannel-label"><code>label</code></dfn>
+              <p>The {{label}}
               attribute represents a label that can be used to distinguish this
               {{RTCDataChannel}} object from other
               {{RTCDataChannel}} objects. Scripts are allowed
@@ -9564,52 +9558,52 @@ interface RTCDataChannel : EventTarget {
               with the same label. On getting, the attribute MUST return the
               value of the <a>[[\DataChannelLabel]]</a> slot.</p>
             </dd>
-            <dt data-tests="RTCPeerConnection-createDataChannel.html"><code>ordered</code> of type <span class=
+            <dt data-tests="RTCPeerConnection-createDataChannel.html"><dfn id=
+              "dom-datachannel-ordered">ordered</dfn> of type <span class=
             "idlAttrType">boolean</span>, readonly</dt>
             <dd>
-              <p>The <dfn id=
-              "dom-datachannel-ordered"><code>ordered</code></dfn> attribute
+              <p>The {{ordered}} attribute
               returns true if the {{RTCDataChannel}} is
               ordered, and false if out of order delivery is allowed. On
               getting, the attribute MUST return the value of the <a>[[\Ordered]]</a> slot.</p>
             </dd>
-            <dt data-tests="RTCPeerConnection-createDataChannel.html"><code>maxPacketLifeTime</code> of type <span class=
+            <dt data-tests="RTCPeerConnection-createDataChannel.html"><dfn id=
+              "dom-datachannel-maxpacketlifetime">maxPacketLifeTime</dfn> of type <span class=
             "idlAttrType">unsigned short</span>, readonly,
             nullable</dt>
             <dd>
-              <p>The <dfn id=
-              "dom-datachannel-maxpacketlifetime"><code>maxPacketLifeTime</code></dfn>
+              <p>The {{maxPacketLifeTime}}
               attribute returns the length of the time window (in milliseconds)
               during which transmissions and retransmissions may occur in
               unreliable mode. On getting, the attribute MUST return the value
               of the <a>[[\MaxPacketLifeTime]]</a>
               slot.</p>
             </dd>
-            <dt data-tests="RTCPeerConnection-createDataChannel.html"><code>maxRetransmits</code> of type <span class=
+            <dt data-tests="RTCPeerConnection-createDataChannel.html"><dfn id=
+              "dom-datachannel-maxretransmits">maxRetransmits</dfn> of type <span class=
             "idlAttrType">unsigned short</span>, readonly,
             nullable</dt>
             <dd>
-              <p>The <dfn id=
-              "dom-datachannel-maxretransmits"><code>maxRetransmits</code></dfn>
+              <p>The {{maxRetransmits}}
               attribute returns the maximum number of retransmissions that are
               attempted in unreliable mode. On getting, the attribute MUST
               return the value of the <a>[[\MaxRetransmits]]</a> slot.</p>
             </dd>
-            <dt data-tests="RTCPeerConnection-createDataChannel.html"><code>protocol</code> of type <span class=
+            <dt data-tests="RTCPeerConnection-createDataChannel.html"><dfn id=
+              "dom-datachannel-protocol">protocol</dfn> of type <span class=
             "idlAttrType">USVString</span>, readonly</dt>
             <dd>
-              <p>The <dfn id=
-              "dom-datachannel-protocol"><code>protocol</code></dfn> attribute
+              <p>The {{protocol}} attribute
               returns the name of the sub-protocol used with this
               {{RTCDataChannel}}. On getting, the attribute MUST
               return the value of the <a>[[\DataChannelProtocol]]</a>
               slot.</p>
             </dd>
-            <dt data-tests="RTCPeerConnection-createDataChannel.html,RTCPeerConnection-ondatachannel.html"><code>negotiated</code> of type <span class=
+            <dt data-tests="RTCPeerConnection-createDataChannel.html,RTCPeerConnection-ondatachannel.html"><dfn id=
+              "dom-datachannel-negotiated">negotiated</dfn> of type <span class=
             "idlAttrType">boolean</span>, readonly</dt>
             <dd>
-              <p>The <dfn id=
-              "dom-datachannel-negotiated"><code>negotiated</code></dfn>
+              <p>The {{negotiated}}
               attribute returns true if this {{RTCDataChannel}}
               was negotiated by the application, or false otherwise. On getting,
               the attribute MUST return the value of the <a>[[\Negotiated]]</a> slot.</p>
@@ -9617,7 +9611,7 @@ interface RTCDataChannel : EventTarget {
             <dt data-tests="RTCDataChannel-id.html, RTCPeerConnection-createDataChannel.html"><dfn data-idl>id</dfn> of type <span class=
             "idlAttrType">unsigned short</span>, readonly, nullable</dt>
             <dd>
-              <p>The <code>id</code> attribute returns the ID for this
+              <p>The {{id}} attribute returns the ID for this
               {{RTCDataChannel}}. The value is initially null,
               which is what will be returned
               if the ID was not provided at channel creation time, and the DTLS
@@ -9628,20 +9622,20 @@ interface RTCDataChannel : EventTarget {
               value, it will not change. On getting, the attribute MUST return
               the value of the <a>[[\DataChannelId]]</a> slot.</p>
             </dd>
-            <dt data-tests="RTCDataChannel-send.html, RTCPeerConnection-createDataChannel.html"><code>readyState</code> of type <span class=
+            <dt data-tests="RTCDataChannel-send.html, RTCPeerConnection-createDataChannel.html"><dfn id=
+              "dom-datachannel-readystate">readyState</dfn> of type <span class=
             "idlAttrType">{{RTCDataChannelState}}</span>, readonly</dt>
             <dd>
-              <p>The <dfn id=
-              "dom-datachannel-readystate"><code>readyState</code></dfn>
+              <p>The {{readyState}}
               attribute represents the state of the {{RTCDataChannel}}
               object. On getting, the attribute MUST return the value
               of the <a>[[\ReadyState]]</a> slot.</p>
             </dd>
-            <dt><code>bufferedAmount</code> of type <span class=
+            <dt><dfn id=
+              "dom-datachannel-bufferedamount">bufferedAmount</dfn> of type <span class=
             "idlAttrType">unsigned long</span>, readonly</dt>
             <dd>
-              <p data-tests="RTCDataChannel-bufferedAmount.html">The <dfn id=
-              "dom-datachannel-bufferedamount"><code>bufferedAmount</code></dfn>
+              <p data-tests="RTCDataChannel-bufferedAmount.html">The {{bufferedAmount}}
               attribute MUST, on getting, return the value of the
               <a>[[\BufferedAmount]]</a> slot. The attribute exposes the number
               of bytes of application data
@@ -9661,14 +9655,13 @@ interface RTCDataChannel : EventTarget {
               <a>[[\BufferedAmount]]</a> with the number of bytes that was
               sent.</p>
             </dd>
-            <dt data-tests="RTCDataChannel-bufferedAmount.html"><code>bufferedAmountLowThreshold</code> of type <span class=
+            <dt data-tests="RTCDataChannel-bufferedAmount.html"><dfn data-idl>bufferedAmountLowThreshold</dfn> of type <span class=
             "idlAttrType">unsigned long</span></dt>
             <dd>
-              <p>The <dfn data-idl>bufferedAmountLowThreshold</dfn>
+              <p>The {{bufferedAmountLowThreshold}}
               attribute sets the threshold at which the {{RTCDataChannel/bufferedAmount}} is considered to be
               low. When the {{RTCDataChannel/bufferedAmount}} decreases from above
-              this threshold to equal or below it, the <code title=
-              "event-RTCDataChannel-bufferedamountlow">{{bufferedamountlow}}</code>
+              this threshold to equal or below it, the {{bufferedamountlow}}
               event fires. The {{RTCDataChannel/bufferedAmountLowThreshold}} is
               initially zero on each new {{RTCDataChannel}},
               but the application may change its value at any time.</p>
@@ -9685,9 +9678,9 @@ interface RTCDataChannel : EventTarget {
             "idlAttrType">EventHandler</span></dt>
             <dd>
               <p>The event type of this event handler is {{RTCErrorEvent}}.
-              <code>errorDetail</code> contains "sctp-failure",
-              <code>sctpCauseCode</code> contains the SCTP
-              Cause Code value, and <code>message</code>
+              {{RTCError/errorDetail}} contains "sctp-failure",
+              {{RTCError/sctpCauseCode}} contains the SCTP
+              Cause Code value, and {{DOMException/message}}
               contains the SCTP Cause-Specific-Information,
               possibly with additional text.</p></dd>
             <dt><dfn data-idl>onclosing</dfn> of type <span class=
@@ -9702,19 +9695,19 @@ interface RTCDataChannel : EventTarget {
             "idlAttrType">EventHandler</span></dt>
             <dd><p>The event type of this event handler is
             {{message}}.</p></dd>
-            <dt data-tests="RTCDataChannel-send.html"><code>binaryType</code> of type <span class=
+            <dt data-tests="RTCDataChannel-send.html"><dfn id=
+              "dom-datachannel-binarytype">binaryType</dfn> of type <span class=
             "idlAttrType">DOMString</span></dt>
             <dd data-cite="html">
-              <p>The <dfn id=
-              "dom-datachannel-binarytype"><code>binaryType</code></dfn>
+              <p>The {{binaryType}}
               attribute MUST, on getting, return the value to which it was
               last set. On setting, if the new value is either the string
-              <code>"blob"</code> or the string <code>"arraybuffer"</code>,
+              <code class=html>"blob"</code> or the string <code class=html>"arraybuffer"</code>,
               then set the IDL attribute to this new value. Otherwise,
               [= exception/throw =] a {{SyntaxError}}. <span  data-tests="RTCPeerConnection-createDataChannel.html">When an
               {{RTCDataChannel}} object is
               created, the {{RTCDataChannel/binaryType}} attribute MUST be
-              initialized to the string "<code>blob</code>".</span></p>
+              initialized to the string <code class=html>"blob"</code>.</span></p>
               <p>This attribute controls how binary data is exposed to scripts.
               See Web Socket's {{WebSocket/binaryType}}.</p>
             </dd>
@@ -9724,13 +9717,13 @@ interface RTCDataChannel : EventTarget {
           <h2>Methods</h2>
           <dl data-link-for="RTCDataChannel" data-dfn-for="RTCDataChannel"
           class="methods">
-            <dt><code>close</code></dt>
+            <dt><dfn>close</dfn></dt>
             <dd>
               <p>Closes the {{RTCDataChannel}}. It may be
               called regardless of whether the
               {{RTCDataChannel}} object was created by this
               peer or the remote peer.</p>
-              <p>When the <dfn>close</dfn> method is called, the user agent
+              <p>When the {{close}} method is called, the user agent
               MUST run the following steps:</p>
               <ol>
                 <li>
@@ -9757,31 +9750,31 @@ interface RTCDataChannel : EventTarget {
             <dd>
               <p>Run the steps described by the [= send()
               algorithm =] with argument type
-              <code>string</code> object.</p>
+              <code class=param>string</code> object.</p>
             </dd>
             <dt data-tests="RTCDataChannel-send.html"><dfn data-lt="send!overload-1" data-lt-nodefault=
-            "true"><code>send</code></dfn></dt>
+            "true">send</dfn></dt>
             <dd>
               <p>Run the steps described by the [= send()
               algorithm =] with argument type
               {{Blob}} object.</p>
             </dd>
             <dt data-tests="RTCDataChannel-send.html"><dfn data-lt="send!overload-2" data-lt-nodefault=
-            "true"><code>send</code></dfn></dt>
+            "true">send</dfn></dt>
             <dd>
               <p>Run the steps described by the [= 
               send() algorithm =] with argument type
               {{ArrayBuffer}} object.</p>
             </dd>
             <dt data-tests="RTCDataChannel-send.html"><dfn data-lt="send!overload-3" data-lt-nodefault=
-            "true"><code>send</code></dfn></dt>
+            "true">send</dfn></dt>
             <dd>
               <p>Run the steps described by the [= send()
               algorithm =] with argument type
               {{ArrayBufferView}} object.</p>
             </dd>
           </dl>
-      <p>The <code>send()</code> method is overloaded to handle
+      <p>The <code class=overload>send()</code> method is overloaded to handle
       different data argument types. When any version of the method is called,
       the user agent MUST <dfn id="datachannel-send" data-lt="send() algorithm" data-lt-nodefault>run the following steps</dfn>:</p>
       <ol>
@@ -9799,7 +9792,7 @@ interface RTCDataChannel : EventTarget {
           argument:</p>
           <ul>
             <li>
-              <p><code>string</code> object:</p>
+              <p><code class=param>string</code> object:</p>
               <p>Let <var>data</var> be a byte buffer that represents the
               result of encoding the method's argument as UTF-8.</p>
             </li>
@@ -9831,8 +9824,8 @@ interface RTCDataChannel : EventTarget {
           <code>null</code> and <code>undefined</code>.</div>
         </li>
         <li data-tests="RTCDataChannel-send.html">
-          <p>If the byte size of <var>data</var> exceeds the value of <code>
-          {{RTCSctpTransport/maxMessageSize}}</code> on
+          <p>If the byte size of <var>data</var> exceeds the value of
+          {{RTCSctpTransport/maxMessageSize}} on
           <var>channel</var>'s associated {{RTCSctpTransport}},
           [= exception/throw =] a {{TypeError}}.</p>
         </li>
@@ -9989,7 +9982,7 @@ interface RTCDataChannelEvent : Event {
           <h2>Constructors</h2>
           <dl data-link-for="RTCDataChannelEvent" data-dfn-for=
           "RTCDataChannelEvent" class="constructors">
-            <dt data-tests="idlharness.https.window.js"><dfn><code>RTCDataChannelEvent.constructor()</code></dfn></dt>
+            <dt data-tests="idlharness.https.window.js"><dfn>RTCDataChannelEvent.constructor()</dfn></dt>
             <dd>
             </dd>
           </dl>
@@ -9998,11 +9991,11 @@ interface RTCDataChannelEvent : Event {
           <h2>Attributes</h2>
           <dl data-link-for="RTCDataChannelEvent" data-dfn-for=
           "RTCDataChannelEvent" class="attributes">
-            <dt><code>channel</code> of type <span class=
+            <dt><dfn id=
+              "dom-datachannelevent-channel">channel</dfn> of type <span class=
             "idlAttrType">{{RTCDataChannel}}</span>, readonly</dt>
             <dd>
-              <p>The <dfn id=
-              "dom-datachannelevent-channel"><code>channel</code></dfn>
+              <p>The {{channel}}
               attribute represents the {{RTCDataChannel}}
               object associated with the event.</p>
             </dd>
@@ -10037,19 +10030,19 @@ interface RTCDataChannelEvent : Event {
         <li>
           <p><a>[[\ReadyState]]</a> slot is
           {{RTCDataChannelState/"connecting"}} and at least one event listener is registered
-          for <code>open</code> events, <code>message</code> events,
-          <code>error</code> events, or <code>close</code> events.</p>
+          for <code class=event>open</code> events, <code class=event>message</code> events,
+          <code class=event>error</code> events, or <code class=event>close</code> events.</p>
         </li>
         <li>
           <p><a>[[\ReadyState]]</a> slot is
           {{RTCDataChannelState/"open"}} and at least one event listener is registered for
-          <code>message</code> events, <code>error</code> events, or
-          <code>close</code> events.</p>
+          <code class=event>message</code> events, <code class=event>error</code> events, or
+          <code class=event>close</code> events.</p>
         </li>
         <li>
           <p><a>[[\ReadyState]]</a> slot is
           {{RTCDataChannelState/"closing"}} and at least one event listener is registered
-          for <code>error</code> events, or <code>close</code> events.</p>
+          for <code class=event>error</code> events, or <code class=event>close</code> events.</p>
         </li>
         <li>
           <p>[= underlying data transport =] is established and data is queued
@@ -10077,12 +10070,12 @@ interface RTCDataChannelEvent : Event {
           <h2>Attributes</h2>
           <dl data-link-for="RTCRtpSender" data-dfn-for="RTCRtpSender" class=
           "attributes">
-            <dt><code>dtmf</code> of type <span class=
+            <dt><dfn>dtmf</dfn> of type <span class=
             "idlAttrType">{{RTCDTMFSender}}</span>, readonly, nullable</dt>
             <dd>
-              <p>On getting, the <dfn>dtmf</dfn> attribute returns the value
-              of the <a>[[\Dtmf]]</a>internal slot, which represents a <code>
-              {{RTCDTMFSender}}</code> which can be used to send DTMF, or
+              <p>On getting, the {{dtmf}} attribute returns the value
+              of the <a>[[\Dtmf]]</a>internal slot, which represents a
+              {{RTCDTMFSender}} which can be used to send DTMF, or
               null if unset. The <a>[[\Dtmf]]</a>internal slot is set
               when the kind of an {{RTCRtpSender}}'s
               <a>[[\SenderTrack]]</a> is <code>"audio"</code>.</p>
@@ -10093,7 +10086,7 @@ interface RTCDataChannelEvent : Event {
     </section>
     <section>
       <h4><dfn>RTCDTMFSender</dfn></h4>
-      <p>To <dfn>create an <code>RTCDTMFSender</code></dfn>, the user agent MUST
+      <p>To <dfn>create an RTCDTMFSender</dfn>, the user agent MUST
         run the following steps:</p>
         <ol>
           <li>
@@ -10139,11 +10132,11 @@ interface RTCDTMFSender : EventTarget {
               DTMF. On getting, the user agent MUST return the result of running
               [= determine if DTMF can be sent =] for <var>dtmfSender</var>.</p>
             </dd>
-            <dt><code>toneBuffer</code> of type <span class=
+            <dt><dfn id=
+              "dom-RTCDTMFSender-tonebuffer">toneBuffer</dfn> of type <span class=
             "idlAttrType">DOMString</span>, readonly</dt>
             <dd>
-              <p>The <dfn id=
-              "dom-RTCDTMFSender-tonebuffer"><code>toneBuffer</code></dfn>
+              <p>The {{toneBuffer}}
               attribute MUST return a list of the tones remaining to be played
               out. For the syntax, content, and interpretation of this list,
               see {{insertDTMF}}.</p>
@@ -10154,10 +10147,10 @@ interface RTCDTMFSender : EventTarget {
           <h2>Methods</h2>
           <dl data-link-for="RTCDTMFSender" data-dfn-for="RTCDTMFSender" class=
           "methods">
-            <dt><code>insertDTMF</code></dt>
+            <dt><dfn id=
+              "dom-RTCDTMFSender-insertDTMF">insertDTMF</dfn></dt>
             <dd>
-              <p>An {{RTCDTMFSender}} object's <dfn id=
-              "dom-RTCDTMFSender-insertDTMF"><code>insertDTMF</code></dfn>
+              <p>An {{RTCDTMFSender}} object's {{insertDTMF}}
               method is used to send DTMF tones.</p>
               <p data-tests="RTCDTMFSender-insertDTMF.https.html">The tones parameter is treated as a series of characters. The
               characters 0 through 9, A through D, #, and * generate the
@@ -10195,22 +10188,24 @@ interface RTCDTMFSender : EventTarget {
                 <li>If [= determine if DTMF can be sent =] for <var>dtmf</var> returns
                 <code>false</code>, [= exception/throw =] an {{InvalidStateError}}.</li>
                 <li>Let <var>tones</var> be the method's first argument.</li>
+                <li>Let <var>duration</var> be the method's second argument.</li>
+                <li>Let <var>interToneGap</var> be the method's third argument.</li>
                 <li data-tests="RTCDTMFSender-insertDTMF.https.html">If <var>tones</var> contains any {{unrecognized}}
                 characters, [= exception/throw =] an {{InvalidCharacterError}}.
                 </li>
                 <li>Set the object's <a>[[\ToneBuffer]]</a> slot to
                 <var>tones</var>.</li>
                 <li>Set <var>dtmf</var>.<a>[[\Duration]]</a> to the
-                value of the <code>duration</code> parameter.</li>
+                value of <var>duration</var>.</li>
                 <li>Set <var>dtmf</var>.<a>[[\InterToneGap]]</a> to the
-                value of the <code>interToneGap</code> parameter.</li>
-                <li data-tests="RTCDTMFSender-ontonechange-long.https.html,RTCDTMFSender-ontonechange.https.html">If the value of the <code>duration</code> parameter is less than 40 ms,
+                value of <var>interToneGap</var>.</li>
+                <li data-tests="RTCDTMFSender-ontonechange-long.https.html,RTCDTMFSender-ontonechange.https.html">If the value of <var>duration</var> is less than 40 ms,
                 set <var>dtmf</var>.<a>[[\Duration]]</a> to 40 ms.</li>
-                <li data-tests="RTCDTMFSender-ontonechange-long.https.html,RTCDTMFSender-ontonechange.https.html">If the value of the <code>duration</code> parameter is greater than 6000 ms,
+                <li data-tests="RTCDTMFSender-ontonechange-long.https.html,RTCDTMFSender-ontonechange.https.html">If the value of <var>duration</var> parameter is greater than 6000 ms,
                 set <var>dtmf</var>.<a>[[\Duration]]</a> to 6000 ms.</li>
-                <li data-tests="RTCDTMFSender-ontonechange.https.html">If the value of the <code>interToneGap</code> parameter is less than 30 ms,
+                <li data-tests="RTCDTMFSender-ontonechange.https.html">If the value of <var>interToneGap</var> is less than 30 ms,
                 set <var>dtmf</var>.<a>[[\InterToneGap]]</a> to 30 ms.</li>
-                <li data-tests="RTCDTMFSender-ontonechange-long.https.html,RTCDTMFSender-ontonechange.https.html">If the value of the <code>interToneGap</code> parameter is greater than 6000 ms,
+                <li data-tests="RTCDTMFSender-ontonechange-long.https.html,RTCDTMFSender-ontonechange.https.html">If the value of <var>interToneGap</var> is greater than 6000 ms,
                 set <var>dtmf</var>.<a>[[\InterToneGap]]</a> to 6000 ms.</li>
                 <li data-tests="RTCDTMFSender-ontonechange.https.html">If <a>[[\ToneBuffer]]</a> slot is an empty string,
                 abort these steps.</li>
@@ -10219,7 +10214,7 @@ interface RTCDTMFSender : EventTarget {
                 steps (<em>Playout task</em>):
                   <ol>
                     <li>If <var>transceiver</var>.<a>[[\CurrentDirection]]</a>
-                    is neither <code>sendrecv</code> nor <code>sendonly</code>,
+                    is neither {{RTCRtpTransceiverDirection/"sendrecv"}} nor {{RTCRtpTransceiverDirection/"sendonly"}},
                     abort these steps.</li>
                     <li>If the <a>[[\ToneBuffer]]</a> slot contains the empty
                     string, [= fire an event =] named {{tonechange}}
@@ -10248,12 +10243,12 @@ interface RTCDTMFSender : EventTarget {
                   </ol>
                 </li>
               </ol>
-              <p>Since <code>insertDTMF</code> replaces the tone
+              <p>Since {{insertDTMF}} replaces the tone
               buffer, in order to add to the DTMF tones being played,
-              it is necessary to call <code>insertDTMF</code> with a
+              it is necessary to call {{insertDTMF}} with a
               string containing both the remaining tones (stored in the
               <a>[[\ToneBuffer]]</a> slot) and the new tones appended
-              together. Calling {{RTCDTMFSender/insertDTMF}} with an empty tones
+              together. Calling {{insertDTMF}} with an empty tones
               parameter can be used to cancel all tones queued to play after
               the currently playing tone.</p>
             </dd>
@@ -10278,9 +10273,9 @@ interface RTCDTMFSender : EventTarget {
         return <code>false</code>.</li>
         <li>If <var>transceiver</var>.<a>[[\CurrentDirection]]</a> is neither {{RTCRtpTransceiverDirection/"sendrecv"}}
         nor {{RTCRtpTransceiverDirection/"sendonly"}} return <code>false</code>.</li>
-        <li>If <var>sender</var>.<a>[[\SendEncodings]]</a><code>[0].active</code> is
+        <li>If <var>sender</var>.<a>[[\SendEncodings]]</a><code>[0]</code>.{{RTCRtpEncodingParameters/active}} is
         <code>false</code> return <code>false</code>.</li>
-        <li>If no codec with mimetype <code>"audio/telephone-event"</code> has been
+        <li>If no codec with mimetype <code class=mime>"audio/telephone-event"</code> has been
         negotiated for sending with this <var>sender</var>, return <code>false</code>.</li>
         <li>Otherwise, return <code>true</code>.</li>
       </ol>
@@ -10300,7 +10295,7 @@ interface RTCDTMFToneChangeEvent : Event {
           <h2>Constructors</h2>
           <dl data-link-for="RTCDTMFToneChangeEvent" data-dfn-for=
           "RTCDTMFToneChangeEvent" class="constructors">
-            <dt><dfn><code>RTCDTMFToneChangeEvent.constructor()</code></dfn></dt>
+            <dt><dfn>RTCDTMFToneChangeEvent.constructor()</dfn></dt>
             <dd>
             </dd>
           </dl>
@@ -10309,10 +10304,10 @@ interface RTCDTMFToneChangeEvent : Event {
           <h2>Attributes</h2>
           <dl data-link-for="RTCDTMFToneChangeEvent" data-dfn-for=
           "RTCDTMFToneChangeEvent" class="attributes">
-            <dt><code>tone</code> of type <span class=
+            <dt><dfn data-idl>tone</dfn> of type <span class=
             "idlAttrType">DOMString</span>, readonly</dt>
             <dd>
-              <p>The <dfn data-idl>tone</dfn> attribute contains the
+              <p>The {{tone}} attribute contains the
               character for the tone (including ",") that has just
               begun playout (see {{RTCDTMFSender/insertDTMF}} ). If
               the value is the empty string, it indicates that the
@@ -10336,7 +10331,7 @@ interface RTCDTMFToneChangeEvent : Event {
             "idlMemberType">DOMString</span>, defaulting to
               <code>""</code></dt>
             <dd>
-              <p>The <code>tone</code> attribute contains the
+              <p>The {{tone}} attribute contains the
               character for the tone (including ",") that has just
               begun playout (see {{RTCDTMFSender/insertDTMF}} ). If
               the value is the empty string, it indicates that the
@@ -10395,13 +10390,12 @@ interface RTCDTMFToneChangeEvent : Event {
           <h2>Methods</h2>
           <dl data-link-for="RTCPeerConnection" data-dfn-for=
           "RTCPeerConnection" class="methods">
-            <dt data-tests="RTCPeerConnection-getStats.https.html,getstats.html"><code>getStats</code></dt>
+            <dt data-tests="RTCPeerConnection-getStats.https.html,getstats.html"><dfn id=
+              "widl-RTCPeerConnection-getStats-Promise-RTCStatsReport--MediaStreamTrack-selector">getStats</dfn></dt>
             <dd>
               <p>Gathers stats for the given {{selector}} and reports the
               result asynchronously.</p>
-              <p>When the <dfn id=
-              "widl-RTCPeerConnection-getStats-Promise-RTCStatsReport--MediaStreamTrack-selector">
-              <code>getStats()</code></dfn> method is invoked, the user agent
+              <p>When the {{getStats()}} method is invoked, the user agent
               MUST run the following steps:</p>
               <ol>
                 <li>
@@ -10421,7 +10415,7 @@ interface RTCDTMFToneChangeEvent : Event {
                   <p>If <var>selectorArg</var> is a {{MediaStreamTrack}}
                   let <var>selector</var> be an {{RTCRtpSender}} or
                   {{RTCRtpReceiver}} on <var>connection</var> which
-                  <code>track</code> member matches <var>selectorArg</var>.
+                  {{RTCRtpSender/track}} attribute matches <var>selectorArg</var>.
                   If no such sender or receiver exists, or if more than one
                   sender or receiver fit this criteria, return a promise
                   [= rejected =] with a newly
@@ -10478,9 +10472,8 @@ interface RTCDTMFToneChangeEvent : Event {
 interface RTCStatsReport {
   readonly maplike&lt;DOMString, object&gt;;
 };</pre>
-        <p>This interface has "entries", "forEach", "get", "has", "keys",
-        "values", @@iterator methods and a "size" getter brought by
-        <code>readonly maplike</code>.</p>
+        <p>This <a data-cite="webidl">maplike</a> interface has "entries", "forEach", "get", "has", "keys",
+        "values", @@iterator methods and a "size" getter.</p>
         <p>Use these to retrieve the various dictionaries descended from
         {{RTCStats}} that this stats report is composed of. The
         set of supported property names [[!WEBIDL]] is defined as the ids of
@@ -10518,31 +10511,31 @@ interface RTCStatsReport {
           <h2>Dictionary {{RTCStats}} Members</h2>
           <dl data-link-for="RTCStats" data-dfn-for="RTCStats" class=
           "dictionary-members">
-            <dt><code>timestamp</code> of type <span class=
+            <dt><dfn data-idl>timestamp</dfn> of type <span class=
             "idlMemberType">DOMHighResTimeStamp</span></dt>
             <dd>
-              <p>The <dfn data-idl>timestamp</dfn>, of type
+              <p>The {{timestamp}}, of type
               {{DOMHighResTimeStamp}}, associated
               with this object. The time is relative to the UNIX epoch (Jan 1,
               1970, UTC). For statistics that came from a remote source (e.g.,
-              from received RTCP packets), <code>timestamp</code> represents
+              from received RTCP packets), {{timestamp}} represents
               the time at which the information arrived at the local endpoint.
               The remote timestamp can be found in an additional field in an
               {{RTCStats}}-derived dictionary, if
               applicable.</p>
             </dd>
-            <dt data-tests="getstats.html"><code>type</code> of type <span class=
+            <dt data-tests="getstats.html"><dfn data-idl>type</dfn> of type <span class=
             "idlMemberType">{{RTCStatsType}}</span></dt>
             <dd>
               <p>The type of this object.</p>
-              <p>The <dfn data-idl>type</dfn> attribute MUST be initialized
+              <p>The {{type}} attribute MUST be initialized
               to the name of the most specific type this
               {{RTCStats}} dictionary represents.</p>
             </dd>
-            <dt><code>id</code> of type <span class=
+            <dt><dfn data-idl>id</dfn> of type <span class=
             "idlMemberType">DOMString</span></dt>
             <dd>
-              <p>A unique <dfn data-idl>id</dfn> that is associated with
+              <p>A unique {{id}} that is associated with
               the object that was inspected to produce this
               {{RTCStats}} object. Two
               {{RTCStats}} objects, extracted from two
@@ -10743,7 +10736,7 @@ async function gatherStats() {
       the application to get more fine grained control over the transmission
       and reception of {{MediaStreamTrack}}s.</p>
       <p>Channels are the smallest unit considered in the
-      <code>MediaStream</code> specification. Channels are intended to be
+      Media Capture and Streams specification. Channels are intended to be
       encoded together for transmission as, for instance, an RTP payload type.
       All of the channels that a codec needs to encode jointly MUST be in the
       same {{MediaStreamTrack}} and the codecs SHOULD be able to
@@ -10818,7 +10811,7 @@ async function gatherStats() {
       {{MediaStreamTrack}} to
       <code>true</code>. Note that {{RTCPeerConnection/setRemoteDescription}}
       can also lead to [= set the muted state | the setting
-      of the muted state =] of the <code>track</code> to the
+      of the muted state =] of the {{RTCRtpReceiver/track}} to the
       value <code>true</code>.</p>
       <p>The procedures
       <dfn data-lt="add the track" id="add-track">add a track</dfn>,
@@ -10827,8 +10820,8 @@ async function gatherStats() {
       muted state</dfn> are specified in [[!GETUSERMEDIA]].</p>
       <p>When a {{MediaStreamTrack}} track produced by
         an {{RTCRtpReceiver}} <var>receiver</var> has
-        <code>ended</code> [[!GETUSERMEDIA]] (such as via a call to
-        <code><var>receiver</var>.track.stop</code>), the user agent MAY
+        <code class=gum>ended</code> [[!GETUSERMEDIA]] (such as via a call to
+        <var>receiver</var>.{{RTCRtpReceiver/track}}.<code class=gum>stop</code>), the user agent MAY
         choose to free resources allocated for the incoming stream, by
         for instance turning off the decoder of <var>receiver</var>.</p>
       <section>
@@ -10836,19 +10829,19 @@ async function gatherStats() {
         MediaTrackConstraints and MediaTrackSettings</h4>
         <p>The concept of constraints and constrainable properties, including
         {{MediaTrackConstraints}}
-        (<code>MediaStreamTrack.getConstraints()</code>,
-        <code>MediaStreamTrack.applyConstraints()</code>), and
+        ({{MediaStreamTrack}}.<code class=gum>getConstraints()</code>,
+        {{MediaStreamTrack}}.<code class=gum>applyConstraints()</code>), and
         {{MediaTrackSettings}}
-        (<code>MediaStreamTrack.getSettings()</code>) are outlined in
+        ({{MediaStreamTrack}}.<code class=gum>getSettings()</code>) are outlined in
         [[!GETUSERMEDIA]]. However, the constrainable properties of tracks
         sourced from a peer connection are different than those sourced by
-        <code>getUserMedia()</code>; the constraints and settings applicable to
+        <code class=gum>getUserMedia()</code>; the constraints and settings applicable to
         {{MediaStreamTrack}}s sourced from a [= remote
         source =] are defined here. The settings of a remote track represent
         the latest frame received.
-        <code>MediaStreamTrack.getCapabilities()</code> MUST always return the
-        empty set and <code>MediaStreamTrack.applyConstraints()</code> MUST
-        always reject with <code>OverconstrainedError</code> on remote tracks
+        {{MediaStreamTrack}}.<code class=gum>getCapabilities()</code> MUST always return the
+        empty set and {{MediaStreamTrack}}.<code class=gum>applyConstraints()</code> MUST
+        always reject with <code class=gum>OverconstrainedError</code> on remote tracks
         for constraints defined here.</p>
         <p>The following constrainable properties are defined to apply to video
         {{MediaStreamTrack}}s sourced from a [= remote
@@ -11279,8 +11272,8 @@ async function sendDTMF() {
 }
       </pre>
       <p>Send the DTMF signal "1234", and light up the active key using
-      <code>lightKey(key)</code> while the tone is playing (assuming that
-      <code>lightKey("")</code> will darken all the keys):</p>
+      <code class=example>lightKey(key)</code> while the tone is playing (assuming that
+      <code class=example>lightKey("")</code> will darken all the keys):</p>
       <pre class="example highlight">
 const wait = (ms) =&gt; new Promise((resolve) =&gt; setTimeout(resolve, ms));
 
@@ -11354,7 +11347,7 @@ if (sender.dtmf.canInsertDTMF) {
       </ol>
       <p>Together, they manage signaling for the rest of the application in a
       manner that doesn't deadlock. The example assumes a
-      <code>polite</code> boolean variable indicating the designated role:</p>
+      <var>polite</var> boolean variable indicating the designated role:</p>
       <pre class="example highlight">
 // The perfect negotiation logic, separated from the rest of an application ---
 let offering = false, ignoredOffer = false;
@@ -11396,10 +11389,10 @@ signaling.onmessage = async ({data: {description, candidate}}) => {
 }
       </pre>
       <p>Note that this is timing sensitive, and uses deliberate versions
-      of <code>setLocalDescription</code> (without arguments) and
-      <code>setRemoteDescription</code> (with implicit rollback) to avoid
+      of {{RTCPeerConnection/setLocalDescription}} (without arguments) and
+      {{RTCPeerConnection/setRemoteDescription}} (with implicit rollback) to avoid
       races with other signaling messages being serviced.</p>
-      <p>The <code>ignoredOffer</code> variable is needed, because
+      <p>The <var>ignoredOffer</var> variable is needed, because
       the {{RTCPeerConnection}} object on the impolite side is never
       told about ignored offers. We must therefore suppress errors from
       incoming candidates belonging to such offers.</p>
@@ -11463,10 +11456,10 @@ interface RTCError : DOMException {
               </li>
               <li data-tests="RTCError.html">
                 <p>Invoke the {{DOMException}} constructor of <var>e</var> with the
-                <code>message</code> argument set to <var>message</var> and the
-                <code>name</code> argument set to <code>"RTCError"</code>.</p>
+                {{DOMException/message}} argument set to <var>message</var> and the
+                {{DOMException/name}} argument set to <code>"RTCError"</code>.</p>
                 <p class="note">This name does not have a mapping to a legacy
-                code so <var>e</var>'s <code>code</code> attribute will return
+                code so <var>e</var>'s {{DOMException/code}} attribute will return
                 0.</p>
               </li>
               <li data-tests="RTCError.html">
@@ -11493,21 +11486,21 @@ interface RTCError : DOMException {
           <dt data-tests="RTCError.html,RTCPeerConnection-setRemoteDescription-offer.html"><dfn data-idl>sdpLineNumber</dfn> of type <span
           class="idlAttrType">long</span>, readonly, nullable</dt>
           <dd>
-            <p>If <code>errorDetail</code> is {{RTCErrorDetailType/"sdp-syntax-error"}}
+            <p>If {{RTCError/errorDetail}} is {{RTCErrorDetailType/"sdp-syntax-error"}}
             this is the line number where the error was detected (the first
             line has line number 1).</p>
           </dd>
           <dt data-tests="RTCError.html"><dfn data-idl>sctpCauseCode</dfn> of type <span
           class="idlAttrType">long</span>, readonly, nullable</dt>
           <dd>
-            <p>If <code>errorDetail</code> is {{RTCErrorDetailType/"sctp-failure"}} this
+            <p>If {{RTCError/errorDetail}} is {{RTCErrorDetailType/"sctp-failure"}} this
             is the SCTP cause code of the failed SCTP negotiation.</p>
           </dd>
           <dt data-tests="RTCError.html"><dfn data-idl>receivedAlert</dfn> of type <span
           class="idlAttrType">unsigned long</span>, readonly,
           nullable</dt>
           <dd>
-            <p>If <code>errorDetail</code> is {{RTCErrorDetailType/"dtls-failure"}} and
+            <p>If {{RTCError/errorDetail}} is {{RTCErrorDetailType/"dtls-failure"}} and
             a fatal DTLS alert was received, this is the value of the DTLS
             alert received.</p>
           </dd>
@@ -11515,7 +11508,7 @@ interface RTCError : DOMException {
           class="idlAttrType">unsigned long</span>, readonly,
           nullable</dt>
           <dd>
-            <p>If <code>errorDetail</code> is {{RTCErrorDetailType/"dtls-failure"}} and
+            <p>If {{RTCError/errorDetail}} is {{RTCErrorDetailType/"dtls-failure"}} and
             a fatal DTLS alert was sent, this is the value of the DTLS alert
             sent.</p>
           </dd>
@@ -11614,11 +11607,11 @@ interface RTCError : DOMException {
               <td><dfn data-idl>dtls-failure</dfn></td>
               <td>The DTLS negotiation has failed or the connection
               has been terminated with a fatal error. The
-              <code>message</code> contains information relating to
+              {{DOMException/message}} contains information relating to
               the nature of error.  If a fatal DTLS alert was received,
-              the <code>receivedAlert</code> attribute is set to the
+              the {{RTCError/receivedAlert}} attribute is set to the
               value of the DTLS alert received. If a fatal DTLS alert was
-              sent, the <code>sentAlert</code> attribute is set to
+              sent, the {{RTCError/sentAlert}} attribute is set to
               the value of the DTLS alert sent.</td>
             </tr>
             <tr>
@@ -11635,12 +11628,12 @@ interface RTCError : DOMException {
               <td><dfn data-idl>sctp-failure</dfn></td>
               <td>The SCTP negotiation has failed or the connection
               has been terminated with a fatal error. The
-              <code>sctpCauseCode</code> attribute is set to the
+              {{RTCError/sctpCauseCode}} attribute is set to the
               SCTP cause code.</td>
             </tr>
             <tr>
               <td data-tests="RTCPeerConnection-setRemoteDescription-offer.html"><dfn data-idl>sdp-syntax-error</dfn></td>
-              <td>The SDP syntax is not valid. The <code>sdpLineNumber</code>
+              <td>The SDP syntax is not valid. The {{RTCError/sdpLineNumber}}
               attribute is set to the line number in the SDP where the syntax
               error was detected.</td>
             </tr>
@@ -11732,7 +11725,7 @@ interface RTCErrorEvent : Event {
       </tbody>
       <tbody>
         <tr>
-          <td><dfn id="event-datachannel-open"><code>open</code></dfn></td>
+          <td><dfn id="event-datachannel-open"><code class=event>open</code></dfn></td>
           <td>{{Event}}</td>
           <td>
             The {{RTCDataChannel}} object's [= underlying data
@@ -11741,13 +11734,13 @@ interface RTCErrorEvent : Event {
         </tr>
         <tr>
           <td><dfn id=
-          "event-datachannel-message"><code>message</code></dfn></td>
+          "event-datachannel-message"><code class=event>message</code></dfn></td>
           <td><dfn id=the-messageevent-interfaces>{{MessageEvent}}</dfn> [[html]]</td>
           <td>A message was successfully received.</td>
         </tr>
         <tr>
           <td><dfn id=
-          "event-datachannel-bufferedamountlow"><code>bufferedamountlow</code></dfn></td>
+          "event-datachannel-bufferedamountlow"><code class=event>bufferedamountlow</code></dfn></td>
           <td>{{Event}}</td>
           <td>The {{RTCDataChannel}} object's
           {{RTCDataChannel/bufferedAmount}}
@@ -11816,17 +11809,17 @@ interface RTCErrorEvent : Event {
         </tr>
         -->
         <tr>
-          <td><dfn id="event-track"><code>track</code></dfn></td>
+          <td><dfn id="event-track"><code class=event>track</code></dfn></td>
           <td>{{RTCTrackEvent}}</td>
           <td>New incoming media has been negotiated for a specific
             {{RTCRtpReceiver}}, and that receiver's
-            <code>track</code> has been added to any associated remote
+            {{RTCRtpReceiver/track}} has been added to any associated remote
             {{MediaStream}}s.
           </td>
         </tr>
         <tr>
           <td><dfn id=
-          "event-negotiation"><code>negotiationneeded</code></dfn></td>
+          "event-negotiation"><code class=event>negotiationneeded</code></dfn></td>
           <td>{{Event}}</td>
           <td>The browser wishes to inform the application that session
           negotiation needs to be done (i.e. a createOffer call followed by
@@ -11834,7 +11827,7 @@ interface RTCErrorEvent : Event {
         </tr>
         <tr>
           <td><dfn id=
-          "event-signalingstatechange"><code>signalingstatechange</code></dfn></td>
+          "event-signalingstatechange"><code class=event>signalingstatechange</code></dfn></td>
           <td>{{Event}}</td>
           <td>
             The [= signaling state =] has changed. This state change is the
@@ -11844,7 +11837,7 @@ interface RTCErrorEvent : Event {
         </tr>
         <tr>
           <td><dfn id=
-          "event-iceconnectionstatechange"><code>iceconnectionstatechange</code></dfn></td>
+          "event-iceconnectionstatechange"><code class=event>iceconnectionstatechange</code></dfn></td>
           <td>{{Event}}</td>
           <td>
             The {{RTCPeerConnection}}'s [= ICE connection state =]
@@ -11853,7 +11846,7 @@ interface RTCErrorEvent : Event {
         </tr>
         <tr>
           <td><dfn id=
-          "event-icegatheringstatechange"><code>icegatheringstatechange</code></dfn></td>
+          "event-icegatheringstatechange"><code class=event>icegatheringstatechange</code></dfn></td>
           <td>{{Event}}</td>
           <td>
             The {{RTCPeerConnection}}'s [= ICE gathering state =] has
@@ -11861,14 +11854,14 @@ interface RTCErrorEvent : Event {
           </td>
         </tr>
         <tr>
-          <td><dfn id="event-icecandidate"><code>icecandidate</code></dfn></td>
+          <td><dfn id="event-icecandidate"><code class=event>icecandidate</code></dfn></td>
           <td>{{RTCPeerConnectionIceEvent}}</td>
           <td>A new {{RTCIceCandidate}} is made available to
           the script.</td>
         </tr>
         <tr>
           <td><dfn id=
-          "event-connectionstatechange"><code>connectionstatechange</code></dfn></td>
+          "event-connectionstatechange"><code class=event>connectionstatechange</code></dfn></td>
           <td>{{Event}}</td>
           <td>
             The {{RTCPeerConnection}}.{{RTCPeerConnection/connectionState}} has changed.
@@ -11876,12 +11869,12 @@ interface RTCErrorEvent : Event {
         </tr>
         <tr>
           <td><dfn id=
-          "event-icecandidateerror"><code>icecandidateerror</code></dfn></td>
+          "event-icecandidateerror"><code class=event>icecandidateerror</code></dfn></td>
           <td>{{RTCPeerConnectionIceErrorEvent}}</td>
           <td>A failure occured when gathering ICE candidates.</td>
         </tr>
         <tr>
-          <td><dfn id="event-datachannel"><code>datachannel</code></dfn></td>
+          <td><dfn id="event-datachannel">datachannel</dfn></td>
           <td>{{RTCDataChannelEvent}}</td>
           <td>A new {{RTCDataChannel}} is dispatched to the
           script in response to the other peer creating a channel.</td>
@@ -11901,7 +11894,7 @@ interface RTCErrorEvent : Event {
       <tbody>
         <tr>
           <td><dfn id=
-          "event-RTCDTMFSender-tonechange"><code>tonechange</code></dfn></td>
+          "event-RTCDTMFSender-tonechange"><code class=event>tonechange</code></dfn></td>
           <td>{{RTCDTMFToneChangeEvent}}</td>
           <td data-tests="RTCDTMFSender-ontonechange-long.https.html">The {{RTCDTMFSender}} object has either just
           begun playout of a tone (returned as the {{RTCDTMFToneChangeEvent/tone}} attribute) or just ended
@@ -11926,20 +11919,20 @@ interface RTCErrorEvent : Event {
       <tbody>
         <tr>
           <td><dfn id="event-icetransport-statechange" data-lt=
-          "RTCIceTransport state change"><code>statechange</code></dfn></td>
+          "RTCIceTransport state change"><code class=event>statechange</code></dfn></td>
           <td>{{Event}}</td>
           <td>The {{RTCIceTransport}} state changes.</td>
         </tr>
         <tr>
           <td><dfn id=
-          "event-icetransport-gatheringstatechange"><code>gatheringstatechange</code></dfn></td>
+          "event-icetransport-gatheringstatechange"><code class=event>gatheringstatechange</code></dfn></td>
           <td>{{Event}}</td>
           <td>The {{RTCIceTransport}} gathering state
           changes.</td>
         </tr>
         <tr>
           <td><dfn id=
-          "event-icetransport-selectedcandidatepairchange"><code>selectedcandidatepairchange</code></dfn></td>
+          "event-icetransport-selectedcandidatepairchange"><code class=event>selectedcandidatepairchange</code></dfn></td>
           <td>{{Event}}</td>
           <td>The {{RTCIceTransport}}'s selected candidate pair
           changes.</td>
@@ -11960,12 +11953,12 @@ interface RTCErrorEvent : Event {
         <tr>
           <td><dfn id="event-dtlstransport-statechange" data-lt=
           "RTCDtlsTransport state change" data-lt-nodefault=
-          ""><code>statechange</code></dfn></td>
+          ""><code class=event>statechange</code></dfn></td>
           <td>{{Event}}</td>
           <td>The {{RTCDtlsTransport}} state changes.</td>
         </tr>
         <tr>
-          <td><dfn data-lt="RTCDtlsTransport error" data-lt-noDefault><code>error</code></dfn></td>
+          <td><dfn data-lt="RTCDtlsTransport error" data-lt-noDefault><code class=event>error</code></dfn></td>
           <td>{{RTCErrorEvent}}</td>
           <td>An error occurred on the {{RTCDtlsTransport}}
           (either "dtls-error" or "fingerprint-failure").</td>
@@ -11986,7 +11979,7 @@ interface RTCErrorEvent : Event {
         <tr>
           <td><dfn id="event-sctptransport-statechange" data-lt=
           "RTCSctpTransport state change" data-lt-nodefault=
-          ""><code>statechange</code></dfn></td>
+          ""><code class=event>statechange</code></dfn></td>
           <td>{{Event}}</td>
           <td>The {{RTCSctpTransport}} state changes.</td>
         </tr>
@@ -12078,7 +12071,7 @@ interface RTCErrorEvent : Event {
       adversaries that can observe the network, so this has to be regarded as
       public information.</p>
       <p>Communication certificates may be opaquely shared using
-      <code>postMessage</code> in anticipation of future needs. User agents are
+      {{MessagePort/postMessage()}} in anticipation of future needs. User agents are
       strongly encouraged to isolate the private keying material these objects
       hold a handle to, from the processes that have access to the
       {{RTCCertificate}} objects, to reduce memory attack surface.</p>
@@ -12088,8 +12081,8 @@ interface RTCErrorEvent : Event {
       <p>As described above, the list of IP addresses exposed by the WebRTC API
       can be used as a persistent cross-origin state.</p>
       <p>Beyond IP addresses, the WebRTC API exposes information about the
-      underlying media system via the <code>RTCRtpSender.getCapabilities</code>
-      and <code>RTCRtpReceiver.getCapabilities</code> methods, including
+      underlying media system via the {{RTCRtpSender}}.{{RTCRtpSender/getCapabilities}}
+      and {{RTCRtpReceiver}}.{{RTCRtpReceiver/getCapabilities}} methods, including
       detailed and ordered information about the codecs that the system is able
       to produce and consume. A subset of that information is likely to be
       represented in the SDP session descriptions generated, exposed and
@@ -12103,7 +12096,7 @@ interface RTCErrorEvent : Event {
     </section>
     <section>
       <h2>Setting SDP from remote endpoints</h2>
-      <p><code>setRemoteDescription</code> guards against malformed and invalid
+      <p>{{RTCPeerConnection/setRemoteDescription}} guards against malformed and invalid
       SDP by throwing exceptions, but makes no attempt to guard against SDP that
       might be unexpected by the application. Setting the remote description can
       cause significant resources to be allocated (including image buffers and
@@ -12111,7 +12104,7 @@ interface RTCErrorEvent : Event {
       bandwidth implications) among other things. An application that does not
       guard against malicious SDP could be at risk of resource deprivation,
       unintentionally allowing incoming media or at risk of not having certain
-      events fire like <code>ontrack</code> if the other endpoint does not
+      events fire like {{RTCPeerConnection/ontrack}} if the other endpoint does not
       negotiate sending. Applications need to be on guard against malevolent
       SDP.</p>
     </section>

--- a/webrtc.js
+++ b/webrtc.js
@@ -149,9 +149,11 @@ var respecConfig = {
           value: "IETF RTCWEB Working Group",
           href: "https://tools.ietf.org/wg/rtcweb/"
         }
-      ]
+      ],
     }
+
   ],
+  xref: ["dom", "hr-time", "webidl", "html", "mediacapture-streams", "fileapi"],
   preProcess: [
     highlightTests,
     markTestableAssertions,


### PR DESCRIPTION
Help ensure consistent formatting
Help detect external references that are not "exported" by original specs and keep links in sync with external specs


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2417.html" title="Last updated on Dec 20, 2019, 5:59 PM UTC (fc76e66)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2417/c58af67...fc76e66.html" title="Last updated on Dec 20, 2019, 5:59 PM UTC (fc76e66)">Diff</a>