### PR TITLE
Add "process remote tracks" algorithm to fix missing rollback steps.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1175,7 +1175,7 @@
         <ol>
           <li data-tests="RTCPeerConnection-setLocalDescription-rollback.html,RTCPeerConnection-setRemoteDescription-rollback.html">
             <p>If <code><var>description</var>.type</code> is
-            <code>"rollback"</code> and <a>signaling state</a> is either
+            <code>"rollback"</code> and <var>connection</var>'s <a>signaling state</a> is either
             <code>"stable"</code>, <code>"have-local-pranswer"</code>, or
             <code>"have-remote-pranswer"</code>, then <a>reject</a> <var>p</var>
             with a newly <a data-link-for="exception" data-lt="create">created</a>
@@ -1296,7 +1296,7 @@
                         <var>connection</var>.<a>[[\PendingLocalDescription]]</a>
                         to a new <code><a>RTCSessionDescription</a></code> object
                         constructed from <var>description</var>, set
-                        <a>signaling state</a> to <code>"have-local-offer"</code>,
+                        <var>connection</var>'s <a>signaling state</a> to <code>"have-local-offer"</code>,
                         and <a>release early candidates</a>.</p>
                       </li>
                       <!-- C) transition haveRemoteOffer or haveLocalProvAnswer to
@@ -1328,22 +1328,22 @@
                         <p>If <var>description</var> is of type <code>"pranswer"</code>,
                         then set <var>connection</var>.<a>[[\PendingLocalDescription]]</a>
                         to a new <code><a>RTCSessionDescription</a></code> object
-                        constructed from <var>description</var>, set
+                        constructed from <var>description</var>, set <var>connection</var>'s
                         <a>signaling state</a> to <code>"have-local-pranswer"</code>,
                         and <a>release early candidates</a>.</p>
                       </li>
                     </ol>
                   </li>
                   <li>
-                    <p>Otherwise, if <var>remote</var> is <code>true</code>,
-                    then run one of the following steps:</p>
+                    <p>Otherwise, (if <var>remote</var> is <code>true</code>) run
+                    one of the following steps:</p>
                     <ol>
                       <!-- D) transition stable to haveRemoteOffer -->
                       <li data-tests="RTCPeerConnection-setRemoteDescription-offer.html">
                         <p>If <var>description</var> is of type <code>"offer"</code>, set
                         <var>connection</var>.<a>[[\PendingRemoteDescription]]</a>
                         attribute to a new <code><a>RTCSessionDescription</a></code>
-                        object constructed from <var>description</var>, and set
+                        object constructed from <var>description</var>, and set <var>connection</var>'s
                         <a>signaling state</a> to <code>"have-remote-offer"</code>.</p>
                       </li>
                       <!-- F) transition haveRemoteOffer or haveLocalProvAnswer to
@@ -1375,7 +1375,7 @@
                         <p>If <var>description</var> is of type <code>"pranswer"</code>,
                         then set <var>connection</var>.<a>[[\PendingRemoteDescription]]</a>
                         to a new <code><a>RTCSessionDescription</a></code> object
-                        constructed from <var>description</var> and
+                        constructed from <var>description</var> and set <var>connection</var>'s
                         <a>signaling state</a> to <code>"have-remote-pranswer"</code>.</p>
                       </li>
                     </ol>
@@ -1799,24 +1799,19 @@
                             to <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\LastStableStateReceiverTransport]]</a>.</p>
                           </li>
                           <li>
-                            <p><a>Set the associated remote streams</a> with
-                            <var>transceiver</var>.<a>[[\Receiver]]</a>,
-                            <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\LastStableStateAssociatedRemoteMediaStreams]]</a>,
-                            <var>addList</var>, and <var>removeList</var>.</p>
-                          </li>
-                          <li>
                             <p>Set <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\ReceiveCodecs]]</a>
                             to <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\LastStableStateReceiveCodecs]]</a>.</p>
                           </li>
                           <li>
-                            <p>If <var>remote</var> is <code>true</code>, run the following sub steps:</p>
+                            <p>If the <a>signaling state</a> of <var>connection</var>
+                            is <code>"have-remote-offer"</code>, run the following
+                            sub steps:</p>
                             <ol>
                               <li>
-                                <p>Let <var>msids</var> be the a list of MSIDs that
-                                <var>transceiver</var>'s <a>[[\CurrentRemoteDescription]]</a> indicates
-                                <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\ReceiverTrack]]</a>
-                                is to be associated with, or an empty list if no association is
-                                indicated.</p>
+                                <p>Let <var>msids</var> be a list of the <code>id</code>s
+                                of all <code><a>MediaStream</a></code> objects in
+                                <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\LastStableStateAssociatedRemoteMediaStreams]]</a>,
+                                or an empty list if there are none.</p>
                               </li>
                               <li data-tests="RTCPeerConnection-ontrack.https.html,RTCPeerConnection-setRemoteDescription-tracks.https.html,RTCTrackEvent-fire.html">
                                 <p><a>Process remote tracks</a> with <var>transceiver</var>,
@@ -1839,8 +1834,8 @@
                       <li>
                         <p>Set <var>connection</var>.<a>[[\PendingLocalDescription]]</a>
                         and <var>connection</var>.<a>[[\PendingRemoteDescription]]</a>
-                        to <code>null</code>, and set <a>signaling state</a> to
-                        <code>"stable"</code>.</p>
+                        to <code>null</code>, and set <var>connection</var>'s
+                        <a>signaling state</a> to <code>"stable"</code>.</p>
                       </li>
                     </ol>
                   </li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1696,38 +1696,9 @@
                             </div>
                           </li>
                           <li data-tests="RTCPeerConnection-ontrack.https.html,RTCPeerConnection-setRemoteDescription-tracks.https.html,RTCTrackEvent-fire.html">
-                            <p><a>Set the associated remote streams</a> given
-                            <var>transceiver</var>.<a>[[\Receiver]]</a>,
-                            <var>msids</var>, <var>addList</var>, and
-                            <var>removeList</var>.</p>
-                          </li>
-                          <li data-tests="RTCPeerConnection-ontrack.https.html,RTCPeerConnection-setRemoteDescription-tracks.https.html,RTCPeerConnection-transceivers.https.html">
-                            <p>If <var>direction</var> is <code>"sendrecv"</code> or
-                            <code>"recvonly"</code> and <var>transceiver</var>.<a>[[\FiredDirection]]</a>
-                            is neither <code>"sendrecv"</code> nor <code>"recvonly"</code>,
-                            or the previous step increased the length of <var>addList</var>,
-                            <a>process the addition of a remote track</a> for
-                            the <a>media description</a>, given <var>transceiver</var>
-                            and <var>trackEventInits</var>.</p>
-                          </li>
-                          <li>
-                            <p>If <var>direction</var> is <code>"sendonly"</code> or
-                            <code>"inactive"</code>,
-                            set <var>transceiver</var>.<a>[[\Receptive]]</a>
-                            to <code>false</code>.</p>
-                          </li>
-                          <li data-tests="RTCPeerConnection-remote-track-mute.https.html">
-                            <p>If <var>direction</var> is
-                            <code>"sendonly"</code> or <code>"inactive"</code>, and
-                            <var>transceiver</var>.<a>[[\FiredDirection]]</a>
-                            is either <code>"sendrecv"</code> or <code>"recvonly"</code>,
-                            <a>process the removal of a remote track</a> for
-                            the <a>media description</a>, given <var>transceiver</var>
-                            and <var>muteTracks</var>.</p>
-                          </li>
-                          <li>
-                            <p>Set <var>transceiver</var>.<a>[[\FiredDirection]]</a> to
-                            <var>direction</var>.</p>
+                            <p><a>Process remote tracks</a> with <var>transceiver</var>,
+                            <var>direction</var>, <var>msids</var>, <var>addList</var>,
+                            <var>removeList</var>, and <var>trackEventInits</var>.</p>
                           </li>
                           <li>
                             <p>Set
@@ -1837,60 +1808,31 @@
                             <p>Set <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\ReceiveCodecs]]</a>
                             to <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\LastStableStateReceiveCodecs]]</a>.</p>
                           </li>
+                          <li>
+                            <p>If <var>remote</var> is <code>true</code>, run the following sub steps:</p>
+                            <ol>
+                              <li>
+                                <p>Let <var>msids</var> be the a list of MSIDs that
+                                <var>transceiver</var>'s <a>[[\CurrentRemoteDescription]]</a> indicates
+                                <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\ReceiverTrack]]</a>
+                                is to be associated with, or an empty list if no association is
+                                indicated.</p>
+                              </li>
+                              <li data-tests="RTCPeerConnection-ontrack.https.html,RTCPeerConnection-setRemoteDescription-tracks.https.html,RTCTrackEvent-fire.html">
+                                <p><a>Process remote tracks</a> with <var>transceiver</var>,
+                                <var>transceiver</var>'s <a>[[\CurrentDirection]]</a>,
+                                <var>msids</var>, <var>addList</var>, <var>removeList</var>, and
+                                <var>trackEventInits</var>.</p>
+                              </li>
+                            </ol>
+                          </li>
                           <li data-tests="RTCPeerConnection-setDescription-transceiver.html">
                             <p>If the <var>transceiver</var> was created by applying the
                             <code><a>RTCSessionDescription</a></code> that is
                             being rolled back, and a track has never been attached to
-                            it via <code>addTrack</code>, run the following steps:</p>
-                            <ol>
-                              <li>
-                                <p>If the <var>transceiver</var>'s <a>[[\FiredDirection]]</a>
-                                is either <code>"sendrecv"</code> or <code>"recvonly"</code>,
-                                <a>process the removal of a remote track</a> with
-                                <var>transceiver</var> and <var>muteTracks</var> and set
-                                <a>[[\FiredDirection]]</a> to <code>"inactive"</code>.</p>
-                              </li>
-                              <li>
-                                <p><a data-lt="stop the RTCRtpTransceiver">Stop the
-                                RTCRtpTransceiver</a> <var>transceiver</var>.</p>
-                              </li>
-                              <li>
-                                <p>Remove <var>transceiver</var> from <var>connection</var>'s
-                                <a href="#transceivers-set">set of transceivers</a>.</p>
-                              </li>
-                            </ol>
-                          </li>
-                          <li>
-                            <p>Otherwise, (if the <var>transceiver</var> was not just removed)
-                            run the following steps:</p>
-                            <ol>
-                              <li>
-                                <p>If the <var>transceiver</var>'s <a>[[\FiredDirection]]</a>
-                                is either <code>"sendonly"</code> or <code>"inactive"</code>
-                                and <var>transceiver</var>'s <a>[[\CurrentDirection]]</a> is
-                                either <code>"sendrecv"</code> or <code>"recvonly"</code>,
-                                or the "set the associated remote streams" step above increased
-                                the length of <var>addList</var>, 
-                                <a>process the addition of a remote track</a> with
-                                <var>transceiver</var> and <var>trackEventInits</var> and
-                                set the <var>transceiver</var>'s <a>[[\Receptive]]</a> slot
-                                to <code>true</code>.</p>
-                              </li>
-                              <li>
-                                <p>If the <var>transceiver</var>'s <a>[[\FiredDirection]]</a>
-                                is either <code>"sendrecv"</code> or <code>"recvonly"</code>
-                                and <var>transceiver</var>'s <a>[[\CurrentDirection]]</a> is
-                                either <code>"sendonly"</code>, <code>"inactive"</code> or
-                                <code>null</code>, <a>process the removal of a remote track</a>
-                                with <var>transceiver</var> and <var>muteTracks</var> and
-                                set the <var>transceiver</var>'s <a>[[\Receptive]]</a> slot
-                                to <code>false</code>.</p>
-                              </li>
-                              <li>
-                                <p>Set the <var>transceiver</var>'s <a>[[\FiredDirection]]</a>
-                                slot to <var>transceiver</var>.<a>[[\CurrentDirection]]</a>.</p>
-                              </li>
-                            </ol>
+                            it via <code>addTrack</code>, then <a>stop the RTCRtpTransceiver</a>
+                            <var>transceiver</var>, and remove it from <var>connection</var>'s
+                            <a href="#transceivers-set">set of transceivers</a>.</p>
                           </li>
                         </ol>
                       </li>
@@ -5782,12 +5724,48 @@ interface RTCCertificate {
         makes it available for reuse, the application would need to call
         <code>RTCRtpTransceiver.<a data-link-for="RTCRtpTransceiver">stop</a>()</code>
         and subsequently initiate negotiation from its end.</p>
+        <p>To <dfn id="process-remote-tracks">
+        process remote tracks</dfn> given an <code>RTCRtpTransceiver</code>
+        <var>transceiver</var>, <var>direction</var>, <var>msids</var>,
+        <var>addList</var>, <var>removeList</var>, and <var>trackEventInits</var>,
+        run the following steps:</p>
+        <ol data-tests="RTCPeerConnection-transceivers.https.html">
+          <li data-tests="RTCPeerConnection-ontrack.https.html,RTCPeerConnection-setRemoteDescription-tracks.https.html,RTCTrackEvent-fire.html">
+            <p><a>Set the associated remote streams</a> with
+            <var>transceiver</var>.<a>[[\Receiver]]</a>, <var>msids</var>,
+            <var>addList</var>, and <var>removeList</var>.</p>
+          </li>
+          <li data-tests="RTCPeerConnection-ontrack.https.html,RTCPeerConnection-setRemoteDescription-tracks.https.html,RTCPeerConnection-transceivers.https.html">
+            <p>If <var>direction</var> is <code>"sendrecv"</code> or
+            <code>"recvonly"</code> and <var>transceiver</var>.<a>[[\FiredDirection]]</a>
+            is neither <code>"sendrecv"</code> nor <code>"recvonly"</code>,
+            or the previous step increased the length of <var>addList</var>,
+            <a>process the addition of a remote track</a> with <var>transceiver</var>
+            and <var>trackEventInits</var>.</p>
+          </li>
+          <li>
+            <p>If <var>direction</var> is <code>"sendonly"</code> or
+            <code>"inactive"</code>, set <var>transceiver</var>.<a>[[\Receptive]]</a>
+            to <code>false</code>.</p>
+          </li>
+          <li data-tests="RTCPeerConnection-remote-track-mute.https.html">
+            <p>If <var>direction</var> is <code>"sendonly"</code> or
+            <code>"inactive"</code>, and
+            <var>transceiver</var>.<a>[[\FiredDirection]]</a>
+            is either <code>"sendrecv"</code> or <code>"recvonly"</code>,
+            <a>process the removal of a remote track</a> for
+            the <a>media description</a>, with <var>transceiver</var>
+            and <var>muteTracks</var>.</p>
+          </li>
+          <li>
+            <p>Set <var>transceiver</var>.<a>[[\FiredDirection]]</a> to
+            <var>direction</var>.</p>
+          </li>
+        </ol>
         <p>To <dfn id="process-remote-track-addition">
-        process the addition of a remote track</dfn> for
-        an incoming media description <span data-jsep=
-        "applying-a-remote-desc">[[!JSEP]]</span> given
+        process the addition of a remote track</dfn> given an
         <code>RTCRtpTransceiver</code> <var>transceiver</var> and
-        <var>trackEventInits</var>, the user agent MUST run the following steps:</p>
+        <var>trackEventInits</var>, run the following steps:</p>
         <ol data-tests="RTCPeerConnection-transceivers.https.html">
           <li>
             <p>Let <var>receiver</var> be <var>transceiver</var>.<a>[[\Receiver]]</a>.
@@ -5809,11 +5787,9 @@ interface RTCCertificate {
           </li>
         </ol>
         <p>To <dfn id="process-remote-track-removal">
-        process the removal of a remote track</dfn> for
-        an incoming media description <span data-jsep=
-        "applying-a-remote-desc">[[!JSEP]]</span> given
+        process the removal of a remote track</dfn> with an
         <code>RTCRtpTransceiver</code> <var>transceiver</var> and
-        <var>muteTracks</var>, the user agent MUST run the following steps:</p>
+        <var>muteTracks</var>, run the following steps:</p>
         <ol data-tests="RTCPeerConnection-remote-track-mute.https.html">
           <li>
             <p>Let <var>receiver</var> be <var>transceiver</var>.<a>[[\Receiver]]</a>.
@@ -5830,8 +5806,7 @@ interface RTCCertificate {
         </ol>
         <p>To <dfn id="set-associated-remote-streams">set the associated remote streams</dfn> given
         <code>RTCRtpReceiver</code> <var>receiver</var>, <var>msids</var>,
-        <var>addList</var>, and <var>removeList</var>, the user agent MUST run
-        the following steps:</p>
+        <var>addList</var>, and <var>removeList</var>, run the following steps:</p>
         <ol>
           <li>
             <p>Let <var>connection</var> be the


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2396 and some bugs in the rollback algorithm missed in https://github.com/w3c/webrtc-pc/pull/2384.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2418.html" title="Last updated on Dec 19, 2019, 9:22 PM UTC (c0012dc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2418/5690992...jan-ivar:c0012dc.html" title="Last updated on Dec 19, 2019, 9:22 PM UTC (c0012dc)">Diff</a>