### PR TITLE
Use of icecandidateerror for port scanning

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -11920,6 +11920,20 @@ interface RTCErrorEvent : Event {
       involvement.</p>
     </section>
     <section>
+      <h2>Port scanning</h2>
+      <p>Using {{RTCIceServer.url}} and {{onicecandidateerror}} an application
+      can probe the UDP and TCP ports of endpoints on local or remote networks.
+      This goes beyond what can be accomplished with other Web APIs such as
+      Websockets, which cannot currently be used to probe UDP ports.</p>
+      <p>The discovery of endpoint addresses and listening ports can be 
+      sensitive, since this information may enable an attacker to gain
+      information on the architecture of a network that might not otherwise
+      be obtainable due to a firewall, setting the stage for subsequent attacks.</p>
+      <p>Mitigating port probing requires limiting the ports that can be used
+      within {{RTCIceServer.url}} and/or the ports for which [[icecandidateerror]]
+      will fire.</p>
+    </section>
+    <section>
       <h2>Revealing IP addresses</h2>
       <p>Even without WebRTC, the Web server providing a Web application will
       know the public IP address to which the application is delivered. Setting


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/2424


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2425.html" title="Last updated on Dec 29, 2019, 4:38 AM UTC (11a8b66)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2425/e9065b3...11a8b66.html" title="Last updated on Dec 29, 2019, 4:38 AM UTC (11a8b66)">Diff</a>