### PR TITLE
Update examples to use track.onunmute.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -10924,11 +10924,13 @@ pc.onnegotiationneeded = async () =&gt; {
   }
 };
 
-// once media for a remote track arrives, show it in the remote video element
-pc.ontrack = (event) =&gt; {
-  // don't set srcObject again if it is already set.
-  if (remoteView.srcObject) return;
-  remoteView.srcObject = event.streams[0];
+pc.ontrack = event =&gt; {
+  // once media for a remote track arrives, show it in the remote video element
+  event.track.onunmute = () =&gt; {
+    // don't set srcObject again if it is already set.
+    if (remoteView.srcObject) return;
+    remoteView.srcObject = event.streams[0];
+  };
 };
 
 // call start() to initiate
@@ -11009,7 +11011,6 @@ async function warmup(isAnswerer) {
     }
   };
 
-  // once media for the remote track arrives, show it in the remote video element
   pc.ontrack = async (event) =&gt; {
     try {
       if (event.track.kind == 'audio') {
@@ -11030,11 +11031,14 @@ async function warmup(isAnswerer) {
         }
       }
 
-      // don't set srcObject again if it is already set.
-      if (!remoteView.srcObject) {
-        remoteView.srcObject = new MediaStream();
+      // once media for the remote track arrives, show it in the video element
+      event.track.onunmute = () => {
+        // don't set srcObject again if it is already set.
+        if (!remoteView.srcObject) {
+          remoteView.srcObject = new MediaStream();
+        }
+        remoteView.srcObject.addTrack(event.track);
       }
-      remoteView.srcObject.addTrack(event.track);
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/1240.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2427.html" title="Last updated on Jan 2, 2020, 2:34 PM UTC (3101e85)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2427/e9065b3...jan-ivar:3101e85.html" title="Last updated on Jan 2, 2020, 2:34 PM UTC (3101e85)">Diff</a>