### PR TITLE
Remove vestiges of httpRequestStatusCode (editorial)

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -61,7 +61,7 @@
 
     <p>The following features are marked as at risk:</p>
     <ul>
-      <li>All attributes defined in {{RTCError}}: {{RTCError/errorDetail}}, {{RTCError/sdpLineNumber}}, {{RTCError/httpRequestStatusCode}}, {{RTCError/sctpCauseCode}}, {{RTCError/receivedAlert}} and {{RTCError/sentAlert}}.</li>
+      <li>All attributes defined in {{RTCError}}: {{RTCError/errorDetail}}, {{RTCError/sdpLineNumber}}, {{RTCError/sctpCauseCode}}, {{RTCError/receivedAlert}} and {{RTCError/sentAlert}}.</li>
     </ul>
   </section>
   <section class="informative" id="intro">
@@ -11409,7 +11409,6 @@ interface RTCError : DOMException {
   constructor(RTCErrorInit init, optional DOMString message = "");
   readonly attribute RTCErrorDetailType errorDetail;
   readonly attribute long? sdpLineNumber;
-  readonly attribute long? httpRequestStatusCode;
   readonly attribute long? sctpCauseCode;
   readonly attribute unsigned long? receivedAlert;
   readonly attribute unsigned long? sentAlert;
@@ -11496,7 +11495,7 @@ interface RTCError : DOMException {
             <div class="issue atrisk">
               <p>All attributes defined in {{RTCError}} are marked at risk due
               to lack of implementation ({{errorDetail}}, {{sdpLineNumber}},
-              {{httpRequestStatusCode}}, {{sctpCauseCode}},
+              {{sctpCauseCode}},
               {{receivedAlert}} and {{sentAlert}}). This does not include
               attributes inherited from {{DOMException}}.</p>
             </div>
@@ -11509,12 +11508,11 @@ interface RTCError : DOMException {
 >dictionary RTCErrorInit {
   required RTCErrorDetailType errorDetail;
   long sdpLineNumber;
-  long httpRequestStatusCode;
   long sctpCauseCode;
   unsigned long receivedAlert;
   unsigned long sentAlert;
 };</pre>
-        <p data-dfn-for="RTCErrorInit">The <dfn data-idl>errorDetail</dfn>, <dfn data-idl>sdpLineNumber</dfn>, <dfn data-idl>httpRequestStatusCode</dfn>, <dfn data-idl>sctpCauseCode</dfn>, <dfn data-idl>receivedAlert</dfn> and <dfn data-idl>sentAlert</dfn> members of {{RTCErrorInit}} have the same definitions as the attributes of the same name of {{RTCError}}.</p>
+        <p data-dfn-for="RTCErrorInit">The <dfn data-idl>errorDetail</dfn>, <dfn data-idl>sdpLineNumber</dfn>, <dfn data-idl>sctpCauseCode</dfn>, <dfn data-idl>receivedAlert</dfn> and <dfn data-idl>sentAlert</dfn> members of {{RTCErrorInit}} have the same definitions as the attributes of the same name of {{RTCError}}.</p>
       </div>
       </section>
       <section>


### PR DESCRIPTION
Discovered in https://github.com/web-platform-tests/wpt/pull/20944#discussion_r362830670.  Thanks @foolip!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2428.html" title="Last updated on Jan 3, 2020, 3:46 PM UTC (bc191f3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2428/e9065b3...jan-ivar:bc191f3.html" title="Last updated on Jan 3, 2020, 3:46 PM UTC (bc191f3)">Diff</a>