### PR TITLE
Defining "new" in SctpTransportState

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8966,7 +8966,7 @@ interface RTCTrackEvent : Event {
               <p>Let <var>transport</var> have a
               <dfn>[[\SctpTransportState]]</dfn> internal slot initialized to
               <var>initialState</var>, if provided, otherwise
-              <code class=fixme>"new"</code>.</p>
+              {{RTCSctpTransportState/"new"}}.</p>
             </li>
             <li>
               <p>Let <var>transport</var> have a <dfn>[[\MaxMessageSize]]</dfn>

--- a/webrtc.html
+++ b/webrtc.html
@@ -9139,6 +9139,7 @@ interface RTCSctpTransport : EventTarget {
         <div>
           <pre class="idl"
 >enum RTCSctpTransportState {
+  "new",
   "connecting",
   "connected",
   "closed"
@@ -9151,12 +9152,20 @@ interface RTCSctpTransport : EventTarget {
               </tr>
               <tr>
                 <td data-tests="RTCSctpTransport-events.html"><dfn data-idl id=
-                "idl-def-RTCSctpTransportState.connecting">connecting</dfn></td>
+                "idl-def-RTCSctpTransportState.new">new</dfn></td>
                 <td>
-                  <p>The {{RTCSctpTransport}} is in the process of
+                  <p>The {{RTCSctpTransport}} has not yet begun the process of
                   negotiating an association. This is the initial state of the
                   [[\SctpTransportState]] slot when an
                   {{RTCSctpTransport}} is created.</p>
+                </td>
+              </tr>
+              <tr>
+                <td data-tests="RTCSctpTransport-events.html"><dfn data-idl id=
+                "idl-def-RTCSctpTransportState.connecting">connecting</dfn></td>
+                <td>
+                  <p>The {{RTCSctpTransport}} is in the process of
+                  negotiating an association.</p>
                 </td>
               </tr>
               <tr>

--- a/webrtc.html
+++ b/webrtc.html
@@ -9151,8 +9151,7 @@ interface RTCSctpTransport : EventTarget {
                 <th colspan="2">Enumeration description</th>
               </tr>
               <tr>
-                <td data-tests="RTCSctpTransport-events.html"><dfn data-idl id=
-                "idl-def-RTCSctpTransportState.new">new</dfn></td>
+                <td class=untestable><dfn data-idl>new</dfn></td>
                 <td>
                   <p>The {{RTCSctpTransport}} has not yet begun the process of
                   negotiating an association.</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -9155,9 +9155,7 @@ interface RTCSctpTransport : EventTarget {
                 "idl-def-RTCSctpTransportState.new">new</dfn></td>
                 <td>
                   <p>The {{RTCSctpTransport}} has not yet begun the process of
-                  negotiating an association. This is the initial state of the
-                  [[\SctpTransportState]] slot when an
-                  {{RTCSctpTransport}} is created.</p>
+                  negotiating an association.</p>
                 </td>
               </tr>
               <tr>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-pc/issues/2422


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2432.html" title="Last updated on Jan 8, 2020, 7:18 AM UTC (6f8e21b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2432/5fd9983...6f8e21b.html" title="Last updated on Jan 8, 2020, 7:18 AM UTC (6f8e21b)">Diff</a>