### PR TITLE
Fire closing event

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9375,7 +9375,8 @@ interface RTCSctpTransport : EventTarget {
         <li>
           <p>Unless the procedure was initiated by <var>channel</var>.{{RTCDataChannel/close}}, set
           <var>channel</var>.<a>[[\ReadyState]]</a> to
-          {{RTCDataChannelState/"closing"}}.</p>
+          {{RTCDataChannelState/"closing"}} and <a>fire an event</a>
+          named "closing" at <var>channel</var></p>
         </li>
         <li>
           <p>Run the following steps in parallel:</p>
@@ -10035,12 +10036,12 @@ interface RTCDataChannelEvent : Event {
           <p><a>[[\ReadyState]]</a> slot is
           {{RTCDataChannelState/"connecting"}} and at least one event listener is registered
           for <code class=event>open</code> events, <code class=event>message</code> events,
-          <code class=event>error</code> events, or <code class=event>close</code> events.</p>
+          <code class=event>error</code> events, <code class=event>closing</code> events, or <code class=event>close</code> events.</p>
         </li>
         <li>
           <p><a>[[\ReadyState]]</a> slot is
           {{RTCDataChannelState/"open"}} and at least one event listener is registered for
-          <code class=event>message</code> events, <code class=event>error</code> events, or
+          <code class=event>message</code> events, <code class=event>error</code> events, <code class=event>closing</code> events, or
           <code class=event>close</code> events.</p>
         </li>
         <li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -9375,8 +9375,8 @@ interface RTCSctpTransport : EventTarget {
         <li>
           <p>Unless the procedure was initiated by <var>channel</var>.{{RTCDataChannel/close}}, set
           <var>channel</var>.<a>[[\ReadyState]]</a> to
-          {{RTCDataChannelState/"closing"}} and <a>fire an event</a>
-          named "closing" at <var>channel</var></p>
+          {{RTCDataChannelState/"closing"}} and [= fire an event =]
+          named {{closing}} at <var>channel</var>.</p>
         </li>
         <li>
           <p>Run the following steps in parallel:</p>


### PR DESCRIPTION
This fires the closing event only when close was not initiated locally.

Fixes #2433


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2434.html" title="Last updated on Jan 30, 2020, 5:12 AM UTC (f00a26f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2434/f8ddaa8...f00a26f.html" title="Last updated on Jan 30, 2020, 5:12 AM UTC (f00a26f)">Diff</a>