### PR TITLE
Remove unneeded fallback state 'new' for create an RTCSctpTransport

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8941,7 +8941,7 @@ interface RTCTrackEvent : Event {
         <section>
           <h4 id="sctp-transport-create">Create an instance</h4>
           <p>To <dfn>create an {{RTCSctpTransport}}</dfn> with an
-          optional initial state, <var>initialState</var>, run the following
+          initial state, <var>initialState</var>, run the following
           steps:</p>
           <ol>
             <li data-tests="RTCSctpTransport-constructor.html,RTCSctpTransport-events.html ">
@@ -8951,8 +8951,7 @@ interface RTCTrackEvent : Event {
             <li>
               <p>Let <var>transport</var> have a
               <dfn>[[\SctpTransportState]]</dfn> internal slot initialized to
-              <var>initialState</var>, if provided, otherwise
-              <code class=fixme>"new"</code>.</p>
+              <var>initialState</var>.</p>
             </li>
             <li>
               <p>Let <var>transport</var> have a <dfn>[[\MaxMessageSize]]</dfn>


### PR DESCRIPTION
The algorithm only ever calls it with a defined initial state, and the state enum doesn't include (or need) new at this stage
close #2422


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2435.html" title="Last updated on Jan 10, 2020, 2:33 PM UTC (d4f689d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2435/f8ddaa8...d4f689d.html" title="Last updated on Jan 10, 2020, 2:33 PM UTC (d4f689d)">Diff</a>