### PR TITLE
Provide useful anchors for IDL definitions

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2106,7 +2106,7 @@
       </section>
       <section>
         <h3>Interface Definition</h3>
-        <p>The {{RTCPeerConnection}} interface presented in
+        <p>The <dfn>RTCPeerConnection</dfn> interface presented in
         this section is extended by several partial interfaces throughout this
         specification. Notably, the [= RTP Media API =] section, which adds
         the APIs to send and receive {{MediaStreamTrack}}

--- a/webrtc.html
+++ b/webrtc.html
@@ -259,10 +259,12 @@
 };</pre>
           <table data-link-for="RTCIceCredentialType" data-dfn-for=
           "RTCIceCredentialType" class="simple">
-            <tbody>
+            <thead>
               <tr>
                 <th colspan="2">Enumeration description</th>
               </tr>
+            </thead>
+            <tbody>
               <tr>
                 <td data-tests="RTCConfiguration-iceServers.html"><dfn data-idl>password</dfn></td>
                 <td>The credential is a long-term authentication username and
@@ -358,10 +360,12 @@
 };</pre>
           <table data-link-for="RTCIceTransportPolicy" data-dfn-for=
           "RTCIceTransportPolicy" class="simple">
-            <tbody>
+            <thead>
               <tr>
                 <th colspan="2">Enumeration description (non-normative)</th>
               </tr>
+            </thead>
+            <tbody>
               <tr>
                 <td><dfn data-idl>relay</dfn></td>
                 <td>
@@ -414,10 +418,12 @@
 };</pre>
           <table data-link-for="RTCBundlePolicy" data-dfn-for="RTCBundlePolicy"
           class="simple">
-            <tbody>
+            <thead>
               <tr>
                 <th colspan="2">Enumeration description (non-normative)</th>
               </tr>
+            </thead>
+            <tbody>
               <tr>
                 <td data-tests="RTCRtpSender-transport.https.html,RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl>balanced</dfn></td>
                 <td>Gather ICE candidates for each media type in use (audio,
@@ -454,10 +460,12 @@
 };</pre>
           <table data-link-for="RTCRtcpMuxPolicy" data-dfn-for=
           "RTCRtcpMuxPolicy" class="simple">
-            <tbody>
+            <thead>
               <tr>
                 <th colspan="2">Enumeration description (non-normative)</th>
               </tr>
+            </thead>
+            <tbody>
               <tr>
                 <td><dfn data-idl>require</dfn></td>
                 <td>Gather ICE candidates only for RTP and multiplex RTCP on
@@ -548,10 +556,12 @@
 };</pre>
           <table data-link-for="RTCSignalingState" data-dfn-for=
           "RTCSignalingState" class="simple">
-            <tbody>
+            <thead>
               <tr>
                 <th colspan="2">Enumeration description</th>
               </tr>
+            </thead>
+            <tbody>
               <tr>
                 <td data-tests="RTCPeerConnection-onsignalingstatechanged.https.html,RTCPeerConnection-setRemoteDescription.html"><dfn data-idl>stable</dfn></td>
                 <td>There is no offer/answer exchange in progress. This is
@@ -628,10 +638,12 @@
 };</pre>
           <table data-link-for="RTCIceGatheringState" data-dfn-for=
           "RTCIceGatheringState" class="simple">
-            <tbody>
+            <thead>
               <tr>
                 <th colspan="2">Enumeration description</th>
               </tr>
+            </thead>
+            <tbody>
               <tr>
                 <td data-tests="RTCPeerConnection-iceGatheringState.html"><dfn data-idl>new</dfn></td>
                 <td>Any of the {{RTCIceTransport}}s are in the
@@ -668,10 +680,12 @@
 };</pre>
           <table data-link-for="RTCPeerConnectionState" data-dfn-for=
           "RTCPeerConnectionState" class="simple">
-            <tbody>
+            <thead>
               <tr>
                 <th colspan="2">Enumeration description</th>
               </tr>
+            </thead>
+            <tbody>
               <tr>
                 <td><dfn data-idl>closed</dfn></td>
                 <td>
@@ -735,10 +749,12 @@
 };</pre>
           <table data-link-for="RTCIceConnectionState" data-dfn-for=
           "RTCIceConnectionState" class="simple">
-            <tbody>
+            <thead>
               <tr>
                 <th colspan="2">Enumeration description</th>
               </tr>
+            </thead>
+            <tbody>
               <tr>
                 <td data-tests="RTCPeerConnection-iceConnectionState.https.html"><dfn data-idl>closed</dfn></td>
                 <td>
@@ -3662,10 +3678,12 @@ interface RTCPeerConnection : EventTarget  {
 };</pre>
           <table data-link-for="RTCSdpType" data-dfn-for="RTCSdpType" class=
           "simple">
-            <tbody>
+            <thead>
               <tr>
                 <th colspan="2">Enumeration description</th>
               </tr>
+            </thead>
+            <tbody>
               <tr>
                 <td data-tests="RTCPeerConnection-setLocalDescription-offer.html"><dfn data-idl>offer</dfn></td>
                 <td>
@@ -4305,10 +4323,12 @@ interface RTCIceCandidate {
 };</pre>
             <table data-link-for="RTCIceProtocol" data-dfn-for="RTCIceProtocol"
             class="simple">
-              <tbody>
+              <thead>
                 <tr>
                   <th colspan="2">Enumeration description</th>
                 </tr>
+              </thead>
+              <tbody>
                 <tr>
                   <td><dfn data-idl>udp</dfn></td>
                   <td>A UDP candidate, as described in [[!ICE]].</td>
@@ -4334,10 +4354,12 @@ interface RTCIceCandidate {
 };</pre>
             <table data-link-for="RTCIceTcpCandidateType" data-dfn-for=
             "RTCIceTcpCandidateType" class="simple">
-              <tbody>
+              <thead>
                 <tr>
                   <th colspan="2">Enumeration description</th>
                 </tr>
+              </thead>
+              <tbody>
                 <tr>
                   <td><dfn data-idl>active</dfn></td>
                   <td>An {{RTCIceTcpCandidateType/"active"}} TCP candidate is one for which the
@@ -4376,10 +4398,12 @@ interface RTCIceCandidate {
 };</pre>
             <table data-link-for="RTCIceCandidateType" data-dfn-for=
             "RTCIceCandidateType" class="simple">
-              <tbody>
+              <thead>
                 <tr>
                   <th colspan="2">Enumeration description</th>
                 </tr>
+              </thead>
+              <tbody>
                 <tr>
                   <td data-tests="protocol/candidate-exchange.https.html"><dfn data-idl>host</dfn></td>
                   <td>A host candidate, as defined in Section 4.1.1.1 of
@@ -5565,12 +5589,14 @@ interface RTCCertificate {
   "inactive",
   "stopped"
 };</pre>
-        <table data-link-for="RTCRtpTransceiverDirection" data-dfn-for=
-        "RTCRtpTransceiverDirection" class="simple">
-          <tbody>
+        <table class="simple">
+          <thead>
             <tr>
               <th colspan="2"><dfn>RTCRtpTransceiverDirection</dfn> Enumeration description</th>
             </tr>
+          </thead>
+          <tbody data-link-for="RTCRtpTransceiverDirection" data-dfn-for=
+        "RTCRtpTransceiverDirection">
             <tr>
               <td data-tests="RTCPeerConnection-transceivers.https.html"><dfn data-idl>sendrecv</dfn></td>
               <td>The {{RTCRtpTransceiver}}'s
@@ -7827,10 +7853,12 @@ interface RTCDtlsTransport : EventTarget {
 };</pre>
         <table data-link-for="RTCDtlsTransportState" data-dfn-for=
         "RTCDtlsTransportState" class="simple">
-          <tbody>
+          <thead>
             <tr>
               <th colspan="2">Enumeration description</th>
             </tr>
+          </thead>
+          <tbody>
             <tr>
               <td><dfn data-idl>new</dfn></td>
               <td>DTLS has not started negotiating yet.</td>
@@ -8394,10 +8422,12 @@ interface RTCIceTransport : EventTarget {
 };</pre>
         <table data-link-for="RTCIceGathererState" data-dfn-for=
         "RTCIceGathererState" class="simple">
-          <tbody>
+          <thead>
             <tr>
               <th colspan="2">{{RTCIceGathererState}} Enumeration description</th>
             </tr>
+          </thead>
+          <tbody>
             <tr>
               <td><dfn data-idl>new</dfn></td>
               <td>The {{RTCIceTransport}} was just created, and
@@ -8434,10 +8464,12 @@ interface RTCIceTransport : EventTarget {
 };</pre>
         <table data-link-for="RTCIceTransportState" data-dfn-for=
         "RTCIceTransportState" class="simple">
-          <tbody>
+          <thead>
             <tr>
               <th colspan="2">{{RTCIceTransportState}} Enumeration description</th>
             </tr>
+          </thead>
+          <tbody>
             <tr>
               <td><dfn data-idl>new</dfn></td>
               <td>The {{RTCIceTransport}} is gathering
@@ -8577,10 +8609,12 @@ interface RTCIceTransport : EventTarget {
 };</pre>
         <table data-link-for="RTCIceRole" data-dfn-for="RTCIceRole" class=
         "simple">
-          <tbody>
+          <thead>
             <tr>
               <th colspan="2">{{RTCIceRole}} Enumeration description</th>
             </tr>
+          </thead>
+          <tbody>
             <tr>
               <td><dfn data-idl>unknown</dfn></td>
               <td>An agent whose role as defined by [[!ICE]], Section 3,
@@ -8609,10 +8643,12 @@ interface RTCIceTransport : EventTarget {
 };</pre>
         <table data-link-for="RTCIceComponent" data-dfn-for="RTCIceComponent"
         class="simple">
-          <tbody>
+          <thead>
             <tr>
               <th colspan="2">{{RTCIceComponent}} Enumeration description</th>
             </tr>
+          </thead>
+          <tbody>
             <tr>
               <td><dfn data-idl>rtp</dfn></td>
               <td>The ICE Transport is used for RTP (or RTCP multiplexing),
@@ -9130,10 +9166,12 @@ interface RTCSctpTransport : EventTarget {
 };</pre>
           <table data-link-for="RTCSctpTransportState" data-dfn-for=
           "RTCSctpTransportState" class="simple">
-            <tbody>
+            <thead>
               <tr>
                 <th colspan="2">Enumeration description</th>
               </tr>
+            </thead>
+            <tbody>
               <tr>
                 <td data-tests="RTCSctpTransport-events.html"><dfn data-idl id=
                 "idl-def-RTCSctpTransportState.connecting">connecting</dfn></td>
@@ -9927,12 +9965,14 @@ interface RTCDataChannel : EventTarget {
   "closing",
   "closed"
 };</pre>
-        <table data-link-for="RTCDataChannelState" data-dfn-for=
-        "RTCDataChannelState" class="simple">
-          <tbody>
+        <table class="simple">
+          <thead>
             <tr>
               <th colspan="2"><dfn>RTCDataChannelState</dfn> Enumeration description</th>
             </tr>
+          </thead>
+          <tbody data-link-for="RTCDataChannelState" data-dfn-for=
+               "RTCDataChannelState">
             <tr>
               <td data-tests="RTCPeerConnection-createDataChannel.html"><dfn data-idl>connecting</dfn></td>
               <td>
@@ -11534,10 +11574,12 @@ interface RTCError : DOMException {
         </div>
         <table data-link-for="RTCErrorDetailType" data-dfn-for=
         "RTCErrorDetailType" class="simple">
-          <tbody>
+          <thead>
             <tr>
               <th colspan="2">Enumeration description</th>
             </tr>
+          </thead>
+          <tbody>
             <tr>
               <td><dfn data-idl>data-channel-failure</dfn></td>
               <td>The data channel has failed.</td>
@@ -11652,13 +11694,13 @@ interface RTCErrorEvent : Event {
     <p>The following events fire on {{RTCDataChannel}}
     objects:</p>
     <table>
-      <tbody>
+      <thead>
         <tr>
           <th>Event name</th>
           <th>Interface</th>
           <th>Fired when...</th>
         </tr>
-      </tbody>
+      </thead>
       <tbody>
         <tr>
           <td><dfn id="event-datachannel-open"><code class=event>open</code></dfn></td>
@@ -11709,13 +11751,13 @@ interface RTCErrorEvent : Event {
     <p>The following events fire on {{RTCPeerConnection}}
     objects:</p>
     <table>
-      <tbody>
+      <thead>
         <tr>
           <th>Event name</th>
           <th>Interface</th>
           <th>Fired when...</th>
         </tr>
-      </tbody>
+      </thead>
       <tbody>
         <tr>
           <td><dfn id="event-track"><code class=event>track</code></dfn></td>
@@ -11793,13 +11835,13 @@ interface RTCErrorEvent : Event {
     <p>The following events fire on {{RTCDTMFSender}}
     objects:</p>
     <table>
-      <tbody>
+      <thead>
         <tr>
           <th>Event name</th>
           <th>Interface</th>
           <th>Fired when...</th>
         </tr>
-      </tbody>
+      </thead>
       <tbody>
         <tr>
           <td><dfn id=
@@ -11818,13 +11860,13 @@ interface RTCErrorEvent : Event {
     <p>The following events fire on {{RTCIceTransport}}
     objects:</p>
     <table>
-      <tbody>
+      <thead>
         <tr>
           <th>Event name</th>
           <th>Interface</th>
           <th>Fired when...</th>
         </tr>
-      </tbody>
+      </thead>
       <tbody>
         <tr>
           <td><dfn id="event-icetransport-statechange" data-lt=
@@ -11851,13 +11893,13 @@ interface RTCErrorEvent : Event {
     <p>The following events fire on {{RTCDtlsTransport}}
     objects:</p>
     <table>
-      <tbody>
+      <thead>
         <tr>
           <th>Event name</th>
           <th>Interface</th>
           <th>Fired when...</th>
         </tr>
-      </tbody>
+      </thead>
       <tbody>
         <tr>
           <td><dfn id="event-dtlstransport-statechange" data-lt=
@@ -11877,13 +11919,13 @@ interface RTCErrorEvent : Event {
     <p>The following events fire on {{RTCSctpTransport}}
     objects:</p>
     <table>
-      <tbody>
+      <thead>
         <tr>
           <th>Event name</th>
           <th>Interface</th>
           <th>Fired when...</th>
         </tr>
-      </tbody>
+      </thead>
       <tbody>
         <tr>
           <td><dfn id="event-sctptransport-statechange" data-lt=


### PR DESCRIPTION
Needed to benefit from autolinks in spec editing tools


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2436.html" title="Last updated on Jan 13, 2020, 1:33 PM UTC (4a34498)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2436/fbb1554...4a34498.html" title="Last updated on Jan 13, 2020, 1:33 PM UTC (4a34498)">Diff</a>