### PR TITLE
Add more ReSpec auto-links

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -120,7 +120,7 @@
     <p>The term <dfn>media description</dfn> is defined in [[!RFC4566]].</p>
     <p>The term <dfn>media transport</dfn> is defined in [[!RFC7656]].</p>
     <p>The term <dfn>generation</dfn> is defined in [[!TRICKLE-ICE]] Section 2.</p>
-    <p>The terms <dfn data-cite="!WEBRTC-STATS#dfn-stats-object">stats object</dfn> and <dfn data-cite="!WEBRTC-STATS#dfn-monitored-object">monitored object</dfn>, the dictionaries <dfn data-cite="!WEBRTC-STATS#dom-rtcstatstype">RTCStatsType</dfn>, <dfn data-cite="WEBRTC-STATS#dom-rtcinboundrtpstreamstats">RTCInboundRtpStreamStats</dfn>, <dfn data-cite="WEBRTC-STATS#dom-rtcoutboundrtpstreamstats">RTCOutboundRtpStreamStats</dfn> are defined in [[!WEBRTC-STATS]].</p>
+    <p>The terms <dfn data-cite="!WEBRTC-STATS#dfn-stats-object">stats object</dfn> and <dfn data-cite="!WEBRTC-STATS#dfn-monitored-object">monitored object</dfn> are defined in [[!WEBRTC-STATS]].</p>
     <p>When referring to exceptions, the terms [= exception/throw =] and
     [= exception/create =] are
     defined in [[!WEBIDL]].</p>
@@ -305,13 +305,13 @@
                 {{RTCIceCredentialType/"password"}}, then this attribute specifies the
                 username to use with that TURN server.</p>
               </dd>
-              <dt><dfn data-idl>credential</dfn> of type DOMString</dt>
+              <dt><dfn data-idl>credential</dfn> of type {{DOMString}}</dt>
               <dd>
                 <p>If this {{RTCIceServer}} object represents a
                 TURN server, then this attribute specifies the credential to
                 use with that TURN server.</p>
                 <p>If {{credentialType}} is {{RTCIceCredentialType/"password"}},
-                {{credential}} is a DOMString, and represents a
+                {{credential}} is a {{DOMString}}, and represents a
                 long-term authentication password, as described in
                 [[!RFC5389]], Section 10.2.</p>
                 <p class="note">To support additional values of
@@ -330,7 +330,7 @@
             </dl>
           </section>
         </div>
-        <p>An example array of RTCIceServer objects is:</p>
+        <p>An example array of {{RTCIceServer}} objects is:</p>
         <pre class="example highlight">
 [
   {urls: 'stun:stun1.example.net'},
@@ -444,9 +444,9 @@
       <section>
         <h4><dfn>RTCRtcpMuxPolicy</dfn> Enum</h4>
         <p>As described in <span data-jsep="constructor">[[!JSEP]]</span>, the
-        RtcpMuxPolicy affects what ICE candidates are gathered to support
+        {{RTCRtcpMuxPolicy}} affects what ICE candidates are gathered to support
         non-multiplexed RTCP. The only value defined in this spec is
-        "require".</p>
+        {{RTCRtcpMuxPolicy/"require"}}.</p>
         <div>
           <pre id="target-rtcp-mux-policy" class="idl"
 >enum RTCRtcpMuxPolicy {
@@ -513,10 +513,10 @@
                 {{RTCPeerConnection/currentLocalDescription}} attribute.</p>
                 <p class="note">Performing an ICE restart is recommended when
                 {{RTCPeerConnection/iceConnectionState}} transitions to
-                "{{RTCIceConnectionState/failed}}".
+                {{RTCIceConnectionState/"failed"}}.
                 An application may additionally choose to listen for the
                 {{RTCPeerConnection/iceConnectionState}} transition to
-                "{{RTCIceConnectionState/disconnected}}"
+                {{RTCIceConnectionState/"disconnected"}}
                 and then use other sources of information (such as using
                 {{RTCPeerConnection/getStats}} to measure if the number of bytes sent
                 or received over the next couple of seconds increases) to determine
@@ -645,7 +645,7 @@
                 {{RTCIceGathererState/"gathering"}} state.</td>
               </tr>
               <tr>
-                <td data-tests="RTCPeerConnection-iceGatheringState.html,protocol/candidate-exchange.https.html "><dfn data-idl>complete</dfn></td>
+                <td data-tests="RTCPeerConnection-iceGatheringState.html,protocol/candidate-exchange.https.html"><dfn data-idl>complete</dfn></td>
                 <td>At least one {{RTCIceTransport}} exists,
                 and all {{RTCIceTransport}}s are in the
                 {{RTCIceGathererState/"complete"}} gathering state.</td>
@@ -823,7 +823,7 @@
         document and in [[!JSEP]]. The [= ICE Agent =] also provides
         indications to the user agent when the state of its internal
         representation of an {{RTCIceTransport}} changes, as
-        described in <a href= "#rtcicetransport"></a>.</p>
+        described in <a href="#rtcicetransport"></a>.</p>
 
         <p>The task source for the tasks listed in this section is the
         [= networking task source =].</p>
@@ -851,7 +851,7 @@
           <li>
             <p>If any of the steps enumerated below fails for a reason not
               specified here, [= exception/throw =] an {{UnknownError}}
-              with the "message" field set to an appropriate description.
+              with the {{DOMException/message}} attribute set to an appropriate description.
             </p>
           </li>
           <li>
@@ -1210,7 +1210,7 @@
                     <p>If the content of <var>description</var> is not
                     valid SDP syntax, then [= reject =] <var>p</var> with an
                     {{RTCError}} (with {{RTCError/errorDetail}}
-                    set to "sdp-syntax-error" and the {{RTCError/sdpLineNumber}}
+                    set to {{RTCErrorDetailType/"sdp-syntax-error"}} and the {{RTCError/sdpLineNumber}}
                     attribute set to the line number in the SDP where
                     the syntax error was detected) and abort these steps.</p>
                   </li>
@@ -1393,7 +1393,7 @@
                         {{RTCSctpTransportState/"connecting"}} and assign the result to the
                         <a>[[\SctpTransport]]</a> slot. Otherwise, if an SCTP
                         association is established,
-                        but the "max-message-size" SDP attribute is updated,
+                        but the <code class=sdp>max-message-size</code> SDP attribute is updated,
                         [= update the data max message size =] of
                         <var>connection</var>.<a>[[\SctpTransport]]</a>.</p>
                       </li>
@@ -1736,8 +1736,8 @@
                                     <li>If <a>[[\IceRole]]</a> is not {{RTCIceRole/unknown}}, do not modify <a>[[\IceRole]]</a>.</li>
                                     <li>If <var>description</var> is a local offer,
                                       set it to {{RTCIceRole/controlling}}.</li>
-                                    <li>If <var>description</var> is a remote offer, and contains "a=ice-lite", set <a>[[\IceRole]]</a> to {{RTCIceRole/controlling}}.</li>
-                                    <li>If <var>description</var> is a remote offer, and does not contain "a=ice-lite", set <a>[[\IceRole]]</a> to {{RTCIceRole/controlled}}.</li>
+                                    <li>If <var>description</var> is a remote offer, and contains <code class=sdp>a=ice-lite</code>, set <a>[[\IceRole]]</a> to {{RTCIceRole/controlling}}.</li>
+                                    <li>If <var>description</var> is a remote offer, and does not contain <code class=sdp>a=ice-lite</code>, set <a>[[\IceRole]]</a> to {{RTCIceRole/controlled}}.</li>
                                   </ul>
                                   This ensures that <a>[[\IceRole]]</a> always has a value after the first offer is processed.
                                 </div>
@@ -1805,7 +1805,7 @@
                             <p>If the <var>transceiver</var> was created by applying the
                             {{RTCSessionDescription}} that is
                             being rolled back, and a track has never been attached to
-                            it via {{RTCPeerConnection/addTrack()}}, then <a>stop the RTCRtpTransceiver</a>
+                            it via {{RTCPeerConnection/addTrack()}}, then [= stop the RTCRtpTransceiver =]
                             <var>transceiver</var>, and remove it from <var>connection</var>'s
                             [= set of transceivers =].</p>
                           </li>
@@ -1874,7 +1874,7 @@
                     [= fire an event =] named {{RTCDataChannel/error}} using the
                     {{RTCErrorEvent}} interface with the
                     {{RTCError/errorDetail}} attribute set to
-                    "data-channel-failure" at <var>channel</var>.</p>
+                    {{RTCErrorDetailType/"data-channel-failure"}} at <var>channel</var>.</p>
                   </li>
                   <li id="remote-mute" data-tests="RTCPeerConnection-remote-track-mute.https.html">
                     <p>For each <var>track</var> in <var>muteTracks</var>,
@@ -2096,7 +2096,7 @@
         the APIs to send and receive {{MediaStreamTrack}}
         objects.</p>
         <div>
-          <pre class="idl" data-tests="idlharness.https.window.js" data-cite="DOM HTML"
+          <pre class="idl" data-tests="idlharness.https.window.js"
 >[Exposed=Window]
 interface RTCPeerConnection : EventTarget  {
   constructor(optional RTCConfiguration configuration = {});
@@ -2514,14 +2514,14 @@ interface RTCPeerConnection : EventTarget  {
                       </li>
                       <li>
                         <p>If the length of the <a>[[\SendEncodings]]</a> slot
-                          of the RTCRtpSender is
+                          of the {{RTCRtpSender}} is
                           larger than 1, then
                           for each encoding given in <a>[[\SendEncodings]]</a>
-                          of the RTCRtpSender, add an "a=rid send" line to the
+                          of the {{RTCRtpSender}}, add an <code class=sdp>a=rid send</code> line to the
                           corresponding media section, and add an
-                          "a=simulcast:send"
+                          <code class=sdp>a=simulcast:send</code>
                           line giving the RIDs in the same order as
-                          given in the "encodings" field. No RID restrictions
+                          given in the {{RTCRtpSendParameters/encodings}} field. No RID restrictions
                           are set.
                         </p>
                         <p class="note">
@@ -2724,14 +2724,14 @@ interface RTCPeerConnection : EventTarget  {
                       </li>
                       <li>
                        <p>If the length of the <a>[[\SendEncodings]]</a> slot
-                          of the RTCRtpSender is
+                          of the {{RTCRtpSender}} is
                           larger than 1, then
                           for each encoding given in <a>[[\SendEncodings]]</a>
-                          of the RTCRtpSender, add an "a=rid send" line to the
+                          of the {{RTCRtpSender}}, add an <code class=sdp>a=rid send</code> line to the
                           corresponding media section, and add an
-                          "a=simulcast:send"
+                          <code class=sdp>a=simulcast:send</code>
                           line giving the RIDs in the same order as
-                          given in the "encodings" field. No RID restrictions
+                          given in the {{RTCRtpSendParameters/encodings}} field. No RID restrictions
                           are set.
                         </p>
                        </li>
@@ -3109,7 +3109,7 @@ interface RTCPeerConnection : EventTarget  {
                     </ol>
                   </li>
                 </ol>
-                <p class="note">Due to WebIDL processing, addIceCandidate(null)
+                <p class="note">Due to WebIDL processing, {{RTCPeerConnection/addIceCandidate}}(<code>null</code>)
                 is interpreted as a call with the default dictionary present, which, in the
                 above algorithm, indicates end-of-candidates for all media
                 descriptions and ICE candidate generation. This is by design for
@@ -3271,7 +3271,7 @@ interface RTCPeerConnection : EventTarget  {
           if these methods are supported it is mandatory to implement
           according to what is specified here.</p>
         <div class="note">
-          The addStream method that used to exist on
+          The <code>addStream</code> method that used to exist on
           {{RTCPeerConnection}} is easy to polyfill as:
           <pre>RTCPeerConnection.prototype.addStream = function(stream) {
   stream.getTracks().forEach((track) =&gt; this.addTrack(track, stream));
@@ -3546,30 +3546,30 @@ interface RTCPeerConnection : EventTarget  {
             {{RTCPeerConnection}} object.</p>
           </li>
           <li>
-            <p>For each "offerToReceive&lt;Kind&gt;" member in <var>options</var> with
+            <p>For each <code>offerToReceive<var>&lt;Kind&gt;</var></code> member in <var>options</var> with
             kind, <var>kind</var>, run the following steps:</p>
             <ol>
               <li>
                 If the value of the dictionary member is false,
                 <ol>
                   <li data-tests="legacy/RTCPeerConnection-createOffer-offerToReceive.html,legacy/RTCRtpTransceiver-with-OfferToReceive-options.https.html">
-                    <p>For each non-stopped "sendrecv" transceiver of
+                    <p>For each non-stopped {{RTCRtpTransceiverDirection/"sendrecv"}} transceiver of
                     [= transceiver kind =] <var>kind</var>, set
                     <var>transceiver</var>.<a>[[\Direction]]</a> to
-                    "sendonly".</p>
+                    {{RTCRtpTransceiverDirection/"sendonly"}}.</p>
                   </li>
                   <li data-tests="legacy/RTCPeerConnection-createOffer-offerToReceive.html,legacy/RTCRtpTransceiver-with-OfferToReceive-options.https.html">
-                    <p>For each non-stopped "recvonly" transceiver of
+                    <p>For each non-stopped {{RTCRtpTransceiverDirection/"recvonly"}} transceiver of
                     [= transceiver kind =] <var>kind</var>, set
                     <var>transceiver</var>.<a>[[\Direction]]</a> to
-                    "inactive".</p>
+                    {{RTCRtpTransceiverDirection/"inactive"}}.</p>
                   </li>
                 </ol>
                 <p>Continue with the next option, if any.</p>
               </li>
               <li>
-                <p>If <var>connection</var> has any non-stopped "sendrecv"
-                or "recvonly" transceivers of [= transceiver kind =]
+                <p>If <var>connection</var> has any non-stopped {{RTCRtpTransceiverDirection/"sendrecv"}}
+                or {{RTCRtpTransceiverDirection/"recvonly"}} transceivers of [= transceiver kind =]
                 <var>kind</var>, continue with the next option, if any.</p>
               </li>
               <li>
@@ -3585,7 +3585,7 @@ interface RTCPeerConnection : EventTarget  {
               </li>
               <li>
                 <p>Set <var>transceiver</var>.<a>[[\Direction]]</a>
-                to "recvonly".</p>
+                to {{RTCRtpTransceiverDirection/"recvonly"}}.</p>
               </li>
             </ol>
           </li>
@@ -3649,7 +3649,7 @@ interface RTCPeerConnection : EventTarget  {
       <h3>Session Description Model</h3>
       <section>
         <h4><dfn>RTCSdpType</dfn></h4>
-        <p>The RTCSdpType enum describes the type of an
+        <p>The {{RTCSdpType}} enum describes the type of an
         {{RTCSessionDescriptionInit}} or
         {{RTCSessionDescription}} instance.</p>
         <div>
@@ -3824,7 +3824,7 @@ interface RTCSessionDescription {
       <section class="informative">
         <h4>Clearing Negotiation-Needed</h4>
         <p>The negotiation-needed flag is cleared when an
-        {{RTCSessionDescription}} of type "answer" [= set an RTCSessionDescription | is applied =], and the supplied description matches
+        {{RTCSessionDescription}} of type {{RTCSdpType/"answer"}} [= set an RTCSessionDescription | is applied =], and the supplied description matches
         the state of the
         {{RTCRtpTransceiver}}s and
         {{RTCDataChannel}}s that currently exist on the
@@ -3856,7 +3856,7 @@ interface RTCSessionDescription {
             {{RTCSignalingState/"stable"}}, abort these steps.</p>
 
             <p class="note">The negotiation-needed flag will be
-            updated once the state transitions to "stable", as part of the steps
+            updated once the state transitions to {{RTCSignalingState/"stable"}}, as part of the steps
             for [= setting an RTCSessionDescription =].
             </p>
           </li>
@@ -3943,8 +3943,8 @@ interface RTCSessionDescription {
                     <p>If <var>transceiver</var>.<a>[[\Direction]]</a> is
                     {{RTCRtpTransceiverDirection/"sendrecv"}} or {{RTCRtpTransceiverDirection/"sendonly"}},
                     and the [= associated =] m= section in <var>description</var>
-                    either doesn't contain a single "a=msid" line, or the number
-                    of MSIDs from the "a=msid" lines in this m= section,
+                    either doesn't contain a single <code class=sdp>a=msid</code> line, or the number
+                    of MSIDs from the <code class=sdp>a=msid</code> lines in this <code class=sdp>m=</code> section,
                     or the MSID values themselves, differ from what is in
                     <var>transceiver</var>.sender.<a>[[\AssociatedMediaStreamIds]]</a>,
                     return <code>true</code>.
@@ -4228,7 +4228,7 @@ interface RTCIceCandidate {
               <dd>To invoke the {{toJSON()}} operation of the {{RTCIceCandidate}} interface, run the following steps:
                 <ol>
                   <li>Let <var>json</var> be a new {{RTCIceCandidateInit}} dictionary.</li>
-                  <li>For each attribute identifier <var>attr</var> in «"candidate", "sdpMid", "sdpMLineIndex", "usernameFragment"»:
+                  <li>For each attribute identifier <var>attr</var> in «{{candidate}}, {{sdpMid}}, {{sdpMLineIndex}}, {{usernameFragment}}»:
                     <ol>
                       <li>Let <var>value</var> be the result of getting the underlying value of the attribute identified by <var>attr</var>, given this {{RTCIceCandidate}} object.</li>
                       <li>Set <code><var>json</var>[<var>attr</var>]</code> to <var>value</var>.</li>
@@ -4263,8 +4263,8 @@ interface RTCIceCandidate {
               <dt><dfn data-idl>sdpMid</dfn> of type <span class=
               "idlMemberType">DOMString</span>, nullable, defaulting to
               <code>null</code></dt>
-              <dd>If not <code>null</code>, this contains the media stream
-              "identification-tag" defined in [[!RFC5888]] for the
+              <dd>If not <code>null</code>, this contains the [= media stream
+              "identification-tag" =] defined in [[!RFC5888]] for the
               media component this candidate is associated with.</dd>
               <dt><dfn data-idl>sdpMLineIndex</dfn> of type <span class=
               "idlMemberType">unsigned short</span>, nullable,
@@ -4407,7 +4407,7 @@ interface RTCIceCandidate {
       </section>
       <section>
         <h4><dfn>RTCPeerConnectionIceEvent</dfn></h4>
-        <p>The <code class=event>icecandidate</code> event of the RTCPeerConnection uses
+        <p>The <code class=event>icecandidate</code> event of the {{RTCPeerConnection}} uses
         the {{RTCPeerConnectionIceEvent}} interface.</p>
         <p data-tests="RTCPeerConnectionIceEvent-constructor.html">When firing an {{RTCPeerConnectionIceEvent}} event
         that contains an {{RTCIceCandidate}} object, it MUST
@@ -4501,7 +4501,7 @@ interface RTCPeerConnectionIceEvent : Event {
           </section>
         </div>
         <div>
-          <pre class="idl"  data-cite="DOM"
+          <pre class="idl"
 >dictionary RTCPeerConnectionIceEventInit : EventInit {
   RTCIceCandidate? candidate;
   DOMString? url;
@@ -4529,7 +4529,7 @@ interface RTCPeerConnectionIceEvent : Event {
       </section>
       <section>
         <h4><dfn>RTCPeerConnectionIceErrorEvent</dfn></h4>
-        <p>The <code class=event>icecandidateerror</code> event of the RTCPeerConnection
+        <p>The <code class=event>icecandidateerror</code> event of the {{RTCPeerConnection}}
         uses the {{RTCPeerConnectionIceErrorEvent}}
         interface.</p>
         <div>
@@ -4594,7 +4594,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 {{errorCode}} will be set to the value 701 which is
                 outside the STUN error code range. This error is only fired
                 once per server URL while in the
-                {{RTCIceGatheringState}} of "gathering".</p>
+                {{RTCIceGatheringState}} of {{RTCIceGatheringState/"gathering"}}.</p>
               </dd>
               <dt><dfn data-idl>errorText</dfn> of type <span class=
               "idlAttrType">USVString</span>, readonly</dt>
@@ -4609,7 +4609,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           </section>
         </div>
         <div>
-          <pre class="idl"  data-cite="DOM"
+          <pre class="idl"
 >dictionary RTCPeerConnectionIceErrorEventInit : EventInit {
   DOMString hostCandidate;
   DOMString url;
@@ -5013,8 +5013,8 @@ interface RTCCertificate {
     and each track to be received is associated with exactly
     one {{RTCRtpReceiver}}.</p>
     <p>The encoding and transmission of each {{MediaStreamTrack}}
-    SHOULD be made such that its characteristics (width, height and frameRate
-    for video tracks; volume, sampleSize, sampleRate and channelCount for audio
+    SHOULD be made such that its characteristics (<code class=gum>width</code>, <code class=gum>height</code> and <code class=gum>frameRate</code>
+    for video tracks; <code class=fixme>volume</code>, <code class=gum>sampleSize</code>, <code class=gum>sampleRate</code> and <code class=gum>channelCount</code> for audio
     tracks) are to a reasonable degree retained by the track created on the
     remote side. There are situations when this does not apply, there may for
     example be resource constraints at either endpoint or in the network or
@@ -5046,7 +5046,7 @@ interface RTCCertificate {
       <p>The RTP media API extends the {{RTCPeerConnection}}
       interface as described below.</p>
       <div>
-        <pre class="idl" data-tests="idlharness.https.window.js" data-cite="HTML"
+        <pre class="idl" data-tests="idlharness.https.window.js"
 >partial interface RTCPeerConnection {
   sequence&lt;RTCRtpSender&gt; getSenders();
   sequence&lt;RTCRtpReceiver&gt; getReceivers();
@@ -5279,7 +5279,7 @@ interface RTCCertificate {
                     </li>
                   </ol>
                 </li>
-                <li data-cite="fetch">
+                <li>
                   <p>A track could have contents that are inaccessible to the
                   application. This can be due to anything that would make
                   a track <a data-cite="!fetch#concept-cors-check">
@@ -5353,7 +5353,7 @@ interface RTCCertificate {
                   <p>If <var>sender</var> is not in <var>senders</var> (which
                   indicates its transceiver was stopped or removed due to
                   [= setting an RTCSessionDescription =]
-                  of type "rollback"), then abort these steps.</p>
+                  of type {{RTCSdpType/"rollback"}}), then abort these steps.</p>
                 </li>
                 <li>
                   <p>If <var>sender</var>.<a>[[\SenderTrack]]</a> is null,
@@ -6006,12 +6006,12 @@ interface RTCRtpSender {
                         being available, [= reject =] <var>p</var> with a newly
                         created {{RTCError}} whose
                         {{RTCError/errorDetail}} is set to
-                        "hardware-encoder-not-available" and abort these steps.</li>
+                        {{RTCErrorDetailType/"hardware-encoder-not-available"}} and abort these steps.</li>
                         <li>If an error occurred due to a hardware encoder not
                         supporting <var>parameters</var>, [= reject =]
                         <var>p</var> with a newly created
                         {{RTCError}} whose {{RTCError/errorDetail}}
-                        is set to "hardware-encoder-error" and abort these
+                        is set to {{RTCErrorDetailType/"hardware-encoder-error"}} and abort these
                         steps.</li>
                         <li>For all other errors, [= reject =] <var>p</var>
                         with a newly [= exception/create | created =]
@@ -6360,8 +6360,8 @@ async function updateParameters() {
               entries for RTX, RED and FEC mechanisms. Corresponding to each
               media codec where retransmission via RTX is enabled, there will
               be an entry in {{codecs}} with a {{RTCRtpCodecParameters/mimeType}}
-              attribute indicating retransmission via "audio/rtx" or
-              "video/rtx", and an {{RTCRtpCodecParameters/sdpFmtpLine}} attribute (providing
+              attribute indicating retransmission via <code class=mime>audio/rtx</code> or
+              <code class=mime>video/rtx</code>, and an {{RTCRtpCodecParameters/sdpFmtpLine}} attribute (providing
               the "apt" and "rtx-time" parameters). <a>Read-only parameter</a>.</p>
             </dd>
           </dl>
@@ -6383,10 +6383,10 @@ async function updateParameters() {
             <dt data-tests="RTCRtpParameters-transactionId.html"><dfn data-idl>transactionId</dfn> of type <span class=
             "idlMemberType">DOMString</span>, required</dt>
             <dd>
-              <p>An unique identifier for the last set of parameters applied.
-              Ensures that setParameters can only be called based on a previous
-              getParameters, and that there are no intervening changes.
-              <a>Read-only parameter</a>.</p></dd>
+              <p>A unique identifier for the last set of parameters applied.
+              Ensures that {{RTCRtpSender/setParameters}} can only be called based on a previous
+              {{RTCRtpSender/getParameters}}, and that there are no intervening changes.
+              [= Read-only parameter =].</p></dd>
             <dt><dfn data-idl>encodings</dfn> of type <span class=
             "idlMemberType">sequence&lt;{{RTCRtpEncodingParameters}}&gt;</span>,
             required</dt>
@@ -6471,7 +6471,7 @@ async function updateParameters() {
               as long as the {{maxBitrate}} value is not exceeded.
               The encoding may also be further constrained by other
               limits (such as per-transport or per-session
-              bandwidth limits) below the maximum specified here. maxBitrate is
+              bandwidth limits) below the maximum specified here. {{maxBitrate}} is
               computed the same way as the Transport Independent Application Specific Maximum (TIAS)
               bandwidth defined in [[RFC3890]] Section 6.2.2, which is the
               maximum bandwidth needed without counting IP or other transport
@@ -6633,7 +6633,7 @@ async function updateParameters() {
             <dt data-tests="RTCRtpParameters-codecs.html"><dfn data-idl>sdpFmtpLine</dfn> of type <span class=
             "idlMemberType">DOMString</span></dt>
             <dd>
-              <p>The "format specific parameters" field from the "a=fmtp" line
+              <p>The "format specific parameters" field from the <code class=sdp>a=fmtp</code> line
               in the SDP corresponding to the codec, if one exists, as defined
               by <span data-jsep="parsing-a-desc">[[!JSEP]]</span>. For an
               {{RTCRtpSender}}, these parameters come from the
@@ -6716,7 +6716,7 @@ async function updateParameters() {
             <dt data-tests="RTCRtpReceiver-getCapabilities.html"><dfn data-idl>sdpFmtpLine</dfn> of type <span class=
             "idlMemberType">DOMString</span></dt>
             <dd>
-              <p>The "format specific parameters" field from the "a=fmtp" line
+              <p>The "format specific parameters" field from the <code class=sdp>a=fmtp</code> line
               in the SDP corresponding to the codec, if one exists.</p>
             </dd>
           </dl>
@@ -7009,7 +7009,7 @@ interface RTCRtpReceiver {
       particular {{RTCRtpReceiver}} contain information from a
       single point in the RTP stream.</div>
       <div>
-        <pre class="idl" data-cite="HR-TIME"
+        <pre class="idl"
 >dictionary RTCRtpContributingSource {
   required DOMHighResTimeStamp timestamp;
   required unsigned long source;
@@ -7559,13 +7559,13 @@ interface RTCRtpTransceiver {
           end user. The user agent is therefore expected to allocate bandwidth
           between encodings in such a way that all simulcast streams are
           usable on their own; for instance, if two simulcast streams
-          have the same "maxBitrate", one would expect to see a
+          have the same {{RTCRtpEncodingParameters/maxBitrate}}, one would expect to see a
           similar bitrate on both streams. If bandwidth does not
           permit all simulcast streams to be sent in an usable form,
           the user agent is expected to stop sending some of the simulcast streams.
         </p>
         <p>As defined in <span data-jsep="simulcast">[[!JSEP]]</span>, an offer from a user-agent will
-        only contain a "send" description and no "recv" description on the "a=simulcast" line.
+        only contain a "send" description and no "recv" description on the <code class=sdp>a=simulcast</code> line.
         Alternatives and restrictions (described in [[MMUSIC-SIMULCAST]]) are not supported.</p>
         <p>This specification does not define how to configure {{RTCPeerConnection/createOffer}} to receive multiple
         RTP encodings. However when {{RTCPeerConnection/setRemoteDescription}} is called with a corresponding remote
@@ -7721,8 +7721,8 @@ async function onOffHold() {
             [= Fire an event =] named
             <code class=event><a data-lt="RTCDtlsTransport error">error</a></code>
             using the {{RTCErrorEvent}} interface with its
-            errorDetail attribute set to either "dtls-failure" or
-            "fingerprint-failure", as appropriate, and other fields
+            errorDetail attribute set to either {{RTCErrorDetailType/"dtls-failure"}} or
+            {{RTCErrorDetailType/"fingerprint-failure"}}, as appropriate, and other fields
             set as described under the {{RTCErrorDetailType}} enum
             description, at <var>transport</var>.
           </p>
@@ -7764,7 +7764,7 @@ async function onOffHold() {
         </li>
       </ol>
       <div>
-        <pre class="idl" data-tests="idlharness.https.window.js"  data-cite="DOM HTML"
+        <pre class="idl" data-tests="idlharness.https.window.js"
 >[Exposed=Window]
 interface RTCDtlsTransport : EventTarget {
   [SameObject] readonly attribute RTCIceTransport iceTransport;
@@ -8209,7 +8209,7 @@ interface RTCDtlsTransport : EventTarget {
         </li>
       </ul>
       <div>
-        <pre class="idl" data-tests="idlharness.https.window.js"  data-cite="DOM HTML"
+        <pre class="idl" data-tests="idlharness.https.window.js"
 >[Exposed=Window]
 interface RTCIceTransport : EventTarget {
   readonly attribute RTCIceRole role;
@@ -8244,7 +8244,7 @@ interface RTCIceTransport : EventTarget {
               attribute MUST return the ICE component of the transport. When
               RTCP mux is used, a single
               {{RTCIceTransport}} transports both RTP and RTCP
-              and {{component}} is set to "RTP".</p>
+              and {{component}} is set to {{RTCIceComponent/"rtp"}}.</p>
             </dd>
             <dt><dfn id="dom-icetransport-state">state</dfn> of type <span class=
             "idlAttrType">{{RTCIceTransportState}}</span>, readonly</dt>
@@ -8460,8 +8460,8 @@ interface RTCIceTransport : EventTarget {
               and/or waiting for additional remote candidates. If consent
               checks [[!RFC7675]] fail on the connection in use, and there are
               no other successful candidate pairs available, then the state
-              transitions to "checking" (if there are candidate pairs remaining
-              to be checked) or "disconnected" (if there are no candidate pairs
+              transitions to {{RTCIceTransportState/"checking"}} (if there are candidate pairs remaining
+              to be checked) or {{RTCIceTransportState/"disconnected"}} (if there are no candidate pairs
               to check, but the peer is still gathering and/or waiting for
               additional remote candidates).</td>
             </tr>
@@ -8472,7 +8472,7 @@ interface RTCIceTransport : EventTarget {
               candidates, finished checking all candidate pairs and found a
               connection. If consent checks [[!RFC7675]] subsequently fail on
               all successful candidate pairs, the state transitions to
-              "failed".</td>
+              {{RTCIceTransportState/"failed"}}.</td>
             </tr>
             <tr>
               <td><dfn data-idl>disconnected</dfn></td>
@@ -8697,7 +8697,7 @@ interface RTCTrackEvent : Event {
         </section>
       </div>
       <div>
-        <pre class="idl"  data-cite="DOM"
+        <pre class="idl"
 >dictionary RTCTrackEventInit : EventInit {
   required RTCRtpReceiver receiver;
   required MediaStreamTrack track;
@@ -8754,7 +8754,7 @@ interface RTCTrackEvent : Event {
       <p>The Peer-to-peer data API extends the
       {{RTCPeerConnection}} interface as described below.</p>
       <div>
-        <pre class="idl" data-tests="idlharness.https.window.js" data-cite="HTML"
+        <pre class="idl" data-tests="idlharness.https.window.js"
 >partial interface RTCPeerConnection {
   readonly attribute RTCSctpTransport? sctp;
   RTCDataChannel createDataChannel(USVString label,
@@ -8980,7 +8980,7 @@ interface RTCTrackEvent : Event {
             </li>
             <li data-tests="RTCSctpTransport-maxMessageSize.html">
               <p>Let <var>remoteMaxMessageSize</var> be the value of the
-              "max-message-size" SDP attribute read from the remote description,
+              <code class=sdp>max-message-size</code> SDP attribute read from the remote description,
               as described in [[!SCTP-SDP]] (section 6), or 65536 if the
               attribute is missing.</p>
             </li>
@@ -9052,15 +9052,15 @@ interface RTCTrackEvent : Event {
               <p>[= Fire an event =] named <code class=event><a data-lt="
               RTCSctpTransport state change">statechange</a></code> at <var>
                   transport</var>.</p>
-              <p class="note">This event is fired before the "open" events
+              <p class="note">This event is fired before the <code class=event>open</code> events
                 fired by [= announce the rtcdatachannel as open |
-                announcing the channel as open =]; the "open"
+                announcing the channel as open =]; the <code class=event>open</code>
                 events are fired from a queued task.</p>
             </li>
           </ol>
         </section>
         <div>
-          <pre class="idl" data-tests="idlharness.https.window.js"  data-cite="DOM HTML"
+          <pre class="idl" data-tests="idlharness.https.window.js"
 >[Exposed=Window]
 interface RTCSctpTransport : EventTarget {
   readonly attribute RTCDtlsTransport transport;
@@ -9168,7 +9168,7 @@ interface RTCSctpTransport : EventTarget {
                       or applying a remote description that rejects data or
                       changes the SCTP port.</li>
                     <li>the underlying DTLS association has transitioned
-                      to "closed" state.</li>
+                      to {{RTCDtlsTransportState/"closed"}} state.</li>
                   </ul>
                   <p>
                     Note that the last transition is logical due to the
@@ -9420,7 +9420,7 @@ interface RTCSctpTransport : EventTarget {
           <dfn id="data-transport-closed-error">with an error</dfn>, [= fire
           an event =] named {{error}} using the
           {{RTCErrorEvent}} interface with its
-          {{RTCError/errorDetail}} attribute set to "sctp-failure"
+          {{RTCError/errorDetail}} attribute set to {{RTCErrorDetailType/"sctp-failure"}}
           at <var>channel</var>.</p>
         </li>
         <li>
@@ -9453,7 +9453,7 @@ interface RTCSctpTransport : EventTarget {
           <p>[= Fire an event =] named {{RTCDataChannel/error}} using the
           {{RTCErrorEvent}} interface with the
           {{RTCError/errorDetail}} attribute set to
-          "data-channel-failure" at <var>channel</var>.</p>
+          {{RTCErrorDetailType/"data-channel-failure"}} at <var>channel</var>.</p>
         </li>
         <li>
           <p>[= Fire an event =] named {{close}} at
@@ -9512,7 +9512,7 @@ interface RTCSctpTransport : EventTarget {
           <p>[= Fire an event =] named {{message}} using the
           {{MessageEvent}}
           interface with its <code class=html>origin</code> attribute initialized to the
-          <a data-cite="html">serialization of an origin</a>
+          <a>serialization of an origin</a>
           of <var>connection</var>.<a>[[\DocumentOrigin]]</a>,
           and the <code class=html>data</code> attribute initialized to <var>data</var> at
           <var>channel</var>.</p>
@@ -9520,7 +9520,7 @@ interface RTCSctpTransport : EventTarget {
       </ol>
       </section>
       <div>
-        <pre class="idl" data-tests="idlharness.https.window.js"  data-cite="DOM HTML"
+        <pre class="idl" data-tests="idlharness.https.window.js"
 >[Exposed=Window]
 interface RTCDataChannel : EventTarget {
   readonly attribute USVString label;
@@ -9701,7 +9701,7 @@ interface RTCDataChannel : EventTarget {
             <dt data-tests="RTCDataChannel-send.html"><dfn id=
               "dom-datachannel-binarytype">binaryType</dfn> of type <span class=
             "idlAttrType">DOMString</span></dt>
-            <dd data-cite="html">
+            <dd>
               <p>The {{binaryType}}
               attribute MUST, on getting, return the value to which it was
               last set. On setting, if the new value is either the string
@@ -9913,8 +9913,8 @@ interface RTCDataChannel : EventTarget {
             <dt data-tests="RTCPeerConnection-createDataChannel.html"><dfn data-idl>id</dfn> of type <span class=
             "idlMemberType">unsigned short</span></dt>
             <dd>
-              <p>Sets the channel ID when "negotiated" is true.
-                Ignored when "negotiated" is false.</p>
+              <p>Sets the channel ID when {{RTCDataChannelInit/negotiated}} is true.
+                Ignored when {{RTCDataChannelInit/negotiated}} is false.</p>
             </dd>
           </dl>
         </section>
@@ -10006,7 +10006,7 @@ interface RTCDataChannelEvent : Event {
         </section>
       </div>
       <div>
-        <pre class="idl" data-cite="DOM"
+        <pre class="idl"
 >dictionary RTCDataChannelEventInit : EventInit {
   required RTCDataChannel channel;
 };</pre>
@@ -10110,8 +10110,7 @@ interface RTCDataChannelEvent : Event {
           </li>
        </ol>
       <div>
-        <pre class="idl" data-tests  data-cite="DOM HTML"
->[Exposed=Window]
+        <pre class="idl" data-tests>[Exposed=Window]
 interface RTCDTMFSender : EventTarget {
   void insertDTMF(DOMString tones, optional unsigned long duration = 100, optional unsigned long interToneGap = 70);
   attribute EventHandler ontonechange;
@@ -10169,10 +10168,10 @@ interface RTCDTMFSender : EventTarget {
               each character passed in the tones parameters. The duration
               cannot be more than 6000 ms or less than 40 ms. The default
               duration is 100 ms for each tone.</p>
-              <p>The interToneGap parameter indicates the gap between tones in
+              <p>The <var>interToneGap</var> parameter indicates the gap between tones in
               ms. The user agent clamps it to at least 30 ms and at most
               6000 ms. The default value is 70 ms.</p>
-              <p>The browser MAY increase the duration and interToneGap times
+              <p>The browser MAY increase the <var>duration</var> and <var>interToneGap</var> times
               to cause the times that DTMF start and stop to align with the
               boundaries of RTP packets but it MUST not increase either of them
               by more than the duration of a single RTP audio packet.</p>
@@ -10227,12 +10226,12 @@ interface RTCDTMFSender : EventTarget {
                     object and abort these steps.</li>
                     <li>Remove the first character from the <a>[[\ToneBuffer]]</a>
                     slot and let that character be <var>tone</var>.</li>
-                    <li>If <var>tone</var> is "," delay sending tones for
+                    <li>If <var>tone</var> is <code>","</code> delay sending tones for
                     <code>2000</code> ms on
                     the associated RTP media stream, and queue a task to
                     be executed in <code>2000</code> ms from now that
                     runs the steps labelled <em>Playout task</em>.</li>
-                    <li>If <var>tone</var> is not "," start playout of
+                    <li>If <var>tone</var> is not <code>","</code> start playout of
                     <var>tone</var> for <a>[[\Duration]]</a> ms on the associated
                     RTP media stream, using the appropriate codec, then
                     queue a task to be executed in <a>[[\Duration]]</a>
@@ -10311,7 +10310,7 @@ interface RTCDTMFToneChangeEvent : Event {
             "idlAttrType">DOMString</span>, readonly</dt>
             <dd>
               <p>The {{tone}} attribute contains the
-              character for the tone (including ",") that has just
+              character for the tone (including <code>","</code>) that has just
               begun playout (see {{RTCDTMFSender/insertDTMF}} ). If
               the value is the empty string, it indicates that the
               <a>[[\ToneBuffer]]</a> slot is an empty string and that
@@ -10335,7 +10334,7 @@ interface RTCDTMFToneChangeEvent : Event {
               <code>""</code></dt>
             <dd>
               <p>The {{tone}} attribute contains the
-              character for the tone (including ",") that has just
+              character for the tone (including <code>","</code>) that has just
               begun playout (see {{RTCDTMFSender/insertDTMF}} ). If
               the value is the empty string, it indicates that the
               <a>[[\ToneBuffer]]</a> slot is an empty string and that
@@ -10371,7 +10370,7 @@ interface RTCDTMFToneChangeEvent : Event {
       <p>
         With a few exceptions, [= monitored object =]s, once created, exist for
         the duration of their associated {{RTCPeerConnection}}.
-        This ensures statistics from them are available in the result from getStats()
+        This ensures statistics from them are available in the result from {{RTCPeerConnection/getStats()}}
         even past the associated peer connection being {{RTCPeerConnection/close}}d.
       </p>
       <p>Only a few monitored objects have
@@ -10385,8 +10384,7 @@ interface RTCDTMFToneChangeEvent : Event {
       <p>The Statistics API extends the {{RTCPeerConnection}}
       interface as described below.</p>
       <div>
-        <pre class="idl" data-tests="idlharness.https.window.js" data-cite="HTML"
->partial interface RTCPeerConnection {
+        <pre class="idl" data-tests="idlharness.https.window.js">partial interface RTCPeerConnection {
   Promise&lt;RTCStatsReport&gt; getStats(optional MediaStreamTrack? selector = null);
 };</pre>
         <section>
@@ -10396,7 +10394,7 @@ interface RTCDTMFToneChangeEvent : Event {
             <dt data-tests="RTCPeerConnection-getStats.https.html,getstats.html"><dfn id=
               "widl-RTCPeerConnection-getStats-Promise-RTCStatsReport--MediaStreamTrack-selector">getStats</dfn></dt>
             <dd>
-              <p>Gathers stats for the given {{selector}} and reports the
+              <p>Gathers stats for the given [= selector =] and reports the
               result asynchronously.</p>
               <p>When the {{getStats()}} method is invoked, the user agent
               MUST run the following steps:</p>
@@ -10463,20 +10461,18 @@ interface RTCDTMFToneChangeEvent : Event {
       <p>An {{RTCStatsReport}} may be composed of several
       {{RTCStats}}-derived dictionaries, each reporting stats
       for one underlying object that the implementation thinks is relevant for
-      the {{selector}}. One achieves the total for the {{selector}} by
+      the [= selector =]. One achieves the total for the [= selector =] by
       summing over all the stats of a certain type; for instance, if an
       {{RTCRtpSender}} uses multiple SSRCs to carry its track over the
       network, the {{RTCStatsReport}} may contain one
       {{RTCStats}}-derived dictionary per SSRC (which can be
-      distinguished by the value of the "ssrc" stats attribute).</p>
+      distinguished by the value of the {{RTCRtpStreamStats/ssrc}} stats attribute).</p>
       <div>
         <pre class="idl" data-tests
 >[Exposed=Window]
 interface RTCStatsReport {
   readonly maplike&lt;DOMString, object&gt;;
 };</pre>
-        <p>This <a data-cite="webidl">maplike</a> interface has "entries", "forEach", "get", "has", "keys",
-        "values", @@iterator methods and a "size" getter.</p>
         <p>Use these to retrieve the various dictionaries descended from
         {{RTCStats}} that this stats report is composed of. The
         set of supported property names [[!WEBIDL]] is defined as the ids of
@@ -10497,8 +10493,8 @@ interface RTCStatsReport {
       application. Thus, applications MUST be prepared to deal with unknown
       stats.</p>
       <p>Statistics need to be synchronized with each other in order to yield
-      reasonable values in computation; for instance, if "bytesSent" and
-      "packetsSent" are both reported, they both need to be reported over the
+      reasonable values in computation; for instance, if {{RTCSentRtpStreamStats/bytesSent}} and
+      {{RTCSentRtpStreamStats/packetsSent}} are both reported, they both need to be reported over the
       same interval, so that "average packet size" can be computed as "bytes /
       packets" - if the intervals are different, this will yield errors. Thus
       implementations MUST return synchronized values for all stats in an
@@ -10571,7 +10567,7 @@ interface RTCStatsReport {
       <p>The <dfn>stats selection algorithm</dfn> is as follows:</p>
       <ol>
         <li>
-          Let <var>result</var> be an empty RTCStatsReport.
+          Let <var>result</var> be an empty {{RTCStatsReport}}.
         </li>
         <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html">If <var>selector</var> is <code>null</code>, gather stats for the
           whole <var>connection</var>, add them to <var>result</var>, return
@@ -10581,12 +10577,12 @@ interface RTCStatsReport {
           and add the following objects to <var>result</var>:
           <ul>
             <li>
-            All {{RTCOutboundRTPStreamStats}} objects representing RTP
+            All {{RTCOutboundRtpStreamStats}} objects representing RTP
             streams being sent by <var>selector</var>.
             </li>
             <li>
             All stats objects referenced directly or indirectly by the
-            {{RTCOutboundRTPStreamStats}} objects added.
+            {{RTCOutboundRtpStreamStats}} objects added.
             </li>
           </ul>
         </li>
@@ -10594,12 +10590,12 @@ interface RTCStatsReport {
           for and add the following objects to <var>result</var>:
           <ul>
             <li>
-            All {{RTCInboundRTPStreamStats}} objects representing RTP
+            All {{RTCInboundRtpStreamStats}} objects representing RTP
             streams being received by <var>selector</var>.
             </li>
             <li>
             All stats objects referenced directly or indirectly by the
-            {{RTCInboundRTPStreamStats}} added.
+            {{RTCInboundRtpStreamStats}} added.
             </li>
           </ul>
         </li>
@@ -10614,58 +10610,58 @@ interface RTCStatsReport {
       range of use cases. Not all of them have to be implemented by every
       WebRTC implementation.</p>
       <p>An implementation MUST support generating statistics of the following
-      types when the corresponding objects exist on a PeerConnection, with the
+      types when the corresponding objects exist on a {{RTCPeerConnection}}, with the
       attributes that are listed when they are valid for that object:</p>
       <ul>
-        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCRtpStreamStats, with attributes ssrc, kind,
-        transportId, codecId</li>
-        <li data-tests="RTCPeerConnection-getStats.https.html,RTCRtpReceiver-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCReceivedRtpStreamStats, with all required attributes from its
-        inherited dictionaries, and also attributes packetsReceived,
-        packetsLost, jitter, packetsDiscarded</li>
-        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCRtpReceiver-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCInboundRtpStreamStats, with all required attributes from its
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">{{RTCRtpStreamStats}}, with attributes {{RTCRtpStreamStats/ssrc}}, {{RTCRtpStreamStats/kind}},
+        {{RTCRtpStreamStats/transportId}}, {{RTCRtpStreamStats/codecId}}</li>
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCRtpReceiver-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">{{RTCReceivedRtpStreamStats}}, with all required attributes from its
+        inherited dictionaries, and also attributes {{RTCReceivedRtpStreamStats/packetsReceived}},
+        {{RTCReceivedRtpStreamStats/packetsLost}}, {{RTCReceivedRtpStreamStats/jitter}}, {{RTCReceivedRtpStreamStats/packetsDiscarded}}, {{RTCReceivedRtpStreamStats/framesDropped}}, {{RTCReceivedRtpStreamStats/partialFramesLost}}</li>
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCRtpReceiver-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">{{RTCInboundRtpStreamStats}}, with all required attributes from its
         inherited dictionaries, and also attributes
-        receiverId, remoteId, framesDecoded, nackCount,
-        framesReceived, framesDecoded, framesDropped, partialFramesLost,
-        totalAudioEnergy, totalSamplesDuration</li>
-        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCRemoteInboundRTPStreamStats, with all required attributes from
-        its inherited dictionaries, and also attributes localId, bytesReceived,
-        roundTripTime</li>
-        <li data-tests="RTCPeerConnection-getStats.https.html,RTCRtpSender-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCSentRtpStreamStats, with all required attributes from its
-        inherited dictionaries, and also attributes packetsSent, bytesSent</li>
+        {{RTCInboundRtpStreamStats/receiverId}}, {{RTCInboundRtpStreamStats/remoteId}}, {{RTCInboundRtpStreamStats/framesDecoded}}, {{RTCInboundRtpStreamStats/nackCount}},
+        {{RTCInboundRtpStreamStats/framesReceived}}, {{RTCInboundRtpStreamStats/framesDecoded}}, {{RTCInboundRtpStreamStats/bytesReceived}},
+        {{RTCInboundRtpStreamStats/totalAudioEnergy}}, {{RTCInboundRtpStreamStats/totalSamplesDuration}}</li>
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">{{RTCRemoteInboundRtpStreamStats}}, with all required attributes from
+        its inherited dictionaries, and also attributes {{RTCRemoteInboundRtpStreamStats/localId}},
+        {{RTCRemoteInboundRtpStreamStats/roundTripTime}}</li>
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCRtpSender-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">{{RTCSentRtpStreamStats}}, with all required attributes from its
+        inherited dictionaries, and also attributes {{RTCSentRtpStreamStats/packetsSent}}, {{RTCSentRtpStreamStats/bytesSent}}</li>
         <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCRtpSender-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCOutboundRtpStreamStats, with all required attributes from its
-        inherited dictionaries, and also attributes senderId, remoteId, framesEncoded, nackCount,
-        framesSent</li>
-        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCRemoteOutboundRtpStreamStats, with all required attributes from
-        its inherited dictionaries, and also attributes localId, remoteTimestamp
+        inherited dictionaries, and also attributes {{RTCOutboundRtpStreamStats/senderId}}, {{RTCOutboundRtpStreamStats/remoteId}}, {{RTCOutboundRtpStreamStats/framesEncoded}}, {{RTCOutboundRtpStreamStats/nackCount}},
+        {{RTCOutboundRtpStreamStats/framesSent}}</li>
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">{{RTCRemoteOutboundRtpStreamStats}}, with all required attributes from
+        its inherited dictionaries, and also attributes {{RTCRemoteOutboundRtpStreamStats/localId}}, {{RTCRemoteOutboundRtpStreamStats/remoteTimestamp}}
         </li>
-        <li data-tests="RTCPeerConnection-getStats.https.html,getstats.html,RTCPeerConnection-mandatory-getStats.https.html">RTCPeerConnectionStats, with attributes dataChannelsOpened,
-        dataChannelsClosed</li>
-        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCDataChannelStats, with attributes label, protocol,
-        dataChannelIdentifier, state, messagesSent, bytesSent, messagesReceived,
-        bytesReceived</li>
-        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCMediaSourceStats with attributes
-        trackIdentifier, kind</li>
-        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCAudioSourceStats, with all required attributes from its inherited dictionaries and
-        totalAudioEnergy, totalSamplesDuration</li>
-        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCVideoSourceStats, with all required attributes from its inherited dictionaries and
-        width, height, framesPerSecond</li>
-        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCMediaHandlerStats with attributes trackIdentifier</li>
-        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCAudioHandlerStats, with all required attributes from its inherited dictionaries</li>
-        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCVideoHandlerStats, with all required attributes from its inherited dictionaries</li>
-        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCVideoSenderStats, with all required attributes from its inherited dictionaries</li>
-        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCVideoReceiverStats, with all required attributes from its inherited dictionaries</li>
-        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCCodecStats, with attributes payloadType, codecType, mimeType, clockRate,
-        channels, sdpFmtpLine</li>
-        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCTransportStats, with attributes bytesSent, bytesReceived,
-        selectedCandidatePairId,
-        localCertificateId, remoteCertificateId</li>
-        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCIceCandidatePairStats, with attributes transportId,
-        localCandidateId, remoteCandidateId, state, priority, nominated,
-        bytesSent, bytesReceived, totalRoundTripTime, currentRoundTripTime</li>
-        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCIceCandidateStats, with attributes address, port, protocol,
-        candidateType, url</li>
-        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">RTCCertificateStats, with attributes fingerprint,
-        fingerprintAlgorithm, base64Certificate, issuerCertificateId</li>
+        <li data-tests="RTCPeerConnection-getStats.https.html,getstats.html,RTCPeerConnection-mandatory-getStats.https.html">{{RTCPeerConnectionStats}}, with attributes {{RTCPeerConnectionStats/dataChannelsOpened}},
+        {{RTCPeerConnectionStats/dataChannelsClosed}}</li>
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">{{RTCDataChannelStats}}, with attributes {{RTCDataChannelStats/label}} , {{RTCDataChannelStats/protocol}},
+        {{RTCDataChannelStats/dataChannelIdentifier}}, {{RTCDataChannelStats/state}}, {{RTCDataChannelStats/messagesSent}}, {{RTCDataChannelStats/bytesSent}}, {{RTCDataChannelStats/messagesReceived}},
+        {{RTCDataChannelStats/bytesReceived}}</li>
+        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">{{RTCMediaSourceStats}} with attributes
+        {{RTCMediaSourceStats/trackIdentifier}}, {{RTCMediaSourceStats/kind}}</li>
+        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">{{RTCAudioSourceStats}}, with all required attributes from its inherited dictionaries and
+        {{RTCAudioSourceStats/totalAudioEnergy}}, {{RTCAudioSourceStats/totalSamplesDuration}}</li>
+        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">{{RTCVideoSourceStats}}, with all required attributes from its inherited dictionaries and
+        {{RTCVideoSourceStats/width}}, {{RTCVideoSourceStats/height}}, {{RTCVideoSourceStats/framesPerSecond}}</li>
+        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">{{RTCMediaHandlerStats}} with attributes {{RTCMediaHandlerStats/trackIdentifier}}</li>
+        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">{{RTCAudioHandlerStats}}, with all required attributes from its inherited dictionaries</li>
+        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">{{RTCVideoHandlerStats}}, with all required attributes from its inherited dictionaries</li>
+        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">{{RTCVideoSenderStats}}, with all required attributes from its inherited dictionaries</li>
+        <li data-tests="RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">{{RTCVideoReceiverStats}}, with all required attributes from its inherited dictionaries</li>
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">{{RTCCodecStats}}, with attributes {{RTCCodecStats/payloadType}}, {{RTCCodecStats/codecType}}, {{RTCCodecStats/mimeType}}, {{RTCCodecStats/clockRate}},
+        {{RTCCodecStats/channels}}, {{RTCCodecStats/sdpFmtpLine}}</li>
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">{{RTCTransportStats}}, with attributes {{RTCTransportStats/bytesSent}}, {{RTCTransportStats/bytesReceived}},
+        {{RTCTransportStats/selectedCandidatePairId}},
+        {{RTCTransportStats/localCertificateId}}, {{RTCTransportStats/remoteCertificateId}}</li>
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">{{RTCIceCandidatePairStats}}, with attributes {{RTCIceCandidatePairStats/transportId}},
+        {{RTCIceCandidatePairStats/localCandidateId}}, {{RTCIceCandidatePairStats/remoteCandidateId}}, {{RTCIceCandidatePairStats/state}}, {{RTCIceCandidatePairStats/priority}}, {{RTCIceCandidatePairStats/nominated}},
+        {{RTCIceCandidatePairStats/bytesSent}}, {{RTCIceCandidatePairStats/bytesReceived}}, {{RTCIceCandidatePairStats/totalRoundTripTime}}, {{RTCIceCandidatePairStats/currentRoundTripTime}}</li>
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">{{RTCIceCandidateStats}}, with attributes {{RTCIceCandidateStats/address}}, {{RTCIceCandidateStats/port}}, {{RTCIceCandidateStats/protocol}},
+        {{RTCIceCandidateStats/candidateType}}, {{RTCIceCandidateStats/url}}</li>
+        <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">{{RTCCertificateStats}}, with attributes {{RTCCertificateStats/fingerprint}},
+        {{RTCCertificateStats/fingerprintAlgorithm}}, {{RTCCertificateStats/base64Certificate}}, {{RTCCertificateStats/issuerCertificateId}}</li>
       </ul>
       <p>An implementation MAY support generating any other statistic defined
       in [[!WEBRTC-STATS]], and MAY generate statistics that are not
@@ -11561,7 +11557,7 @@ interface RTCError : DOMException {
               the local certificate against the provided fingerprints,
               this error is not generated. Instead a "bad_certificate"
               (42) DTLS alert might be received from the remote peer,
-              resulting in a "dtls-failure".</td>
+              resulting in a {{RTCErrorDetailType/"dtls-failure"}}.</td>
             </tr>
             <tr>
               <td><dfn data-idl>sctp-failure</dfn></td>
@@ -11693,7 +11689,7 @@ interface RTCErrorEvent : Event {
           <td>{{Event}}</td>
           <td>
             The {{RTCDataChannel}} object transitions to the
-            "closing" state
+            {{RTCDataChannelState/"closing"}} state
           </td>
         </tr>
         <tr>
@@ -11870,7 +11866,7 @@ interface RTCErrorEvent : Event {
           <td><dfn data-lt="RTCDtlsTransport error" data-lt-noDefault><code class=event>error</code></dfn></td>
           <td>{{RTCErrorEvent}}</td>
           <td>An error occurred on the {{RTCDtlsTransport}}
-          (either "dtls-error" or "fingerprint-failure").</td>
+          (either {{RTCErrorDetailType/"dtls-failure"}} or {{RTCErrorDetailType/"fingerprint-failure"}}).</td>
         </tr>
       </tbody>
     </table>
@@ -12074,7 +12070,7 @@ effectively and consistently standardise RTT support internationally.</p>
     and Peter Saint-Andre. Dan Burnett would like to acknowledge the
     significant support received from Voxeo and Aspect during the development
     of this specification.</p>
-    <p>The RTCRtpSender and RTCRtpReceiver objects were initially described in
+    <p>The {{RTCRtpSender}} and {{RTCRtpReceiver}} objects were initially described in
     the <a href="https://www.w3.org/community/ortc/">W3C ORTC CG</a>, and have
     been adapted for use in this specification.</p>
   </section>

--- a/webrtc.js
+++ b/webrtc.js
@@ -149,7 +149,7 @@ var respecConfig = {
     }
 
   ],
-  xref: ["dom", "hr-time", "webidl", "html", "mediacapture-streams", "fileapi"],
+  xref: ["dom", "hr-time", "webidl", "html", "mediacapture-streams", "fileapi", "webrtc-stats"],
   preProcess: [
     highlightTests,
     markTestableAssertions,


### PR DESCRIPTION
Fix a few bugs in the process ('RTP' => 'rtp', 'dtls-error' => 'dtls-failure', capitalization mistakes in stats dictionary names, association of members to stat dictionaries)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2439.html" title="Last updated on Jan 15, 2020, 8:15 AM UTC (4b2ca23)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2439/fbb1554...4b2ca23.html" title="Last updated on Jan 15, 2020, 8:15 AM UTC (4b2ca23)">Diff</a>