### PR TITLE
Handle ICE state and candidate pair changes in the same task

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<li lang="en">
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <link href="webrtc.css" rel="stylesheet">

--- a/webrtc.html
+++ b/webrtc.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<li lang="en">
 <head>
   <meta charset="utf-8">
   <link href="webrtc.css" rel="stylesheet">
@@ -8132,10 +8132,14 @@ interface RTCDtlsTransport : EventTarget {
         </li>
       </ol>
 
-      <p>When the [= ICE Agent =] indicates that the
-      {{RTCIceTransportState}} for an
-      {{RTCIceTransport}} has changed, the user agent MUST queue
-      a task that runs the following steps:</p>
+      <p>The {{RTCIceTransportState}} of an {{RTCIceTransport}} may change
+      because a candidate pair with a usable connection was found and selected
+      or it may change without the selected candidate pair changing - the
+      selected pair and {{RTCIceTransportState}} are related and are handled in
+      the same task:</p>
+      <p>When the [= ICE Agent =] indicates that an {{RTCIceTransport}} has
+      changed the selected candidate pair, the {{RTCIceTransportState}} or
+      both, the user agent MUST queue a task that runs the following steps:</p>
       <ol>
         <li class="no-test-needed">
           <p>Let <var>connection</var> be the
@@ -8151,79 +8155,94 @@ interface RTCDtlsTransport : EventTarget {
           whose state is changing.</p>
         </li>
         <li>
-          <p>Set <var>transport</var>.<a>[[\IceTransportState]]</a> to the new
-          indicated {{RTCIceTransportState}}.</p>
-        </li>
-        <li>
-          <p>Set <var>connection</var>'s [= ICE connection state =] to the
-          value of deriving a new state value as described by the
-          {{RTCIceConnectionState}} enum.</p>
-        </li>
-        <li>
-          <p>Let <var>iceConnectionStateChanged</var> be <code>true</code> if
-          the <a>ice connection state</a> changed in the previous step,
-          otherwise <code>false</code>.</p>
-        </li>
-        <li>
-          <p>Set <var>connection</var>'s [= connection state =] to the value of
-          deriving a new state value as described by the
-          {{RTCPeerConnectionState}} enum.</p>
-        </li>
-        <li>
-          <p>Let <var>connectionStateChanged</var> be <code>true</code> if
-          the [= connection state =] changed in the previous step, otherwise
+          <p>Let <var>selectedCandidatePairChanged</var> be
           <code>false</code>.</p>
         </li>
         <li>
-          <p>[= Fire an event =] named {{statechange}} at
+          <p>Let <var>transportIceConnectionStateChanged</var> be
+          <code>false</code>.</p>
+        </li>
+        <li>
+          <p>Let <var>connectionIceConnectionStateChanged</var> be
+          <code>false</code>.</p>
+        </li>
+        <li>
+          <p>Let <var>connectionStateChanged</var> be <code>false</code>.</p>
+        </li>
+        <li>
+          <p>If <var>transport</var>'s selected candidate pair is changing, run
+          the following steps:</p>
+        </li>
+        <ol>
+          <li>
+            <p>Let <var>newCandidatePair</var> be a newly created
+            {{RTCIceCandidatePair}} representing the indicated pair if one is
+            selected, and <code>null</code> otherwise.</p>
+          </li>
+          <li data-tests="RTCIceTransport.html">
+            <p>Set <var>transport</var>.<a>[[\SelectedCandidatePair]]</a>
+            to <var>newCandidatePair</var>.</p>
+          </li>
+          <li>
+            <p>Set <var>selectedCandidatePairChanged</var> to
+            <code>true</code>.</p>
+          </li>
+        </ol>
+        <li>
+          <p>If <var>transport</var>'s {{RTCIceTransportState}} is changing, run
+          the following steps:</p>
+        </li>
+        <ol>
+          <li>
+            <p>Set <var>transport</var>.<a>[[\IceTransportState]]</a> to the new
+            indicated {{RTCIceTransportState}}.</p>
+          </li>
+          <li>
+            <p>Set <var>transportIceConnectionStateChanged</var> to
+            <code>true</code>.</p>
+          </li>
+          <li>
+            <p>Set <var>connection</var>'s [= ICE connection state =] to the
+            value of deriving a new state value as described by the
+            {{RTCIceConnectionState}} enum.</p>
+          </li>
+          <li>
+            <p>If the <a>ice connection state</a> changed in the previous step,
+            set <var>connectionIceConnectionStateChanged</var> to
+            <code>true</code>.</p>
+          </li>
+          <li>
+            <p>Set <var>connection</var>'s [= connection state =] to the value
+            of deriving a new state value as described by the
+            {{RTCPeerConnectionState}} enum.</p>
+          </li>
+          <li>
+            <p>If the [= connection state =] changed in the previous step, set
+            <var>connectionStateChanged</var> to <code>true</code>.</p>
+          </li>
+        </ol>
+        <li>
+          <p>If <var>selectedCandidatePairChanged</var> is <code>true</code>,
+          [= fire an event =] named {{selectedcandidatepairchange}} at
+          <var>transport</var>.</p>
+        </li>
+        <li>
+          <p>If <var>transportIceConnectionStateChanged</var> is
+          <code>true</code>, [= fire an event =] named {{statechange}} at
           <var>transport</var>.</p>
         </li>
         <li data-tests="RTCIceConnectionState-candidate-pair.https.html,RTCPeerConnection-getStats.https.html,RTCPeerConnection-iceConnectionState-disconnected.https.html,RTCPeerConnection-iceConnectionState.https.html,RTCPeerConnection-track-stats.https.html">
-          <p>If <var>iceConnectionStateChanged</var> is <code>true</code>,
-          [= fire an event =] named
-          {{iceconnectionstatechange}} at
-          <var>connection</var>.</p>
+          <p>If <var>connectionIceConnectionStateChanged</var> is
+          <code>true</code>, [= fire an event =] named
+          {{iceconnectionstatechange}} at <var>connection</var>.</p>
         </li>
         <li>
           <p>If <var>connectionStateChanged</var> is <code>true</code>,
-          [= fire an event =] named
-          {{connectionstatechange}} at
+          [= fire an event =] named {{connectionstatechange}} at
           <var>connection</var>.</p>
         </li>
       </ol>
 
-      <p>When the [= ICE Agent =] indicates that the selected candidate pair
-      for an {{RTCIceTransport}} has changed, the user agent
-      MUST queue a task that runs the following steps:</p>
-      <ol>
-        <li class="no-test-needed">
-          <p>Let <var>connection</var> be the
-          {{RTCPeerConnection}} object associated with this
-          [= ICE Agent =].</p>
-        </li>
-        <li>
-          <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
-          <code>true</code>, abort these steps.</p>
-        </li>
-        <li class="no-test-needed">
-          <p>Let <var>transport</var> be the {{RTCIceTransport}}
-          whose selected candidate pair is changing.</p>
-        </li>
-        <li>
-          <p>Let <var>newCandidatePair</var> be a newly created
-          {{RTCIceCandidatePair}} representing the indicated
-          pair if one is selected, and <code>null</code> otherwise.</p>
-        </li>
-        <li data-tests="RTCIceTransport.html">
-          <p>Set <var>transport</var>.<a>[[\SelectedCandidatePair]]</a>
-          to <var>newCandidatePair</var>.</p>
-        </li>
-        <li>
-          <p>[= Fire an event =] named
-          {{selectedcandidatepairchange}} at
-          <var>transport</var>.</p>
-        </li>
-      </ol>
       <p>An {{RTCIceTransport}} object has the following internal slots:</p>
       <ul>
         <li><dfn>[[\IceTransportState]]</dfn> initialized to

--- a/webrtc.html
+++ b/webrtc.html
@@ -8136,7 +8136,7 @@ interface RTCDtlsTransport : EventTarget {
       because a candidate pair with a usable connection was found and selected
       or it may change without the selected candidate pair changing. The
       selected pair and {{RTCIceTransportState}} are related and are handled in
-      the same task:</p>
+      the same task.</p>
       <p>When the [= ICE Agent =] indicates that an {{RTCIceTransport}} has
       changed either the selected candidate pair, the {{RTCIceTransportState}} or
       both, the user agent MUST queue a task that runs the following steps:</p>
@@ -8170,7 +8170,7 @@ interface RTCDtlsTransport : EventTarget {
           <p>Let <var>connectionStateChanged</var> be <code>false</code>.</p>
         </li>
         <li>
-          <p>If <var>transport</var>'s selected candidate pair is changing, run
+          <p>If <var>transport</var>'s selected candidate pair was changed, run
           the following steps:</p>
           <ol>
             <li>
@@ -8189,7 +8189,7 @@ interface RTCDtlsTransport : EventTarget {
           </ol>  
         </li>
         <li>
-          <p>If <var>transport</var>'s {{RTCIceTransportState}} is changing, run
+          <p>If <var>transport</var>'s {{RTCIceTransportState}} was changed, run
           the following steps:</p>
           <ol>
             <li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -8134,11 +8134,11 @@ interface RTCDtlsTransport : EventTarget {
 
       <p>The {{RTCIceTransportState}} of an {{RTCIceTransport}} may change
       because a candidate pair with a usable connection was found and selected
-      or it may change without the selected candidate pair changing - the
+      or it may change without the selected candidate pair changing. The
       selected pair and {{RTCIceTransportState}} are related and are handled in
       the same task:</p>
       <p>When the [= ICE Agent =] indicates that an {{RTCIceTransport}} has
-      changed the selected candidate pair, the {{RTCIceTransportState}} or
+      changed either the selected candidate pair, the {{RTCIceTransportState}} or
       both, the user agent MUST queue a task that runs the following steps:</p>
       <ol>
         <li class="no-test-needed">

--- a/webrtc.html
+++ b/webrtc.html
@@ -8172,55 +8172,55 @@ interface RTCDtlsTransport : EventTarget {
         <li>
           <p>If <var>transport</var>'s selected candidate pair is changing, run
           the following steps:</p>
+          <ol>
+            <li>
+              <p>Let <var>newCandidatePair</var> be a newly created
+              {{RTCIceCandidatePair}} representing the indicated pair if one is
+              selected, and <code>null</code> otherwise.</p>
+            </li>
+            <li data-tests="RTCIceTransport.html">
+              <p>Set <var>transport</var>.<a>[[\SelectedCandidatePair]]</a>
+              to <var>newCandidatePair</var>.</p>
+            </li>
+            <li>
+              <p>Set <var>selectedCandidatePairChanged</var> to
+              <code>true</code>.</p>
+            </li>
+          </ol>  
         </li>
-        <ol>
-          <li>
-            <p>Let <var>newCandidatePair</var> be a newly created
-            {{RTCIceCandidatePair}} representing the indicated pair if one is
-            selected, and <code>null</code> otherwise.</p>
-          </li>
-          <li data-tests="RTCIceTransport.html">
-            <p>Set <var>transport</var>.<a>[[\SelectedCandidatePair]]</a>
-            to <var>newCandidatePair</var>.</p>
-          </li>
-          <li>
-            <p>Set <var>selectedCandidatePairChanged</var> to
-            <code>true</code>.</p>
-          </li>
-        </ol>
         <li>
           <p>If <var>transport</var>'s {{RTCIceTransportState}} is changing, run
           the following steps:</p>
+          <ol>
+            <li>
+              <p>Set <var>transport</var>.<a>[[\IceTransportState]]</a> to the
+              new indicated {{RTCIceTransportState}}.</p>
+            </li>
+            <li>
+              <p>Set <var>transportIceConnectionStateChanged</var> to
+              <code>true</code>.</p>
+            </li>
+            <li>
+              <p>Set <var>connection</var>'s [= ICE connection state =] to the
+              value of deriving a new state value as described by the
+              {{RTCIceConnectionState}} enum.</p>
+            </li>
+            <li>
+              <p>If the <a>ice connection state</a> changed in the previous
+              step, set <var>connectionIceConnectionStateChanged</var> to
+              <code>true</code>.</p>
+            </li>
+            <li>
+              <p>Set <var>connection</var>'s [= connection state =] to the value
+              of deriving a new state value as described by the
+              {{RTCPeerConnectionState}} enum.</p>
+            </li>
+            <li>
+              <p>If the [= connection state =] changed in the previous step, set
+              <var>connectionStateChanged</var> to <code>true</code>.</p>
+            </li>
+          </ol>
         </li>
-        <ol>
-          <li>
-            <p>Set <var>transport</var>.<a>[[\IceTransportState]]</a> to the new
-            indicated {{RTCIceTransportState}}.</p>
-          </li>
-          <li>
-            <p>Set <var>transportIceConnectionStateChanged</var> to
-            <code>true</code>.</p>
-          </li>
-          <li>
-            <p>Set <var>connection</var>'s [= ICE connection state =] to the
-            value of deriving a new state value as described by the
-            {{RTCIceConnectionState}} enum.</p>
-          </li>
-          <li>
-            <p>If the <a>ice connection state</a> changed in the previous step,
-            set <var>connectionIceConnectionStateChanged</var> to
-            <code>true</code>.</p>
-          </li>
-          <li>
-            <p>Set <var>connection</var>'s [= connection state =] to the value
-            of deriving a new state value as described by the
-            {{RTCPeerConnectionState}} enum.</p>
-          </li>
-          <li>
-            <p>If the [= connection state =] changed in the previous step, set
-            <var>connectionStateChanged</var> to <code>true</code>.</p>
-          </li>
-        </ol>
         <li>
           <p>If <var>selectedCandidatePairChanged</var> is <code>true</code>,
           [= fire an event =] named {{selectedcandidatepairchange}} at


### PR DESCRIPTION
Fixes #2283.

If the selected candidate pair causes the ICE connection state to change, we surface all state changes first and fire all events later, in the following order:
- transport.selectedcandidatepairchange
- transport.statechange
- connection.iceconnectionstatechange
- connection.connectionstatechange

This gives a well-defined event firing order. It also makes it possible to inspect the state of the connection or transport and not find inconsistencies, e.g. in selectedcandidatepairchange we are guaranteed to see an up-to-date transport.state or vice versa.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2444.html" title="Last updated on Jan 23, 2020, 3:32 PM UTC (34fe4a2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2444/7e02bc9...henbos:34fe4a2.html" title="Last updated on Jan 23, 2020, 3:32 PM UTC (34fe4a2)">Diff</a>