### PR TITLE
Fix RTCPeerConnectionState references to dependent states

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -696,39 +696,45 @@
               <tr>
                 <td data-tests="protocol/dtls-fingerprint-validation.html"><dfn data-idl>failed</dfn></td>
                 <td>The previous state doesn't apply and any
-                {{RTCIceTransport}}s or
+                {{RTCIceTransport}}s are in the
+                {{RTCIceTransportState/"failed"}} state or any
                 {{RTCDtlsTransport}}s are in the
-                <code class=fixme>"failed"</code> state.</td>
+                {{RTCDtlsTransportState/"failed"}} state.</td>
               </tr>
               <tr>
                 <td><dfn data-idl>disconnected</dfn></td>
                 <td>None of the previous states apply and any
-                {{RTCIceTransport}}s or
-                {{RTCDtlsTransport}}s are in the
-                <code class=fixme>"disconnected"</code> state.</td>
+                {{RTCIceTransport}}s are in the
+                {{RTCIceTransportState/"disconnected"}} state.</td>
               </tr>
               <tr>
                 <td><dfn data-idl>new</dfn></td>
                 <td>None of the previous states apply and all
-                {{RTCIceTransport}}s and
-                {{RTCDtlsTransport}}s are in the
-                <code class=fixme>"new"</code> or <code class=fixme>"closed"</code> state, or there are
-                no transports.</td>
+                {{RTCIceTransport}}s are in the {{RTCIceTransportState/"new"}}
+                or {{RTCIceTransportState/"closed"}} state and all
+                {{RTCDtlsTransport}}s are in the {{RTCDtlsTransportState/"new"}}
+                or {{RTCDtlsTransportState/"closed"}} state, or there are no
+                transports.</td>
               </tr>
               <tr>
                 <td data-tests="RTCPeerConnection-connectionState.https.html"><dfn data-idl>connecting</dfn></td>
                 <td>None of the previous states apply and all
-                {{RTCIceTransport}}s or
+                {{RTCIceTransport}}s are in the {{RTCIceTransportState/"new"}}
+                or {{RTCIceTransportState/"checking"}} state and all
                 {{RTCDtlsTransport}}s are in the
-                <code class=fixme>"new"</code>, <code class=fixme>"connecting"</code> or <code class=fixme>"checking"</code> state.</td>
+                {{RTCDtlsTransportState/"new"}} or
+                {{RTCDtlsTransportState/"connecting"}} state.</td>
               </tr>
               <tr>
                 <td data-tests="RTCPeerConnection-connectionState.https.html"><dfn data-idl>connected</dfn></td>
                 <td>None of the previous states apply and all
-                {{RTCIceTransport}}s and
+                {{RTCIceTransport}}s are in the
+                {{RTCIceTransportState/"connected"}},
+                {{RTCIceTransportState/"completed"}} or
+                {{RTCIceTransportState/"closed"}} state and all
                 {{RTCDtlsTransport}}s are in the
-                <code class=fixme>"connected"</code>, <code class=fixme>"completed"</code> or
-                <code class=fixme>"closed"</code> state.</td>
+                {{RTCDtlsTransportState/"connected"}} or
+                {{RTCDtlsTransportState/"closed"}} state.</td>
               </tr>
             </tbody>
           </table>

--- a/webrtc.html
+++ b/webrtc.html
@@ -720,7 +720,7 @@
                 <td data-tests="RTCPeerConnection-connectionState.https.html"><dfn data-idl>connecting</dfn></td>
                 <td>None of the previous states apply and all
                 {{RTCIceTransport}}s are in the {{RTCIceTransportState/"new"}}
-                or {{RTCIceTransportState/"checking"}} state and all
+                or {{RTCIceTransportState/"checking"}} state, and all
                 {{RTCDtlsTransport}}s are in the
                 {{RTCDtlsTransportState/"new"}} or
                 {{RTCDtlsTransportState/"connecting"}} state.</td>

--- a/webrtc.html
+++ b/webrtc.html
@@ -711,7 +711,7 @@
                 <td><dfn data-idl>new</dfn></td>
                 <td>None of the previous states apply and all
                 {{RTCIceTransport}}s are in the {{RTCIceTransportState/"new"}}
-                or {{RTCIceTransportState/"closed"}} state and all
+                or {{RTCIceTransportState/"closed"}} state, and all
                 {{RTCDtlsTransport}}s are in the {{RTCDtlsTransportState/"new"}}
                 or {{RTCDtlsTransportState/"closed"}} state, or there are no
                 transports.</td>

--- a/webrtc.html
+++ b/webrtc.html
@@ -731,7 +731,7 @@
                 {{RTCIceTransport}}s are in the
                 {{RTCIceTransportState/"connected"}},
                 {{RTCIceTransportState/"completed"}} or
-                {{RTCIceTransportState/"closed"}} state and all
+                {{RTCIceTransportState/"closed"}} state, and all
                 {{RTCDtlsTransport}}s are in the
                 {{RTCDtlsTransportState/"connected"}} or
                 {{RTCDtlsTransportState/"closed"}} state.</td>


### PR DESCRIPTION
Fixes #2421.

While fixing this, I discovered and filed #2446, but this PR does not intent to change any definitions, only fix inconsistent references - e.g. RTCIceTransportState has "checking" but not "connecting" and RTCDtlsTransportState has "connecting" but not "checking", so we should not say that 'all RTCIceTransports are "new", "checking" or "connecting"' etc.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2447.html" title="Last updated on Jan 23, 2020, 3:45 PM UTC (80dd62d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2447/7e02bc9...henbos:80dd62d.html" title="Last updated on Jan 23, 2020, 3:45 PM UTC (80dd62d)">Diff</a>