### PR TITLE
Construct RTCError with name 'OperationError'.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -11475,7 +11475,8 @@ interface RTCError : DOMException {
               <li data-tests="RTCError.html">
                 <p>Invoke the {{DOMException}} constructor of <var>e</var> with the
                 {{DOMException/message}} argument set to <var>message</var> and the
-                {{DOMException/name}} argument set to <code>"RTCError"</code>.</p>
+                {{DOMException/name}} argument set to
+                <code>"OperationError"</code>.</p>
                 <p class="note">This name does not have a mapping to a legacy
                 code so <var>e</var>.{{DOMException/code}} will return
                 0.</p>


### PR DESCRIPTION
Fixes #2437.
This is the same as previously merged PR #2375 that accidentally got reverted at some point.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2448.html" title="Last updated on Jan 22, 2020, 1:28 PM UTC (5ebb54b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2448/7e02bc9...henbos:5ebb54b.html" title="Last updated on Jan 22, 2020, 1:28 PM UTC (5ebb54b)">Diff</a>