### PR TITLE
RTCPeerConnectionIceErrorEventInit with address and port

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4635,8 +4635,8 @@ interface RTCPeerConnectionIceErrorEvent : Event {
         <div>
           <pre class="idl"
 >dictionary RTCPeerConnectionIceErrorEventInit : EventInit {
-  attribute DOMString? address;
-  attribute unsigned short? port;
+  DOMString? address;
+  unsigned short? port;
   DOMString url;
   required unsigned short errorCode;
   USVString statusText;

--- a/webrtc.html
+++ b/webrtc.html
@@ -4635,7 +4635,8 @@ interface RTCPeerConnectionIceErrorEvent : Event {
         <div>
           <pre class="idl"
 >dictionary RTCPeerConnectionIceErrorEventInit : EventInit {
-  DOMString hostCandidate;
+  attribute DOMString? address;
+  attribute unsigned short? port;
   DOMString url;
   required unsigned short errorCode;
   USVString statusText;
@@ -4646,11 +4647,17 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             <dl data-link-for="RTCPeerConnectionIceErrorEventInit"
             data-dfn-for="RTCPeerConnectionIceErrorEventInit" class=
             "dictionary-members">
-              <dt><dfn data-idl>hostCandidate</dfn> of type <span class=
-              "idlMemberType">DOMString</span></dt>
+              <dt><dfn data-idl>address</dfn> of type <span class=
+              "idlMemberType">DOMString</span>, nullable</dt>
               <dd>
-                <p>The local address and port used to communicate
-                 with the STUN or TURN server.</p>
+                <p>The local address used to communicate with the STUN or TURN
+                server, or <code>null</code>.</p>
+              </dd>
+              <dt><dfn data-idl>port</dfn> of type <span class=
+              "idlMemberType">unsigned short</span>, nullable</dt>
+              <dd>
+                <p>The local port used to communicate with the STUN or TURN
+                server, or <code>null</code>.</p>
               </dd>
               <dt><dfn data-idl>url</dfn> of type <span class=
               "idlMemberType">DOMString</span></dt>


### PR DESCRIPTION
Fixes #2438.
The hostCandidate of RTCPeerConnectionIceEvent was replaced with address and port already, the Init dictionary must follow.
Note we have yet to define the event constructor so there are no references that need to be fixed... (we should define the constructor though, but not in this PR)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2449.html" title="Last updated on Jan 22, 2020, 2:20 PM UTC (e9423f4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2449/7e02bc9...henbos:e9423f4.html" title="Last updated on Jan 22, 2020, 2:20 PM UTC (e9423f4)">Diff</a>