### PR TITLE
Make 4.4.1 Operation's NOTE say 'signaling state'

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -846,7 +846,7 @@
 
         <p class="note" data-link-for="RTCPeerConnection">The state of the SDP
           negotiation is represented by
-        the [= connection state =] and the internal
+        the [= signaling state =] and the internal
         variables <a>[[\CurrentLocalDescription]]</a>,
         <a>[[\CurrentRemoteDescription]]</a>, <a>[[\PendingLocalDescription]]</a>
         and <a>[[\PendingRemoteDescription]]</a>. These are only set


### PR DESCRIPTION
Fixes #2430.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2450.html" title="Last updated on Jan 22, 2020, 1:46 PM UTC (c5b1f5f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2450/7e02bc9...henbos:c5b1f5f.html" title="Last updated on Jan 22, 2020, 1:46 PM UTC (c5b1f5f)">Diff</a>