### PR TITLE
Clarify that removed codec need not be listed

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7476,15 +7476,14 @@ interface RTCRtpTransceiver {
               include this {{RTCRtpTransceiver}} until this method is
               called again. Setting <var>codecs</var> to an empty sequence
               resets codec preferences to any default value.</p>
-              <p class="note">Preferred codecs have their payload types listed
+              <p class="note">Codecs have their payload types listed
               under each m= section in the SDP, defining the mapping between
               payload types and codecs. These payload types are referenced by
-              the a=video or a=audio lines in the order of preference. While a
-              previously negotiated codec's payload type must not be reused in
-              future offers or answers to map to a different codec, if a codec
-              that was previously negotiated is removed from the list, the
-              subsequent offers and answers do not need to continue to define
-              that payload type in the SDP.</p>
+              the m=video or m=audio lines in the order of preference. Since a
+              previously negotiated codec's payload type is not reused in
+              future offers or answers, if a codec that was previously
+              negotiated is removed from the list, the subsequent offers and
+              answers do not need to continue to define that payload type in the SDP.</p>
               <p>The <var>codecs</var> sequence passed into
               {{setCodecPreferences}} can only contain codecs that are
               returned by {{RTCRtpSender}}.{{RTCRtpSender/getCapabilities}}(<var>kind</var>) or

--- a/webrtc.html
+++ b/webrtc.html
@@ -7479,11 +7479,13 @@ interface RTCRtpTransceiver {
               <p class="note">Codecs have their payload types listed
               under each m= section in the SDP, defining the mapping between
               payload types and codecs. These payload types are referenced by
-              the m=video or m=audio lines in the order of preference. Since a
-              previously negotiated codec's payload type is not reused in
-              future offers or answers, if a codec that was previously
-              negotiated is removed from the list, the subsequent offers and
-              answers do not need to continue to define that payload type in the SDP.</p>
+              the m=video or m=audio lines in the order of preference, and
+              codecs that are not negotiated do not apear in this list.
+              A previously negotiated codec that is subsequently removed
+              disappears from the m=video or m=audio line, and while its codec
+              payload type is not to be reused in future offers or answers,
+              its payload type may also be removed from the mapping of payload
+              types in the SDP.</p>
               <p>The <var>codecs</var> sequence passed into
               {{setCodecPreferences}} can only contain codecs that are
               returned by {{RTCRtpSender}}.{{RTCRtpSender/getCapabilities}}(<var>kind</var>) or

--- a/webrtc.html
+++ b/webrtc.html
@@ -7476,6 +7476,15 @@ interface RTCRtpTransceiver {
               include this {{RTCRtpTransceiver}} until this method is
               called again. Setting <var>codecs</var> to an empty sequence
               resets codec preferences to any default value.</p>
+              <p class="note">Preferred codecs have their payload types listed
+              under each m= section in the SDP, defining the mapping between
+              payload types and codecs. These payload types are referenced by
+              the a=video or a=audio lines in the order of preference. While a
+              previously negotiated codec's payload type must not be reused in
+              future offers or answers to map to a different codec, if a codec
+              that was previously negotiated is removed from the list, the
+              subsequent offers and answers do not need to continue to define
+              that payload type in the SDP.</p>
               <p>The <var>codecs</var> sequence passed into
               {{setCodecPreferences}} can only contain codecs that are
               returned by {{RTCRtpSender}}.{{RTCRtpSender/getCapabilities}}(<var>kind</var>) or

--- a/webrtc.html
+++ b/webrtc.html
@@ -7480,7 +7480,8 @@ interface RTCRtpTransceiver {
               under each m= section in the SDP, defining the mapping between
               payload types and codecs. These payload types are referenced by
               the m=video or m=audio lines in the order of preference, and
-              codecs that are not negotiated do not apear in this list.
+              codecs that are not negotiated do not apear in this list as
+              defined in section 5.2.1 of [[!JSEP]].
               A previously negotiated codec that is subsequently removed
               disappears from the m=video or m=audio line, and while its codec
               payload type is not to be reused in future offers or answers,


### PR DESCRIPTION
Fixes #2371.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2452.html" title="Last updated on Jan 31, 2020, 9:13 AM UTC (03defe1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2452/7e02bc9...henbos:03defe1.html" title="Last updated on Jan 31, 2020, 9:13 AM UTC (03defe1)">Diff</a>