### PR TITLE
fix stun/turn uri rfc references

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2052,12 +2052,12 @@
                       <var>scheme name</var> is <code class=scheme>turn</code> or
                       <code class=scheme>turns</code>, and parsing the
                       <var>url</var> using the syntax defined in
-                      [[!RFC7064]] fails, [= exception/throw =] a
+                      [[!RFC7065]] fails, [= exception/throw =] a
                       {{SyntaxError}}. If <var>scheme
                       name</var> is <code class=scheme>stun</code> or
                       <code class=scheme>stuns</code>, and parsing the
                       <var>url</var> using the syntax defined in
-                      [[!RFC7065]] fails, [= exception/throw =] a
+                      [[!RFC7064]] fails, [= exception/throw =] a
                       {{SyntaxError}}. </p>
                     </li>
                     <li>


### PR DESCRIPTION
which were mixed up


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-pc/pull/2453.html" title="Last updated on Jan 23, 2020, 2:09 PM UTC (d54e545)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2453/7e02bc9...fippo:d54e545.html" title="Last updated on Jan 23, 2020, 2:09 PM UTC (d54e545)">Diff</a>