### PR TITLE
pc.close() does not fire connectionstatechange either

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3223,7 +3223,7 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>Set <var>connection</var>'s [= signaling state =] to
-                    {{RTCSignalingState/"closed"}}.</p>
+                    {{RTCSignalingState/"closed"}}. This does not fire any event.</p>
                   </li>
                   <li data-tests="RTCPeerConnection-transceivers.https.html">
                     <p>Let <var>transceivers</var> be the result of executing the
@@ -3273,8 +3273,7 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>Set <var>connection</var>'s [= ICE connection state =] to
-                      {{RTCIceConnectionState/"closed"}}. This does not fire any event.
-                    </p>
+                      {{RTCIceConnectionState/"closed"}}. This does not fire any event.</p>
                   </li>
                   <li>
                     <p>Set <var>connection</var>'s [= connection state =] to

--- a/webrtc.html
+++ b/webrtc.html
@@ -3278,7 +3278,7 @@ interface RTCPeerConnection : EventTarget  {
                   </li>
                   <li>
                     <p>Set <var>connection</var>'s [= connection state =] to
-                    {{RTCPeerConnectionState/"closed"}}.</p>
+                    {{RTCPeerConnectionState/"closed"}}. This does not fire any event.</p>
                   </li>
                 </ol>
               </dd>


### PR DESCRIPTION
for ease of review expand to the bullet point above where this is copied from


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-pc/pull/2461.html" title="Last updated on Feb 6, 2020, 1:19 PM UTC (5f9c341)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2461/539595f...fippo:5f9c341.html" title="Last updated on Feb 6, 2020, 1:19 PM UTC (5f9c341)">Diff</a>