### PR TITLE
Check signalingState in queued task before firing ONN.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3886,8 +3886,12 @@ interface RTCSessionDescription {
             [= operations chain =]:</p>
             <ol>
               <li>
-                <p class="untestable">If <var>connection</var>.<a>[[\IsClosed]]</a>
+                <p class="needs-test">If <var>connection</var>.<a>[[\IsClosed]]</a>
                 is <code>true</code>, abort these steps.</p>
+              </li>
+              <li class="needs-test">
+                <p>If <var>connection</var>'s [= signaling state =] is not
+                {{RTCSignalingState/"stable"}}, abort these steps.</p>
               </li>
               <li>
                 <p>If <var>connection</var>.<a>[[\NegotiationNeeded]]</a>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1864,26 +1864,8 @@
                   </li>
                   <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
                     <p>If <var>connection</var>'s [= signaling state =] is now
-                    {{RTCSignalingState/"stable"}}, [= update the negotiation-needed
-                    flag =]. If <var>connection</var>.<a>[[\NegotiationNeeded]]</a>
-                    was <code>true</code> both before and after this update,
-                    <p>[= Chain =] a step to
-                    queue a task that runs the following steps, to
-                    <var>connection</var>'s [= operations chain =]:</p>
-                    <ol>
-                      <li>
-                        <p>If <var>connection</var>.<a>[[\IsClosed]]</a>
-                        is <code>true</code>, abort these steps.</p>
-                      </li>
-                      <li>
-                        <p>If <var>connection</var>.<a>[[\NegotiationNeeded]]</a>
-                        is <code>false</code>, abort these steps.</p>
-                      </li>
-                      <li>
-                        <p>[= Fire an event =] named {{negotiationneeded}}
-                        at <var>connection</var>.</p>
-                      </li>
-                    </ol>
+                    {{RTCSignalingState/"stable"}}, [= clear the negotiation-needed
+                    flag =] and [= update the negotiation-needed flag =].
                   </li>
                   <li>
                     <p>If <var>connection</var>'s [= signaling state =]


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2471.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2472.html" title="Last updated on Feb 13, 2020, 1:41 AM UTC (f4b8102)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2472/b4d01d6...jan-ivar:f4b8102.html" title="Last updated on Feb 13, 2020, 1:41 AM UTC (f4b8102)">Diff</a>