### PR TITLE
Add unit for RTCRtpEncodingParameters#maxBitrate. (Fixes #2462).

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6522,7 +6522,7 @@ async function updateParameters() {
               computed the same way as the Transport Independent Application Specific Maximum (TIAS)
               bandwidth defined in [[RFC3890]] Section 6.2.2, which is the
               maximum bandwidth needed without counting IP or other transport
-                layers like TCP or UDP.</p>
+                layers like TCP or UDP. The unit of {{maxBitrate} is bits per second.</p>
               <p class="note">
                 How the bitrate is achieved is media and encoding dependent.
                 For video, a frame will always be sent as fast as possible,


### PR DESCRIPTION
Fixes Issue https://github.com/w3c/webrtc-pc/issues/2462


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rasmusbrandt/webrtc-pc/pull/2485.html" title="Last updated on Mar 2, 2020, 10:03 PM UTC (55696f4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2485/35f2a6d...rasmusbrandt:55696f4.html" title="Last updated on Mar 2, 2020, 10:03 PM UTC (55696f4)">Diff</a>