### PR TITLE
Have update negotiation-needed steps return a promise

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3848,19 +3848,22 @@ interface RTCSessionDescription {
         <p class="untestable">The process below occurs where referenced elsewhere in this document.
         It also may occur as a result of internal changes within the
         implementation that affect negotiation. If such changes occur, the user
-        agent MUST queue a task to [= update the negotiation-needed
-        flag =].</p>
+        agent MUST [= update the negotiation-needed flag =].</p>
         <p data-tests="">To <dfn>update the negotiation-needed flag</dfn> for
         <var>connection</var>, queue a task to [= chain =] the following steps
         to <var>connection</var>'s [= operations chain =]:</p>
         <ol>
+          <li>
+            <p>Let <var>p</var> be a new promise resolved with
+            <code>undefined</code>.</p>
+          </li>
           <li class=untestable>
             <p>If <var>connection</var>.<a>[[\IsClosed]]</a> is
-            <code>true</code>, abort these steps.</p>
+            <code>true</code>, return <var>p</var>.</p>
           </li>
           <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
             <p>If <var>connection</var>'s [= signaling state =] is not
-            {{RTCSignalingState/"stable"}}, abort these steps.</p>
+            {{RTCSignalingState/"stable"}}, return <var>p</var>.</p>
 
             <p class="note">The negotiation-needed flag will be
             updated once the state transitions to {{RTCSignalingState/"stable"}}, as part of the steps
@@ -3872,11 +3875,11 @@ interface RTCSessionDescription {
             checking if negotiation is needed =] is <code>false</code>,
             <dfn>clear the negotiation-needed flag</dfn> by setting
             <var>connection</var>.<a>[[\NegotiationNeeded]]</a> to
-            <code>false</code>, and abort these steps.</p>
+            <code>false</code>, and return <var>p</var>.</p>
           </li>
           <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
             <p>If <var>connection</var>.<a>[[\NegotiationNeeded]]</a> is
-            already <code>true</code>, abort these steps.</p>
+            already <code>true</code>, return <var>p</var>.</p>
           </li>
           <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
             <p>Set <var>connection</var>.<a>[[\NegotiationNeeded]]</a> to
@@ -3885,6 +3888,9 @@ interface RTCSessionDescription {
           <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
             <p>[= Fire an event =] named {{negotiationneeded}}
             at <var>connection</var>.</p>
+          </li>
+          <li>
+            <p>return <var>p</var>.</p>
           </li>
         </ol>
         <div class="note">


### PR DESCRIPTION
The [update the negotiation-needed flag](https://w3c.github.io/webrtc-pc/#dfn-update-the-negotiation-needed-flag) algorithm says to: _"queue a task to [chain](https://w3c.github.io/webrtc-pc/#dfn-chain) the following steps to connection's operations chain:"_.

The steps therefore need to return a promise, because the [chain](https://w3c.github.io/webrtc-pc/#dfn-chain) function expects it (_"Upon fulfillment or rejection of the promise returned by the operation, run the following steps"_).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 9, 2020, 9:13 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fjan-ivar%2Fwebrtc-pc%2Fa1899aaffd8734a56db4595685b838817cb96df5%2Fwebrtc.html%3FisPreview%3Dtrue)

```
Navigation timeout of 30000 ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webrtc-pc%232488.)._
</details>
