### PR TITLE
Add missing onicecandidate & comments to perfect negotiation example.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -11478,8 +11478,13 @@ pc.ontrack = ({streams}) =&gt; {
 
 // - The perfect negotiation logic, separated from the rest of the application ---
 
+// keep track of some negotiation state to prevent races and errors
 let offering = false, ignoredOffer = false;
 
+// send any ice candidates to the other peer
+pc.onicecandidate = ({candidate}) =&gt; signaling.send({candidate});
+
+// let the "negotiationneeded" event trigger offer generation
 pc.onnegotiationneeded = async () => {
   try {
     offering = true;

--- a/webrtc.html
+++ b/webrtc.html
@@ -11471,9 +11471,13 @@ async function start() {
   }
 }
 
-pc.ontrack = ({streams}) =&gt; {
-  if (remoteView.srcObject) return;
-  remoteView.srcObject = streams[0];
+pc.ontrack = ({track, streams}) =&gt; {
+  // once media for a remote track arrives, show it in the remote video element
+  track.onunmute = () =&gt; {
+    // don't set srcObject again if it is already set.
+    if (remoteView.srcObject) return;
+    remoteView.srcObject = streams[0];
+  };
 };
 
 // - The perfect negotiation logic, separated from the rest of the application ---


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: write EPROTO 140222018242432:error:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert protocol version:../deps/openssl/openssl/ssl/s23_clnt.c:772:
 :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 16, 2020, 3:05 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fwebrtc-pc%2Fpull%2F2491%2F58520d5.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fjan-ivar%2Fwebrtc-pc%2Fpull%2F2491.html)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webrtc-pc%232491.)._
</details>
