### PR TITLE
Tweak test annotations chapter 7.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -10177,7 +10177,7 @@ interface RTCDataChannelEvent : Event {
           "attributes">
             <dt><dfn>dtmf</dfn> of type <span class=
             "idlAttrType">{{RTCDTMFSender}}</span>, readonly, nullable</dt>
-            <dd class="test-needed">
+            <dd class="needs-tests">
               <p>On getting, the {{dtmf}} attribute returns the value
               of the <a>[[\Dtmf]]</a> internal slot, which represents a
               {{RTCDTMFSender}} which can be used to send DTMF, or
@@ -10408,11 +10408,11 @@ interface RTCDTMFToneChangeEvent : Event {
           <h2>Attributes</h2>
           <dl data-link-for="RTCDTMFToneChangeEvent" data-dfn-for=
           "RTCDTMFToneChangeEvent" class="attributes">
-            <dt class="test-needed">
+            <dt class="needs-tests">
               <dfn data-idl>tone</dfn> of type
               <span class="idlAttrType">DOMString</span>, readonly</dt>
             <dd>
-              <p class="test-needed">The {{tone}} attribute contains the
+              <p class="needs-tests">The {{tone}} attribute contains the
               character for the tone (including <code>","</code>) that has just
               begun playout (see {{RTCDTMFSender/insertDTMF}} ). If
               the value is the empty string, it indicates that the
@@ -10436,7 +10436,7 @@ interface RTCDTMFToneChangeEvent : Event {
             "idlMemberType">DOMString</span>, defaulting to
               <code>""</code></dt>
             <dd>
-              <p class="test-needed">The {{tone}} attribute contains the
+              <p class="needs-tests">The {{tone}} attribute contains the
               character for the tone (including <code>","</code>) that has just
               begun playout (see {{RTCDTMFSender/insertDTMF}} ). If
               the value is the empty string, it indicates that the
@@ -10697,7 +10697,7 @@ interface RTCStatsReport {
           Let <var>result</var> be an empty {{RTCStatsReport}}.
         </li>
         <!-- TODO(webrtc-pc#2466): Do we have a test for null selector? -->
-        <li class="test-needed">If <var>selector</var> is <code>null</code>, gather stats for the
+        <li class="needs-tests">If <var>selector</var> is <code>null</code>, gather stats for the
           whole <var>connection</var>, add them to <var>result</var>, return
           <var>result</var>, and abort these steps.
         </li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -10177,12 +10177,12 @@ interface RTCDataChannelEvent : Event {
           "attributes">
             <dt><dfn>dtmf</dfn> of type <span class=
             "idlAttrType">{{RTCDTMFSender}}</span>, readonly, nullable</dt>
-            <dd>
+            <dd class="test-needed">
               <p>On getting, the {{dtmf}} attribute returns the value
-              of the <a>[[\Dtmf]]</a>internal slot, which represents a
+              of the <a>[[\Dtmf]]</a> internal slot, which represents a
               {{RTCDTMFSender}} which can be used to send DTMF, or
-              <code>null</code> if unset. The <a>[[\Dtmf]]</a>internal slot is set
-              when the kind of an {{RTCRtpSender}}'s
+              <code>null</code> if unset. The <a>[[\Dtmf]]</a> internal slot
+              is set when the kind of an {{RTCRtpSender}}'s
               <a>[[\SenderTrack]]</a> is <code>"audio"</code>.</p>
             </dd>
           </dl>
@@ -10408,10 +10408,11 @@ interface RTCDTMFToneChangeEvent : Event {
           <h2>Attributes</h2>
           <dl data-link-for="RTCDTMFToneChangeEvent" data-dfn-for=
           "RTCDTMFToneChangeEvent" class="attributes">
-            <dt><dfn data-idl>tone</dfn> of type <span class=
-            "idlAttrType">DOMString</span>, readonly</dt>
+            <dt class="test-needed">
+              <dfn data-idl>tone</dfn> of type
+              <span class="idlAttrType">DOMString</span>, readonly</dt>
             <dd>
-              <p>The {{tone}} attribute contains the
+              <p class="test-needed">The {{tone}} attribute contains the
               character for the tone (including <code>","</code>) that has just
               begun playout (see {{RTCDTMFSender/insertDTMF}} ). If
               the value is the empty string, it indicates that the
@@ -10435,7 +10436,7 @@ interface RTCDTMFToneChangeEvent : Event {
             "idlMemberType">DOMString</span>, defaulting to
               <code>""</code></dt>
             <dd>
-              <p>The {{tone}} attribute contains the
+              <p class="test-needed">The {{tone}} attribute contains the
               character for the tone (including <code>","</code>) that has just
               begun playout (see {{RTCDTMFSender/insertDTMF}} ). If
               the value is the empty string, it indicates that the


### PR DESCRIPTION
Fixes #2464

@dontcallmedom : The test annotations to section 7.4 (RTCDTMFToneChangeEvent)
do not work. Can you take a look?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2494.html" title="Last updated on Apr 16, 2020, 1:30 PM UTC (739a16e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2494/58520d5...739a16e.html" title="Last updated on Apr 16, 2020, 1:30 PM UTC (739a16e)">Diff</a>