### PR TITLE
Add [[Mid]] internal slot & separate JSEP state

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1206,7 +1206,7 @@
             "processing-a-local-desc processing-a-remote-desc">[[!JSEP]]</span>,
             with these additional restrictions: Use <var>jsepSetOfTransceivers</var>
             as the source of truth with regard to what "RtpTransceivers" exist, and
-            their <a>[[\JsepMidProperty]]</a> internal slot as their "mid property".
+            their <a>[[\JsepMid]]</a> internal slot as their "mid property".
             If applying <var>description</var>
             leads to modifying a transceiver <var>transceiver</var>, and
             <var>transceiver</var>.<a>[[\Sender]]</a>.<a>[[\SendEncodings]]</a>
@@ -1463,7 +1463,7 @@
                                 [= media description =].</p>
                               </li>
                               <li data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html">
-                                <p>Set <var>transceiver</var>.<a>[[\Mid]]</a> to <var>transceiver</var>.<a>[[\JsepMidProperty]]</a>.</p>
+                                <p>Set <var>transceiver</var>.<a>[[\Mid]]</a> to <var>transceiver</var>.<a>[[\JsepMid]]</a>.</p>
                               </li>
                               <li data-tests="RTCRtpTransceiver-stop.html">
                                 <p>If <var>transceiver</var>.<a>[[\Stopped]]</a>
@@ -1674,7 +1674,7 @@
                           </li>
                           <li data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCRtpTransceiver.https.html">
                             <p>Set <var>transceiver</var>.<a>[[\Mid]]</a> to
-                            <var>transceiver</var>.<a>[[\JsepMidProperty]]</a>.</p>
+                            <var>transceiver</var>.<a>[[\JsepMid]]</a>.</p>
                           </li>
                           <li>
                             <p>Let <var>direction</var> be an
@@ -1790,7 +1790,7 @@
                             a [= media description =] prior to applying the
                             {{RTCSessionDescription}} that is being rolled
                             back, disassociate it and set both
-                            <var>transceiver</var>.<a>[[\JsepMidProperty]]</a> and
+                            <var>transceiver</var>.<a>[[\JsepMid]]</a> and
                             <var>transceiver</var>.<a>[[\Mid]]</a>
                             to <code>null</code>.</p>
                           </li>
@@ -7222,7 +7222,7 @@ interface RTCRtpReceiver {
           initialized to an empty list.</p>
         </li>
         <li class="untestable">
-          <p>Let <var>transceiver</var> have a <dfn>[[\JsepMidProperty]]</dfn> internal slot,
+          <p>Let <var>transceiver</var> have a <dfn>[[\JsepMid]]</dfn> internal slot,
           initialized to <code>null</code>. This is the "RtpTransceiver mid property" defined in
           <span data-jsep="initial-offers initial-answers">[[!JSEP]]</span>, and is only modified
           there.</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -964,16 +964,6 @@
             <p>Let <var>connection</var> have an <dfn>[[\EarlyCandidates]]</dfn>
               internal slot, initialized to an empty list.</p>
           </li>
-          <li data-tests="RTCPeerConnection-transceivers.https.html, RTCRtpTransceiver.https.html">
-            <p>Let <var>connection</var> have a <dfn>[[\Mid]]</dfn>
-            internal slot, initialized to <code>null</code>.
-            This is the "mid" attribute as defined in <span data-jsep=
-            "initial-offers initial-answers">[[!JSEP]]</span>.</p>
-          </li>
-          <li data-tests="RTCPeerConnection-transceivers.https.html, RTCRtpTransceiver.https.html">
-            <p>Let <var>connection</var> have a <dfn>[[\CurrentMid]]</dfn>
-              internal slot, initialized to <code>null</code>.</p>
-          </li>
           <li data-tests="RTCPeerConnection-constructor.html">
             <p>Set <var>connection</var>'s [= signaling state =] to
             {{RTCSignalingState/"stable"}}.</p>
@@ -1207,7 +1197,7 @@
             {{InvalidStateError}} and abort these steps.</p>
           </li>
           <li>
-            <p>Let <var>jsepSetOfTransceivers</var> be a copy of
+            <p>Let <var>jsepSetOfTransceivers</var> be a shallow copy of
             <var>connection</var>'s [=set of transceivers =].</p>
           </li>
           <li>
@@ -1216,7 +1206,7 @@
             "processing-a-local-desc processing-a-remote-desc">[[!JSEP]]</span>,
             with these additional restrictions: Use <var>jsepSetOfTransceivers</var>
             as the source of truth with regard to what "RtpTransceivers" exist, and
-            the <a>[[\Mid]]</a> internal slot as their "mid property".
+            their <a>[[\JsepMidProperty]]</a> internal slot as their "mid property".
             If applying <var>description</var>
             leads to modifying a transceiver <var>transceiver</var>, and
             <var>transceiver</var>.<a>[[\Sender]]</a>.<a>[[\SendEncodings]]</a>
@@ -1463,7 +1453,7 @@
                         <var>description</var>:</p>
                         <ol>
                           <li>
-                            <p>If the [= media description =] is not yet [= associated =]
+                            <p>If the [= media description =] was not yet [= associated =]
                             with an {{RTCRtpTransceiver}} object then run
                             the following steps:</p>
                             <ol>
@@ -1473,8 +1463,7 @@
                                 [= media description =].</p>
                               </li>
                               <li data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html">
-                                <p>Set <var>transceiver</var>.<a>[[\CurrentMid]]</a> to the [= media stream "identification-tag" =] of
-                                the [= media description =].</p>
+                                <p>Set <var>transceiver</var>.<a>[[\Mid]]</a> to <var>transceiver</var>.<a>[[\JsepMidProperty]]</a>.</p>
                               </li>
                               <li data-tests="RTCRtpTransceiver-stop.html">
                                 <p>If <var>transceiver</var>.<a>[[\Stopped]]</a>
@@ -1684,11 +1673,8 @@
                             </ol>
                           </li>
                           <li data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCRtpTransceiver.https.html">
-                            <p>Set <var>transceiver</var>.<a>[[\CurrentMid]]</a> to the [= media stream "identification-tag" =] of
-                            the corresponding [= media description =]. If the [=media
-                            description =] has no [= media stream "identification-tag" =], and <var>transceiver</var>.<a>[[\CurrentMid]]</a>
-                            is <code>null</code> then generate a random value as described in
-                            <span data-jsep="applying-a-remote-desc">[[!JSEP]]</span>.</p>
+                            <p>Set <var>transceiver</var>.<a>[[\Mid]]</a> to
+                            <var>transceiver</var>.<a>[[\JsepMidProperty]]</a>.</p>
                           </li>
                           <li>
                             <p>Let <var>direction</var> be an
@@ -1803,9 +1789,9 @@
                             <p>If the <var>transceiver</var> was not [= associated =] with
                             a [= media description =] prior to applying the
                             {{RTCSessionDescription}} that is being rolled
-                            back, disassociate it and set
-                            <var>transceiver</var>.<a>[[\Mid]]</a> and
-                            <var>transceiver</var>.<a>[[\CurrentMid]]</a>
+                            back, disassociate it and set both
+                            <var>transceiver</var>.<a>[[\JsepMidProperty]]</a> and
+                            <var>transceiver</var>.<a>[[\Mid]]</a>
                             to <code>null</code>.</p>
                           </li>
                           <li>
@@ -7235,6 +7221,16 @@ interface RTCRtpReceiver {
           <p>Let <var>transceiver</var> have a <dfn>[[\PreferredCodecs]]</dfn> internal slot,
           initialized to an empty list.</p>
         </li>
+        <li class="untestable">
+          <p>Let <var>transceiver</var> have a <dfn>[[\JsepMidProperty]]</dfn> internal slot,
+          initialized to <code>null</code>. This is the "RtpTransceiver mid property" defined in
+          <span data-jsep="initial-offers initial-answers">[[!JSEP]]</span>, and is only modified
+          there.</p>
+        </li>
+        <li data-tests="RTCRtpTransceiver.https.html">
+          <p>Let <var>transceiver</var> have a <dfn>[[\Mid]]</dfn> internal slot,
+          initialized to <code>null</code>.</p>
+        </li>
         <li class="no-test-needed">
           <p>Return <var>transceiver</var>.</p>
         </li>
@@ -7266,14 +7262,14 @@ interface RTCRtpTransceiver {
               <p>The {{mid}}
               attribute is the [= media stream "identification-tag" =] negotiated and present in the
               local and remote descriptions. On getting, the
-              attribute MUST return the value of the <a>[[\CurrentMid]]</a> slot.</p>
+              attribute MUST return the value of the <a>[[\Mid]]</a> slot.</p>
             </dd>
             <dt data-tests="RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html"><dfn data-idl>sender</dfn> of type <span class=
             "idlAttrType">{{RTCRtpSender}}</span>, readonly</dt>
             <dd>
               <p>The {{sender}} attribute exposes the
               {{RTCRtpSender}} corresponding to the RTP media
-              that may be sent with mid = <a>[[\CurrentMid]]</a>. On getting,
+              that may be sent with mid = <a>[[\Mid]]</a>. On getting,
               the attribute MUST return the value of the <a>[[\Sender]]</a>
               slot.</p>
             </dd>
@@ -7282,7 +7278,7 @@ interface RTCRtpTransceiver {
             <dd>
               <p>The {{receiver}} attribute is the
               {{RTCRtpReceiver}} corresponding to the RTP media
-              that may be received with mid = <a>[[\CurrentMid]]</a>. On
+              that may be received with mid = <a>[[\Mid]]</a>. On
               getting the attribute MUST return the value of the
               <a>[[\Receiver]]</a> slot.</p>
             </dd>

--- a/webrtc.html
+++ b/webrtc.html
@@ -965,7 +965,13 @@
               internal slot, initialized to an empty list.</p>
           </li>
           <li data-tests="RTCPeerConnection-transceivers.https.html, RTCRtpTransceiver.https.html">
-            <p>Let <var>connection</var> have an <dfn>[[\Mid]]</dfn>
+            <p>Let <var>connection</var> have a <dfn>[[\Mid]]</dfn>
+            internal slot, initialized to <code>null</code>.
+            This is the "mid" attribute as defined in <span data-jsep=
+            "initial-offers initial-answers">[[!JSEP]]</span>.</p>
+          </li>
+          <li data-tests="RTCPeerConnection-transceivers.https.html, RTCRtpTransceiver.https.html">
+            <p>Let <var>connection</var> have a <dfn>[[\CurrentMid]]</dfn>
               internal slot, initialized to <code>null</code>.</p>
           </li>
           <li data-tests="RTCPeerConnection-constructor.html">
@@ -1201,18 +1207,22 @@
             {{InvalidStateError}} and abort these steps.</p>
           </li>
           <li>
+            <p>Let <var>jsepSetOfTransceivers</var> be a copy of
+            <var>connection</var>'s [=set of transceivers =].</p>
+          </li>
+          <li>
             <p data-tests="">In parallel, start the process to apply <var>description</var>
-              as described in <span data-jsep=
-                                  "processing-a-local-desc processing-a-remote-desc">[[!JSEP]]</span>,
-              with the additional restriction that if applying <var>description</var>
-              leads to modifying a transceiver <var>transceiver</var>, and
-              <var>transceiver</var>.<a>[[\Sender]]</a>.<a>[[\SendEncodings]]</a>
-              is non-empty, and not equal to the encodings that would result from
-              processing <var>description</var>, the process of applying <var>description</var>
-              fails.
-              This specification does not allow remotely initiated RID renegotiation.
-            </p>
-
+            as described in <span data-jsep=
+            "processing-a-local-desc processing-a-remote-desc">[[!JSEP]]</span>,
+            with these additional restrictions: Use <var>jsepSetOfTransceivers</var>
+            as the source of truth with regard to what "RtpTransceivers" exist, and
+            the <a>[[\Mid]]</a> internal slot as their "mid property".
+            If applying <var>description</var>
+            leads to modifying a transceiver <var>transceiver</var>, and
+            <var>transceiver</var>.<a>[[\Sender]]</a>.<a>[[\SendEncodings]]</a>
+            is non-empty, and not equal to the encodings that would result from
+            processing <var>description</var>, the process of applying <var>description</var>
+            fails. This specification does not allow remotely initiated RID renegotiation.</p>
             <ol>
               <li>
                 <p>If the process to apply <var>description</var> fails for any
@@ -1463,7 +1473,7 @@
                                 [= media description =].</p>
                               </li>
                               <li data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html">
-                                <p>Set <var>transceiver</var>.<a>[[\Mid]]</a> to the [= media stream "identification-tag" =] of
+                                <p>Set <var>transceiver</var>.<a>[[\CurrentMid]]</a> to the [= media stream "identification-tag" =] of
                                 the [= media description =].</p>
                               </li>
                               <li data-tests="RTCRtpTransceiver-stop.html">
@@ -1674,9 +1684,9 @@
                             </ol>
                           </li>
                           <li data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCRtpTransceiver.https.html">
-                            <p>Set <var>transceiver</var>.<a>[[\Mid]]</a> to the [= media stream "identification-tag" =] of
+                            <p>Set <var>transceiver</var>.<a>[[\CurrentMid]]</a> to the [= media stream "identification-tag" =] of
                             the corresponding [= media description =]. If the [=media
-                            description =] has no [= media stream "identification-tag" =], and <var>transceiver</var>.<a>[[\Mid]]</a>
+                            description =] has no [= media stream "identification-tag" =], and <var>transceiver</var>.<a>[[\CurrentMid]]</a>
                             is <code>null</code> then generate a random value as described in
                             <span data-jsep="applying-a-remote-desc">[[!JSEP]]</span>.</p>
                           </li>
@@ -1794,7 +1804,8 @@
                             a [= media description =] prior to applying the
                             {{RTCSessionDescription}} that is being rolled
                             back, disassociate it and set
-                            <var>transceiver</var>.<a>[[\Mid]]</a>
+                            <var>transceiver</var>.<a>[[\Mid]]</a> and
+                            <var>transceiver</var>.<a>[[\CurrentMid]]</a>
                             to <code>null</code>.</p>
                           </li>
                           <li>
@@ -7254,16 +7265,15 @@ interface RTCRtpTransceiver {
             <dd>
               <p>The {{mid}}
               attribute is the [= media stream "identification-tag" =] negotiated and present in the
-              local and remote descriptions as defined in <span data-jsep=
-              "initial-offers initial-answers">[[!JSEP]]</span>. On getting, the
-              attribute MUST return the value of the <a>[[\Mid]]</a> slot.</p>
+              local and remote descriptions. On getting, the
+              attribute MUST return the value of the <a>[[\CurrentMid]]</a> slot.</p>
             </dd>
             <dt data-tests="RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html"><dfn data-idl>sender</dfn> of type <span class=
             "idlAttrType">{{RTCRtpSender}}</span>, readonly</dt>
             <dd>
               <p>The {{sender}} attribute exposes the
               {{RTCRtpSender}} corresponding to the RTP media
-              that may be sent with mid = <a>[[\Mid]]</a>. On getting,
+              that may be sent with mid = <a>[[\CurrentMid]]</a>. On getting,
               the attribute MUST return the value of the <a>[[\Sender]]</a>
               slot.</p>
             </dd>
@@ -7272,7 +7282,7 @@ interface RTCRtpTransceiver {
             <dd>
               <p>The {{receiver}} attribute is the
               {{RTCRtpReceiver}} corresponding to the RTP media
-              that may be received with mid = <a>[[\Mid]]</a>. On
+              that may be received with mid = <a>[[\CurrentMid]]</a>. On
               getting the attribute MUST return the value of the
               <a>[[\Receiver]]</a> slot.</p>
             </dd>

--- a/webrtc.html
+++ b/webrtc.html
@@ -964,6 +964,10 @@
             <p>Let <var>connection</var> have an <dfn>[[\EarlyCandidates]]</dfn>
               internal slot, initialized to an empty list.</p>
           </li>
+          <li data-tests="RTCPeerConnection-transceivers.https.html, RTCRtpTransceiver.https.html">
+            <p>Let <var>connection</var> have an <dfn>[[\Mid]]</dfn>
+              internal slot, initialized to <code>null</code>.</p>
+          </li>
           <li data-tests="RTCPeerConnection-constructor.html">
             <p>Set <var>connection</var>'s [= signaling state =] to
             {{RTCSignalingState/"stable"}}.</p>
@@ -1459,7 +1463,7 @@
                                 [= media description =].</p>
                               </li>
                               <li data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html">
-                                <p>Set <var>transceiver</var>.{{RTCRtpTransceiver/mid}} value to the [= media stream "identification-tag" =] of
+                                <p>Set <var>transceiver</var>.<a>[[\Mid]]</a> to the [= media stream "identification-tag" =] of
                                 the [= media description =].</p>
                               </li>
                               <li data-tests="RTCRtpTransceiver-stop.html">
@@ -1670,10 +1674,10 @@
                             </ol>
                           </li>
                           <li data-tests="RTCPeerConnection-setDescription-transceiver.html,RTCRtpTransceiver.https.html">
-                            <p>Set <var>transceiver</var>.{{RTCRtpTransceiver/mid}} value to the [= media stream "identification-tag" =] of
+                            <p>Set <var>transceiver</var>.<a>[[\Mid]]</a> to the [= media stream "identification-tag" =] of
                             the corresponding [= media description =]. If the [=media
-                            description =] has no [= media stream "identification-tag" =], and <var>transceiver</var>.{{RTCRtpTransceiver/mid}}
-                            is unset then generate a random value as described in
+                            description =] has no [= media stream "identification-tag" =], and <var>transceiver</var>.<a>[[\Mid]]</a>
+                            is <code>null</code> then generate a random value as described in
                             <span data-jsep="applying-a-remote-desc">[[!JSEP]]</span>.</p>
                           </li>
                           <li>
@@ -1789,7 +1793,8 @@
                             <p>If the <var>transceiver</var> was not [= associated =] with
                             a [= media description =] prior to applying the
                             {{RTCSessionDescription}} that is being rolled
-                            back, disassociate it and set <var>transceiver</var>.{{RTCRtpTransceiver/mid}} value
+                            back, disassociate it and set
+                            <var>transceiver</var>.<a>[[\Mid]]</a>
                             to <code>null</code>.</p>
                           </li>
                           <li>
@@ -5444,7 +5449,8 @@ interface RTCCertificate {
               <p data-tests="RTCPeerConnection-addTransceiver.https.html">The initial value of {{RTCRtpTransceiver/mid}} is null. Setting a new
               {{RTCSessionDescription}} may change it to a
               non-null value, as defined in <span data-jsep=
-              "processing-a-local-desc processing-a-remote-desc">[[!JSEP]]</span>.</p>
+              "processing-a-local-desc processing-a-remote-desc">[[!JSEP]]</span>
+              and [= setting an RTCSessionDescription =].</p>
               <p data-tests="protocol/simulcast-offer.html">The {{RTCRtpTransceiverInit/sendEncodings}} argument can be used to
               specify the number of offered simulcast encodings, and
               optionally their RIDs and encoding parameters.</p>
@@ -7158,10 +7164,16 @@ interface RTCRtpReceiver {
       {{RTCRtpReceiver}} that share a common
       [= media stream "identification-tag" =]. As defined in <span data-jsep="rtptransceivers">[[!JSEP]]</span>,
       an {{RTCRtpTransceiver}} is said to be <dfn>associated</dfn> with
-      a [= media description =] if its {{RTCRtpTransceiver/mid}}
-      property is non-null; otherwise it is said to be disassociated. Conceptually, an
-      [= associated =] transceiver is one that's represented in the last applied session
-      description.</p>
+      a [= media description =] if its "mid"
+      property is non-null and matches a [= media stream "identification-tag" =]
+      in the [= media description =]; otherwise it is said to be disassociated
+      with that [= media description =].</p>
+      <div class="note">
+        <p>A {{RTCRtpTransceiver}} may become associated with a new pending
+        description in JSEP while still being disassociated with the current
+        description. This may happen in [= check if negotiation is needed =].
+        </p>
+      </div>
       <p>The <dfn>transceiver kind</dfn> of an
       {{RTCRtpTransceiver}} is defined by the kind of the
       associated {{RTCRtpReceiver}}'s
@@ -7243,17 +7255,15 @@ interface RTCRtpTransceiver {
               <p>The {{mid}}
               attribute is the [= media stream "identification-tag" =] negotiated and present in the
               local and remote descriptions as defined in <span data-jsep=
-              "initial-offers initial-answers">[[!JSEP]]</span>. Before
-              negotiation is complete, the {{mid}} value may be null.
-              After rollbacks, the value may change from a non-null value
-              to null.</p>
+              "initial-offers initial-answers">[[!JSEP]]</span>. On getting, the
+              attribute MUST return the value of the <a>[[\Mid]]</a> slot.</p>
             </dd>
             <dt data-tests="RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html"><dfn data-idl>sender</dfn> of type <span class=
             "idlAttrType">{{RTCRtpSender}}</span>, readonly</dt>
             <dd>
               <p>The {{sender}} attribute exposes the
               {{RTCRtpSender}} corresponding to the RTP media
-              that may be sent with mid = {{mid}}. On getting,
+              that may be sent with mid = <a>[[\Mid]]</a>. On getting,
               the attribute MUST return the value of the <a>[[\Sender]]</a>
               slot.</p>
             </dd>
@@ -7262,7 +7272,7 @@ interface RTCRtpTransceiver {
             <dd>
               <p>The {{receiver}} attribute is the
               {{RTCRtpReceiver}} corresponding to the RTP media
-              that may be received with mid = {{mid}}. On
+              that may be received with mid = <a>[[\Mid]]</a>. On
               getting the attribute MUST return the value of the
               <a>[[\Receiver]]</a> slot.</p>
             </dd>


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2476.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2505.html" title="Last updated on Apr 16, 2020, 6:34 PM UTC (73b113c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2505/544a656...jan-ivar:73b113c.html" title="Last updated on Apr 16, 2020, 6:34 PM UTC (73b113c)">Diff</a>