### PR TITLE
Don't send closed or error events on closed data channels.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9592,6 +9592,10 @@ interface RTCSctpTransport : EventTarget {
           closed.</p>
         </li>
         <li>
+          If <var>channel</var>.<a>[[\ReadyState]]</a> is
+          {{RTCDataChannelState/"closed"}}, abort these steps.
+        </li
+        <li>
           <p>Set <var>channel</var>.<a>[[\ReadyState]]</a> to
           {{RTCDataChannelState/"closed"}}.</p>
         </li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -39,6 +39,7 @@
           <li>{{RTCDatachannel}}.priority</li>
         </ul>
       </li>
+
       <li>The following features have been added:<ul>
           <li>{{RTCPeerConnection/restartIce()}} method added to {{RTCPeerConnection}}</li>
           <li>Introduced the concept of “perfect negotiation”, with an example to solve signaling races.</li>
@@ -9594,7 +9595,7 @@ interface RTCSctpTransport : EventTarget {
         <li>
           If <var>channel</var>.<a>[[\ReadyState]]</a> is
           {{RTCDataChannelState/"closed"}}, abort these steps.
-        </li
+        </li>
         <li>
           <p>Set <var>channel</var>.<a>[[\ReadyState]]</a> to
           {{RTCDataChannelState/"closed"}}.</p>


### PR DESCRIPTION
Fixes #2511


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2521.html" title="Last updated on Apr 30, 2020, 2:07 PM UTC (f71914f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2521/8f1579d...f71914f.html" title="Last updated on Apr 30, 2020, 2:07 PM UTC (f71914f)">Diff</a>