### PR TITLE
Mark voiceActivityFlag at risk

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -39,6 +39,11 @@
           <li>{{RTCDatachannel}}.priority</li>
         </ul>
       </li>
+      
+      <li>The following features have been marked as "features at risk":<ul>
+          <li>voiceActivityFlag</li>
+          <li>Multiple DTLS certificates</li>
+      </li>
 
       <li>The following features have been added:<ul>
           <li>{{RTCPeerConnection/restartIce()}} method added to {{RTCPeerConnection}}</li>
@@ -229,6 +234,10 @@
                 the certificates is used for a given connection; how
                 certificates are selected is outside the scope of this
                 specification.</p>
+                <div class="issue atrisk">
+                <p>Multiple DTLS certificates is marked as a feature at risk, since
+                there is no clear commitment from implementers.</p>
+              </div>
                 <p>If this value is absent, then a default set of certificates
                 is generated for each {{RTCPeerConnection}}
                 instance.</p>
@@ -7200,6 +7209,10 @@ interface RTCRtpReceiver {
               the peer has signaled that it is not using the V bit by setting the
               "vad" extension attribute to "off", as described in [[!RFC6464]],
               Section 4, {{voiceActivityFlag}} will be absent.</p>
+              <div class="issue atrisk">
+                <p>{{voiceActivityFlag}} is marked as a feature at risk, since there is no
+                clear commitment from implementers.</p>
+              </div>
             </dd>
           </dl>
         </section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -39,12 +39,6 @@
           <li>{{RTCDatachannel}}.priority</li>
         </ul>
       </li>
-      
-      <li>The following features have been marked as "features at risk":<ul>
-          <li>voiceActivityFlag</li>
-          <li>Multiple DTLS certificates</li>
-        </ul>
-      </li>
 
       <li>The following features have been added:<ul>
           <li>{{RTCPeerConnection/restartIce()}} method added to {{RTCPeerConnection}}</li>
@@ -70,6 +64,8 @@
     <p>The following features are marked as at risk:</p>
     <ul>
       <li>All attributes defined in {{RTCError}}: {{RTCError/errorDetail}}, {{RTCError/sdpLineNumber}}, {{RTCError/sctpCauseCode}}, {{RTCError/receivedAlert}} and {{RTCError/sentAlert}}.</li>
+      <li>{{voiceActivityFlag}}</li>
+      <li>Multiple DTLS certificates</li>
     </ul>
   </section>
   <section class="informative" id="intro">

--- a/webrtc.html
+++ b/webrtc.html
@@ -43,6 +43,7 @@
       <li>The following features have been marked as "features at risk":<ul>
           <li>voiceActivityFlag</li>
           <li>Multiple DTLS certificates</li>
+        </ul>
       </li>
 
       <li>The following features have been added:<ul>

--- a/webrtc.html
+++ b/webrtc.html
@@ -65,7 +65,6 @@
     <ul>
       <li>All attributes defined in {{RTCError}}: {{RTCError/errorDetail}}, {{RTCError/sdpLineNumber}}, {{RTCError/sctpCauseCode}}, {{RTCError/receivedAlert}} and {{RTCError/sentAlert}}.</li>
       <li>{{voiceActivityFlag}}</li>
-      <li>Multiple DTLS certificates</li>
     </ul>
   </section>
   <section class="informative" id="intro">
@@ -231,10 +230,6 @@
                 the certificates is used for a given connection; how
                 certificates are selected is outside the scope of this
                 specification.</p>
-                <div class="issue atrisk">
-                <p>Multiple DTLS certificates is marked as a feature at risk, since
-                there is no clear commitment from implementers.</p>
-              </div>
                 <p>If this value is absent, then a default set of certificates
                 is generated for each {{RTCPeerConnection}}
                 instance.</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -64,7 +64,7 @@
     <p>The following features are marked as at risk:</p>
     <ul>
       <li>All attributes defined in {{RTCError}}: {{RTCError/errorDetail}}, {{RTCError/sdpLineNumber}}, {{RTCError/sctpCauseCode}}, {{RTCError/receivedAlert}} and {{RTCError/sentAlert}}.</li>
-      <li>{{voiceActivityFlag}}</li>
+      <li>{{RTCRtpSynchronizationSource/voiceActivityFlag}}</li>
     </ul>
   </section>
   <section class="informative" id="intro">
@@ -7202,7 +7202,7 @@ interface RTCRtpReceiver {
               "vad" extension attribute to "off", as described in [[!RFC6464]],
               Section 4, {{voiceActivityFlag}} will be absent.</p>
               <div class="issue atrisk">
-                <p>{{voiceActivityFlag}} is marked as a feature at risk, since there is no
+                <p>{{RTCRtpSynchronizationSource/voiceActivityFlag}} is marked as a feature at risk, since there is no
                 clear commitment from implementers.</p>
               </div>
             </dd>


### PR DESCRIPTION
Fixes Issue https://github.com/w3c/webrtc-pc/issues/2496


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2523.html" title="Last updated on May 7, 2020, 1:34 PM UTC (51b8650)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2523/2113ca4...51b8650.html" title="Last updated on May 7, 2020, 1:34 PM UTC (51b8650)">Diff</a>