### PR TITLE
Remove partialFramesLost from list of MTI stats

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -10856,7 +10856,7 @@ interface RTCStatsReport {
         {{RTCRtpStreamStats/transportId}}, {{RTCRtpStreamStats/codecId}}</li>
         <li data-tests="RTCPeerConnection-getStats.https.html,RTCRtpReceiver-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">{{RTCReceivedRtpStreamStats}}, with all required attributes from its
         inherited dictionaries, and also attributes {{RTCReceivedRtpStreamStats/packetsReceived}},
-        {{RTCReceivedRtpStreamStats/packetsLost}}, {{RTCReceivedRtpStreamStats/jitter}}, {{RTCReceivedRtpStreamStats/packetsDiscarded}}, {{RTCReceivedRtpStreamStats/framesDropped}}, {{RTCReceivedRtpStreamStats/partialFramesLost}}</li>
+        {{RTCReceivedRtpStreamStats/packetsLost}}, {{RTCReceivedRtpStreamStats/jitter}}, {{RTCReceivedRtpStreamStats/packetsDiscarded}}, {{RTCReceivedRtpStreamStats/framesDropped}}</li>
         <li data-tests="RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCRtpReceiver-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">{{RTCInboundRtpStreamStats}}, with all required attributes from its
         inherited dictionaries, and also attributes
         {{RTCInboundRtpStreamStats/receiverId}}, {{RTCInboundRtpStreamStats/remoteId}}, {{RTCInboundRtpStreamStats/framesDecoded}}, {{RTCInboundRtpStreamStats/nackCount}},


### PR DESCRIPTION
per https://github.com/w3c/webrtc-pc/issues/2497#issuecomment-606224419
close #2497