### PR TITLE
Default scaleResolutionDownBy to 4:2:1 and drop last layers

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5612,7 +5612,7 @@ interface RTCCertificate {
                      <code>2^(length of <var>sendEncodings</var> - encoding
                      index - 1)</code>. This results in smaller-to-larger
                      resolutions where the last encoding has no scaling applied
-                     to it, e.g. 4:2:1 if <var>maxN</var> is 3.
+                     to it, e.g. 4:2:1 if the length is 3.
                    </li>
                    <li>
                      <p>If the number of {{RTCRtpEncodingParameters}} now

--- a/webrtc.html
+++ b/webrtc.html
@@ -1645,6 +1645,13 @@
                             <var>supportedEncodings</var>.
                           </li>
                           <li>
+                            If <var>sendEncodings</var> is non-empty, set each
+                            encoding's
+                            {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
+                            to <code>2^(<var>supportedEncodings</var> - encoding
+                            index - 1)</code>.
+                          </li>
+                          <li>
                             <p>As described by <span data-jsep=
                             "applying-a-remote-desc">[[!JSEP]]</span>, attempt to
                             find an existing {{RTCRtpTransceiver}}
@@ -5585,10 +5592,27 @@ interface RTCCertificate {
                     codec to be used is not known yet.</p>
                   </li>
                   <li>
+                    <p>If <var>sendEncodings</var> contains any encoding whose
+                    {{RTCRtpEncodingParameters/scaleResolutionDownBy}} attribute
+                    is defined, set any undefined
+                    {{RTCRtpEncodingParameters/scaleResolutionDownBy}} of the
+                    other encodings to 1.0.</p>
+                  </li>
+                  <li>
                     <p>If the number of {{RTCRtpEncodingParameters}}
                     stored in <var>sendEncodings</var> exceeds <var>maxN</var>,
                     then trim <var>sendEncodings</var> from the tail until its length
                     is <var>maxN</var>.</p>
+                   </li>
+                   <li>
+                     If the {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
+                     attribues of <var>sendEncodings</var> are still undefined,
+                     initialize each encoding's
+                     {{RTCRtpEncodingParameters/scaleResolutionDownBy}} to
+                     <code>2^(<var>maxN</var> - encoding index - 1)</code>. This
+                     results in smaller-to-larger resolutions where the last
+                     encoding has no scaling applied to it, e.g. 4:2:1 if
+                     <var>maxN</var> is 3.
                    </li>
                    <li>
                      <p>If the number of {{RTCRtpEncodingParameters}} now
@@ -6624,8 +6648,12 @@ async function updateParameters() {
               will be scaled down by a factor of 2 in each dimension, resulting
               in sending a video of one quarter the size. If the value is 1.0,
               the video will not be affected. The value must be greater than or
-              equal to 1.0. By default, the sender will not apply any scaling,
-              (i.e., {{RTCRtpEncodingParameters/scaleResolutionDownBy}} will be 1.0).</p>
+              equal to 1.0. By default, scaling is applied by a factor of two to
+              the power of the layer's number, in order of smaller to higher
+              resolutions, e.g. 4:2:1. If there is only one layer, the sender
+              will by default not apply any scaling, (i.e.
+              {{RTCRtpEncodingParameters/scaleResolutionDownBy}} will be
+              1.0).</p>
             </dd>
           </dl>
         </section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1648,8 +1648,8 @@
                             If <var>sendEncodings</var> is non-empty, set each
                             encoding's
                             {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
-                            to <code>2^(<var>supportedEncodings</var> - encoding
-                            index - 1)</code>.
+                            to <code>2^(length of <var>sendEncodings</var> -
+                            encoding index - 1)</code>.
                           </li>
                           <li>
                             <p>As described by <span data-jsep=
@@ -5609,10 +5609,10 @@ interface RTCCertificate {
                      attribues of <var>sendEncodings</var> are still undefined,
                      initialize each encoding's
                      {{RTCRtpEncodingParameters/scaleResolutionDownBy}} to
-                     <code>2^(<var>maxN</var> - encoding index - 1)</code>. This
-                     results in smaller-to-larger resolutions where the last
-                     encoding has no scaling applied to it, e.g. 4:2:1 if
-                     <var>maxN</var> is 3.
+                     <code>2^(length of <var>sendEncodings</var> - encoding
+                     index - 1)</code>. This results in smaller-to-larger
+                     resolutions where the last encoding has no scaling applied
+                     to it, e.g. 4:2:1 if <var>maxN</var> is 3.
                    </li>
                    <li>
                      <p>If the number of {{RTCRtpEncodingParameters}} now


### PR DESCRIPTION
Fixes #2537.
Fixes #2535.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2554.html" title="Last updated on Jul 8, 2020, 2:58 PM UTC (fe13d85)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2554/bd9e586...henbos:fe13d85.html" title="Last updated on Jul 8, 2020, 2:58 PM UTC (fe13d85)">Diff</a>