### PR TITLE
Stop transports that are no longer used and fire events.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1908,8 +1908,26 @@
                   </li>
                   <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
                     <p>If <var>connection</var>'s [= signaling state =] is now
-                    {{RTCSignalingState/"stable"}}, [= clear the negotiation-needed
-                    flag =] and [= update the negotiation-needed flag =].
+                    {{RTCSignalingState/"stable"}}, run the following steps:</p>
+                    <ol>
+                      <li>
+                        <p>For any <var>transceiver</var> that was removed from
+                        the [= set of transceivers =] in a previous step, if any
+                        of its transports
+                        (<var>transceiver</var>.<a>[[\Sender]]</a>.<a>[[\SenderTransport]]</a>
+                        or <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\ReceiverTransport]]</a>)
+                        are no longer referenced by a non-stopped transceiver,
+                        close the {{RTCDtlsTransport}}s and their associated
+                        {{RTCIceTransport}}s. This results in events firing on
+                        these objects in a queued task.</p>
+                        </li>
+                      </p>
+                      </li>
+                      <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
+                        <p>[= Clear the negotiation-needed flag =] and
+                        [= update the negotiation-needed flag =].</p>
+                      </li>
+                    </ol>
                   </li>
                   <li>
                     <p>If <var>connection</var>'s [= signaling state =]

--- a/webrtc.html
+++ b/webrtc.html
@@ -1916,8 +1916,9 @@
                         of its transports
                         (<var>transceiver</var>.<a>[[\Sender]]</a>.<a>[[\SenderTransport]]</a>
                         or <var>transceiver</var>.<a>[[\Receiver]]</a>.<a>[[\ReceiverTransport]]</a>)
-                        are no longer referenced by a non-stopped transceiver,
-                        close the {{RTCDtlsTransport}}s and their associated
+                        are still not closed and they're no longer referenced by
+                        a non-stopped transceiver, close the
+                        {{RTCDtlsTransport}}s and their associated
                         {{RTCIceTransport}}s. This results in events firing on
                         these objects in a queued task.</p>
                       </li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1911,7 +1911,7 @@
                     {{RTCSignalingState/"stable"}}, run the following steps:</p>
                     <ol>
                       <li>
-                        <p>For any <var>transceiver</var> that was removed from
+                        <p class="needs-test">For any <var>transceiver</var> that was removed from
                         the [= set of transceivers =] in a previous step, if any
                         of its transports
                         (<var>transceiver</var>.<a>[[\Sender]]</a>.<a>[[\SenderTransport]]</a>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1920,8 +1920,7 @@
                         close the {{RTCDtlsTransport}}s and their associated
                         {{RTCIceTransport}}s. This results in events firing on
                         these objects in a queued task.</p>
-                        </li>
-                      </p>
+                      </li>
                       </li>
                       <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
                         <p>[= Clear the negotiation-needed flag =] and


### PR DESCRIPTION
Fixes #2486.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2555.html" title="Last updated on Jul 9, 2020, 2:21 PM UTC (58ecc88)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2555/bd9e586...henbos:58ecc88.html" title="Last updated on Jul 9, 2020, 2:21 PM UTC (58ecc88)">Diff</a>