### PR TITLE
Upgrade WebIDL to use undefined instead of void

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2165,24 +2165,24 @@ interface RTCPeerConnection : EventTarget  {
   constructor(optional RTCConfiguration configuration = {});
   Promise&lt;RTCSessionDescriptionInit&gt; createOffer(optional RTCOfferOptions options = {});
   Promise&lt;RTCSessionDescriptionInit&gt; createAnswer(optional RTCAnswerOptions options = {});
-  Promise&lt;void&gt; setLocalDescription(optional RTCLocalSessionDescriptionInit description = {});
+  Promise&lt;undefined&gt; setLocalDescription(optional RTCLocalSessionDescriptionInit description = {});
   readonly attribute RTCSessionDescription? localDescription;
   readonly attribute RTCSessionDescription? currentLocalDescription;
   readonly attribute RTCSessionDescription? pendingLocalDescription;
-  Promise&lt;void&gt; setRemoteDescription(RTCSessionDescriptionInit description);
+  Promise&lt;undefined&gt; setRemoteDescription(RTCSessionDescriptionInit description);
   readonly attribute RTCSessionDescription? remoteDescription;
   readonly attribute RTCSessionDescription? currentRemoteDescription;
   readonly attribute RTCSessionDescription? pendingRemoteDescription;
-  Promise&lt;void&gt; addIceCandidate(optional RTCIceCandidateInit candidate = {});
+  Promise&lt;undefined&gt; addIceCandidate(optional RTCIceCandidateInit candidate = {});
   readonly attribute RTCSignalingState signalingState;
   readonly attribute RTCIceGatheringState iceGatheringState;
   readonly attribute RTCIceConnectionState iceConnectionState;
   readonly attribute RTCPeerConnectionState connectionState;
   readonly attribute boolean? canTrickleIceCandidates;
-  void restartIce();
+  undefined restartIce();
   RTCConfiguration getConfiguration();
-  void setConfiguration(optional RTCConfiguration configuration = {});
-  void close();
+  undefined setConfiguration(optional RTCConfiguration configuration = {});
+  undefined close();
   attribute EventHandler onnegotiationneeded;
   attribute EventHandler onicecandidate;
   attribute EventHandler onicecandidateerror;
@@ -2196,18 +2196,18 @@ interface RTCPeerConnection : EventTarget  {
   // If these methods are supported
   // they must be implemented as defined
   // in section "Legacy Interface Extensions"
-  Promise&lt;void&gt; createOffer(RTCSessionDescriptionCallback successCallback,
+  Promise&lt;undefined&gt; createOffer(RTCSessionDescriptionCallback successCallback,
                             RTCPeerConnectionErrorCallback failureCallback,
                             optional RTCOfferOptions options = {});
-  Promise&lt;void&gt; setLocalDescription(optional RTCLocalSessionDescriptionInit description = {},
+  Promise&lt;undefined&gt; setLocalDescription(optional RTCLocalSessionDescriptionInit description = {},
                                     VoidFunction successCallback,
                                     RTCPeerConnectionErrorCallback failureCallback);
-  Promise&lt;void&gt; createAnswer(RTCSessionDescriptionCallback successCallback,
+  Promise&lt;undefined&gt; createAnswer(RTCSessionDescriptionCallback successCallback,
                              RTCPeerConnectionErrorCallback failureCallback);
-  Promise&lt;void&gt; setRemoteDescription(RTCSessionDescriptionInit description,
+  Promise&lt;undefined&gt; setRemoteDescription(RTCSessionDescriptionInit description,
                                      VoidFunction successCallback,
                                      RTCPeerConnectionErrorCallback failureCallback);
-  Promise&lt;void&gt; addIceCandidate(RTCIceCandidateInit candidate,
+  Promise&lt;undefined&gt; addIceCandidate(RTCIceCandidateInit candidate,
                                 VoidFunction successCallback,
                                 RTCPeerConnectionErrorCallback failureCallback);
 };</pre>
@@ -3582,7 +3582,7 @@ interface RTCPeerConnection : EventTarget  {
               <h4><dfn>RTCPeerConnectionErrorCallback</dfn></h4>
               <div>
                 <pre class="idl"
->callback RTCPeerConnectionErrorCallback = void (DOMException error);</pre>
+>callback RTCPeerConnectionErrorCallback = undefined (DOMException error);</pre>
                 <section>
                   <h2>Callback {{RTCPeerConnectionErrorCallback}}
                   Parameters</h2>
@@ -3600,7 +3600,7 @@ interface RTCPeerConnection : EventTarget  {
               <h4><dfn>RTCSessionDescriptionCallback</dfn></h4>
               <div>
                 <pre class="idl"
->callback RTCSessionDescriptionCallback = void (RTCSessionDescriptionInit description);</pre>
+>callback RTCSessionDescriptionCallback = undefined (RTCSessionDescriptionInit description);</pre>
                 <section>
                   <h2>Callback {{RTCSessionDescriptionCallback}}
                   Parameters</h2>
@@ -5216,7 +5216,7 @@ interface RTCCertificate {
   sequence&lt;RTCRtpReceiver&gt; getReceivers();
   sequence&lt;RTCRtpTransceiver&gt; getTransceivers();
   RTCRtpSender addTrack(MediaStreamTrack track, MediaStream... streams);
-  void removeTrack(RTCRtpSender sender);
+  undefined removeTrack(RTCRtpSender sender);
   RTCRtpTransceiver addTransceiver((MediaStreamTrack or DOMString) trackOrKind,
                                    optional RTCRtpTransceiverInit init = {});
   attribute EventHandler ontrack;
@@ -6034,10 +6034,10 @@ interface RTCRtpSender {
   readonly attribute MediaStreamTrack? track;
   readonly attribute RTCDtlsTransport? transport;
   static RTCRtpCapabilities? getCapabilities(DOMString kind);
-  Promise&lt;void&gt; setParameters(RTCRtpSendParameters parameters);
+  Promise&lt;undefined&gt; setParameters(RTCRtpSendParameters parameters);
   RTCRtpSendParameters getParameters();
-  Promise&lt;void&gt; replaceTrack(MediaStreamTrack? withTrack);
-  void setStreams(MediaStream... streams);
+  Promise&lt;undefined&gt; replaceTrack(MediaStreamTrack? withTrack);
+  undefined setStreams(MediaStream... streams);
   Promise&lt;RTCStatsReport&gt; getStats();
 };</pre>
         <section>
@@ -7387,8 +7387,8 @@ interface RTCRtpTransceiver {
   [SameObject] readonly attribute RTCRtpReceiver receiver;
   attribute RTCRtpTransceiverDirection direction;
   readonly attribute RTCRtpTransceiverDirection? currentDirection;
-  void stop();
-  void setCodecPreferences(sequence&lt;RTCRtpCodecCapability&gt; codecs);
+  undefined stop();
+  undefined setCodecPreferences(sequence&lt;RTCRtpCodecCapability&gt; codecs);
 };</pre>
         <section>
           <h2>Attributes</h2>
@@ -9816,13 +9816,13 @@ interface RTCDataChannel : EventTarget {
   attribute EventHandler onerror;
   attribute EventHandler onclosing;
   attribute EventHandler onclose;
-  void close();
+  undefined close();
   attribute EventHandler onmessage;
   attribute DOMString binaryType;
-  void send(USVString data);
-  void send(Blob data);
-  void send(ArrayBuffer data);
-  void send(ArrayBufferView data);
+  undefined send(USVString data);
+  undefined send(Blob data);
+  undefined send(ArrayBuffer data);
+  undefined send(ArrayBufferView data);
 };</pre>
         <section>
           <h2>Attributes</h2>
@@ -10392,7 +10392,7 @@ interface RTCDataChannelEvent : Event {
       <div>
         <pre class="idl" data-tests>[Exposed=Window]
 interface RTCDTMFSender : EventTarget {
-  void insertDTMF(DOMString tones, optional unsigned long duration = 100, optional unsigned long interToneGap = 70);
+  undefined insertDTMF(DOMString tones, optional unsigned long duration = 100, optional unsigned long interToneGap = 70);
   attribute EventHandler ontonechange;
   readonly attribute boolean canInsertDTMF;
   readonly attribute DOMString toneBuffer;

--- a/webrtc.js
+++ b/webrtc.js
@@ -107,24 +107,14 @@ var respecConfig = {
   //],
 
   // name of the WG
-  wg:           "Web Real-Time Communications Working Group",
-
-  // URI of the public WG page
-  wgURI:        "https://www.w3.org/groups/wg/webrtc",
-
+  group: "webrtc",
   // name (without the @w3c.org) of the public mailing to which comments are due
   wgPublicList: "public-webrtc",
 
-  // URI of the patent status for this WG, for Rec-track documents
-  // !!!! IMPORTANT !!!!
-  // This is important for Rec-track documents, do not copy a patent URI from a random
-  // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
-  // Team Contact.
-  wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/47318/status",
   testSuiteURI: "https://github.com/web-platform-tests/wpt/tree/master/webrtc/",
   implementationReportURI: "https://wpt.fyi/webrtc",
   previousMaturity: "CR",
-  previousPublishDate: "2018-09-27",
+  previousPublishDate: "2019-12-13",
   lint: {
     "wpt-tests-exist": true
   },


### PR DESCRIPTION
cf https://github.com/heycam/webidl/pull/906


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2565.html" title="Last updated on Aug 25, 2020, 8:40 AM UTC (29ad449)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2565/8863fed...29ad449.html" title="Last updated on Aug 25, 2020, 8:40 AM UTC (29ad449)">Diff</a>