### PR TITLE
Point out that null mid+index only applies to end-of-candidates

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4515,7 +4515,9 @@ interface RTCPeerConnection : EventTarget  {
                             to identify the ICE [= generation =]; if
                             {{RTCIceCandidate/usernameFragment}} is
                             <code>null</code>, process the <var>candidate</var>
-                            for the most recent ICE [= generation =]. If
+                            for the most recent ICE [= generation =].
+                            </p>
+                            <p>If
                             <var>candidate</var>.{{RTCIceCandidate/candidate}}
                             is an empty string, process <var>candidate</var> as
                             an end-of-candidates indication for the
@@ -4523,7 +4525,8 @@ interface RTCPeerConnection : EventTarget  {
                             candidate [= generation =]. If both
                             <var>candidate</var>.{{RTCIceCandidate/sdpMid}} and
                             <var>candidate</var>.{{RTCIceCandidate/sdpMLineIndex}}
-                            are <code>null</code>, then this applies to all [=
+                            are <code>null</code>, then this end-of-candidates
+                            indication applies to all [=
                             media description =]s.
                           </p>
                           <ol>


### PR DESCRIPTION
Fixes #2571


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2577.html" title="Last updated on Sep 22, 2020, 12:15 PM UTC (eb4e0a7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2577/9e537f7...eb4e0a7.html" title="Last updated on Sep 22, 2020, 12:15 PM UTC (eb4e0a7)">Diff</a>