### PR TITLE
Define the set of transports for all connection state enums

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -964,6 +964,11 @@
                 </tr>
               </tbody>
             </table>
+            <p>
+              The set of transports considered is the set of transports
+              presently referenced by the PeerConnection's
+              [= set of transceivers =].
+            </p>
           </div>
         </section>
         <section>
@@ -1068,7 +1073,12 @@
                 </tr>
               </tbody>
             </table>
-          </div>
+             <p>
+              The set of transports considered is the set of transports
+              presently referenced by the PeerConnection's
+              [= set of transceivers =].
+            </p>
+         </div>
         </section>
         <section>
           <h4>
@@ -1179,6 +1189,11 @@
               </tbody>
             </table>
           </div>
+          <p>
+            The set of transports considered is the set of transports
+            presently referenced by the PeerConnection's
+            [= set of transceivers =].
+          </p>
           <p>
             Note that if an {{RTCIceTransport}} is discarded as a result of
             signaling (e.g. RTCP mux or bundling), or created as a result of
@@ -1793,7 +1808,7 @@
               <li>
                 <p>
                   Let <var>jsepSetOfTransceivers</var> be a shallow copy of
-                  <var>connection</var>'s [=set of transceivers =].
+                  <var>connection</var>'s [= set of transceivers =].
                 </p>
               </li>
               <li>


### PR DESCRIPTION
Fixes #2563


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2578.html" title="Last updated on Sep 22, 2020, 12:48 PM UTC (8fb5d04)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2578/9e537f7...8fb5d04.html" title="Last updated on Sep 22, 2020, 12:48 PM UTC (8fb5d04)">Diff</a>