### PR TITLE
Publish automatically updates to the document as CR Drafts

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -19,3 +19,4 @@ jobs:
           # Please use the URL that's appropriate for your working group!
           WG_DECISION_URL: "https://lists.w3.org/Archives/Public/public-webrtc/2016Mar/0031.html"
           CC: "dom@w3.org"
+          INPUT_FILE: webrtc.html

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,0 +1,21 @@
+name: Node CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request: {}
+
+jobs:
+  validate-and-publish:
+    name: Validate and Publish
+    runs-on: ubuntu-latest # only linux supported at present
+    steps:
+      - uses: actions/checkout@v2
+      - uses: w3c/respec-w3c-auto-publish@v1 # use the action
+        with:
+          ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
+          ECHIDNA_MANIFEST_URL: "https://w3c.github.io/webrtc-pc/W3CTRMANIFEST"
+          # Please use the URL that's appropriate for your working group!
+          WG_DECISION_URL: "https://lists.w3.org/Archives/Public/public-webrtc/2016Mar/0031.html"
+          CC: "dom@w3.org"

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -20,3 +20,4 @@ jobs:
           WG_DECISION_URL: "https://lists.w3.org/Archives/Public/public-webrtc/2016Mar/0031.html"
           CC: "dom@w3.org"
           INPUT_FILE: webrtc.html
+          CHECK_LINKS: false

--- a/W3CTRMANIFEST
+++ b/W3CTRMANIFEST
@@ -1,4 +1,4 @@
-webrtc.html?specStatus=CR&shortName=webrtc&crEnd=2020-09-24 respec
+webrtc.html?specStatus=CRD&shortName=webrtc respec
 images/fingerprint.png
 images/icetransportstate.svg
 images/ladder-2party-simple.svg


### PR DESCRIPTION
Based on https://github.com/w3c/respec-w3c-auto-publish
Using the new CR Draft status from process 2020 https://www.w3.org/2020/Process-20200915/#publishing-crud