### PR TITLE
Improve markup for events definitions

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1692,7 +1692,7 @@
               </li>
               <li>
                 <p>
-                  [= Fire an event =] named {{connectionstatechange}} at
+                  [= Fire an event =] named {{RTCPeerConnection/connectionstatechange}} at
                   <var>connection</var>.
                 </p>
               </li>
@@ -1735,7 +1735,7 @@
               </li>
               <li data-tests="protocol/candidate-exchange.https.html">
                 <p>
-                  [= Fire an event =] named {{icegatheringstatechange}} at
+                  [= Fire an event =] named {{RTCPeerConnection/icegatheringstatechange}} at
                   <var>connection</var>.
                 </p>
               </li>
@@ -1743,7 +1743,7 @@
                 <p>
                   If <var>newState</var> is
                   {{RTCIceGatheringState/"complete"}}, [= fire an event =]
-                  named {{icecandidate}} using the
+                  named {{RTCPeerConnection/icecandidate}} using the
                   {{RTCPeerConnectionIceEvent}} interface with the candidate
                   attribute set to <code>null</code> at <var>connection</var>.
                 </p>
@@ -2866,7 +2866,7 @@
                         <p>
                           If <var>connection</var>'s [= signaling state =]
                           changed above, [= fire an event =] named
-                          {{signalingstatechange}} at <var>connection</var>.
+                          {{RTCPeerConnection/signalingstatechange}} at <var>connection</var>.
                         </p>
                       </li>
                       <li>
@@ -2907,7 +2907,7 @@
                         <p>
                           For each entry <var>entry</var> in
                           <var>trackEventInits</var>, [= fire an event =] named
-                          {{track}} using the {{RTCTrackEvent}} interface with
+                          {{RTCPeerConnection/track}} using the {{RTCTrackEvent}} interface with
                           its {{RTCTrackEvent/receiver}} attribute initialized
                           to <var>entry</var>.{{RTCTrackEventInit/receiver}},
                           its {{RTCTrackEvent/track}} attribute initialized to
@@ -3469,14 +3469,14 @@ interface RTCPeerConnection : EventTarget  {
                 </dt>
                 <dd>
                   The event type of this event handler is
-                  {{negotiationneeded}}.
+                  {{RTCPeerConnection/negotiationneeded}}.
                 </dd>
                 <dt data-tests="promises-call.html">
                   <dfn data-idl="">onicecandidate</dfn> of type <span class=
                   "idlAttrType">EventHandler</span>
                 </dt>
                 <dd>
-                  The event type of this event handler is {{icecandidate}}.
+                  The event type of this event handler is {{RTCPeerConnection/icecandidate}}.
                 </dd>
                 <dt data-tests=
                 "RTCPeerConnection-onicecandidateerror.https.html">
@@ -3485,7 +3485,7 @@ interface RTCPeerConnection : EventTarget  {
                 </dt>
                 <dd>
                   The event type of this event handler is
-                  {{icecandidateerror}}.
+                  {{RTCPeerConnection/icecandidateerror}}.
                 </dd>
                 <dt data-tests=
                 "RTCPeerConnection-createOffer.html,RTCPeerConnection-onsignalingstatechanged.https.html">
@@ -3494,7 +3494,7 @@ interface RTCPeerConnection : EventTarget  {
                 </dt>
                 <dd>
                   The event type of this event handler is
-                  {{signalingstatechange}}.
+                  {{RTCPeerConnection/signalingstatechange}}.
                 </dd>
                 <dt data-tests=
                 "RTCPeerConnection-connectionState.https.html,RTCPeerConnection-iceConnectionState.https.html,no-media-call.html,RTCPeerConnection-iceConnectionState-disconnected.https.html,protocol/ice-state.https.html">
@@ -3503,7 +3503,7 @@ interface RTCPeerConnection : EventTarget  {
                 </dt>
                 <dd>
                   The event type of this event handler is
-                  {{iceconnectionstatechange}}
+                  {{RTCPeerConnection/iceconnectionstatechange}}
                 </dd>
                 <dt data-tests=
                 "RTCPeerConnection-iceGatheringState.html,protocol/candidate-exchange.https.html">
@@ -3512,7 +3512,7 @@ interface RTCPeerConnection : EventTarget  {
                 </dt>
                 <dd>
                   The event type of this event handler is
-                  {{icegatheringstatechange}}.
+                  {{RTCPeerConnection/icegatheringstatechange}}.
                 </dd>
                 <dt data-tests=
                 "RTCPeerConnection-iceConnectionState.https.html">
@@ -3521,7 +3521,7 @@ interface RTCPeerConnection : EventTarget  {
                 </dt>
                 <dd>
                   The event type of this event handler is
-                  {{connectionstatechange}}.
+                  {{RTCPeerConnection/connectionstatechange}}.
                 </dd>
               </dl>
             </section>
@@ -5701,8 +5701,9 @@ interface RTCSessionDescription {
           Many changes to state of an {{RTCPeerConnection}} will require
           communication with the remote side via the signaling channel, in
           order to have the desired effect. The app can be kept informed as to
-          when it needs to do signaling, by listening to the <code class=
-          "event">negotiationneeded</code> event. This event is fired according
+          when it needs to do signaling, by listening to the
+          {{RTCPeerConnection/negotiationneeded}} event. This event is fired
+          according
           to the state of the connection's <dfn>negotiation-needed flag</dfn>,
           represented by a <a>[[\NegotiationNeeded]]</a> internal slot.
         </p>
@@ -5823,21 +5824,21 @@ interface RTCSessionDescription {
                 </li>
                 <li data-tests="RTCPeerConnection-onnegotiationneeded.html">
                   <p>
-                    [= Fire an event =] named {{negotiationneeded}} at
+                    [= Fire an event =] named {{RTCPeerConnection/negotiationneeded}} at
                     <var>connection</var>.
                   </p>
                 </li>
               </ol>
               <div class="note">
                 <p>
-                  The task queueing prevents {{negotiationneeded}} from firing
+                  The task queueing prevents {{RTCPeerConnection/negotiationneeded}} from firing
                   prematurely, in the common situation where multiple
                   modifications to <var>connection</var> are being made at
                   once.
                 </p>
                 <p>
                   Additionally, we avoid racing with negotiation methods by
-                  only firing {{negotiationneeded}} when the [= operations
+                  only firing {{RTCPeerConnection/negotiationneeded}} when the [= operations
                   chain =] is empty.
                 </p>
               </div>
@@ -6600,7 +6601,7 @@ interface RTCIceCandidate {
             <dfn>RTCPeerConnectionIceEvent</dfn>
           </h4>
           <p>
-            The <code class="event">icecandidate</code> event of the
+            The {{RTCPeerConnection/icecandidate}} event of the
             {{RTCPeerConnection}} uses the {{RTCPeerConnectionIceEvent}}
             interface.
           </p>
@@ -6615,7 +6616,7 @@ interface RTCIceCandidate {
             to the URL of the ICE server from which the candidate was obtained.
           </p>
           <div class="note">
-            The {{icecandidate}} event is used for three different types of
+            The {{RTCPeerConnection/icecandidate}} event is used for three different types of
             indications:
             <ul>
               <li>
@@ -6651,7 +6652,7 @@ interface RTCIceCandidate {
                   member of the event being set to <code>null</code>. This only
                   exists for backwards compatibility, and this event does not
                   need to be signaled to the remote peer. It's equivalent to an
-                  {{icegatheringstatechange}} event with the
+                  {{RTCPeerConnection/icegatheringstatechange}} event with the
                   {{RTCIceGatheringState/"complete"}} state.
                 </p>
               </li>
@@ -6755,7 +6756,7 @@ interface RTCPeerConnectionIceEvent : Event {
             <dfn>RTCPeerConnectionIceErrorEvent</dfn>
           </h4>
           <p>
-            The <code class="event">icecandidateerror</code> event of the
+            The {{RTCPeerConnection/icecandidateerror}} event of the
             {{RTCPeerConnection}} uses the {{RTCPeerConnectionIceErrorEvent}}
             interface.
           </p>
@@ -7471,7 +7472,7 @@ interface RTCCertificate {
         Additionally, when a remote description is applied that indicates the
         remote endpoint has media to send, the relevant {{MediaStreamTrack}}
         and {{RTCRtpReceiver}} are surfaced to the application via the
-        {{track}} event.
+        {{RTCPeerConnection/track}} event.
       </p>
       <p>
         In order for an {{RTCRtpTransceiver}} to send and/or receive media with
@@ -7542,7 +7543,7 @@ interface RTCCertificate {
               </dt>
               <dd>
                 <p>
-                  The event type of this event handler is {{track}}.
+                  The event type of this event handler is {{RTCPeerConnection/track}}.
                 </p>
               </dd>
             </dl>
@@ -7904,9 +7905,9 @@ interface RTCCertificate {
                 <p>
                   When the other peer stops sending a track in this manner, the
                   track is removed from any remote {{MediaStream}}s that were
-                  initially revealed in the <code class="event">track</code>
+                  initially revealed in the {{RTCPeerConnection/track}}
                   event, and if the {{MediaStreamTrack}} is not already muted,
-                  a <code class="event">mute</code> event is fired at the
+                  a <code class=fixme>mute</code> event is fired at the
                   track.
                 </p>
                 <div class="note">
@@ -11331,8 +11332,7 @@ async function onOffHold() {
           </li>
           <li>
             <p>
-              [= Fire an event =] named <code class="event"><a data-lt=
-              "RTCDtlsTransport error">error</a></code> using the
+              [= Fire an event =] named {{RTCDtlsTransport/error}} using the
               {{RTCErrorEvent}} interface with its errorDetail attribute set to
               either {{RTCErrorDetailType/"dtls-failure"}} or
               {{RTCErrorDetailType/"fingerprint-failure"}}, as appropriate, and
@@ -11342,8 +11342,7 @@ async function onOffHold() {
           </li>
           <li>
             <p>
-              [= Fire an event =] named <code class="event"><a data-lt=
-              "RTCDtlsTransport state change">statechange</a></code> at
+              [= Fire an event =] named {{RTCDtlsTransport/statechange}} at
               <var>transport</var>.
             </p>
           </li>
@@ -11383,8 +11382,7 @@ async function onOffHold() {
           </li>
           <li data-tests="RTCDtlsTransport-state.html">
             <p>
-              [= Fire an event =] named <code class="event"><a data-lt=
-              "RTCDtlsTransport state change">statechange</a></code> at
+              [= Fire an event =] named {{RTCDtlsTransport/statechange}} at
               <var>transport</var>.
             </p>
           </li>
@@ -11433,16 +11431,15 @@ interface RTCDtlsTransport : EventTarget {
                 "idlAttrType">EventHandler</span>
               </dt>
               <dd>
-                The event type of this event handler is <code class=
-                "event"><a data-lt=
-                "RTCDtlsTransport state change">statechange</a></code>.
+                The event type of this event handler is
+                {{RTCDtlsTransport/statechange}}.
               </dd>
               <dt data-tests="">
                 <dfn data-idl="">onerror</dfn> of type <span class=
                 "idlAttrType">EventHandler</span>
               </dt>
               <dd>
-                The event type of this event handler is {{error}}.
+                The event type of this event handler is {{RTCDtlsTransport/error}}.
               </dd>
             </dl>
           </section>
@@ -11638,7 +11635,7 @@ interface RTCDtlsTransport : EventTarget {
           </li>
           <li data-tests="RTCIceTransport-extension.https.html">
             <p>
-              [= Fire an event =] named {{gatheringstatechange}} at
+              [= Fire an event =] named {{RTCIceTransport/gatheringstatechange}} at
               <var>transport</var>.
             </p>
           </li>
@@ -11688,7 +11685,7 @@ interface RTCDtlsTransport : EventTarget {
           </li>
           <li>
             <p>
-              [= Fire an event =] named {{icecandidate}} using the
+              [= Fire an event =] named {{RTCPeerConnection/icecandidate}} using the
               {{RTCPeerConnectionIceEvent}} interface with the candidate
               attribute set to <var>newCandidate</var> at
               <var>connection</var>.
@@ -11712,7 +11709,7 @@ interface RTCDtlsTransport : EventTarget {
           </li>
           <li>
             <p>
-              [= Fire an event =] named {{gatheringstatechange}} at
+              [= Fire an event =] named {{RTCIceTransport/gatheringstatechange}} at
               <var>transport</var>.
             </p>
           </li>
@@ -11848,7 +11845,7 @@ interface RTCDtlsTransport : EventTarget {
           </li>
           <li>
             <p>
-              [= Fire an event =] named {{icecandidate}} using the
+              [= Fire an event =] named {{RTCPeerConnection/icecandidate}} using the
               {{RTCPeerConnectionIceEvent}} interface with the candidate
               attribute set to <var>newCandidate</var> at
               <var>connection</var>.
@@ -11987,14 +11984,14 @@ interface RTCDtlsTransport : EventTarget {
           <li>
             <p>
               If <var>selectedCandidatePairChanged</var> is <code>true</code>,
-              [= fire an event =] named {{selectedcandidatepairchange}} at
+              [= fire an event =] named {{RTCIceTransport/selectedcandidatepairchange}} at
               <var>transport</var>.
             </p>
           </li>
           <li>
             <p>
               If <var>transportIceConnectionStateChanged</var> is
-              <code>true</code>, [= fire an event =] named {{statechange}} at
+              <code>true</code>, [= fire an event =] named {{RTCIceTransport/statechange}} at
               <var>transport</var>.
             </p>
           </li>
@@ -12003,13 +12000,13 @@ interface RTCDtlsTransport : EventTarget {
             <p>
               If <var>connectionIceConnectionStateChanged</var> is
               <code>true</code>, [= fire an event =] named
-              {{iceconnectionstatechange}} at <var>connection</var>.
+              {{RTCPeerConnection/iceconnectionstatechange}} at <var>connection</var>.
             </p>
           </li>
           <li>
             <p>
               If <var>connectionStateChanged</var> is <code>true</code>, [=
-              fire an event =] named {{connectionstatechange}} at
+              fire an event =] named {{RTCPeerConnection/connectionstatechange}} at
               <var>connection</var>.
             </p>
           </li>
@@ -12124,7 +12121,7 @@ interface RTCIceTransport : EventTarget {
               </dt>
               <dd>
                 This event handler, of event handler event type
-                {{selectedcandidatepairchange}}, MUST be fired any time the
+                {{RTCIceTransport/selectedcandidatepairchange}}, MUST be fired any time the
                 {{RTCIceTransport}}'s selected candidate pair changes.
               </dd>
             </dl>
@@ -12642,7 +12639,7 @@ interface RTCIceTransport : EventTarget {
           <dfn>RTCTrackEvent</dfn>
         </h3>
         <p>
-          The {{track}} event uses the {{RTCTrackEvent}} interface.
+          The {{RTCPeerConnection/track}} event uses the {{RTCTrackEvent}} interface.
         </p>
         <div>
           <pre class="idl" data-tests="idlharness.https.window.js">[Exposed=Window]
@@ -12832,7 +12829,7 @@ interface RTCTrackEvent : Event {
                 "idlAttrType">EventHandler</span>
               </dt>
               <dd>
-                The event type of this event handler is {{datachannel}}.
+                The event type of this event handler is {{RTCPeerConnection/datachannel}}.
               </dd>
             </dl>
           </section>
@@ -13210,15 +13207,13 @@ interface RTCTrackEvent : Event {
               </li>
               <li>
                 <p>
-                  [= Fire an event =] named <code class="event"><a data-lt=
-                  "RTCSctpTransport state change">statechange</a></code> at
+                  [= Fire an event =] named {{RTCSctpTransport/statechange}} at
                   <var>transport</var>.
                 </p>
                 <p class="note">
-                  This event is fired before the <code class=
-                  "event">open</code> events fired by [= announce the
+                  This event is fired before the {{RTCDataChannel/open}} events fired by [= announce the
                   rtcdatachannel as open | announcing the channel as open =];
-                  the <code class="event">open</code> events are fired from a
+                  the {{RTCDataChannel/open}} events are fired from a
                   queued task.
                 </p>
               </li>
@@ -13296,9 +13291,8 @@ interface RTCSctpTransport : EventTarget {
                 </dt>
                 <dd>
                   <p>
-                    The event type of this event handler is <code class=
-                    "event"><a data-lt=
-                    "RTCSctpTransport state change">statechange</a></code>.
+                    The event type of this event handler is
+                    {{RTCSctpTransport/statechange}}.
                   </p>
                 </dd>
               </dl>
@@ -13542,7 +13536,7 @@ interface RTCSctpTransport : EventTarget {
             </li>
             <li data-tests="RTCPeerConnection-ondatachannel.html">
               <p>
-                [= Fire an event =] named {{open}} at <var>channel</var>.
+                [= Fire an event =] named {{RTCDataChannel/open}} at <var>channel</var>.
               </p>
             </li>
           </ol>
@@ -13602,18 +13596,18 @@ interface RTCSctpTransport : EventTarget {
             <li data-tests="RTCPeerConnection-ondatachannel.html">
               <p>
                 Set <var>channel</var>.<a>[[\ReadyState]]</a> to
-                {{RTCDataChannelState/"open"}} (but do not fire the {{open}}
+                {{RTCDataChannelState/"open"}} (but do not fire the {{RTCDataChannel/open}}
                 event, yet).
               </p>
               <div class="note">
                 This allows to start sending messages inside of the
-                {{datachannel}} event handler prior to the {{open}} event being
+                {{RTCPeerConnection/datachannel}} event handler prior to the {{RTCDataChannel/open}} event being
                 fired.
               </div>
             </li>
             <li data-tests="RTCPeerConnection-ondatachannel.html">
               <p>
-                [= Fire an event =] named {{datachannel}} using the
+                [= Fire an event =] named {{RTCPeerConnection/datachannel}} using the
                 {{RTCDataChannelEvent}} interface with the
                 {{RTCDataChannelEvent/channel}} attribute set to
                 <var>channel</var> at <var>connection</var>.
@@ -13651,7 +13645,7 @@ interface RTCSctpTransport : EventTarget {
                 <var>channel</var>.{{RTCDataChannel/close}}, set
                 <var>channel</var>.<a>[[\ReadyState]]</a> to
                 {{RTCDataChannelState/"closing"}} and [= fire an event =] named
-                {{closing}} at <var>channel</var>.
+                {{RTCDataChannel/closing}} at <var>channel</var>.
               </p>
             </li>
             <li>
@@ -13683,7 +13677,7 @@ interface RTCSctpTransport : EventTarget {
                 <li>
                   <p>
                     Render the <var>channel</var>'s [= data transport =]
-                    {{closed}} by following the associated procedure.
+                    [=closed=] by following the associated procedure.
                   </p>
                 </li>
               </ol>
@@ -13720,14 +13714,14 @@ interface RTCSctpTransport : EventTarget {
               <p>
                 If the [= underlying data transport | transport =] was closed
                 <dfn id="data-transport-closed-error">with an error</dfn>, [=
-                fire an event =] named {{error}} using the {{RTCErrorEvent}}
+                fire an event =] named {{RTCDataChannel/error}} using the {{RTCErrorEvent}}
                 interface with its {{RTCError/errorDetail}} attribute set to
                 {{RTCErrorDetailType/"sctp-failure"}} at <var>channel</var>.
               </p>
             </li>
             <li>
               <p>
-                [= Fire an event =] named {{close}} at <var>channel</var>.
+                [= Fire an event =] named  <a data-link-for=RTCDataChannel data-link-type=event>close</a> at <var>channel</var>.
               </p>
             </li>
           </ol>
@@ -13770,7 +13764,7 @@ interface RTCSctpTransport : EventTarget {
             </li>
             <li>
               <p>
-                [= Fire an event =] named {{close}} at <var>channel</var>.
+                [= Fire an event =] named <a data-link-for=RTCDataChannel data-link-type=event>close</a> at <var>channel</var>.
               </p>
             </li>
           </ol>
@@ -13851,7 +13845,7 @@ interface RTCSctpTransport : EventTarget {
             <li data-tests=
             "RTCDataChannel-send.html,datachannel-emptystring.html">
               <p>
-                [= Fire an event =] named {{message}} using the
+                [= Fire an event =] named {{RTCDataChannel/message}} using the
                 {{MessageEvent}} interface with its <code class=
                 "html">origin</code> attribute initialized to the
                 <a>serialization of an origin</a> of
@@ -14054,7 +14048,7 @@ interface RTCDataChannel : EventTarget {
                 "idlAttrType">EventHandler</span>
               </dt>
               <dd>
-                The event type of this event handler is {{open}}.
+                The event type of this event handler is {{RTCDataChannel/open}}.
               </dd>
               <dt data-tests="RTCDataChannel-bufferedAmount.html">
                 <dfn data-idl="">onbufferedamountlow</dfn> of type <span class=
@@ -14082,7 +14076,7 @@ interface RTCDataChannel : EventTarget {
               </dt>
               <dd>
                 <p>
-                  The event type of this event handler is {{closing}}.
+                  The event type of this event handler is {{RTCDataChannel/closing}}.
                 </p>
               </dd>
               <dt>
@@ -14091,7 +14085,7 @@ interface RTCDataChannel : EventTarget {
               </dt>
               <dd data-link-for="">
                 <p>
-                  The event type of this event handler is {{close}}.
+                  The event type of this event handler is <a data-link-for=RTCDataChannel data-link-type=event>close</a>.
                 </p>
               </dd>
               <dt data-tests=
@@ -14101,7 +14095,7 @@ interface RTCDataChannel : EventTarget {
               </dt>
               <dd>
                 <p>
-                  The event type of this event handler is {{message}}.
+                  The event type of this event handler is {{RTCDataChannel/message}}.
                 </p>
               </dd>
               <dt data-tests="RTCDataChannel-send.html">
@@ -14135,7 +14129,7 @@ interface RTCDataChannel : EventTarget {
             <dl data-link-for="RTCDataChannel" data-dfn-for="RTCDataChannel"
             class="methods">
               <dt>
-                <dfn>close</dfn>
+                <dfn data-idl>close()</dfn>
               </dt>
               <dd>
                 <p>
@@ -14497,7 +14491,7 @@ interface RTCDataChannel : EventTarget {
           <dfn>RTCDataChannelEvent</dfn>
         </h3>
         <p data-tests="RTCPeerConnection-ondatachannel.html">
-          The {{datachannel}} event uses the {{RTCDataChannelEvent}} interface.
+          The {{RTCPeerConnection/datachannel}} event uses the {{RTCDataChannelEvent}} interface.
         </p>
         <div>
           <pre class="idl" data-tests="idlharness.https.window.js">[Exposed=Window]
@@ -14571,26 +14565,26 @@ interface RTCDataChannelEvent : Event {
             <p>
               <a>[[\ReadyState]]</a> slot is
               {{RTCDataChannelState/"connecting"}} and at least one event
-              listener is registered for <code class="event">open</code>
-              events, <code class="event">message</code> events, <code class=
-              "event">error</code> events, <code class="event">closing</code>
-              events, or <code class="event">close</code> events.
+              listener is registered for {{RTCDataChannel/open}}
+              events, {{RTCDataChannel/message}} events,
+              {{RTCDataChannel/error}} events, {{RTCDataChannel/closing}}
+              events, or <a data-link-for=RTCDataChannel data-link-type=event>close</a> events.
             </p>
           </li>
           <li>
             <p>
               <a>[[\ReadyState]]</a> slot is {{RTCDataChannelState/"open"}} and
-              at least one event listener is registered for <code class=
-              "event">message</code> events, <code class="event">error</code>
-              events, <code class="event">closing</code> events, or
-              <code class="event">close</code> events.
+              at least one event listener is registered for
+              {{RTCDataChannel/message}} events, {{RTCDataChannel/error}}
+              events, {{RTCDataChannel/closing}} events, or
+              <a class=todo data-link-for=RTCDataChannel data-link-type=event>close</a> events.
             </p>
           </li>
           <li>
             <p>
               <a>[[\ReadyState]]</a> slot is {{RTCDataChannelState/"closing"}}
-              and at least one event listener is registered for <code class=
-              "event">error</code> events, or <code class="event">close</code>
+              and at least one event listener is registered for
+              {{RTCDataChannel/error}} events, or <a class=todo data-link-for=RTCDataChannel data-link-type=event>close</a>
               events.
             </p>
           </li>
@@ -14702,7 +14696,7 @@ interface RTCDTMFSender : EventTarget {
               </dt>
               <dd>
                 <p>
-                  The event type of this event handler is {{tonechange}}.
+                  The event type of this event handler is {{RTCDTMFSender/tonechange}}.
                 </p>
               </dd>
               <dt>
@@ -14854,7 +14848,7 @@ interface RTCDTMFSender : EventTarget {
                       steps.
                       </li>
                       <li>If the <a>[[\ToneBuffer]]</a> slot contains the empty
-                      string, [= fire an event =] named {{tonechange}} using
+                      string, [= fire an event =] named {{RTCDTMFSender/tonechange}} using
                       the {{RTCDTMFToneChangeEvent}} interface with the
                       {{RTCDTMFToneChangeEvent/tone}} attribute set to an empty
                       string at the {{RTCDTMFSender}} object and abort these
@@ -14877,7 +14871,7 @@ interface RTCDTMFSender : EventTarget {
                       <a>[[\Duration]]</a> + <a>[[\InterToneGap]]</a> ms from
                       now that runs the steps labelled <em>Playout task</em>.
                       </li>
-                      <li>[= Fire an event =] named {{tonechange}} using the
+                      <li>[= Fire an event =] named {{RTCDTMFSender/tonechange}} using the
                       {{RTCDTMFToneChangeEvent}} interface with the
                       {{RTCDTMFToneChangeEvent/tone}} attribute set to
                       <var>tone</var> at the {{RTCDTMFSender}} object.
@@ -14945,7 +14939,7 @@ interface RTCDTMFSender : EventTarget {
           <dfn>RTCDTMFToneChangeEvent</dfn>
         </h3>
         <p>
-          The {{tonechange}} event uses the {{RTCDTMFToneChangeEvent}}
+          The {{RTCDTMFSender/tonechange}} event uses the {{RTCDTMFToneChangeEvent}}
           interface.
         </p>
         <div>
@@ -17008,8 +17002,8 @@ interface RTCErrorEvent : Event {
         <tbody>
           <tr>
             <td>
-              <dfn id="event-datachannel-open"><code class=
-              "event">open</code></dfn>
+              <dfn data-dfn-for=RTCDataChannel id="event-datachannel-open" data-dfn-type=event>
+              open</dfn>
             </td>
             <td>
               {{Event}}
@@ -17021,11 +17015,11 @@ interface RTCErrorEvent : Event {
           </tr>
           <tr>
             <td>
-              <dfn id="event-datachannel-message"><code class=
-              "event">message</code></dfn>
+              <dfn data-dfn-for=RTCDataChannel id="event-datachannel-message" data-dfn-type=event>
+              message</dfn>
             </td>
             <td>
-              <dfn id="the-messageevent-interfaces">{{MessageEvent}}</dfn>
+              {{MessageEvent}}
               [[html]]
             </td>
             <td>
@@ -17034,8 +17028,8 @@ interface RTCErrorEvent : Event {
           </tr>
           <tr>
             <td>
-              <dfn id="event-datachannel-bufferedamountlow"><code class=
-              "event">bufferedamountlow</code></dfn>
+              <dfn data-dfn-for=RTCDataChannel id="event-datachannel-bufferedamountlow" data-dfn-type=event>
+              bufferedamountlow</dfn>
             </td>
             <td>
               {{Event}}
@@ -17049,7 +17043,7 @@ interface RTCErrorEvent : Event {
           </tr>
           <tr>
             <td>
-              <dfn><code id="event-datachannel-error">error</code></dfn>
+              <dfn  data-dfn-for=RTCDataChannel data-dfn-type=event id="event-datachannel-error">error</dfn>
             </td>
             <td>
               {{RTCErrorEvent}}
@@ -17060,7 +17054,7 @@ interface RTCErrorEvent : Event {
           </tr>
           <tr>
             <td>
-              <dfn><code id="event-datachannel-closing">closing</code></dfn>
+              <dfn  data-dfn-for=RTCDataChannel data-dfn-type=event id="event-datachannel-closing">closing</dfn>
             </td>
             <td>
               {{Event}}
@@ -17072,7 +17066,7 @@ interface RTCErrorEvent : Event {
           </tr>
           <tr>
             <td>
-              <dfn><code id="event-datachannel-close">close</code></dfn>
+              <dfn  data-dfn-for=RTCDataChannel data-dfn-type="event" id="event-datachannel-close">close</dfn>
             </td>
             <td>
               {{Event}}
@@ -17104,7 +17098,7 @@ interface RTCErrorEvent : Event {
         <tbody>
           <tr>
             <td>
-              <dfn id="event-track"><code class="event">track</code></dfn>
+              <dfn data-dfn-for=RTCPeerConnection id="event-track" data-dfn-type=event>track</dfn>
             </td>
             <td>
               {{RTCTrackEvent}}
@@ -17117,8 +17111,8 @@ interface RTCErrorEvent : Event {
           </tr>
           <tr>
             <td>
-              <dfn id="event-negotiation"><code class=
-              "event">negotiationneeded</code></dfn>
+              <dfn  data-dfn-for=RTCPeerConnection id="event-negotiation" data-dfn-type=event>
+              negotiationneeded</dfn>
             </td>
             <td>
               {{Event}}
@@ -17131,8 +17125,8 @@ interface RTCErrorEvent : Event {
           </tr>
           <tr>
             <td>
-              <dfn id="event-signalingstatechange"><code class=
-              "event">signalingstatechange</code></dfn>
+              <dfn  data-dfn-for=RTCPeerConnection id="event-signalingstatechange" data-dfn-type=event>
+              signalingstatechange</dfn>
             </td>
             <td>
               {{Event}}
@@ -17145,8 +17139,8 @@ interface RTCErrorEvent : Event {
           </tr>
           <tr>
             <td>
-              <dfn id="event-iceconnectionstatechange"><code class=
-              "event">iceconnectionstatechange</code></dfn>
+              <dfn  data-dfn-for=RTCPeerConnection id="event-iceconnectionstatechange" data-dfn-type=event>
+              iceconnectionstatechange</dfn>
             </td>
             <td>
               {{Event}}
@@ -17158,8 +17152,8 @@ interface RTCErrorEvent : Event {
           </tr>
           <tr>
             <td>
-              <dfn id="event-icegatheringstatechange"><code class=
-              "event">icegatheringstatechange</code></dfn>
+              <dfn data-dfn-for=RTCPeerConnection id="event-icegatheringstatechange" data-dfn-type=event>
+              icegatheringstatechange</dfn>
             </td>
             <td>
               {{Event}}
@@ -17171,8 +17165,8 @@ interface RTCErrorEvent : Event {
           </tr>
           <tr>
             <td>
-              <dfn id="event-icecandidate"><code class=
-              "event">icecandidate</code></dfn>
+              <dfn data-dfn-for=RTCPeerConnection id="event-icecandidate" data-dfn-type=event>
+              icecandidate</dfn>
             </td>
             <td>
               {{RTCPeerConnectionIceEvent}}
@@ -17183,8 +17177,8 @@ interface RTCErrorEvent : Event {
           </tr>
           <tr>
             <td>
-              <dfn id="event-connectionstatechange"><code class=
-              "event">connectionstatechange</code></dfn>
+              <dfn data-dfn-for=RTCPeerConnection id="event-connectionstatechange" data-dfn-type=event>
+              connectionstatechange</dfn>
             </td>
             <td>
               {{Event}}
@@ -17196,8 +17190,8 @@ interface RTCErrorEvent : Event {
           </tr>
           <tr>
             <td>
-              <dfn id="event-icecandidateerror"><code class=
-              "event">icecandidateerror</code></dfn>
+              <dfn data-dfn-for=RTCPeerConnection id="event-icecandidateerror" data-dfn-type=event>
+              icecandidateerror</dfn>
             </td>
             <td>
               {{RTCPeerConnectionIceErrorEvent}}
@@ -17208,7 +17202,7 @@ interface RTCErrorEvent : Event {
           </tr>
           <tr>
             <td>
-              <dfn id="event-datachannel">datachannel</dfn>
+              <dfn data-dfn-for=RTCPeerConnection id="event-datachannel" data-dfn-type=event>datachannel</dfn>
             </td>
             <td>
               {{RTCDataChannelEvent}}
@@ -17240,8 +17234,8 @@ interface RTCErrorEvent : Event {
         <tbody>
           <tr>
             <td>
-              <dfn id="event-RTCDTMFSender-tonechange"><code class=
-              "event">tonechange</code></dfn>
+              <dfn  data-dfn-for=RTCDTMFSender id="event-RTCDTMFSender-tonechange" data-dfn-type=event>
+              tonechange</dfn>
             </td>
             <td>
               {{RTCDTMFToneChangeEvent}}
@@ -17276,9 +17270,7 @@ interface RTCErrorEvent : Event {
         <tbody>
           <tr>
             <td>
-              <dfn id="event-icetransport-statechange" data-lt=
-              "RTCIceTransport state change"><code class=
-              "event">statechange</code></dfn>
+              <dfn data-dfn-for=RTCIceTransport id="event-icetransport-statechange"  data-dfn-type=event>statechange</dfn>
             </td>
             <td>
               {{Event}}
@@ -17289,8 +17281,7 @@ interface RTCErrorEvent : Event {
           </tr>
           <tr>
             <td>
-              <dfn id="event-icetransport-gatheringstatechange"><code class=
-              "event">gatheringstatechange</code></dfn>
+              <dfn data-dfn-for=RTCIceTransport id="event-icetransport-gatheringstatechange" data-dfn-type=event>gatheringstatechange</dfn>
             </td>
             <td>
               {{Event}}
@@ -17301,9 +17292,8 @@ interface RTCErrorEvent : Event {
           </tr>
           <tr>
             <td>
-              <dfn id=
-              "event-icetransport-selectedcandidatepairchange"><code class=
-              "event">selectedcandidatepairchange</code></dfn>
+              <dfn  data-dfn-for=RTCIceTransport id=
+              "event-icetransport-selectedcandidatepairchange" data-dfn-type=event>selectedcandidatepairchange</dfn>
             </td>
             <td>
               {{Event}}
@@ -17334,9 +17324,8 @@ interface RTCErrorEvent : Event {
         <tbody>
           <tr>
             <td>
-              <dfn id="event-dtlstransport-statechange" data-lt=
-              "RTCDtlsTransport state change" data-lt-nodefault=""><code class=
-              "event">statechange</code></dfn>
+              <dfn data-dfn-for=RTCDtlsTransport id="event-dtlstransport-statechange" data-dfn-type=event>
+              statechange</dfn>
             </td>
             <td>
               {{Event}}
@@ -17347,8 +17336,7 @@ interface RTCErrorEvent : Event {
           </tr>
           <tr>
             <td>
-              <dfn data-lt="RTCDtlsTransport error" data-lt-nodefault=
-              ""><code class="event">error</code></dfn>
+              <dfn data-dfn-for=RTCDtlsTransport data-dfn-type="event">error</dfn>
             </td>
             <td>
               {{RTCErrorEvent}}
@@ -17381,9 +17369,8 @@ interface RTCErrorEvent : Event {
         <tbody>
           <tr>
             <td>
-              <dfn id="event-sctptransport-statechange" data-lt=
-              "RTCSctpTransport state change" data-lt-nodefault=""><code class=
-              "event">statechange</code></dfn>
+              <dfn data-dfn-for=RTCSctpTransport id="event-sctptransport-statechange" data-dfn-type=event>
+              statechange</dfn>
             </td>
             <td>
               {{Event}}


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2595.html" title="Last updated on Feb 15, 2021, 7:55 AM UTC (c824e8a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2595/60f2135...c824e8a.html" title="Last updated on Feb 15, 2021, 7:55 AM UTC (c824e8a)">Diff</a>