### PR TITLE
Require scaleResolutionDownBy to be defined in setParameters

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8852,7 +8852,7 @@ interface RTCRtpSender {
                         <p>
                           Verify that each encoding in <var>encodings</var> has
                           a {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
-                          value greater than or equal to 1.0. If one of the
+                          member whose value is greater than or equal to 1.0. If one of the
                           {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
                           values does not meet this requirement, return a
                           promise [= rejected =] with a newly [=

--- a/webrtc.html
+++ b/webrtc.html
@@ -8121,7 +8121,7 @@ interface RTCCertificate {
                         <p>
                           Verify that the value of each
                           {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
-                          attribute in <var>sendEncodings</var> that is defined
+                          member in <var>sendEncodings</var> that is defined
                           is greater than or equal to 1.0. If one of the
                           {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
                           values does not meet this requirement, [=

--- a/webrtc.html
+++ b/webrtc.html
@@ -8119,10 +8119,10 @@ interface RTCCertificate {
                       </li>
                       <li data-tests="RTCRtpParameters-encodings.html">
                         <p>
-                          Verify that each
+                          Verify that the value of each
                           {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
-                          value in <var>sendEncodings</var> is greater than or
-                          equal to 1.0. If one of the
+                          attribute in <var>sendEncodings</var> that is defined
+                          is greater than or equal to 1.0. If one of the
                           {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
                           values does not meet this requirement, [=
                           exception/throw =] a {{RangeError}}.
@@ -8850,10 +8850,9 @@ interface RTCRtpSender {
                       </li>
                       <li data-tests="RTCRtpParameters-encodings.html">
                         <p>
-                          Verify that each
-                          {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
-                          value in <var>encodings</var> is greater than or
-                          equal to 1.0. If one of the
+                          Verify that each encoding in <var>encodings</var> has
+                          a {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
+                          value greater than or equal to 1.0. If one of the
                           {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
                           values does not meet this requirement, return a
                           promise [= rejected =] with a newly [=


### PR DESCRIPTION
Fixes #2556.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2596.html" title="Last updated on Nov 5, 2020, 3:26 PM UTC (db12987)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2596/60f2135...henbos:db12987.html" title="Last updated on Nov 5, 2020, 3:26 PM UTC (db12987)">Diff</a>