### PR TITLE
Allow piggybacking getCapabilities on most recent offer or answer

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -10133,7 +10133,7 @@ interface RTCRtpReceiver {
                   {{RTCPeerConnection/createAnswer}} there MAY be capabilities
                   that are either unknown when the synchronous
                   {{getCapabilities()}} call is made, or that the user agent
-                  choses not to disclose for other reasons (e.g. privacy). If
+                  chooses not to disclose for other reasons (e.g. privacy). If
                   {{getCapabilities()}} is called after
                   {{RTCPeerConnection/createOffer}} or
                   {{RTCPeerConnection/createAnswer}} has resolved, the

--- a/webrtc.html
+++ b/webrtc.html
@@ -8774,6 +8774,18 @@ interface RTCRtpSender {
                   privacy-sensitive contexts, browsers can consider mitigations
                   such as reporting only a common subset of the capabilities.
                 </p>
+                <p class="no-test-needed">
+                  Prior to calling {{RTCPeerConnection/createOffer}} or
+                  {{RTCPeerConnection/createAnswer}} there MAY be capabilities
+                  that are either unknown when the synchronous
+                  {{getCapabilities()}} call is made, or that the user agent
+                  choses not to disclose for other reasons (e.g. privacy). If
+                  {{getCapabilities()}} is called after
+                  {{RTCPeerConnection/createOffer}} or
+                  {{RTCPeerConnection/createAnswer}} has resolved, the
+                  capabilities returned by this method MUST match that of the
+                  most recently created offer or answer.
+                </p>
               </dd>
               <dt data-tests=
               "RTCRtpParameters-codecs.html,RTCRtpSender-setParameters.html">
@@ -10115,6 +10127,18 @@ interface RTCRtpReceiver {
                   fingerprinting surface of the application. In
                   privacy-sensitive contexts, browsers can consider mitigations
                   such as reporting only a common subset of the capabilities.
+                </p>
+                <p class="no-test-needed">
+                  Prior to calling {{RTCPeerConnection/createOffer}} or
+                  {{RTCPeerConnection/createAnswer}} there MAY be capabilities
+                  that are either unknown when the synchronous
+                  {{getCapabilities()}} call is made, or that the user agent
+                  choses not to disclose for other reasons (e.g. privacy). If
+                  {{getCapabilities()}} is called after
+                  {{RTCPeerConnection/createOffer}} or
+                  {{RTCPeerConnection/createAnswer}} has resolved, the
+                  capabilities returned by this method MUST match that of the
+                  most recently created offer or answer.
                 </p>
               </dd>
               <dt data-tests="RTCRtpReceiver-getParameters.html">

--- a/webrtc.html
+++ b/webrtc.html
@@ -8779,7 +8779,7 @@ interface RTCRtpSender {
                   {{RTCPeerConnection/createAnswer}} there MAY be capabilities
                   that are either unknown when the synchronous
                   {{getCapabilities()}} call is made, or that the user agent
-                  choses not to disclose for other reasons (e.g. privacy). If
+                  chooses not to disclose for other reasons (e.g. privacy). If
                   {{getCapabilities()}} is called after
                   {{RTCPeerConnection/createOffer}} or
                   {{RTCPeerConnection/createAnswer}} has resolved, the


### PR DESCRIPTION
(Issues have been moved around, add a Fixes <issue link> here before landing.)

While the fingerprint note previously already said the capabilities returned could be a subset of the real capabilities in privacy-sensitive contexts, this PR makes it clearer that this can be even more true prior to calling createOffer or createAnswer.

This also resolves any synchronicity issues by allowing the result to be incomplete if the user agent doesn't know some capabilities yet (e.g. may require accessing hardware).

This PR also makes the requirements of this API a little bit clearer by saying that after creating an offer or answer, the capabilities returned MUST match the SDP.

This attempts to clarify two things:
- Allow getCapabilities not to leak anything that we are not already leaking in createOffer.
- By "piggybacking" on createOffer, we get around the limitations of this synchronous API by encouraging you to have already awaited an asynchronous API.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2597.html" title="Last updated on Dec 2, 2020, 11:24 AM UTC (47e9097)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2597/60f2135...henbos:47e9097.html" title="Last updated on Dec 2, 2020, 11:24 AM UTC (47e9097)">Diff</a>