### PR TITLE
Remove optional marker from overloaded version of setLocalDescription

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3241,7 +3241,7 @@ interface RTCPeerConnection : EventTarget  {
   Promise&lt;undefined&gt; createOffer(RTCSessionDescriptionCallback successCallback,
                             RTCPeerConnectionErrorCallback failureCallback,
                             optional RTCOfferOptions options = {});
-  Promise&lt;undefined&gt; setLocalDescription(optional RTCLocalSessionDescriptionInit description = {},
+  Promise&lt;undefined&gt; setLocalDescription(RTCLocalSessionDescriptionInit description,
                                     VoidFunction successCallback,
                                     RTCPeerConnectionErrorCallback failureCallback);
   Promise&lt;undefined&gt; createAnswer(RTCSessionDescriptionCallback successCallback,


### PR DESCRIPTION
optional can only be used on the last argument of a function

(noted by @tidoust)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2600.html" title="Last updated on Nov 13, 2020, 4:02 PM UTC (b93d98a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2600/0153d3b...b93d98a.html" title="Last updated on Nov 13, 2020, 4:02 PM UTC (b93d98a)">Diff</a>