### PR TITLE
Adapt GitHub CI to platform change

### DIFF
--- a/.github/workflows/update-respec.yml
+++ b/.github/workflows/update-respec.yml
@@ -13,8 +13,8 @@ jobs:
       - name: Download latest ReSpec
         run:  wget https://www.w3.org/Tools/respec/respec-w3c.js -O respec-w3c-common.js
       - name: Find respec version
-        run: echo "::set-env name=RESPEC_VERSION::$(cat respec-w3c-common.js | head -1 | cut -d '"' -f 2)"
-      - uses: peter-evans/create-pull-request@v2
+        run: echo "RESPEC_VERSION=$(cat respec-w3c-common.js | head -1 | cut -d '"' -f 2)" >> $GITHUB_ENV
+      - uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.W3C_GITHUB_TOKEN }}
           title: Update to latest ReSpec version


### PR DESCRIPTION
Cf https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/