### PR TITLE
Fix RTCPeerConnectionIceErrorEventInit.statusText to match RTCPeerCon…

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6879,7 +6879,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
   unsigned short? port;
   DOMString url;
   required unsigned short errorCode;
-  USVString statusText;
+  USVString errorText;
 };</pre>
             <section>
               <h2>
@@ -6930,7 +6930,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   </p>
                 </dd>
                 <dt data-tests="">
-                  <dfn data-idl="">statusText</dfn> of type <span class=
+                  <dfn data-idl="">errorText</dfn> of type <span class=
                   "idlMemberType">USVString</span>
                 </dt>
                 <dd>


### PR DESCRIPTION
…nectionIceErrorEvent.errorText

close #2603


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2609.html" title="Last updated on Nov 24, 2020, 7:23 AM UTC (6fd8775)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2609/48a9dc9...6fd8775.html" title="Last updated on Nov 24, 2020, 7:23 AM UTC (6fd8775)">Diff</a>