### PR TITLE
Remove voiceActivityFlag from spec

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -10365,40 +10365,8 @@ interface RTCRtpReceiver {
         <div>
           <pre class="idl">
           dictionary RTCRtpSynchronizationSource : RTCRtpContributingSource {
-  boolean voiceActivityFlag;
 };</pre>
-          <section>
-            <h2>
-              Dictionary RTCRtpSynchronizationSource Members
-            </h2>
-            <dl data-link-for="RTCRtpSynchronizationSource" data-dfn-for=
-            "RTCRtpSynchronizationSource" class="dictionary-members">
-              <dt data-tests=
-              "RTCRtpReceiver-getSynchronizationSources.https.html">
-                <dfn data-idl="">voiceActivityFlag</dfn> of type <span class=
-                "idlMemberType">boolean</span>
-              </dt>
-              <dd>
-                <p class="needs-test">
-                  Only present for audio receivers. Whether the last RTP
-                  packet, delivered from this source, contains voice activity
-                  (true) or not (false). If the RFC 6464 extension header was
-                  not present, or if the peer has signaled that it is not using
-                  the V bit by setting the "vad" extension attribute to "off",
-                  as described in [[!RFC6464]], Section 4,
-                  {{voiceActivityFlag}} will be absent.
-                </p>
-                <div class="issue atrisk">
-                  <p>
-                    {{RTCRtpSynchronizationSource/voiceActivityFlag}} is marked
-                    as a feature at risk, since there is no clear commitment
-                    from implementers.
-                  </p>
-                </div>
-              </dd>
-            </dl>
-          </section>
-        </div>
+          <p>The {{RTCRtpSynchronizationSource}} dictionary is expected to serve as an extension point for the specification to surface data only available in SSRCs.</p>
       </section>
       <section>
         <h3>


### PR DESCRIPTION
The feature was marked at risk, and didn't get enough implementation experience to be kept in the upcoming Proposed Rec.

The said feature is lined up for integration in WebRTC Extensions should there still be interest: https://github.com/w3c/webrtc-extensions/pull/55


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2610.html" title="Last updated on Nov 24, 2020, 10:44 AM UTC (0827924)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2610/48a9dc9...0827924.html" title="Last updated on Nov 24, 2020, 10:44 AM UTC (0827924)">Diff</a>