### PR TITLE
Change RTCPeerConnectionIceErrorEventInit.statusText to errorText

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6775,7 +6775,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
               </h2>
               <dl data-link-for="RTCPeerConnectionIceErrorEvent" data-dfn-for=
               "RTCPeerConnectionIceErrorEvent" class="constructors">
-                <dt>
+                <dt data-tests="RTCPeerConnectionIceErrorEvent.html">
                   <dfn>RTCPeerConnectionIceErrorEvent.constructor()</dfn>
                 </dt>
                 <dd></dd>
@@ -6879,7 +6879,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
   unsigned short? port;
   DOMString url;
   required unsigned short errorCode;
-  USVString statusText;
+  USVString errorText;
 };</pre>
             <section>
               <h2>
@@ -6930,7 +6930,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   </p>
                 </dd>
                 <dt data-tests="">
-                  <dfn data-idl="">statusText</dfn> of type <span class=
+                  <dfn data-idl="">errorText</dfn> of type <span class=
                   "idlMemberType">USVString</span>
                 </dt>
                 <dd>


### PR DESCRIPTION
Fixes #2603
Also points out that a test exists - in the process of being merged
upstream, see Chromium PR for status:

https://chromium-review.googlesource.com/c/chromium/src/+/2555011


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2611.html" title="Last updated on Nov 24, 2020, 2:18 PM UTC (535322e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2611/48a9dc9...535322e.html" title="Last updated on Nov 24, 2020, 2:18 PM UTC (535322e)">Diff</a>