### PR TITLE
Use proper definition reference for HTML origin concept

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1265,15 +1265,13 @@
           <ol>
             <li class="untestable">
               <p>
-                Let <var>window</var> be <var>document</var>'s <a data-cite=
-                "html/#concept-relevant-global">relevant global object</a>.
+                Let <var>window</var> be <var>document</var>'s [=relevant global object=].
               </p>
             </li>
             <li>
               <p>
                 For each {{RTCPeerConnection}} object <var>connection</var>
-                whose <a data-cite="html/#concept-relevant-global">relevant
-                global object</a> is <var>window</var>, [= close the connection
+                whose [=relevant global object=] is <var>window</var>, [= close the connection
                 =] with <var>connection</var> and the value <code>true</code>.
               </p>
             </li>
@@ -1307,8 +1305,7 @@
                   Let <var>connection</var> have a
                   <dfn>[[\DocumentOrigin]]</dfn> internal slot, initialized to
                   the [= relevant settings object =]'s
-                  <a data-cite=
-                  "html#concept-settings-object-origin">origin</a>.
+                  [=environment settings object/origin=].
                 </p>
               </li>
               <li class="no-test-needed">Let <var>configuration</var> be the
@@ -7178,8 +7175,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                         <p>
                           Set <var>certificate</var>.[[\Origin]] to the
                           [= relevant settings object =]'s
-                          <a data-cite=
-                          "html#concept-settings-object-origin">origin</a>.
+                          [=environment settings object/origin=].
                         </p>
                       </li>
                       <li>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2615.html" title="Last updated on Dec 14, 2020, 8:49 AM UTC (ff33ed8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2615/9915912...ff33ed8.html" title="Last updated on Dec 14, 2020, 8:49 AM UTC (ff33ed8)">Diff</a>