### PR TITLE
Update links to IETF to use datatracker rather than tools.ietf.org

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -17591,9 +17591,9 @@ interface RTCErrorEvent : Event {
         communities on this potential gap.
       </p>
       <p>
-        Within the <a href="https://tools.ietf.org/wg/mmusic/">IETF MMUSIC
+        Within the <a href="https://datatracker.ietf.org/wg/mmusic/">IETF MMUSIC
         Working Group</a>, work is ongoing to enable <a href=
-        "https://tools.ietf.org/html/draft-holmberg-mmusic-t140-usage-data-channel">
+        "https://datatracker.ietf.org/doc/html/draft-holmberg-mmusic-t140-usage-data-channel">
         Real-time text to be sent over the WebRTC data channel</a>, allowing
         gateways to be deployed to translate between the SCTP data channel
         protocol and RFC 4103 Real-Time Text. This work, once completed, is

--- a/webrtc.js
+++ b/webrtc.js
@@ -162,7 +162,7 @@ var respecConfig = {
                           el.appendChild(document.createTextNode(" ("));
                           jsepSections.forEach(function (s, i) {
                               var sectionLink = document.createElement("a");
-                              sectionLink.href = "https://tools.ietf.org/html/rfc8829#section-" +  s.slice(0, s.length - 1);
+                              sectionLink.href = "https://datatracker.ietf.org/doc/html/rfc8829#section-" +  s.slice(0, s.length - 1);
                               sectionLink.textContent = "section " + s;
                               if (i > 0) {
                                   if (i == jsepSections.length - 1) {


### PR DESCRIPTION
per https://mailarchive.ietf.org/arch/msg/tools-discuss/oYrAxb3KayPzZ4SNB1DVZTDPPNo/


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2631.html" title="Last updated on Mar 16, 2021, 8:52 AM UTC (86da901)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2631/f4771c5...86da901.html" title="Last updated on Mar 16, 2021, 8:52 AM UTC (86da901)">Diff</a>