### PR TITLE
s/last rtp timestamp/rtp timestamp/

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -10385,7 +10385,7 @@ interface RTCRtpReceiver {
               </dt>
               <dd>
                 <p>
-                  The last RTP timestamp, as defined in [[!RFC3550]] Section
+                  The RTP timestamp, as defined in [[!RFC3550]] Section
                   5.1, of the media played out at <var>timestamp</var>.
                 </p>
               </dd>


### PR DESCRIPTION
since frames never have more than a single timestamp there will only be one per frame.

(this has been sitting on my local disc for too a while...)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-pc/pull/2635.html" title="Last updated on Mar 22, 2021, 10:57 AM UTC (a23c520)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2635/88e62a7...fippo:a23c520.html" title="Last updated on Mar 22, 2021, 10:57 AM UTC (a23c520)">Diff</a>