### PR TITLE
limit number of ice servers to 64

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -286,8 +286,11 @@
                 <dd>
                   <p>
                     An array of objects describing servers available to be used
-                    by ICE, such as STUN and TURN servers. At most 64 elements
-                    are allowed.
+                    by ICE, such as STUN and TURN servers.
+                  </p>
+                  <p class="note">
+                    Existing implementations only utilize the first 32 entries;
+                    the others are ignored.
                   </p>
                 </dd>
                 <dt data-tests="RTCConfiguration-iceTransportPolicy.html">
@@ -1354,14 +1357,6 @@
                   certificates, so that the expiration check is to ensure that
                   keys are not used indefinitely and additional certificate
                   checks are unnecessary.
-                </p>
-              </li>
-              <li data-tests="RTCConfiguration-iceServers.html">
-                <p>
-                  If
-                  <var>configuration</var>.{{RTCConfiguration/iceServer}} is an array
-                  and contains more than 64 elements,
-                  [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
               <li>
@@ -3094,9 +3089,6 @@
               </li>
               <li data-tests="RTCConfiguration-iceServers.html">
                 <p id="config-iceservers">
-                  If <var>configuration</var>.{{RTCConfiguration/iceServers}}
-                  is defined and contains more than 64 elements, then
-                  [= exception/throw =] an {{InvalidAccessError}}.
                   If <var>configuration</var>.{{RTCConfiguration/iceServers}}
                   is defined, then run the following steps for each element:
                 </p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -287,10 +287,10 @@
                   <p>
                     An array of objects describing servers available to be used
                     by ICE, such as STUN and TURN servers.
-                  </p>
-                  <p class="note">
-                    Existing implementations only utilize the first 32 entries;
-                    the others are ignored.
+                    If the number of ICE servers exceeds an
+                    implementation-defined limit, ignore the ICE servers above
+                    the threshold. This implementation defined limit MUST be
+                    at least 32.
                   </p>
                 </dd>
                 <dt data-tests="RTCConfiguration-iceTransportPolicy.html">
@@ -1357,6 +1357,13 @@
                   certificates, so that the expiration check is to ensure that
                   keys are not used indefinitely and additional certificate
                   checks are unnecessary.
+                </p>
+              </li>
+              <li data-tests="RTCConfiguration-iceServers.html">
+                <p>
+                  If
+                  <var>configuration</var>.{{RTCConfiguration/iceServer}} is an array
+                  truncate it to the maximum number of supported elements.
                 </p>
               </li>
               <li>
@@ -3090,7 +3097,8 @@
               <li data-tests="RTCConfiguration-iceServers.html">
                 <p id="config-iceservers">
                   If <var>configuration</var>.{{RTCConfiguration/iceServers}}
-                  is defined, then run the following steps for each element:
+                  is defined, truncate it to the maximum number of supported
+                  elements and then run the following steps for each element:
                 </p>
                 <ol>
                   <li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -286,7 +286,8 @@
                 <dd>
                   <p>
                     An array of objects describing servers available to be used
-                    by ICE, such as STUN and TURN servers.
+                    by ICE, such as STUN and TURN servers. At most 64 elements
+                    are allowed.
                   </p>
                 </dd>
                 <dt data-tests="RTCConfiguration-iceTransportPolicy.html">
@@ -1353,6 +1354,14 @@
                   certificates, so that the expiration check is to ensure that
                   keys are not used indefinitely and additional certificate
                   checks are unnecessary.
+                </p>
+              </li>
+              <li data-tests="RTCConfiguration-iceServers.html">
+                <p>
+                  If
+                  <var>configuration</var>.{{RTCConfiguration/iceServer}} is an array
+                  and contains more than 64 elements,
+                  [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
               <li>
@@ -3085,6 +3094,9 @@
               </li>
               <li data-tests="RTCConfiguration-iceServers.html">
                 <p id="config-iceservers">
+                  If <var>configuration</var>.{{RTCConfiguration/iceServers}}
+                  is defined and contains more than 64 elements, then
+                  [= exception/throw =] an {{InvalidAccessError}}.
                   If <var>configuration</var>.{{RTCConfiguration/iceServers}}
                   is defined, then run the following steps for each element:
                 </p>


### PR DESCRIPTION
limits the number of ICE server entries to 64.
This value is arbitrarily chosen, more than a few servers
do not make sense in practice. As candidates from each
server need a unique priority, the number space is limited.

See
  https://bugs.chromium.org/p/webrtc/issues/detail?id=13195
and
  https://mailarchive.ietf.org/arch/msg/mmusic/isyEwdluHuTl5mMnVUDrmawBnIU/
for background information.

We need to decide whether to throw an error (and if yes, which one) or silently ignore as it is done for certificates


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-pc/pull/2679.html" title="Last updated on Nov 15, 2021, 11:22 AM UTC (012738b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2679/5bff3e5...fippo:012738b.html" title="Last updated on Nov 15, 2021, 11:22 AM UTC (012738b)">Diff</a>