### PR TITLE
RTCPeerConnectionState and RTCIceConnectionState computation should consider sctp transport

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -960,7 +960,7 @@
               </tbody>
             </table>
             <p>
-              The set of transports considered is the set of transports
+              The set of transports considered is the one
               presently referenced by the PeerConnection's
               [= set of transceivers =] and the PeerConnection's
               <dfn data-dfn-for="RTCPeerConnection">[[\SctpTransport]]</dfn>
@@ -1071,7 +1071,7 @@
               </tbody>
             </table>
              <p>
-              The set of transports considered is the set of transports
+              The set of transports considered is the one
               presently referenced by the PeerConnection's
               [= set of transceivers =] and the PeerConnection's
               <dfn data-dfn-for="RTCPeerConnection">[[\SctpTransport]]</dfn>
@@ -1189,7 +1189,7 @@
             </table>
           </div>
           <p>
-            The set of transports considered is the set of transports
+            The set of transports considered is the one
             presently referenced by the PeerConnection's
             [= set of transceivers =] and the PeerConnection's
               <dfn data-dfn-for="RTCPeerConnection">[[\SctpTransport]]</dfn>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-pc/pull/2680.html" title="Last updated on Oct 7, 2021, 2:44 PM UTC (e5d6426)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2680/5bff3e5...youennf:e5d6426.html" title="Last updated on Oct 7, 2021, 2:44 PM UTC (e5d6426)">Diff</a>