### PR TITLE
Fix IDL indenting

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -651,9 +651,11 @@
             is {{RTCRtcpMuxPolicy/"require"}}.
           </p>
           <div>
-            <pre id="target-rtcp-mux-policy" class="idl">enum RTCRtcpMuxPolicy {
-  "require"
-};</pre>
+            <pre id="target-rtcp-mux-policy" class="idl">
+              enum RTCRtcpMuxPolicy {
+                "require"
+              };
+            </pre>
             <table data-link-for="RTCRtcpMuxPolicy" data-dfn-for=
             "RTCRtcpMuxPolicy" class="simple">
               <thead>
@@ -9402,10 +9404,12 @@ async function updateParameters() {
             <dfn>RTCRtpSendParameters</dfn> Dictionary
           </h3>
           <div>
-            <pre class="idl">dictionary RTCRtpSendParameters : RTCRtpParameters {
-  required DOMString transactionId;
-  required sequence&lt;RTCRtpEncodingParameters&gt; encodings;
-};</pre>
+            <pre class="idl">
+              dictionary RTCRtpSendParameters : RTCRtpParameters {
+                required DOMString transactionId;
+                required sequence&lt;RTCRtpEncodingParameters&gt; encodings;
+              };
+            </pre>
             <section>
               <h2>
                 Dictionary {{RTCRtpSendParameters}} Members
@@ -10385,8 +10389,9 @@ interface RTCRtpReceiver {
           </section>
         </div>
         <div>
-          <pre class="idl">dictionary RTCRtpSynchronizationSource : RTCRtpContributingSource {
-};</pre>
+          <pre class="idl">
+            dictionary RTCRtpSynchronizationSource : RTCRtpContributingSource {};
+          </pre>
           <p>The {{RTCRtpSynchronizationSource}} dictionary is expected to serve as an extension point for the specification to surface data only available in SSRCs.</p>
       </section>
       <section>


### PR DESCRIPTION
problem caused by overeager tidy in d3f00123b0ef9d93871d900a75649d932120fd6e
close #2682


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2683.html" title="Last updated on Oct 21, 2021, 6:43 AM UTC (b2d08d0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2683/85bb91c...b2d08d0.html" title="Last updated on Oct 21, 2021, 6:43 AM UTC (b2d08d0)">Diff</a>