### PR TITLE
DOMTimeStamp is now EpochTimeStamp

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7054,7 +7054,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   </li>
                   <li>
                     <p>
-                      Let <var>expires</var> be a {{DOMTimeStamp}} value of
+                      Let <var>expires</var> be a {{EpochTimeStamp}} value of
                       2592000000.
                     </p>
                     <div class="note">
@@ -7240,13 +7240,13 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             {{RTCPeerConnection/generateCertificate}}.
           </p>
           <pre class="idl">dictionary RTCCertificateExpiration {
-  [EnforceRange] DOMTimeStamp expires;
+  [EnforceRange] EpochTimeStamp expires;
 };</pre>
           <dl data-link-for="RTCCertificateExpiration" data-dfn-for=
           "RTCCertificateExpiration" class="methods">
             <dt data-tests=
             "RTCPeerConnection-generateCertificate.html,RTCCertificate.html">
-              <dfn>expires</dfn>, of type {{DOMTimeStamp}}
+              <dfn>expires</dfn>, of type {{EpochTimeStamp}}
             </dt>
             <dd>
               <p>
@@ -7275,7 +7275,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
           <div>
             <pre class="idl" data-tests="idlharness.https.window.js">[Exposed=Window, Serializable]
 interface RTCCertificate {
-  readonly attribute DOMTimeStamp expires;
+  readonly attribute EpochTimeStamp expires;
   sequence&lt;RTCDtlsFingerprint&gt; getFingerprints();
 };</pre>
             <section>
@@ -7285,8 +7285,7 @@ interface RTCCertificate {
               <dl data-link-for="RTCCertificate" data-dfn-for="RTCCertificate"
               class="attributes">
                 <dt data-tests="RTCCertificate.html">
-                  <dfn data-idl="">expires</dfn> of type <span class=
-                  "idlAttrType">DOMTimeStamp</span>, readonly
+                  <dfn data-idl="">expires</dfn> of type {{EpochTimeStamp}}, readonly
                 </dt>
                 <dd>
                   <p>


### PR DESCRIPTION
closes #2674


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2686.html" title="Last updated on Nov 4, 2021, 3:41 PM UTC (fb2d5b9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2686/88b7126...fb2d5b9.html" title="Last updated on Nov 4, 2021, 3:41 PM UTC (fb2d5b9)">Diff</a>