### PR TITLE
Make sure connecting state happens whenever a ICE or DTLS transport is new

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1046,10 +1046,10 @@
                   </td>
                   <td>
                     None of the previous states apply and any
-                    {{RTCIceTransport}} is in the
-                    {{RTCIceTransportState/"checking"}} state or any
-                    {{RTCDtlsTransport}} is in the
-                    {{RTCDtlsTransportState/"connecting"}} state.
+                    {{RTCIceTransport}} is in the {{RTCIceTransportState/"new"}}
+                    or {{RTCIceTransportState/"checking"}} state or any
+                    {{RTCDtlsTransport}} is in the {{RTCDtlsTransportState/"new"}}
+                    or {{RTCDtlsTransportState/"connecting"}} state.
                   </td>
                 </tr>
                 <tr>


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2678


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-pc/pull/2687.html" title="Last updated on Oct 21, 2021, 12:16 PM UTC (634073c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2687/88b7126...youennf:634073c.html" title="Last updated on Oct 21, 2021, 12:16 PM UTC (634073c)">Diff</a>