### PR TITLE
Do all input validation upfront in setConfiguration.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3055,34 +3055,6 @@
                   {{InvalidModificationError}}.
                 </p>
               </li>
-              <li data-tests="RTCConfiguration-iceTransportPolicy.html">
-                <p id="config-icetransportpolicy">
-                  Set the [= ICE Agent =]'s <dfn id=
-                  "ice-transports-setting">ICE transports setting</dfn> to the
-                  value of
-                  <var>configuration</var>.{{RTCConfiguration/iceTransportPolicy}}.
-                  As defined in <span data-jsep=
-                  "setconfiguration">[[!RFC8829]]</span>, if the new [= ICE
-                  transports setting =] changes the existing setting, no action
-                  will be taken until the next gathering phase. If a script
-                  wants this to happen immediately, it should do an ICE
-                  restart.
-                </p>
-              </li>
-              <li data-tests="RTCConfiguration-iceCandidatePoolSize.html">
-                <p>
-                  Set the [= ICE Agent =]'s prefetched <dfn>ICE candidate pool
-                  size</dfn> as defined in <span data-jsep=
-                  "ice-candidate-pool pc-constructor">[[!RFC8829]]</span> to the
-                  value of
-                  <var>configuration</var>.{{RTCConfiguration/iceCandidatePoolSize}}.
-                  If the new [= ICE candidate pool size =] changes the existing
-                  setting, this may result in immediate gathering of new pooled
-                  candidates, or discarding of existing pooled candidates, as
-                  defined in <span data-jsep=
-                  "setconfiguration">[[!RFC8829]]</span>.
-                </p>
-              </li>
               <li>
                 <p>
                   Let <var>validatedServers</var> be an empty list.
@@ -3174,6 +3146,34 @@
                     </p>
                   </li>
                 </ol>
+              </li>
+              <li data-tests="RTCConfiguration-iceTransportPolicy.html">
+                <p id="config-icetransportpolicy">
+                  Set the [= ICE Agent =]'s <dfn id=
+                  "ice-transports-setting">ICE transports setting</dfn> to the
+                  value of
+                  <var>configuration</var>.{{RTCConfiguration/iceTransportPolicy}}.
+                  As defined in <span data-jsep=
+                  "setconfiguration">[[!RFC8829]]</span>, if the new [= ICE
+                  transports setting =] changes the existing setting, no action
+                  will be taken until the next gathering phase. If a script
+                  wants this to happen immediately, it should do an ICE
+                  restart.
+                </p>
+              </li>
+              <li data-tests="RTCConfiguration-iceCandidatePoolSize.html">
+                <p>
+                  Set the [= ICE Agent =]'s prefetched <dfn>ICE candidate pool
+                  size</dfn> as defined in <span data-jsep=
+                  "ice-candidate-pool pc-constructor">[[!RFC8829]]</span> to the
+                  value of
+                  <var>configuration</var>.{{RTCConfiguration/iceCandidatePoolSize}}.
+                  If the new [= ICE candidate pool size =] changes the existing
+                  setting, this may result in immediate gathering of new pooled
+                  candidates, or discarding of existing pooled candidates, as
+                  defined in <span data-jsep=
+                  "setconfiguration">[[!RFC8829]]</span>.
+                </p>
               </li>
               <li>
                 <p>


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2688.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2689.html" title="Last updated on Oct 22, 2021, 7:59 PM UTC (d7cbeb4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2689/8907be1...jan-ivar:d7cbeb4.html" title="Last updated on Oct 22, 2021, 7:59 PM UTC (d7cbeb4)">Diff</a>