### PR TITLE
Convert generateCertificate argument to DOMHighResTimeStamp

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7055,8 +7055,8 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   </li>
                   <li>
                     <p>
-                      Let <var>expires</var> be a {{DOMHighResTimeStamp}} value of
-                      2592000000.
+                      Let <var>expires</var> be a value of
+                      2592000000 (30*24*60*60*1000)
                     </p>
                     <div class="note">
                       <p>
@@ -7241,28 +7241,22 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             {{RTCPeerConnection/generateCertificate}}.
           </p>
           <pre class="idl">dictionary RTCCertificateExpiration {
-  [EnforceRange] DOMHighResTimeStamp expires;
+  [EnforceRange] unsigned long long expires;
 };</pre>
           <dl data-link-for="RTCCertificateExpiration" data-dfn-for=
           "RTCCertificateExpiration" class="methods">
             <dt data-tests=
             "RTCPeerConnection-generateCertificate.html,RTCCertificate.html">
-              <dfn>expires</dfn>, of type {{DOMHighResTimeStamp}}
+              <dfn>expires</dfn>, of type unsigned long long
             </dt>
             <dd>
               <p>
                 An optional {{expires}} attribute MAY be added to the
                 definition of the algorithm that is passed to
                 {{RTCPeerConnection/generateCertificate}}. If this parameter is
-                present it indicates the maximum time that the
-                {{RTCCertificate}} is valid for.
-              </p>
-              <p class="note">
-                The expires attribute is relative to the time origin.
-                Previous versions of this specification claimed that it was
-                relative to the current time, but the definition of
-                {{DOMHighResTimeStamp}} precludes this interpretation.
-                The difference should not matter much in practice.
+                present it indicates the maximum time in milliseconds that the
+                {{RTCCertificate}} is valid for, measured from the time the
+                certificate is created.
               </p>
             </dd>
           </dl>

--- a/webrtc.html
+++ b/webrtc.html
@@ -7031,12 +7031,6 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   if a hash algorithm is needed.
                 </p>
                 <p>
-                  The time used when generating a certificate is of type
-                  {{DOMHighResTimeStamp}}, which means that it is a number
-                  relative to the time origin as specified in [[HR-TIME]],
-                  or "now" if the time origin is undefined.
-                </p>
-                <p>
                   The resulting certificate MUST NOT include information that
                   can be linked to a user or <a>user agent</a>. Randomized
                   values for distinguished name and serial number SHOULD be

--- a/webrtc.html
+++ b/webrtc.html
@@ -7031,6 +7031,12 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   if a hash algorithm is needed.
                 </p>
                 <p>
+                  The time used when generating a certificate is of type
+                  {{DOMHighResTimeStamp}}, which means that it is a number
+                  relative to the time origin as specified in [[HR-TIME]],
+                  or "now" if the time origin is undefined.
+                </p>
+                <p>
                   The resulting certificate MUST NOT include information that
                   can be linked to a user or <a>user agent</a>. Randomized
                   values for distinguished name and serial number SHOULD be
@@ -7049,7 +7055,7 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                   </li>
                   <li>
                     <p>
-                      Let <var>expires</var> be a {{EpochTimeStamp}} value of
+                      Let <var>expires</var> be a {{DOMHighResTimeStamp}} value of
                       2592000000.
                     </p>
                     <div class="note">
@@ -7235,13 +7241,13 @@ interface RTCPeerConnectionIceErrorEvent : Event {
             {{RTCPeerConnection/generateCertificate}}.
           </p>
           <pre class="idl">dictionary RTCCertificateExpiration {
-  [EnforceRange] EpochTimeStamp expires;
+  [EnforceRange] DOMHighResTimeStamp expires;
 };</pre>
           <dl data-link-for="RTCCertificateExpiration" data-dfn-for=
           "RTCCertificateExpiration" class="methods">
             <dt data-tests=
             "RTCPeerConnection-generateCertificate.html,RTCCertificate.html">
-              <dfn>expires</dfn>, of type {{EpochTimeStamp}}
+              <dfn>expires</dfn>, of type {{DOMHighResTimeStamp}}
             </dt>
             <dd>
               <p>
@@ -7249,7 +7255,14 @@ interface RTCPeerConnectionIceErrorEvent : Event {
                 definition of the algorithm that is passed to
                 {{RTCPeerConnection/generateCertificate}}. If this parameter is
                 present it indicates the maximum time that the
-                {{RTCCertificate}} is valid for relative to the current time.
+                {{RTCCertificate}} is valid for.
+              </p>
+              <p class="note">
+                The expires attribute is relative to the time origin.
+                Previous versions of this specification claimed that it was
+                relative to the current time, but the definition of
+                {{DOMHighResTimeStamp}} precludes this interpretation.
+                The difference should not matter much in practice.
               </p>
             </dd>
           </dl>


### PR DESCRIPTION
Also add some explainer notes.

Fixes #2674


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2700.html" title="Last updated on Dec 2, 2021, 10:40 AM UTC (33bcad9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2700/de23f39...33bcad9.html" title="Last updated on Dec 2, 2021, 10:40 AM UTC (33bcad9)">Diff</a>