### PR TITLE
Add test annotations for candidates arriving after SLD

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1440,7 +1440,8 @@
                   to <code>""</code>.
                 </p>
               </li>
-              <li class="untestable">
+              <li data-tests=
+                "RTCPeerConnection-addIceCandidate-timing.https.html,protocol/candidate-exchange.https.html">
                 <p>
                   Let <var>connection</var> have an
                   <dfn data-dfn-for="RTCPeerConnection">[[\EarlyCandidates]]</dfn> internal slot, initialized to
@@ -11707,7 +11708,8 @@ interface RTCDtlsTransport : EventTarget {
               <code>true</code>, abort these steps.
             </p>
           </li>
-          <li>
+          <li data-tests=
+            "RTCPeerConnection-addIceCandidate-timing.https.html,protocol/candidate-exchange.https.html">
             <p>
               If either
               <var>connection</var>.{{RTCPeerConnection/[[PendingLocalDescription]]}} or
@@ -11718,7 +11720,8 @@ interface RTCDtlsTransport : EventTarget {
               these steps.
             </p>
           </li>
-          <li>
+          <li data-tests=
+            "RTCPeerConnection-addIceCandidate-timing.https.html,protocol/candidate-exchange.https.html">
             <p>
               Otherwise, append <var>candidate</var> to
               <var>connection</var>.{{RTCPeerConnection/[[EarlyCandidates]]}}.
@@ -11736,7 +11739,8 @@ interface RTCDtlsTransport : EventTarget {
           run the following steps:
         </p>
         <ol>
-          <li>
+          <li data-tests=
+            "RTCPeerConnection-addIceCandidate-timing.https.html,protocol/candidate-exchange.https.html">
             <p>
               For each candidate, <var>candidate</var>, in
               <var>connection</var>.{{RTCPeerConnection/[[EarlyCandidates]]}}, queue a task
@@ -11769,7 +11773,8 @@ interface RTCDtlsTransport : EventTarget {
               <var>candidate</var> is being made available.
             </p>
           </li>
-          <li>
+          <li data-tests=
+            "RTCPeerConnection-candidate-in-sdp.https.html">
             <p>
               If <var>connection</var>.{{RTCPeerConnection/[[PendingLocalDescription]]}} is
               not <code>null</code>, and represents the ICE [= generation =]
@@ -11806,7 +11811,7 @@ interface RTCDtlsTransport : EventTarget {
               local candidates.
             </p>
           </li>
-          <li>
+          <li data-tests="protocol/candidate-exchange.https.html">
             <p>
               [= Fire an event =] named {{RTCPeerConnection/icecandidate}} using the
               {{RTCPeerConnectionIceEvent}} interface with the candidate


### PR DESCRIPTION
Resubmit of borked https://github.com/w3c/webrtc-pc/pull/2693 (which github wouldn't let me --force-with-lease on top of for some reason).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2702.html" title="Last updated on Dec 2, 2021, 12:24 AM UTC (04761fc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2702/8a36da1...jan-ivar:04761fc.html" title="Last updated on Dec 2, 2021, 12:24 AM UTC (04761fc)">Diff</a>