### PR TITLE
Restrict ICE agent from using administratively prohibited candidates

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1821,6 +1821,22 @@
                     </p>
                   </li>
                   <li>
+                    <p>If <var>remote</var> is <code>false</code> and this
+                    triggers the ICE candidate gathering process in <span data-jsep=
+                     "applying-a-local-desc">[[!RFC8829]]</span>, the [= ICE Agent =]
+                    MUST NOT gather candidates that would be
+                    [= administratively prohibited =].
+                    </p>
+                  </li>
+                  <li>
+                    <p>If <var>remote</var> is <code>true</code> and this
+                    triggers ICE connectivity checks in <span data-jsep=
+                     "applying-a-remote-desc">[[!RFC8829]]</span>, the
+                    [= ICE Agent =] MUST NOT attempt to connect to candidates
+                    that are [= administratively prohibited =].
+                    </p>
+                  </li>
+                  <li>
                     <p>
                       If <var>remote</var> is <code>true</code>, validate
                       back-to-back offers as if answers were applied in


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2675. Also adds same restriction on local gathering, which should come in handy in https://github.com/w3c/webrtc-extensions/pull/81.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2708.html" title="Last updated on Jan 4, 2022, 10:19 PM UTC (6c8c1ab)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2708/cf3f083...jan-ivar:6c8c1ab.html" title="Last updated on Jan 4, 2022, 10:19 PM UTC (6c8c1ab)">Diff</a>