### PR TITLE
Clarify receiver's sdpFmtpLines might differ in have-local-offer

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9768,9 +9768,13 @@ async function updateParameters() {
                     <code class="sdp">a=fmtp</code> line in the SDP
                     corresponding to the codec, if one exists, as defined by
                     <span data-jsep="parsing-a-desc">[[!RFC8829]]</span>. For an
-                    {{RTCRtpSender}}, these parameters come from the current remote
-                    description, and for an {{RTCRtpReceiver}}, they come from
-                    the (potentially pending) local description. <a>Read-only parameter</a>.
+                    {{RTCRtpSender}}, these parameters come from the
+                    {{RTCPeerConnection/[[CurrentRemoteDescription]]}}, and for an
+                    {{RTCRtpReceiver}}, they come from the
+                    local description (which is
+                    {{RTCPeerConnection/[[PendingLocalDescription]]}} if not `null`, and
+                    {{RTCPeerConnection/[[CurrentLocalDescription]]}} otherwise).
+                    <a>Read-only parameter</a>.
                   </p>
                 </dd>
               </dl>

--- a/webrtc.html
+++ b/webrtc.html
@@ -9768,9 +9768,9 @@ async function updateParameters() {
                     <code class="sdp">a=fmtp</code> line in the SDP
                     corresponding to the codec, if one exists, as defined by
                     <span data-jsep="parsing-a-desc">[[!RFC8829]]</span>. For an
-                    {{RTCRtpSender}}, these parameters come from the remote
+                    {{RTCRtpSender}}, these parameters come from the current remote
                     description, and for an {{RTCRtpReceiver}}, they come from
-                    the local description. <a>Read-only parameter</a>.
+                    the (potentially pending) local description. <a>Read-only parameter</a>.
                   </p>
                 </dd>
               </dl>


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2710.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2711.html" title="Last updated on Jan 21, 2022, 8:41 PM UTC (d82d4b6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2711/789fa18...jan-ivar:d82d4b6.html" title="Last updated on Jan 21, 2022, 8:41 PM UTC (d82d4b6)">Diff</a>