### PR TITLE
Clean up definitions

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -203,13 +203,9 @@
       <p>
         The terms <dfn data-lt="fulfill|fulfillment">fulfilled</dfn>,
         <dfn data-lt="reject|rejection|rejecting">rejected</dfn>, <dfn data-lt=
-        "resolve|resolves">resolved</dfn>, <dfn>pending</dfn> and
+        "resolve|resolves">resolved</dfn>,  and
         <dfn>settled</dfn> used in the context of Promises are defined in
         [[!ECMASCRIPT-6.0]].
-      </p>
-      <p>
-        The terms <dfn>bundle</dfn>, <dfn>bundle-only</dfn> and
-        <dfn>bundle-policy</dfn> are defined in [[!RFC8829]].
       </p>
       <p>
         The <dfn data-cite=
@@ -971,7 +967,7 @@
               The set of transports considered is the one
               presently referenced by the PeerConnection's
               [= set of transceivers =] and the PeerConnection's
-              <dfn data-dfn-for="RTCPeerConnection">[[\SctpTransport]]</dfn>
+              {{RTCPeerConnection/[[SctpTransport]]}}
               internal slot if not <code>null</code>.
            </p>
           </div>
@@ -1082,7 +1078,7 @@
               The set of transports considered is the one
               presently referenced by the PeerConnection's
               [= set of transceivers =] and the PeerConnection's
-              <dfn data-dfn-for="RTCPeerConnection">[[\SctpTransport]]</dfn>
+              {{RTCPeerConnection/[[SctpTransport]]}}
               internal slot if not <code>null</code>.
             </p>
          </div>
@@ -1200,7 +1196,7 @@
             The set of transports considered is the one
             presently referenced by the PeerConnection's
             [= set of transceivers =] and the PeerConnection's
-              <dfn data-dfn-for="RTCPeerConnection">[[\SctpTransport]]</dfn>
+              {{RTCPeerConnection/[[SctpTransport]]}}
               internal slot if not <code>null</code>.
           </p>
           <p>
@@ -3172,7 +3168,7 @@
                 <p>
                   As defined in <span data-jsep=
                   "setconfiguration">[[!RFC8829]]</span>, if a new list of servers
-                  replaces the [= ICE Agent =]'s existing ICE servers list, no
+                  replaces the [= ICE Agent =]'s existing [= ICE servers list=], no
                   action will be taken until the next gathering phase. If a
                   script wants this to happen immediately, it should do an ICE
                   restart. However, if the [= ICE candidate pool size | ICE
@@ -5566,12 +5562,11 @@ interface RTCSessionDescription {
               <dl data-link-for="RTCSessionDescription" data-dfn-for=
               "RTCSessionDescription" class="constructors">
                 <dt>
-                  <dfn>constructor()</dfn>
+                  <dfn id="dom-sessiondescription">constructor()</dfn>
                 </dt>
                 <dd>
                   <p data-tests="">
-                    The <dfn id="dom-sessiondescription"><code class=
-                    "constructor">RTCSessionDescription()</code></dfn>
+                    The {{RTCSessionDescription()}}
                     constructor takes a dictionary argument,
                     <var>description</var>, whose content is used to initialize
                     the new {{RTCSessionDescription}} object. This constructor
@@ -5729,7 +5724,7 @@ interface RTCSessionDescription {
             Clearing Negotiation-Needed
           </h4>
           <p>
-            The negotiation-needed flag is cleared when a session description
+            The [=negotiation-needed flag=] is cleared when a session description
             of type {{RTCSdpType/"answer"}} [= set a session description | is
             set =] successfully, and the supplied description
             matches the state of the {{RTCRtpTransceiver}}s and
@@ -5794,7 +5789,7 @@ interface RTCSessionDescription {
                     {{RTCSignalingState/"stable"}}, abort these steps.
                   </p>
                   <p class="note">
-                    The negotiation-needed flag will be updated once the state
+                    The [=negotiation-needed flag=] will be updated once the state
                     transitions to {{RTCSignalingState/"stable"}}, as part of
                     the steps for [= setting a session description =].
                   </p>
@@ -13667,8 +13662,8 @@ interface RTCSctpTransport : EventTarget {
                 </li>
                 <li>
                   <p>
-                    Render the <var>channel</var>'s [= data transport =]
-                    [=closed=] by following the associated procedure.
+                    [= RTCDataChannel underlying data transport/closed | Close=] the <var>channel</var>'s [= data transport =]
+                     by following the associated procedure.
                   </p>
                 </li>
               </ol>
@@ -13682,7 +13677,7 @@ interface RTCSctpTransport : EventTarget {
           <p>
             When an {{RTCDataChannel}} object's [= underlying data transport =]
             has been <dfn id="data-transport-closed" data-dfn-for=
-            "">closed</dfn>, the user agent MUST queue a task to run the
+            "RTCDataChannel underlying data transport">closed</dfn>, the user agent MUST queue a task to run the
             following steps:
           </p>
           <ol data-tests="RTCDataChannel-close.html">
@@ -13704,7 +13699,7 @@ interface RTCSctpTransport : EventTarget {
             <li>
               <p>
                 If the [= underlying data transport | transport =] was closed
-                <dfn id="data-transport-closed-error">with an error</dfn>, [=
+                <span id="data-transport-closed-error">with an error</span>, [=
                 fire an event =] named {{RTCDataChannel/error}} using the {{RTCErrorEvent}}
                 interface with its {{RTCError/errorDetail}} attribute set to
                 {{RTCErrorDetailType/"sctp-failure"}} at <var>channel</var>.
@@ -13765,9 +13760,8 @@ interface RTCSctpTransport : EventTarget {
             Receiving messages on a data channel
           </h4>
           <p>
-            When an <dfn data-lt=
-            "receive an rtcdatachannel message">{{RTCDataChannel}} message has
-            been received</dfn> via the [= underlying data transport =] with
+            When an {{RTCDataChannel}} message has
+            been received via the [= underlying data transport =] with
             type <var>type</var> and data <var>rawData</var>, the user agent
             MUST queue a task to run the following steps:
           </p>
@@ -15956,9 +15950,9 @@ async function gatherStats(pc) {
             </thead>
             <tbody>
               <tr id="def-constraint-width">
-                <td data-tests="">
-                  <dfn>width</dfn>
-                </td>
+                <th data-tests="">
+                  width
+                </th>
                 <td>
                   {{ConstrainULong}}
                 </td>
@@ -15968,9 +15962,9 @@ async function gatherStats(pc) {
                 </td>
               </tr>
               <tr id="def-constraint-height">
-                <td data-tests="">
-                  <dfn>height</dfn>
-                </td>
+                <th data-tests="">
+                  height
+                </th>
                 <td>
                   {{ConstrainULong}}
                 </td>
@@ -15980,9 +15974,9 @@ async function gatherStats(pc) {
                 </td>
               </tr>
               <tr id="def-constraint-frameRate">
-                <td data-tests="">
-                  <dfn>frameRate</dfn>
-                </td>
+                <th data-tests="">
+                  frameRate
+                </th>
                 <td>
                   {{ConstrainDouble}}
                 </td>
@@ -15992,9 +15986,9 @@ async function gatherStats(pc) {
                 </td>
               </tr>
               <tr id="def-constraint-aspect">
-                <td data-tests="">
-                  <dfn>aspectRatio</dfn>
-                </td>
+                <th data-tests="">
+                  aspectRatio
+                </th>
                 <td>
                   {{ConstrainDouble}}
                 </td>
@@ -16480,13 +16474,13 @@ if (sender.dtmf.canInsertDTMF) {
         <ol>
           <li>
             <p>
-              The <dfn>polite peer</dfn> uses rollback to avoid collision with
+              The polite peer uses rollback to avoid collision with
               an incoming offer.
             </p>
           </li>
           <li>
             <p>
-              The <dfn>impolite peer</dfn> ignores an incoming offer when this
+              The impolite peer ignores an incoming offer when this
               would collide with its own.
             </p>
           </li>
@@ -16494,7 +16488,7 @@ if (sender.dtmf.canInsertDTMF) {
         <p>
           Together, they manage signaling for the rest of the application in a
           manner that doesn't deadlock. The example assumes a
-          <code>polite</code> boolean variable indicating the designated role:
+          <var>polite</var> boolean variable indicating the designated role:
         </p>
         <pre class="example highlight">
 const signaling = new SignalingChannel(); // handles JSON.stringify/parse
@@ -17041,7 +17035,7 @@ interface RTCErrorEvent : Event {
           </tr>
           <tr>
             <td>
-              <dfn  data-dfn-for=RTCDataChannel data-dfn-type="event" id="event-datachannel-close">close</dfn>
+              <dfn data-dfn-for=RTCDataChannel data-dfn-type="event" id="event-datachannel-close">close</dfn>
             </td>
             <td>
               {{Event}}


### PR DESCRIPTION
Remove unneeded definitions
Instantiate definitions that are used but were not marked up


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2728.html" title="Last updated on May 2, 2022, 10:06 AM UTC (f9ad3a3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2728/21549c3...f9ad3a3.html" title="Last updated on May 2, 2022, 10:06 AM UTC (f9ad3a3)">Diff</a>