### PR TITLE
Export internal slots used by webrtc-ice

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -12005,19 +12005,19 @@ interface RTCDtlsTransport : EventTarget {
         </p>
         <ul>
           <li>
-            <dfn data-dfn-for="RTCIceTransport">[[\IceTransportState]]</dfn> initialized to
+            <dfn class=export data-dfn-for="RTCIceTransport">[[\IceTransportState]]</dfn> initialized to
             {{RTCIceTransportState/"new"}}
           </li>
           <li>
-            <dfn data-dfn-for="RTCIceTransport">[[\IceGathererState]]</dfn> initialized to
+            <dfn class=export data-dfn-for="RTCIceTransport">[[\IceGathererState]]</dfn> initialized to
             {{RTCIceGatheringState/"new"}}
           </li>
           <li data-tests="RTCIceTransport.html">
-            <dfn data-dfn-for="RTCIceTransport">[[\SelectedCandidatePair]]</dfn> initialized to
+            <dfn class=export data-dfn-for="RTCIceTransport">[[\SelectedCandidatePair]]</dfn> initialized to
             <code>null</code>
           </li>
           <li>
-            <dfn data-dfn-for="RTCIceTransport">[[\IceRole]]</dfn> initialized to {{RTCIceRole/"unknown"}}
+            <dfn class=export data-dfn-for="RTCIceTransport">[[\IceRole]]</dfn> initialized to {{RTCIceRole/"unknown"}}
           </li>
         </ul>
         <div>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1392,7 +1392,7 @@
               </li>
               <li data-tests="RTCPeerConnection-addTrack.https.html">
                 <p>
-                  Let <var>connection</var> have an <dfn data-dfn-for="RTCPeerConnection">[[\IsClosed]]</dfn>
+                  Let <var>connection</var> have an <dfn data-dfn-for="RTCPeerConnection" class=export>[[\IsClosed]]</dfn>
                   internal slot, initialized to <code>false</code>.
                 </p>
               </li>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2740.html" title="Last updated on Jun 9, 2022, 8:45 AM UTC (9c36571)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2740/434cdbd...9c36571.html" title="Last updated on Jun 9, 2022, 8:45 AM UTC (9c36571)">Diff</a>