### PR TITLE
Don't queue a task in the determine DTMF algorithm.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -14890,8 +14890,8 @@ interface RTCDTMFSender : EventTarget {
         </h3>
         <p>
           To <dfn>determine if DTMF can be sent</dfn> for an {{RTCDTMFSender}}
-          instance <var>dtmfSender</var>, the user agent MUST queue a task that
-          runs the following steps:
+          instance <var>dtmfSender</var>, the user agent MUST run the following
+          steps:
         </p>
         <ol>
           <li class="no-test-needed">Let <var>sender</var> be the


### PR DESCRIPTION
Fixes #2738.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2742.html" title="Last updated on Jun 15, 2022, 6:57 PM UTC (21d3d33)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2742/c508d44...jan-ivar:21d3d33.html" title="Last updated on Jun 15, 2022, 6:57 PM UTC (21d3d33)">Diff</a>