### PR TITLE
Synchronize MTI stats with webrtc-stats cleanup

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -15435,7 +15435,6 @@ interface RTCStatsReport {
               </td>
               <td data-tests=
               "RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCRtpReceiver-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">
-                {{RTCInboundRtpStreamStats/receiverId}},
                 {{RTCInboundRtpStreamStats/remoteId}},
                 {{RTCInboundRtpStreamStats/framesDecoded}},
                 {{RTCInboundRtpStreamStats/nackCount}},
@@ -15475,7 +15474,6 @@ interface RTCStatsReport {
               </td>
               <td data-tests=
               "RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCRtpSender-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">
-                {{RTCOutboundRtpStreamStats/senderId}},
                 {{RTCOutboundRtpStreamStats/remoteId}},
                 {{RTCOutboundRtpStreamStats/framesEncoded}},
                 {{RTCOutboundRtpStreamStats/nackCount}},
@@ -15619,23 +15617,6 @@ interface RTCStatsReport {
                 {{RTCDataChannelStats/messagesReceived}},
                 {{RTCDataChannelStats/bytesReceived}}
               </td>
-            </tr>
-            <tr>
-              <th class="row">
-                {{RTCStatsType/"sender"}}
-              </th>
-              <td rowspan="2">
-                {{RTCMediaHandlerStats}}
-              </td>
-              <td rowspan="2" data-tests=
-              "RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">
-                {{RTCMediaHandlerStats/trackIdentifier}}
-              </td>
-            </tr>
-            <tr>
-              <th class="row">
-                {{RTCStatsType/"receiver"}}
-              </th>
             </tr>
             <tr>
               <th class="row">

--- a/webrtc.html
+++ b/webrtc.html
@@ -15397,7 +15397,7 @@ interface RTCStatsReport {
               </td>
               <td data-tests=
               "RTCPeerConnection-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">
-                {{RTCCodecStats/payloadType}}, {{RTCCodecStats/codecType}},
+                {{RTCCodecStats/payloadType}},
                 {{RTCCodecStats/mimeType}}, {{RTCCodecStats/clockRate}},
                 {{RTCCodecStats/channels}}, {{RTCCodecStats/sdpFmtpLine}}
               </td>
@@ -15425,7 +15425,6 @@ interface RTCStatsReport {
                 {{RTCReceivedRtpStreamStats/packetsReceived}},
                 {{RTCReceivedRtpStreamStats/packetsLost}},
                 {{RTCReceivedRtpStreamStats/jitter}},
-                {{RTCInboundRtpStreamStats/packetsDiscarded}},
                 {{RTCReceivedRtpStreamStats/framesDropped}}
               </td>
             </tr>
@@ -15442,6 +15441,7 @@ interface RTCStatsReport {
                 {{RTCInboundRtpStreamStats/bytesReceived}},
                 {{RTCInboundRtpStreamStats/totalAudioEnergy}},
                 {{RTCInboundRtpStreamStats/totalSamplesDuration}}
+                {{RTCInboundRtpStreamStats/packetsDiscarded}},
               </td>
             </tr>
             <tr>
@@ -15503,7 +15503,6 @@ interface RTCStatsReport {
                 {{RTCReceivedRtpStreamStats/packetsReceived}},
                 {{RTCReceivedRtpStreamStats/packetsLost}},
                 {{RTCReceivedRtpStreamStats/jitter}},
-                {{RTCInboundRtpStreamStats/packetsDiscarded}},
                 {{RTCReceivedRtpStreamStats/framesDropped}}
               </td>
             </tr>

--- a/webrtc.html
+++ b/webrtc.html
@@ -15425,7 +15425,7 @@ interface RTCStatsReport {
                 {{RTCReceivedRtpStreamStats/packetsReceived}},
                 {{RTCReceivedRtpStreamStats/packetsLost}},
                 {{RTCReceivedRtpStreamStats/jitter}},
-                {{RTCReceivedRtpStreamStats/packetsDiscarded}},
+                {{RTCInboundRtpStreamStats/packetsDiscarded}},
                 {{RTCReceivedRtpStreamStats/framesDropped}}
               </td>
             </tr>
@@ -15503,7 +15503,7 @@ interface RTCStatsReport {
                 {{RTCReceivedRtpStreamStats/packetsReceived}},
                 {{RTCReceivedRtpStreamStats/packetsLost}},
                 {{RTCReceivedRtpStreamStats/jitter}},
-                {{RTCReceivedRtpStreamStats/packetsDiscarded}},
+                {{RTCInboundRtpStreamStats/packetsDiscarded}},
                 {{RTCReceivedRtpStreamStats/framesDropped}}
               </td>
             </tr>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2744.html" title="Last updated on Jun 16, 2022, 6:49 AM UTC (d3f3bc0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2744/c508d44...d3f3bc0.html" title="Last updated on Jun 16, 2022, 6:49 AM UTC (d3f3bc0)">Diff</a>