### PR TITLE
Add inbound-rtp.trackIdentifier to MTI.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -15408,6 +15408,7 @@ interface RTCStatsReport {
               </td>
               <td data-tests=
               "RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCRtpReceiver-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">
+                {{RTCInboundRtpStreamStats/trackIdentifier}},
                 {{RTCInboundRtpStreamStats/remoteId}},
                 {{RTCInboundRtpStreamStats/framesDecoded}},
                 {{RTCInboundRtpStreamStats/nackCount}},


### PR DESCRIPTION
Fixes #2747


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/2748.html" title="Last updated on Jun 30, 2022, 3:09 PM UTC (223ed74)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2748/5e0eab7...henbos:223ed74.html" title="Last updated on Jun 30, 2022, 3:09 PM UTC (223ed74)">Diff</a>