### PR TITLE
Remove unused RTCRtpDecodingParameters

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9457,14 +9457,6 @@ async function updateParameters() {
             </section>
           </div>
         </section>
-        <section id="rtcrtpdecodingparameters">
-          <h3>
-            <dfn>RTCRtpDecodingParameters</dfn> Dictionary
-          </h3>
-          <div>
-            <pre class="idl">dictionary RTCRtpDecodingParameters : RTCRtpCodingParameters {};</pre>
-          </div>
-        </section>
         <section id="rtcrtpencodingparameters">
           <h3>
             <dfn>RTCRtpEncodingParameters</dfn> Dictionary


### PR DESCRIPTION
Leftover from RTCRtpReceiveParameters.encodings, which was removed in #2383.

Fixes #2752


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Orphis/webrtc-pc/pull/2753.html" title="Last updated on Jul 20, 2022, 8:23 AM UTC (bcda039)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2753/fbf4a93...Orphis:bcda039.html" title="Last updated on Jul 20, 2022, 8:23 AM UTC (bcda039)">Diff</a>