### PR TITLE
remove interaction between encoding.active and simulcast ~rid

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2521,19 +2521,6 @@
                                       <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}.
                                     </p>
                                   </li>
-                                  <li>
-                                    <p>
-                                      Update the paused status as indicated by
-                                      [[RFC8853]] of each simulcast
-                                      layer by setting the
-                                      {{RTCRtpEncodingParameters/active}}
-                                      member on the corresponding dictionaries
-                                      in
-                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
-                                      to <code>true</code> for unpaused or to
-                                      <code>false</code> for paused.
-                                    </p>
-                                  </li>
                                 </ol>
                               </li>
                               <li data-tests=


### PR DESCRIPTION
since this would imply setParameters can trigger changes to the
SDP that require negotiation.

Applications that rely on this behavior can still inspect the SDP
(or rely on other means of signaling) and manually change the
encodings active property to not send a particular encoding.

Fixes #2735


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-pc/pull/2754.html" title="Last updated on Jul 20, 2022, 12:27 PM UTC (89fdf17)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2754/fbf4a93...fippo:89fdf17.html" title="Last updated on Jul 20, 2022, 12:27 PM UTC (89fdf17)">Diff</a>