### PR TITLE
Note that RFC7728 is not supported.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -11105,8 +11105,8 @@ interface RTCRtpTransceiver {
             offer from a user-agent will only contain a "send" description and
             no "recv" description on the <code class="sdp">a=simulcast</code>
             line. Alternatives and restrictions (described in
-            [[RFC8853]]) are not supported. Also, pausing of sending using
-            offers and answers is not supported.
+            [[RFC8853]]) are not supported. Also, pausing or unpausing of
+            sending using offers and answers is not supported.
             <div class="note">
               Specifically, [[RFC7728]] is not supported.
             </div>

--- a/webrtc.html
+++ b/webrtc.html
@@ -11107,6 +11107,9 @@ interface RTCRtpTransceiver {
             line. Alternatives and restrictions (described in
             [[RFC8853]]) are not supported.
           </p>
+          <p class="note">
+            For offers and answers, [[RFC7728]] is not supported.
+          </p>
           <p class="needs-test">
             This specification does not define how to configure reception of
             multiple RTP encodings using {{RTCPeerConnection/createOffer}},

--- a/webrtc.html
+++ b/webrtc.html
@@ -11077,7 +11077,7 @@ interface RTCRtpTransceiver {
             {{RTCRtpEncodingParameters/active}} member to <code>false</code>
             effectively disabling the layer.
           </p>
-          <p data-tests="simulcast/getStats.https.html">
+          <p data-tests="simulcast/getStats.https.html,simulcast/basic.https.html,protocol/simulcast-offer.html,protocol/simulcast-answer.html">
             While {{RTCRtpSender/setParameters}} cannot modify the [= simulcast
             envelope =], it is still possible to control the number of streams
             that are sent and the characteristics of those streams. Using
@@ -11085,6 +11085,8 @@ interface RTCRtpTransceiver {
             inactive by setting the {{RTCRtpEncodingParameters/active}} member
             to <code>false</code>, or can be reactivated by setting the
             {{RTCRtpEncodingParameters/active}} member to <code>true</code>.
+            [[?RFC7728]] (RTP Pause/Resume) is not supported, nor is signaling
+            of pause/resume via SDP Offer/Answer.
             Using {{RTCRtpSender/setParameters}}, stream characteristics can be
             changed by modifying attributes such as
             {{RTCRtpEncodingParameters/maxBitrate}}.
@@ -11100,16 +11102,12 @@ interface RTCRtpTransceiver {
             permit all simulcast streams to be sent in an usable form, the user
             agent is expected to stop sending some of the simulcast streams.
           </p>
-          <p data-tests="simulcast/basic.https.html,protocol/simulcast-offer.html,protocol/simulcast-answer.html">
+          <p data-tests="simulcast/basic.https.html">
             As defined in <span data-jsep="simulcast">[[!RFC8829]]</span>, an
             offer from a user-agent will only contain a "send" description and
             no "recv" description on the <code class="sdp">a=simulcast</code>
             line. Alternatives and restrictions (described in
-            [[RFC8853]]) are not supported. Also, pausing or unpausing of
-            sending using offers and answers is not supported.
-            <div class="note">
-              Specifically, [[RFC7728]] is not supported.
-            </div>
+            [[RFC8853]]) are not supported.
           </p>
           <p class="needs-test">
             This specification does not define how to configure reception of

--- a/webrtc.html
+++ b/webrtc.html
@@ -11100,15 +11100,16 @@ interface RTCRtpTransceiver {
             permit all simulcast streams to be sent in an usable form, the user
             agent is expected to stop sending some of the simulcast streams.
           </p>
-          <p data-tests="simulcast/basic.https.html">
+          <p data-tests="simulcast/basic.https.html,protocol/simulcast-offer.html,protocol/simulcast-answer.html">
             As defined in <span data-jsep="simulcast">[[!RFC8829]]</span>, an
             offer from a user-agent will only contain a "send" description and
             no "recv" description on the <code class="sdp">a=simulcast</code>
             line. Alternatives and restrictions (described in
-            [[RFC8853]]) are not supported.
-          </p>
-          <p class="note">
-            For offers and answers, [[RFC7728]] is not supported.
+            [[RFC8853]]) are not supported. Also, pausing of sending using
+            offers and answers is not supported.
+            <div class="note">
+              Specifically, [[RFC7728]] is not supported.
+            </div>
           </p>
           <p class="needs-test">
             This specification does not define how to configure reception of


### PR DESCRIPTION
Follow-up to #2754. I made it a note to avoid it being normative reference.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2755.html" title="Last updated on Jul 20, 2022, 8:27 PM UTC (8e7df38)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2755/fbf4a93...jan-ivar:8e7df38.html" title="Last updated on Jul 20, 2022, 8:27 PM UTC (8e7df38)">Diff</a>