### PR TITLE
Fix "does not allow remotely initiated RID renegotiation" step

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1834,7 +1834,10 @@
                   </li>
                   <li>
                     <p>
-                      If applying <var>description</var> leads to modifying a
+                      If <var>remote</var> is <code>true</code>, and
+                      <var>description</var> is of type {{RTCSdpType/"offer"}}
+                      and contains a request to receive simulcast, and applying
+                      <var>description</var> leads to modifying a
                       transceiver <var>transceiver</var>, and
                       <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
                       is non-empty, and not equal to the encodings that would


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2743.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2757.html" title="Last updated on Jul 27, 2022, 9:03 PM UTC (46c60bb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2757/d6ed794...jan-ivar:46c60bb.html" title="Last updated on Jul 27, 2022, 9:03 PM UTC (46c60bb)">Diff</a>