### PR TITLE
Don't let offers to receive simulcast overwrite existing [[SendEncodings]]

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2471,8 +2471,7 @@
                                       the previously negototiated layers, then
                                       remove the dictionaries that correspond to
                                       the missing layers from
-                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}, but do not reorder
-                                      them.
+                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}.
                                     </p>
                                   </li>
 				  <li id="rm-simulcast-pause" class="diff-rm"><!-- kept for candidate amendment management --></li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1758,21 +1758,30 @@
                   <li>
                     <p id="remote-rid-reneg">
                       If <var>remote</var> is <code>true</code>, and
-                      <var>description</var> is of type {{RTCSdpType/"offer"}}
-                      and contains a request to receive simulcast, and applying
-                      <var>description</var> leads to modifying a
-                      transceiver <var>transceiver</var>, and
-                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
-                      is non-empty, and not equal to the encodings that would
-                      result from processing <var>description</var>, the
-                      process of applying <var>description</var> fails. This
-                      specification does not allow remotely initiated RID
-                      renegotiation.
+                      <var>description</var> is of type
+                      {{RTCSdpType/"offer"}}, then for each
+                      [= media description =] requesting to receive simulcast
+                      that already has an existing {{RTCRtpTransceiver}} object,
+                      <var>transceiver</var>, associated with it, as described in
+                      <span data-jsep="applying-a-remote-desc">[[!RFC8829]]</span>,
+                      if the rid values specified in the simulcast attribute (up
+                      to the maximum number the implementation supports) differ
+                      in name, order or number from the ones previously used to
+                      populate
+                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}},
+                      then [= description fails | fail =] the process of
+                      applying <var>description</var>.
+                      <div class="note">
+                        This specification does not allow remotely initiated RID
+                        renegotiation.
+                      </div>
                     </p>
                   </li>
                   <li>
                     <p>
-                      If the process to apply <var>description</var> fails for
+                      If the <dfn data-lt="description fails"
+                      id="set-pc-configuration">process to apply
+                      <var>description</var> fails</dfn> for
                       any reason, then the user agent MUST queue a task that
                       runs the following steps:
                     </p>
@@ -2322,7 +2331,8 @@
                               <li>
                                 <p>
                                   If the <var>description</var> is of type
-                                  {{RTCSdpType/"offer"}} and contains a request
+                                  {{RTCSdpType/"offer"}} and the
+                                  [= media description =] contains a request
                                   to receive simulcast, use the order of the
                                   rid values specified in the simulcast
                                   attribute to create an
@@ -2363,42 +2373,16 @@
                               <li>
                                 <p>
                                   If a suitable transceiver was found
-                                  (<var>transceiver</var> is set) and
+                                  (<var>transceiver</var> is set),
                                   <var>proposedSendEncodings</var> is non-empty,
-                                  run the following steps:
+                                  and
+                                  <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
+                                  is empty, then set
+                                  <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
+                                  to <var>proposedSendEncodings</var>, and set
+                                  <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[LastReturnedParameters]]}}
+                                  to <code>null</code>.
                                 </p>
-                                <ol>
-                                  <li class="needs-test">
-                                    <p>
-                                      If
-                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
-                                      is non-empty, then for each encoding,
-                                      <var>encoding</var>, in
-                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}},
-                                      copy all of <var>encoding</var>'s members
-                                      and their values to the encoding with the
-                                      same {{RTCRtpCodingParameters/rid}} in
-                                      <var>proposedSendEncodings</var>, if there
-                                      is one.
-                                    </p>
-                                    <p>
-                                      Set
-                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
-                                      to <var>proposedSendEncodings</var>, and set
-                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[LastReturnedParameters]]}}
-                                      to <code>null</code>.
-                                      <div class="note">
-                                        If this step produces a net change in an
-                                        existing non-empty
-                                        <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}},
-                                        then the process of applying
-                                        <var>description</var> fails. This
-                                        specification does not allow remotely
-                                        initiated RID renegotiation.
-                                      </div>
-                                    </p>
-                                  </li>
-                                </ol>
                               </li>
                               <li>
                                 <p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1764,14 +1764,18 @@
                       that already has an existing {{RTCRtpTransceiver}} object,
                       <var>transceiver</var>, associated with it, as described in
                       <span data-jsep="applying-a-remote-desc">[[!RFC8829]]</span>,
-                      if the rid values specified in the simulcast attribute (up
-                      to the maximum number the implementation supports) differ
-                      in name, order or number from the ones previously used to
-                      populate
-                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}},
+                      if the first encoding in
+                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
+                      [=map/contains=] a {{RTCRtpCodingParameters/rid}} member, and its
+                      value does not match the first rid in the simulcast attribute,
                       then [= description fails | fail =] the process of
                       applying <var>description</var>.
                       <div class="note">
+                        A change in the number of rid values is tolerated in
+                        remote offers as long as the first rid matches the rid
+                        of the first encoding that was previously negotiated.
+                        Mismatched or out-of-order rids result in layer reduction,
+                        and layer expansion is prevented in user agent answers.
                         This specification does not allow remotely initiated RID
                         renegotiation.
                       </div>
@@ -2373,16 +2377,69 @@
                               <li>
                                 <p>
                                   If a suitable transceiver was found
-                                  (<var>transceiver</var> is set),
+                                  (<var>transceiver</var> is set), and
                                   <var>proposedSendEncodings</var> is non-empty,
-                                  and
-                                  <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
-                                  is empty, then set
-                                  <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
-                                  to <var>proposedSendEncodings</var>, and set
-                                  <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[LastReturnedParameters]]}}
-                                  to <code>null</code>.
+                                  run the following steps:
                                 </p>
+                                <ol>
+                                  <li class="needs-test">
+                                    <p>
+                                      If the length of
+                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
+                                      is `1`, and the lone encoding
+                                      [=map/contains=] no
+                                      {{RTCRtpCodingParameters/rid}} member, set
+                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
+                                      to <var>proposedSendEncodings</var>.
+                                    </p>
+                                  </li>
+                                  <li class="needs-test">
+                                    <p>
+                                      Assert: The first encoding of
+                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
+                                      and the first encoding of
+                                      <var>proposedSendEncodings</var> both
+                                      [=map/contain=] a
+                                      {{RTCRtpCodingParameters/rid}} member, and
+                                      their values match.
+                                    </p>
+                                  </li>
+                                  <li class="needs-test">
+                                    <p>
+                                      Set the length of
+                                      <var>proposedSendEncodings</var> to the lesser
+                                      of its own length and the length of
+                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}.
+                                    </p>
+                                  </li>
+                                  <li class="needs-test">
+                                    <p>
+                                      Reduce the length of
+                                      <var>proposedSendEncodings</var> until all
+                                      encodings in it [=map/contain=] only
+                                      {{RTCRtpCodingParameters/rid}} member
+                                      values that match the
+                                      {{RTCRtpCodingParameters/rid}} member
+                                      value of the same-position encoding in
+                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}.
+                                    </p>
+                                  </li>
+                                  <li class="needs-test">
+                                    <p>
+                                      Set the length of
+                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
+                                      to the length of
+                                      <var>proposedSendEncodings</var>.
+                                    </p>
+                                  </li>
+                                  <li>
+                                    <p>
+                                      Set
+                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[LastReturnedParameters]]}}
+                                      to <code>null</code>.
+                                    </p>
+                                  </li>
+                                </ol>
                               </li>
                               <li>
                                 <p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1773,7 +1773,8 @@
                       <div class="note">
                         A change in the number of rid values is tolerated in
                         remote offers as long as the first rid matches the rid
-                        of the first encoding that was previously negotiated.
+                        of the first encoding that was previously negotiated, or
+                        there are no rid values.
                         Mismatched or out-of-order rids result in layer reduction,
                         and layer expansion is prevented in user agent answers.
                         This specification does not allow remotely initiated RID

--- a/webrtc.html
+++ b/webrtc.html
@@ -1764,18 +1764,18 @@
                       that already has an existing {{RTCRtpTransceiver}} object,
                       <var>transceiver</var>, associated with it, as described in
                       <span data-jsep="applying-a-remote-desc">[[!RFC8829]]</span>,
-                      if the first encoding in
+                      if none of the encodings in
                       <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
-                      [=map/contains=] a {{RTCRtpCodingParameters/rid}} member, and its
-                      value does not match the first rid in the simulcast attribute,
-                      then [= description fails | fail =] the process of
-                      applying <var>description</var>.
+                      [=map/contain=] a {{RTCRtpCodingParameters/rid}} member
+                      whose value matches any of the rids in the simulcast
+                      attribute, then [= description fails | fail =] the
+                      process of applying <var>description</var>.
                       <div class="note">
-                        A change in the number of rid values is tolerated in
-                        remote offers as long as the first rid matches the rid
-                        of the first encoding that was previously negotiated, or
-                        there are no rid values.
-                        Mismatched or out-of-order rids result in layer reduction,
+                        A change in rids values is tolerated in remote offers to
+                        receive simulcast as long as at least one rid matches a
+                        rid in the encodings that were previously negotiated, or
+                        the offer is to no longer receive simulcast.
+                        Mismatched or out-of-order rids result in layer removal,
                         and layer expansion is prevented in user agent answers.
                         This specification does not allow remotely initiated RID
                         renegotiation.
@@ -2391,51 +2391,7 @@
                                       [=map/contains=] no
                                       {{RTCRtpCodingParameters/rid}} member, set
                                       <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
-                                      to <var>proposedSendEncodings</var>.
-                                    </p>
-                                  </li>
-                                  <li class="needs-test">
-                                    <p>
-                                      Assert: The first encoding of
-                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
-                                      and the first encoding of
-                                      <var>proposedSendEncodings</var> both
-                                      [=map/contain=] a
-                                      {{RTCRtpCodingParameters/rid}} member, and
-                                      their values match.
-                                    </p>
-                                  </li>
-                                  <li class="needs-test">
-                                    <p>
-                                      Set the length of
-                                      <var>proposedSendEncodings</var> to the lesser
-                                      of its own length and the length of
-                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}.
-                                    </p>
-                                  </li>
-                                  <li class="needs-test">
-                                    <p>
-                                      Reduce the length of
-                                      <var>proposedSendEncodings</var> until all
-                                      encodings in it [=map/contain=] only
-                                      {{RTCRtpCodingParameters/rid}} member
-                                      values that match the
-                                      {{RTCRtpCodingParameters/rid}} member
-                                      value of the same-position encoding in
-                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}.
-                                    </p>
-                                  </li>
-                                  <li class="needs-test">
-                                    <p>
-                                      Set the length of
-                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
-                                      to the length of
-                                      <var>proposedSendEncodings</var>.
-                                    </p>
-                                  </li>
-                                  <li>
-                                    <p>
-                                      Set
+                                      to <var>proposedSendEncodings</var>, and set
                                       <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[LastReturnedParameters]]}}
                                       to <code>null</code>.
                                     </p>
@@ -2511,9 +2467,9 @@
                                   </li>
                                   <li>
                                     <p>
-                                      If <var>description</var> rejects any of
+                                      If <var>description</var> is missing any of
                                       the offered layers, then remove the
-                                      dictionaries that correspond to rejected
+                                      dictionaries that correspond to the missing
                                       layers from
                                       <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}.
                                     </p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -2330,24 +2330,24 @@
                                   each of the simulcast layers, populating the
                                   {{RTCRtpCodingParameters/rid}} member
                                   according to the corresponding rid value, and
-                                  let <var>receiveEncodings</var> be the list
-                                  containing the created dictionaries.
-                                  Otherwise, let <var>receiveEncodings</var> be an
-                                  empty list.
+                                  let <var>proposedSendEncodings</var> be the
+                                  list containing the created dictionaries.
+                                  Otherwise, let <var>proposedSendEncodings</var>
+                                  be an empty list.
                                 </p>
                               </li>
                               <li>Let <var>supportedEncodings</var> be the
                               maximum number of encodings that the
                               implementation can support. If the length of
-                              <var>receiveEncodings</var> is greater than
+                              <var>proposedSendEncodings</var> is greater than
                               <var>supportedEncodings</var>, truncate
-                              <var>receiveEncodings</var> so that its length is
+                              <var>proposedSendEncodings</var> so that its length is
                               <var>supportedEncodings</var>.
                               </li>
-                              <li>If <var>receiveEncodings</var> is non-empty, set
-                              each encoding's
+                              <li>If <var>proposedSendEncodings</var> is non-empty,
+                              set each encoding's
                               {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
-                              to <code>2^(length of <var>receiveEncodings</var> -
+                              to <code>2^(length of <var>proposedSendEncodings</var> -
                               encoding index - 1)</code>.
                               </li>
                               <li>
@@ -2364,8 +2364,8 @@
                                 <p>
                                   If a suitable transceiver was found
                                   (<var>transceiver</var> is set) and
-                                  <var>receiveEncodings</var> is non-empty, run
-                                  the following steps:
+                                  <var>proposedSendEncodings</var> is non-empty,
+                                  run the following steps:
                                 </p>
                                 <ol>
                                   <li class="needs-test">
@@ -2378,12 +2378,13 @@
                                       copy all of <var>encoding</var>'s members
                                       and their values to the encoding with the
                                       same {{RTCRtpCodingParameters/rid}} in
-                                      <var>receiveEncodings</var>, if there is one.
+                                      <var>proposedSendEncodings</var>, if there
+                                      is one.
                                     </p>
                                     <p>
                                       Set
                                       <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
-                                      to <var>receiveEncodings</var>, and set
+                                      to <var>proposedSendEncodings</var>, and set
                                       <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[LastReturnedParameters]]}}
                                       to <code>null</code>.
                                       <div class="note">
@@ -2412,7 +2413,7 @@
                                       [= Create an RTCRtpSender =],
                                       <var>sender</var>, from the [= media
                                       description =] using
-                                      <var>receiveEncodings</var>.
+                                      <var>proposedSendEncodings</var>.
                                     </p>
                                   </li>
                                   <li data-tests=

--- a/webrtc.html
+++ b/webrtc.html
@@ -2330,24 +2330,24 @@
                                   each of the simulcast layers, populating the
                                   {{RTCRtpCodingParameters/rid}} member
                                   according to the corresponding rid value, and
-                                  let <var>sendEncodings</var> be the list
+                                  let <var>receiveEncodings</var> be the list
                                   containing the created dictionaries.
-                                  Otherwise, let <var>sendEncodings</var> be an
+                                  Otherwise, let <var>receiveEncodings</var> be an
                                   empty list.
                                 </p>
                               </li>
                               <li>Let <var>supportedEncodings</var> be the
                               maximum number of encodings that the
                               implementation can support. If the length of
-                              <var>sendEncodings</var> is greater than
+                              <var>receiveEncodings</var> is greater than
                               <var>supportedEncodings</var>, truncate
-                              <var>sendEncodings</var> so that its length is
+                              <var>receiveEncodings</var> so that its length is
                               <var>supportedEncodings</var>.
                               </li>
-                              <li>If <var>sendEncodings</var> is non-empty, set
+                              <li>If <var>receiveEncodings</var> is non-empty, set
                               each encoding's
                               {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
-                              to <code>2^(length of <var>sendEncodings</var> -
+                              to <code>2^(length of <var>receiveEncodings</var> -
                               encoding index - 1)</code>.
                               </li>
                               <li>
@@ -2364,12 +2364,40 @@
                                 <p>
                                   If a suitable transceiver was found
                                   (<var>transceiver</var> is set) and
-                                  <var>sendEncodings</var> is non-empty, set
-                                  <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
-                                  to <var>sendEncodings</var>, and set
-                                  <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[LastReturnedParameters]]}}
-                                  to <code>null</code>.
+                                  <var>receiveEncodings</var> is non-empty, run
+                                  the following steps:
                                 </p>
+                                <ol>
+                                  <li class="needs-test">
+                                    <p>
+                                      If
+                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
+                                      is non-empty, then for each encoding,
+                                      <var>encoding</var>, in
+                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}},
+                                      copy all of <var>encoding</var>'s members
+                                      and their values to the encoding with the
+                                      same {{RTCRtpCodingParameters/rid}} in
+                                      <var>receiveEncodings</var>, if there is one.
+                                    </p>
+                                    <p>
+                                      Set
+                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
+                                      to <var>receiveEncodings</var>, and set
+                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[LastReturnedParameters]]}}
+                                      to <code>null</code>.
+                                      <div class="note">
+                                        If this step produces a net change in an
+                                        existing non-empty
+                                        <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}},
+                                        then the process of applying
+                                        <var>description</var> fails. This
+                                        specification does not allow remotely
+                                        initiated RID renegotiation.
+                                      </div>
+                                    </p>
+                                  </li>
+                                </ol>
                               </li>
                               <li>
                                 <p>
@@ -2384,7 +2412,7 @@
                                       [= Create an RTCRtpSender =],
                                       <var>sender</var>, from the [= media
                                       description =] using
-                                      <var>sendEncodings</var>.
+                                      <var>receiveEncodings</var>.
                                     </p>
                                   </li>
                                   <li data-tests=

--- a/webrtc.html
+++ b/webrtc.html
@@ -1780,7 +1780,7 @@
                   <li>
                     <p>
                       If the <dfn data-lt="description fails"
-                      id="set-pc-configuration">process to apply
+                      id="fail-description">process to apply
                       <var>description</var> fails</dfn> for
                       any reason, then the user agent MUST queue a task that
                       runs the following steps:

--- a/webrtc.html
+++ b/webrtc.html
@@ -2468,10 +2468,11 @@
                                   <li>
                                     <p>
                                       If <var>description</var> is missing any of
-                                      the offered layers, then remove the
-                                      dictionaries that correspond to the missing
-                                      layers from
-                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}.
+                                      the previously negototiated layers, then
+                                      remove the dictionaries that correspond to
+                                      the missing layers from
+                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}, but do not reorder
+                                      them.
                                     </p>
                                   </li>
 				  <li id="rm-simulcast-pause" class="diff-rm"><!-- kept for candidate amendment management --></li>


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2722. cc @docfaraday


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2758.html" title="Last updated on Oct 13, 2022, 12:49 PM UTC (561937b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2758/aac8167...jan-ivar:561937b.html" title="Last updated on Oct 13, 2022, 12:49 PM UTC (561937b)">Diff</a>