### PR TITLE
Clarify simulcast envelope is determined by negotiation.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -11062,7 +11062,7 @@ interface RTCRtpTransceiver {
             simulcast.
           </p>
           <p class="needs-test">
-            An exception is when the client is the answerer. Upon calling the
+            An exception is when the user agent is the answerer. Upon calling the
             {{RTCPeerConnection/setRemoteDescription}} method with a remote
             offer to receive simulcast, the [= simulcast envelope =] is
             configured on the {{RTCRtpTransceiver}} to contain the layers

--- a/webrtc.html
+++ b/webrtc.html
@@ -11062,7 +11062,10 @@ interface RTCRtpTransceiver {
             simulcast.
           </p>
           <p class="needs-test">
-            After negotiation, the [= simulcast envelope =] is
+            Another implication is that the answerer cannot set the [=
+            simulcast envelope =] directly. Upon calling the
+            {{RTCPeerConnection/setRemoteDescription}} method with a remote
+            offer to receive simulcast, the [= simulcast envelope =] is
             configured on the {{RTCRtpTransceiver}} to contain the layers
             described by the specified session description. Once the
             envelope is determined, layers cannot be removed. They can be

--- a/webrtc.html
+++ b/webrtc.html
@@ -11062,8 +11062,7 @@ interface RTCRtpTransceiver {
             simulcast.
           </p>
           <p class="needs-test">
-            Another implication is that the answerer cannot set the [=
-            simulcast envelope =] directly. Upon calling the
+            An exception is when the client is the answerer. Upon calling the
             {{RTCPeerConnection/setRemoteDescription}} method with a remote
             offer to receive simulcast, the [= simulcast envelope =] is
             configured on the {{RTCRtpTransceiver}} to contain the layers

--- a/webrtc.html
+++ b/webrtc.html
@@ -11039,13 +11039,17 @@ interface RTCRtpTransceiver {
           </h3>
           <p data-test="simulcast/basic.https.html">
             Simulcast functionality is provided via the
-            {{RTCPeerConnection/addTransceiver}} method of the
-            {{RTCPeerConnection}} object and the {{RTCRtpSender/setParameters}}
-            method of the {{RTCRtpSender}} object.
+            {{RTCPeerConnection/addTransceiver}} method with a
+            {{RTCRtpTransceiverInit/sendEncodings}} argument or the
+            {{RTCPeerConnection/setRemoteDescription}} method with a remote
+            offer to receive simulcast, both on the {{RTCPeerConnection}} object,
+            and the {{RTCRtpSender/setParameters}}
+            method on the {{RTCRtpSender}} object.
           </p>
           <p class="needs-test">
-            The {{RTCPeerConnection/addTransceiver}} method establishes the
-            <dfn>simulcast envelope</dfn> which includes the maximum number of
+            An {{RTCRtpTransceiver}}'s <dfn>simulcast envelope</dfn> is
+            established through the first negotiation it participates in, and
+            includes the maximum number of
             simulcast streams that can be sent, as well as the ordering of the
             {{RTCRtpSendParameters/encodings}}. While characteristics of
             individual simulcast streams can be modified using the
@@ -11058,10 +11062,7 @@ interface RTCRtpTransceiver {
             simulcast.
           </p>
           <p class="needs-test">
-            Another implication is that the answerer cannot set the [=
-            simulcast envelope =] directly. Upon calling the
-            {{RTCPeerConnection/setRemoteDescription}} method of the
-            {{RTCPeerConnection}} object, the [= simulcast envelope =] is
+            After negotiation, the [= simulcast envelope =] is
             configured on the {{RTCRtpTransceiver}} to contain the layers
             described by the specified session description. Once the
             envelope is determined, layers cannot be removed. They can be


### PR DESCRIPTION
First pass at updating simulcast envelope. We still need to decide whether to allow answers in subsequent renegotiation to continue to narrow the envelope, which is https://github.com/w3c/webrtc-pc/issues/2723.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2760.html" title="Last updated on Jul 28, 2022, 3:06 PM UTC (ffa23b7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2760/d6ed794...jan-ivar:ffa23b7.html" title="Last updated on Jul 28, 2022, 3:06 PM UTC (ffa23b7)">Diff</a>