### PR TITLE
rtcicecandidate: add relayProtocol

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6578,7 +6578,7 @@ interface RTCIceCandidate {
             </h4>
             <p>
               The {{RTCIceServerTransportProtocol}} represents the type of the transport
-              protocol used between the client and the server, as defined in [[RFC5766]] section 2.1.
+              protocol used between the client and the server, as defined in [[RFC8656]] section 3.1.
             </p>
             <div>
               <pre class="idl">enum RTCIceServerTransportProtocol {

--- a/webrtc.html
+++ b/webrtc.html
@@ -5976,6 +5976,7 @@ interface RTCIceCandidate {
   readonly attribute DOMString? relatedAddress;
   readonly attribute unsigned short? relatedPort;
   readonly attribute DOMString? usernameFragment;
+  readonly attribute DOMString? relayProtocol;
   RTCIceCandidateInit toJSON();
 };</pre>
             <section>
@@ -6277,6 +6278,17 @@ interface RTCIceCandidate {
                 <dd>
                   This carries the <code class="ice">ufrag</code> as defined in
                   section 15.4 of [[RFC5245]].
+                </dd>
+                <dt>
+                  <dfn>relayProtocol</dfn> of type <span class=
+                  "idlMemberType">DOMString</span>
+                </dt>
+                <dd>
+                  <p>
+                    It is the protocol used by the endpoint to communicate with the TURN server. This
+                    is only present for local relay candidates. Valid values are <code>"udp"</code>,
+                    <code>"tcp"</code>, or <code>"tls"</code>.
+                  </p>
                 </dd>
               </dl>
             </section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -5976,7 +5976,7 @@ interface RTCIceCandidate {
   readonly attribute DOMString? relatedAddress;
   readonly attribute unsigned short? relatedPort;
   readonly attribute DOMString? usernameFragment;
-  readonly attribute DOMString? relayProtocol;
+  readonly attribute RTCIceServerTransportProtocol? relayProtocol;
   RTCIceCandidateInit toJSON();
 };</pre>
             <section>
@@ -6281,13 +6281,12 @@ interface RTCIceCandidate {
                 </dd>
                 <dt>
                   <dfn>relayProtocol</dfn> of type <span class=
-                  "idlMemberType">DOMString</span>
+                  "idlMemberType">RTCIceServerTransportProtocol</span>
                 </dt>
                 <dd>
                   <p>
-                    It is the protocol used by the endpoint to communicate with the TURN server. This
-                    is only present for local relay candidates. Valid values are <code>"udp"</code>,
-                    <code>"tcp"</code>, or <code>"tls"</code>.
+                    The protocol used by the endpoint to communicate with the TURN server. This
+                    is only present for local relay candidates.
                   </p>
                 </dd>
               </dl>
@@ -6567,6 +6566,57 @@ interface RTCIceCandidate {
                     <td>
                       A relay candidate, as defined in Section 7.1.3.2.1 of
                       [[RFC5245]].
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
+          <section>
+            <h4>
+              <dfn>RTCIceServerTransportProtocol</dfn> Enum
+            </h4>
+            <p>
+              The {{RTCIceServerTransportProtocol}} represents the type of the transport
+              protocol used between the client, as defined in [[RFC5766]] section 2.1.
+            </p>
+            <div>
+              <pre class="idl">enum RTCIceServerTransportProtocol {
+  "udp",
+  "tcp",
+  "tls",
+};</pre>
+              <table data-link-for="RTCIceServerTransportProtocol" data-dfn-for=
+		     "RTCIceServerTransportProtocol" class="simple">
+		<caption>{{RTCIceServerTransportProtocol}} Enumeration description</caption>
+                <thead>
+                  <tr>
+		    <th>Enum value</th><th>Description</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td data-tests="">
+                      <dfn data-idl="">udp</dfn>
+                    </td>
+                    <td>
+                      The TURN client is using UDP as transport to the server.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td data-tests="">
+                      <dfn data-idl="">tcp</dfn>
+                    </td>
+                    <td>
+                      The TURN client is using TCP as transport to the server.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td data-tests="">
+                      <dfn data-idl="">tls</dfn>
+                    </td>
+                    <td>
+                      The TURN client is using TLS as transport to the server.
                     </td>
                   </tr>
                 </tbody>

--- a/webrtc.html
+++ b/webrtc.html
@@ -6578,7 +6578,7 @@ interface RTCIceCandidate {
             </h4>
             <p>
               The {{RTCIceServerTransportProtocol}} represents the type of the transport
-              protocol used between the client, as defined in [[RFC5766]] section 2.1.
+              protocol used between the client and the server, as defined in [[RFC5766]] section 2.1.
             </p>
             <div>
               <pre class="idl">enum RTCIceServerTransportProtocol {


### PR DESCRIPTION
which is already defined in webrtc-stats
  https://w3c.github.io/webrtc-stats/#dom-rtcicecandidatestats-relayprotocol
for local candidates


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-pc/pull/2763.html" title="Last updated on Sep 22, 2022, 2:37 PM UTC (4850e4b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2763/1451471...fippo:4850e4b.html" title="Last updated on Sep 22, 2022, 2:37 PM UTC (4850e4b)">Diff</a>