### PR TITLE
Remove references to RTCIceCredentialType

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -389,36 +389,6 @@
         </section>
         <section>
           <h4>
-            <dfn>RTCIceCredentialType</dfn> Enum
-          </h4>
-          <div>
-            <pre class="idl">enum RTCIceCredentialType {
-  "password"
-};</pre>
-            <table data-link-for="RTCIceCredentialType" data-dfn-for=
-		   "RTCIceCredentialType" class="simple">
-	      <caption>{{RTCIceCredentialType}} Enumeration description</caption>
-              <thead>
-                <tr>
-		  <th>Enum value</th><th>Description</th>
-		</tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td data-tests="RTCConfiguration-iceServers.html">
-                    <dfn data-idl="">password</dfn>
-                  </td>
-                  <td>
-                    The credential is a long-term authentication username and
-                    password, as described in [[!RFC5389]], Section 10.2.
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </section>
-        <section>
-          <h4>
             <dfn>RTCIceServer</dfn> Dictionary
           </h4>
           <p>
@@ -431,7 +401,6 @@
   required (DOMString or sequence&lt;DOMString&gt;) urls;
   DOMString username;
   DOMString credential;
-  RTCIceCredentialType credentialType = "password";
 };</pre>
             <section>
               <h2>
@@ -457,9 +426,8 @@
                 <dd>
                   <p>
                     If this {{RTCIceServer}} object represents a TURN server,
-                    and {{credentialType}} is
-                    {{RTCIceCredentialType/"password"}}, then this attribute
-                    specifies the username to use with that TURN server.
+                    then this attribute specifies the username to use with
+                    that TURN server.
                   </p>
                 </dd>
                 <dt data-tests="RTCConfiguration-iceServers.html">
@@ -472,27 +440,8 @@
                     that TURN server.
                   </p>
                   <p>
-                    If {{credentialType}} is
-                    {{RTCIceCredentialType/"password"}}, {{credential}}
-                    represents a long-term authentication password, as
-                    described in [[!RFC5389]], Section 10.2.
-                  </p>
-                  <p class="note">
-                    To support additional values of {{credentialType}},
-                    {{credential}} may evolve in future as a union.
-                  </p>
-                </dd>
-                <dt data-tests="RTCConfiguration-iceServers.html">
-                  <dfn data-idl="">credentialType</dfn> of type <span class=
-                  "idlMemberType">{{RTCIceCredentialType}}</span>, defaulting
-                  to {{RTCIceCredentialType/"password"}}
-                </dt>
-                <dd>
-                  <p>
-                    If this {{RTCIceServer}} object represents a TURN server,
-                    then this attribute specifies how <var>credential</var>
-                    should be used when that TURN server requests
-                    authorization.
+                    {{credential}} represents a long-term authentication
+                    password, as described in [[!RFC5389]], Section 10.2.
                   </p>
                 </dd>
               </dl>
@@ -507,7 +456,6 @@
   {urls: ['turns:turn.example.org', 'turn:turn.example.net'],
     username: 'user',
     credential: 'myPassword',
-    credentialType: 'password'},
 ];
         </pre>
         </section>
@@ -3100,8 +3048,6 @@
                           If <var>scheme name</var> is <code class=
                           "scheme">turn</code> or <code class=
                           "scheme">turns</code>, and
-                          <var>server</var>.{{RTCIceServer/credentialType}} is
-                          {{RTCIceCredentialType/"password"}}, and
                           <var>server</var>.{{RTCIceServer/credential}} is not
                           a <span class="idlMemberType">DOMString</span>, then
                           [= exception/throw =] an {{InvalidAccessError}}.


### PR DESCRIPTION
Fixes #2746


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Orphis/webrtc-pc/pull/2767.html" title="Last updated on Sep 7, 2022, 10:48 PM UTC (85ce93d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2767/7a1c514...Orphis:85ce93d.html" title="Last updated on Sep 7, 2022, 10:48 PM UTC (85ce93d)">Diff</a>