### PR TITLE
Update link to WebSockets interface

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -232,7 +232,7 @@
       <h2>
         Peer-to-peer connections
       </h2>
-      <section>
+      <section class=informative>
         <h3>
           Introduction
         </h3>
@@ -243,8 +243,8 @@
           required protocols. Communications are coordinated by the exchange of
           control messages (called a signaling protocol) over a signaling
           channel which is provided by unspecified means, but generally by a
-          script in the page via the server, e.g. using <a data-cite="?html/web-sockets.html#websocket">Web
-          Sockets</a> or <code>XMLHttpRequest</code> [[?xhr]].
+          script in the page via the server, e.g. using {{WebSocket}} or
+	  {{XMLHttpRequest}}.
         </p>
       </section>
       <section>

--- a/webrtc.js
+++ b/webrtc.js
@@ -134,7 +134,7 @@ var respecConfig = {
     }
 
   ],
-  xref: ["dom", "hr-time", "webidl", "html", "mediacapture-streams", "fileapi", "webrtc-stats", "websockets"],
+  xref: ["dom", "hr-time", "webidl", "html", "mediacapture-streams", "fileapi", "webrtc-stats", "websockets", "xhr"],
   preProcess: [
     highlightTests,
     markTestableAssertions,


### PR DESCRIPTION
Moved from HTML to standalone spec - now relying on xref for automatic link (and updated xhr link along with it) Marked intro section as informative to make sure underlying references are also only counted as information in this context


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2768.html" title="Last updated on Sep 8, 2022, 11:52 AM UTC (6697467)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2768/7a1c514...6697467.html" title="Last updated on Sep 8, 2022, 11:52 AM UTC (6697467)">Diff</a>