### PR TITLE
Update sendEncodings validation and initialization.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7974,14 +7974,13 @@ interface RTCCertificate {
                   <li data-tests=
                   "RTCPeerConnection-addTransceiver.https.html,RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html">
                     <p>
-                      If the first argument is a string, let it be
-                      <var>kind</var> and run the following steps:
+                      If the first argument is a string, let <var>kind</var> be
+                      the first argument and run the following steps:
                     </p>
                     <ol>
                       <li>
                         <p>
-                          If <var>kind</var> is not a legal
-                          {{MediaStreamTrack}} <code class="ext">kind</code>,
+                          If <var>kind</var> is neither `"audio"` nor `"video"`,
                           [= exception/throw =] a {{TypeError}}.
                         </p>
                       </li>
@@ -7995,9 +7994,9 @@ interface RTCCertificate {
                   <li data-tests=
                   "RTCPeerConnection-addTransceiver.https.html,RTCPeerConnection-transceivers.https.html,RTCRtpTransceiver.https.html">
                     <p>
-                      If the first argument is a {{MediaStreamTrack}}, let it
-                      be <var>track</var> and let <var>kind</var> be
-                      <var>track.kind</var>.
+                      If the first argument is a {{MediaStreamTrack}}, let
+                      <var>track</var> be the first argument and let <var>kind</var> be
+                      <var>track</var>.{{MediaStreamTrack/kind}}.
                     </p>
                   </li>
                   <li data-tests="RTCRtpTransceiver.https.html">
@@ -8013,17 +8012,18 @@ interface RTCCertificate {
                       <li data-tests=
                       "RTCPeerConnection-addTransceiver.https.html">
                         <p>
-                          Verify that each {{RTCRtpCodingParameters/rid}} value
-                          in <var>sendEncodings</var> conforms to the grammar
-                          specified in Section 10 of [[RFC8851]]. If one of
-                          the RIDs does not meet these requirements, [=
+                          If any {{RTCRtpEncodingParameters}} dictionary in
+                          <var>sendEncodings</var> [=map/contains=] a
+                          {{RTCRtpCodingParameters/rid}} member whose value
+                          does not conform to the grammar requirements specified
+                          in Section 10 of [[RFC8851]], [=
                           exception/throw =] a {{TypeError}}.
                         </p>
                       </li>
                       <li>
                         <p>
                           If any {{RTCRtpEncodingParameters}} dictionary in
-                          <var>sendEncodings</var> contains a <a>read-only
+                          <var>sendEncodings</var> [=map/contains=] a <a>read-only
                           parameter</a> other than
                           {{RTCRtpCodingParameters/rid}}, [= exception/throw =]
                           an {{InvalidAccessError}}.
@@ -8031,12 +8031,19 @@ interface RTCCertificate {
                       </li>
                       <li data-tests="RTCRtpParameters-encodings.html">
                         <p>
-                          Verify that the value of each
+                          If <var>kind</var> is `"audio"` and any
+                          {{RTCRtpEncodingParameters}} dictionary in
+                          <var>sendEncodings</var> [=map/contains=] a
                           {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
-                          member in <var>sendEncodings</var> that is defined
-                          is greater than or equal to 1.0. If one of the
+                          member, [=exception/throw =] a {{TypeError}}.
+                        </p>
+                      </li>
+                      <li data-tests="RTCRtpParameters-encodings.html">
+                        <p>
+                          If any {{RTCRtpEncodingParameters}} dictionary in
+                          <var>sendEncodings</var> [=map/contains=] a
                           {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
-                          values does not meet this requirement, [=
+                          member whose value is less than `1.0`, [=
                           exception/throw =] a {{RangeError}}.
                         </p>
                       </li>
@@ -8051,12 +8058,13 @@ interface RTCCertificate {
                       </li>
                       <li>
                         <p>
-                          If <var>sendEncodings</var> contains any encoding
-                          whose
+                          If any {{RTCRtpEncodingParameters}} dictionary in
+                          <var>sendEncodings</var> [=map/contains=] a
                           {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
-                          attribute is defined, set any undefined
-                          {{RTCRtpEncodingParameters/scaleResolutionDownBy}} of
-                          the other encodings to 1.0.
+                          member, then for each {{RTCRtpEncodingParameters}}
+                          dictionary in <var>sendEncodings</var> without one,
+                          add a {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
+                          member with the value `1.0`.
                         </p>
                       </li>
                       <li>
@@ -8067,15 +8075,20 @@ interface RTCCertificate {
                           until its length is <var>maxN</var>.
                         </p>
                       </li>
-                      <li>If the
-                      {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
-                      attribues of <var>sendEncodings</var> are still
-                      undefined, initialize each encoding's
-                      {{RTCRtpEncodingParameters/scaleResolutionDownBy}} to
-                      <code>2^(length of <var>sendEncodings</var> - encoding
-                      index - 1)</code>. This results in smaller-to-larger
-                      resolutions where the last encoding has no scaling
-                      applied to it, e.g. 4:2:1 if the length is 3.
+                      <li>
+                        <p>
+                          If no {{RTCRtpEncodingParameters}} dictionaries in
+                          <var>sendEncodings</var> [=map/contain=] a
+                          {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
+                          member, then for each {{RTCRtpEncodingParameters}} in
+                          <var>sendEncodings</var>, add a
+                          {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
+                          member with the value
+                          <code>2^(length of <var>sendEncodings</var> - encoding
+                          index - 1)</code>. This results in smaller-to-larger
+                          resolutions where the last encoding has no scaling
+                          applied to it, e.g. 4:2:1 if the length is 3.
+                        </p>
                       </li>
                       <li>
                         <p>
@@ -8574,8 +8587,14 @@ interface RTCCertificate {
               If <var>sendEncodings</var> is given as input to this algorithm,
               and is non-empty, set the {{RTCRtpSender/[[SendEncodings]]}} slot to
               <var>sendEncodings</var>. Otherwise, set it to a list containing
-              a single {{RTCRtpEncodingParameters}} with
-              {{RTCRtpEncodingParameters/active}} set to <code>true</code>.
+              a single new {{RTCRtpEncodingParameters}} dictionary, and if
+              <var>kind</var> is `"video"`, add a
+              {{RTCRtpEncodingParameters/scaleResolutionDownBy}} member with the
+              value `1.0` to that dictionary.
+            </p>
+            <p class="note">{{RTCRtpEncodingParameters}} dictionaries contain
+              {{RTCRtpEncodingParameters/active}} members whose values are
+              <code>true</code> by default.
             </p>
           </li>
           <li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -8007,13 +8007,13 @@ interface RTCCertificate {
                     </p>
                   </li>
                   <li>Validate <var>sendEncodings</var> by running the
-                  following steps:
+                  following steps, where each {{RTCRtpEncodingParameters}}
+                  dictionary in it is an "encoding":
                     <ol>
                       <li data-tests=
                       "RTCPeerConnection-addTransceiver.https.html">
                         <p>
-                          If any {{RTCRtpEncodingParameters}} dictionary in
-                          <var>sendEncodings</var> [=map/contains=] a
+                          If any encoding [=map/contains=] a
                           {{RTCRtpCodingParameters/rid}} member whose value
                           does not conform to the grammar requirements specified
                           in Section 10 of [[RFC8851]], [=
@@ -8022,8 +8022,7 @@ interface RTCCertificate {
                       </li>
                       <li>
                         <p>
-                          If any {{RTCRtpEncodingParameters}} dictionary in
-                          <var>sendEncodings</var> [=map/contains=] a <a>read-only
+                          If any encoding [=map/contains=] a <a>read-only
                           parameter</a> other than
                           {{RTCRtpCodingParameters/rid}}, [= exception/throw =]
                           an {{InvalidAccessError}}.
@@ -8032,16 +8031,14 @@ interface RTCCertificate {
                       <li data-tests="RTCRtpParameters-encodings.html">
                         <p>
                           If <var>kind</var> is `"audio"` and any
-                          {{RTCRtpEncodingParameters}} dictionary in
-                          <var>sendEncodings</var> [=map/contains=] a
+                          encoding [=map/contains=] a
                           {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
                           member, [=exception/throw =] a {{TypeError}}.
                         </p>
                       </li>
                       <li data-tests="RTCRtpParameters-encodings.html">
                         <p>
-                          If any {{RTCRtpEncodingParameters}} dictionary in
-                          <var>sendEncodings</var> [=map/contains=] a
+                          If any encoding [=map/contains=] a
                           {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
                           member whose value is less than `1.0`, [=
                           exception/throw =] a {{RangeError}}.
@@ -8058,18 +8055,16 @@ interface RTCCertificate {
                       </li>
                       <li>
                         <p>
-                          If any {{RTCRtpEncodingParameters}} dictionary in
-                          <var>sendEncodings</var> [=map/contains=] a
+                          If any encoding [=map/contains=] a
                           {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
-                          member, then for each {{RTCRtpEncodingParameters}}
-                          dictionary in <var>sendEncodings</var> without one,
+                          member, then for each encoding without one,
                           add a {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
                           member with the value `1.0`.
                         </p>
                       </li>
                       <li>
                         <p>
-                          If the number of {{RTCRtpEncodingParameters}} stored
+                          If the number of encodings stored
                           in <var>sendEncodings</var> exceeds <var>maxN</var>,
                           then trim <var>sendEncodings</var> from the tail
                           until its length is <var>maxN</var>.
@@ -8077,11 +8072,10 @@ interface RTCCertificate {
                       </li>
                       <li>
                         <p>
-                          If no {{RTCRtpEncodingParameters}} dictionaries in
-                          <var>sendEncodings</var> [=map/contain=] a
+                          If <var>kind</var> is `"video"` and none of the
+                          encodings [=map/contain=] a
                           {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
-                          member, then for each {{RTCRtpEncodingParameters}} in
-                          <var>sendEncodings</var>, add a
+                          member, then for each encoding, add a
                           {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
                           member with the value
                           <code>2^(length of <var>sendEncodings</var> - encoding
@@ -8092,7 +8086,7 @@ interface RTCCertificate {
                       </li>
                       <li>
                         <p>
-                          If the number of {{RTCRtpEncodingParameters}} now
+                          If the number of encodings now
                           stored in <var>sendEncodings</var> is <code>1</code>,
                           then remove any {{RTCRtpCodingParameters/rid}} member
                           from the lone entry.

--- a/webrtc.html
+++ b/webrtc.html
@@ -8785,11 +8785,20 @@ interface RTCRtpSender {
                       </li>
                       <li data-tests="RTCRtpParameters-encodings.html">
                         <p>
-                          Verify that each encoding in <var>encodings</var> has
+                          If <a>transceiver kind</a> is `"audio"`, and
+                          any encoding in <var>encodings</var> [=map/contains=]
                           a {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
-                          member whose value is greater than or equal to 1.0. If one of the
-                          {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
-                          values does not meet this requirement, return a
+                          member, return a promise [= rejected =] with a newly
+                          [= exception/created =] {{TypeError}}.
+                        </p>
+                      </li>
+                      <li data-tests="RTCRtpParameters-encodings.html">
+                        <p>
+                          If <a>transceiver kind</a> is `"video"`,
+                          verify that all <var>encodings</var> [=map/contain=]
+                          a {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
+                          member whose value is greater than or equal to 1.0. If
+                          any encoding does not meet this requirement, return a
                           promise [= rejected =] with a newly [=
                           exception/created =] {{RangeError}}.
                         </p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -8030,10 +8030,9 @@ interface RTCCertificate {
                       </li>
                       <li data-tests="RTCRtpParameters-encodings.html">
                         <p>
-                          If <var>kind</var> is `"audio"` and any
-                          encoding [=map/contains=] a
+                          If <var>kind</var> is `"audio"`, remove the
                           {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
-                          member, [=exception/throw =] a {{TypeError}}.
+                          member from all encodings that [=map/contain=] one.
                         </p>
                       </li>
                       <li data-tests="RTCRtpParameters-encodings.html">
@@ -8785,20 +8784,30 @@ interface RTCRtpSender {
                       </li>
                       <li data-tests="RTCRtpParameters-encodings.html">
                         <p>
-                          If <a>transceiver kind</a> is `"audio"`, and
-                          any encoding in <var>encodings</var> [=map/contains=]
-                          a {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
-                          member, return a promise [= rejected =] with a newly
-                          [= exception/created =] {{TypeError}}.
+                          If <a>transceiver kind</a> is `"audio"`, remove the
+                          {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
+                          member from all <var>encodings</var> that
+                          [=map/contain=] one.
+                        </p>
+                      </li>
+                      <li data-tests="RTCRtpParameters-encodings.html">
+                        <p>
+                          If <a>transceiver kind</a> is `"video"`, then for
+                          each encoding in <var>encodings</var> that doesn't
+                          [=map/contain=] a
+                          {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
+                          member, add a
+                          {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
+                          member with the value `1.0`.
                         </p>
                       </li>
                       <li data-tests="RTCRtpParameters-encodings.html">
                         <p>
                           If <a>transceiver kind</a> is `"video"`,
-                          verify that all <var>encodings</var> [=map/contain=]
-                          a {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
-                          member whose value is greater than or equal to 1.0. If
-                          any encoding does not meet this requirement, return a
+                          and any encoding in <var>encodings</var>
+                          [=map/contains=] a
+                          {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
+                          member whose value is less than `1.0`, return a
                           promise [= rejected =] with a newly [=
                           exception/created =] {{RangeError}}.
                         </p>

--- a/webrtc.js
+++ b/webrtc.js
@@ -134,7 +134,7 @@ var respecConfig = {
     }
 
   ],
-  xref: ["dom", "hr-time", "webidl", "html", "mediacapture-streams", "fileapi", "webrtc-stats", "websockets", "xhr"],
+  xref: ["dom", "hr-time", "webidl", "html", "mediacapture-streams", "fileapi", "webrtc-stats", "websockets", "xhr", "infra"],
   preProcess: [
     highlightTests,
     markTestableAssertions,


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2730. @docfaraday PTAL. [Ignore-whitespace diff](https://github.com/w3c/webrtc-pc/pull/2772/files?diff=unified&w=1) recommended.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2772.html" title="Last updated on Sep 26, 2022, 11:00 PM UTC (e38e7be)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2772/dcfa578...jan-ivar:e38e7be.html" title="Last updated on Sep 26, 2022, 11:00 PM UTC (e38e7be)">Diff</a>