### PR TITLE
add url attribute to RTCIceCandidate

### DIFF
--- a/amendments.json
+++ b/amendments.json
@@ -196,6 +196,15 @@
       "id": 16
     }
   ],
+  "rtcpeerconnectioniceevent-attributes": [
+    {
+      "description": "Add deprecation notice to RTCPeerConnectionIceEvent.url",
+      "pr": 2773,
+      "type": "correction",
+      "status": "candidate",
+      "id": 23
+    }
+  ],
   "rtcicecandidate-attributes": [
     {
       "description": "Add RTCIceCandidate.relayProtocol",
@@ -204,6 +213,13 @@
       "type": "addition",
       "status": "candidate",
       "id": 16
+    },
+    {
+      "description": "Add RTCIceCandidate.url",
+      "pr": 2773,
+      "type": "addition",
+      "status": "candidate",
+      "id": 23
     }
   ],
   "rtcicecredentialtype-enum": [

--- a/base-rec.html
+++ b/base-rec.html
@@ -7016,9 +7016,9 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-rtc
               </dl>
             </section>
             <section>
-              <h5 id="attributes-5">
+              <h5 id="rtcpeerconnectioniceevent-attributes">
                 Attributes
-              <a class="self-link" aria-label="§" href="#attributes-5"></a></h5>
+              <a class="self-link" aria-label="§" href="#rtcpeerconnectioniceevent-attributes"></a></h5>
               <dl data-link-for="RTCPeerConnectionIceEvent" data-dfn-for="RTCPeerConnectionIceEvent" class="attributes">
                 <dt data-tests="RTCPeerConnectionIceEvent-constructor.html" class="has-tests">
                   <dfn data-idl="attribute" data-export="" data-dfn-type="attribute" id="dom-rtcpeerconnectioniceevent-candidate" data-title="candidate" data-dfn-for="RTCPeerConnectionIceEvent" data-type="RTCIceCandidate" data-lt="candidate" data-local-lt="RTCPeerConnectionIceEvent.candidate"><code>candidate</code></dfn> of type <span class="idlAttrType"><a data-link-type="idl" href="#dom-rtcicecandidate" class="internalDFN" id="ref-for-dom-rtcicecandidate-15"><code><code>RTCIceCandidate</code></code></a></span>, readonly, nullable

--- a/webrtc.html
+++ b/webrtc.html
@@ -6251,11 +6251,11 @@ interface RTCIceCandidate {
                     is only present for local relay candidates.
                   </p>
                 </dd>
-                <dt>
+                <dt class="add-to-rtcicecandidate-attributes">
                   <dfn>url</dfn> of type <span class=
                   "idlMemberType">DOMString</span>
                 </dt>
-                <dd>
+                <dd class="add-to-rtcicecandidate-attributes">
                   <p>
                     For local candidates of type {{RTCIceCandidateType/"srflx"}} or type
                     {{RTCIceCandidateType/"relay"}} this is the URL of the ICE server
@@ -6660,7 +6660,7 @@ interface RTCIceCandidate {
             </ul>
           </div>
           <div>
-            <pre class="idl" data-tests="idlharness.https.window.js">[Exposed=Window]
+            <pre class="idl" data-tests="idlharness.https.window.js" id="webidl-rtcpeerconnectioniceevent">[Exposed=Window]
 interface RTCPeerConnectionIceEvent : Event {
   constructor(DOMString type, optional RTCPeerConnectionIceEventInit eventInitDict = {});
   readonly attribute RTCIceCandidate? candidate;
@@ -6683,7 +6683,7 @@ interface RTCPeerConnectionIceEvent : Event {
                 Attributes
               </h2>
               <dl data-link-for="RTCPeerConnectionIceEvent" data-dfn-for=
-              "RTCPeerConnectionIceEvent" class="attributes">
+              "RTCPeerConnectionIceEvent" id="rtcpeerconnectioniceevent-attributes" class="attributes">
                 <dt data-tests="RTCPeerConnectionIceEvent-constructor.html">
                   <dfn data-idl="">candidate</dfn> of type <span class=
                   "idlAttrType">{{RTCIceCandidate}}</span>, readonly, nullable
@@ -6714,7 +6714,7 @@ interface RTCPeerConnectionIceEvent : Event {
                     TURN server, this parameter will be set to
                     <code>null</code>.
                   </p>
-                  <p class="note">
+                  <p class="note" class="add-to-rtcpeerconnectioniceevent-attributes">
                     This attribute is deprecated; it exists for legacy compatibility reasons only.
                     Prefer the candidate {{RTCIceCandidate/url}}.
                   </p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -5938,6 +5938,7 @@ interface RTCIceCandidate {
   readonly attribute unsigned short? relatedPort;
   readonly attribute DOMString? usernameFragment;
   readonly attribute RTCIceServerTransportProtocol? relayProtocol;
+  readonly attribute DOMString? url;
   RTCIceCandidateInit toJSON();
 };</pre>
             <section>
@@ -6248,6 +6249,17 @@ interface RTCIceCandidate {
                   <p>
                     The protocol used by the endpoint to communicate with the TURN server. This
                     is only present for local relay candidates.
+                  </p>
+                </dd>
+                <dt>
+                  <dfn>url</dfn> of type <span class=
+                  "idlMemberType">DOMString</span>
+                </dt>
+                <dd>
+                  <p>
+                    For local candidates of type {{RTCIceCandidateType/"srflx"}} or type
+                    {{RTCIceCandidateType/"relay"}} this is the URL of the ICE server
+                    from which the candidate was obtained.
                   </p>
                 </dd>
               </dl>
@@ -6701,6 +6713,10 @@ interface RTCPeerConnectionIceEvent : Event {
                     candidate. If the candidate was not gathered from a STUN or
                     TURN server, this parameter will be set to
                     <code>null</code>.
+                  </p>
+                  <p class="note">
+                    This attribute is deprecated; it exists for legacy compatibility reasons only.
+                    Prefer the candidate {{RTCIceCandidate/url}}.
                   </p>
                 </dd>
               </dl>


### PR DESCRIPTION
aligning with how this is defined in webrtc-stats
      https://w3c.github.io/webrtc-stats/#dom-rtcicecandidatestats-url
and add deprecation note to the url attribute on the RTCIceEvent

@youennf since you mentioned this was implemented in Safari, can you please check if it actually shows the correct value? Given the trouble I had reconstructing the url in the lowest layers I would not be surprised if this was the empty strings.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-pc/pull/2773.html" title="Last updated on Oct 26, 2022, 6:50 PM UTC (73a0a9c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2773/67341a6...fippo:73a0a9c.html" title="Last updated on Oct 26, 2022, 6:50 PM UTC (73a0a9c)">Diff</a>