### PR TITLE
TypeError on duplicate rids

### DIFF
--- a/amendments.json
+++ b/amendments.json
@@ -224,5 +224,14 @@
       "status": "candidate",
       "id": 17
     }
+  ],
+  "dom-rtcpeerconnection-addtransceiver": [
+    {
+      "description": "TypeError on duplicate rids",
+      "pr": 2775,
+      "type": "correction",
+      "status": "candidate",
+      "id": 18
+    }
   ]
 }

--- a/amendments.json
+++ b/amendments.json
@@ -29,13 +29,6 @@
       "type": "correction",
       "status": "candidate",
       "id": 6
-    },
-    {
-      "description": "TypeError unless all or none of encodings have rids",
-      "pr": 2774,
-      "type": "correction",
-      "status": "candidate",
-      "id": 18
     }
   ],
   "rtcicegatheringstate-description": [
@@ -226,6 +219,13 @@
     }
   ],
   "dom-rtcpeerconnection-addtransceiver": [
+    {
+      "description": "TypeError unless all or none of encodings have rids",
+      "pr": 2774,
+      "type": "correction",
+      "status": "candidate",
+      "id": 18
+    },
     {
       "description": "TypeError on duplicate rids",
       "pr": 2775,

--- a/webrtc.html
+++ b/webrtc.html
@@ -8066,6 +8066,17 @@ interface RTCCertificate {
                           exception/throw =] a {{TypeError}}.
                         </p>
                       </li>
+                      <li data-tests=
+                      "RTCPeerConnection-addTransceiver.https.html">
+                        <p>
+                          If any encoding [=map/contains=] a
+                          {{RTCRtpCodingParameters/rid}} member whose value
+                          is the same as that of a {{RTCRtpCodingParameters/rid}}
+                          [=map/contains | contained=] in another encoding in
+                          <var>sendEncodings</var>, [=exception/throw =] a
+                          {{TypeError}}.
+                        </p>
+                      </li>
                       <li>
                         <p>
                           If any {{RTCRtpEncodingParameters}} dictionary in


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2733.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2775.html" title="Last updated on Oct 13, 2022, 1:09 AM UTC (c302eea)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2775/828c191...jan-ivar:c302eea.html" title="Last updated on Oct 13, 2022, 1:09 AM UTC (c302eea)">Diff</a>