### PR TITLE
Allow offers to turn off or prune simulcast just like answers

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2420,6 +2420,7 @@
                               <li>
                                 <p>
                                   If <var>description</var> is of type
+                                  {{RTCSdpType/"offer"}},
                                   {{RTCSdpType/"answer"}} or
                                   {{RTCSdpType/"pranswer"}}, and
                                   <var>transceiver</var>.
@@ -2440,9 +2441,9 @@
                                   </li>
                                   <li>
                                     <p>
-                                      If <var>description</var> rejects any of
+                                      If <var>description</var> is missing any of
                                       the offered layers, then remove the
-                                      dictionaries that correspond to rejected
+                                      dictionaries that correspond to missing
                                       layers from
                                       <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}.
                                     </p>


### PR DESCRIPTION
Fixes #2762 (specifically https://github.com/w3c/webrtc-pc/issues/2762#issuecomment-1264036923, the other observations in that issue are being addressed by https://github.com/w3c/webrtc-pc/pull/2758 instead).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2779.html" title="Last updated on Oct 6, 2022, 1:56 PM UTC (22c1b39)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2779/0349b39...jan-ivar:22c1b39.html" title="Last updated on Oct 6, 2022, 1:56 PM UTC (22c1b39)">Diff</a>