### PR TITLE
Remove maxFramerate like scaleResolutionDownBy for audio.

### DIFF
--- a/amendments.json
+++ b/amendments.json
@@ -270,6 +270,13 @@
       "type": "correction",
       "status": "candidate",
       "id": 20
+    },
+    {
+      "description": "Remove maxFramerate like scaleResolutionDownBy for audio",
+      "pr": 2799,
+      "type": "correction",
+      "status": "candidate",
+      "id": 24
     }
   ],
   "setparameters-algo": [
@@ -293,6 +300,13 @@
       "type": "addition",
       "status": "candidate",
       "id": 19
+    },
+    {
+      "description": "Remove maxFramerate like scaleResolutionDownBy for audio",
+      "pr": 2799,
+      "type": "correction",
+      "status": "candidate",
+      "id": 24
     }
   ],
   "create-sender-algo": [

--- a/webrtc.html
+++ b/webrtc.html
@@ -8140,8 +8140,10 @@ interface RTCCertificate {
                       <li data-tests="RTCRtpParameters-encodings.html">
                         <p>
                           If <var>kind</var> is `"audio"`, remove the
-                          {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
-                          member from all encodings that [=map/contain=] one.
+                          {{RTCRtpEncodingParameters/scaleResolutionDownBy}} and
+                          {{RTCRtpEncodingParameters/maxFramerate}}
+                          members from all encodings that [=map/contain=] any of
+                          them.
                         </p>
                       </li>
                       <li data-tests="RTCRtpParameters-encodings.html">
@@ -9622,7 +9624,10 @@ async function updateParameters() {
                   "idlMemberType">double</span>
                 </dt>
                 <dd>
-                  <p>When present, indicates the maximum frame rate that can be used to
+                  <p>
+                    This member can only be present if the sender's <code class=
+                    "gum">kind</code> is <code>"video"</code>.
+                    When present, indicates the maximum frame rate that can be used to
                     send this encoding, in frames per second. The <a>user agent</a> is free
                     to allocate bandwidth between the encodings, as long as the
                     {{maxFramerate}} value is not exceeded.</p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -8907,9 +8907,10 @@ interface RTCRtpSender {
                       <li data-tests="RTCRtpParameters-encodings.html">
                         <p>
                           If <a>transceiver kind</a> is `"audio"`, remove the
-                          {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
-                          member from all <var>encodings</var> that
-                          [=map/contain=] one.
+                          {{RTCRtpEncodingParameters/scaleResolutionDownBy}} and
+                          {{RTCRtpEncodingParameters/maxFramerate}}
+                          members from all <var>encodings</var> that
+                          [=map/contain=] any of them.
                         </p>
                       </li>
                       <li data-tests="RTCRtpParameters-encodings.html">


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2793.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2799.html" title="Last updated on Nov 17, 2022, 10:17 PM UTC (240b65f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2799/90dc200...jan-ivar:240b65f.html" title="Last updated on Nov 17, 2022, 10:17 PM UTC (240b65f)">Diff</a>