### PR TITLE
Prune createAnswer()'s encodings and [[SendEncodings]] in sLD(answer).

### DIFF
--- a/amendments.json
+++ b/amendments.json
@@ -349,7 +349,7 @@
   ],
   "apply-local-description": [
     {
-      "description": "Prune createAnswer()'s encodings and [[SendEncodings]] in sLD(answer).",
+      "description": "Prune createAnswer()'s encodings and SendEncodings in sLD(answer).",
       "pr": 2801,
       "difftype": "modify",
       "type": "correction",
@@ -359,7 +359,7 @@
   ],
   "create-answer-restrictions": [
     {
-      "description": "Prune createAnswer()'s encodings and [[SendEncodings]] in sLD(answer).",
+      "description": "Prune createAnswer()'s encodings and SendEncodings in sLD(answer).",
       "pr": 2801,
       "difftype": "modify",
       "type": "correction",

--- a/amendments.json
+++ b/amendments.json
@@ -346,5 +346,25 @@
       "status": "candidate",
       "id": 22
     }
+  ],
+  "apply-local-description": [
+    {
+      "description": "Prune createAnswer()'s encodings and [[SendEncodings]] in sLD(answer).",
+      "pr": 2801,
+      "difftype": "modify",
+      "type": "correction",
+      "status": "candidate",
+      "id": 26
+    }
+  ],
+  "create-answer-restrictions": [
+    {
+      "description": "Prune createAnswer()'s encodings and [[SendEncodings]] in sLD(answer).",
+      "pr": 2801,
+      "difftype": "modify",
+      "type": "correction",
+      "status": "candidate",
+      "id": 26
+    }
   ]
 }

--- a/base-rec.html
+++ b/base-rec.html
@@ -2773,7 +2773,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
                               run the following steps for each <a data-link-type="dfn" href="#dfn-media-description" class="internalDFN" id="ref-for-dfn-media-description-2">media
                               description</a> in <var>description</var>:
                             </p>
-                            <ol>
+                            <ol id="apply-local-description">
                               <li>
                                 <p>
                                   If the <a data-link-type="dfn" href="#dfn-media-description" class="internalDFN" id="ref-for-dfn-media-description-3">media description</a> was not yet <a data-link-type="dfn" href="#dfn-associated" class="internalDFN" id="ref-for-dfn-associated-1">associated</a> with an <a data-link-type="idl" href="#dom-rtcrtptransceiver" class="internalDFN" id="ref-for-dom-rtcrtptransceiver-1"><code><code>RTCRtpTransceiver</code></code></a>
@@ -4512,7 +4512,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-rtc
                         generate an SDP answer, <var>sdpString</var>, as
                         described in <span>[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8829" title="JavaScript Session Establishment Protocol (JSEP)">RFC8829</a></cite>] (<a href="https://tools.ietf.org/html/rfc8829#section-5.3">section 5.3.</a>)</span>.
                       </p>
-                      <ol>
+                      <ol id="create-answer-restrictions">
                         <li>
                           <p>
                             The <i>codec preferences</i> of an m= section's

--- a/webrtc.html
+++ b/webrtc.html
@@ -4046,7 +4046,8 @@ interface RTCPeerConnection : EventTarget  {
                             in the answer any RID not found in the corresponding
                             transceiver's
                             {{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}.
-                            If there are any identically named RIDs, remove all
+                            If there are any identically named RIDs in the
+                            <code class="sdp">a=simulcast</code> attribute, remove all
                             but the first one. No RID restrictions are set.
                           </p>
                           <div class="note">

--- a/webrtc.html
+++ b/webrtc.html
@@ -2275,6 +2275,35 @@
                                 <ol>
                                   <li>
                                     <p>
+                                      If <var>transceiver</var>.
+                                      {{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
+                                      .length is greater than <code>1</code>, then
+                                      run the following steps:
+                                    </p>
+                                    <ol>
+                                      <li>
+                                        <p>
+                                          If <var>description</var> is missing
+                                          all of the previously negotiated layers,
+                                          then remove all dictionaries in
+                                          <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
+                                          except the first one, and skip the next
+                                          step.
+                                        </p>
+                                      </li>
+                                      <li>
+                                        <p>
+                                          If <var>description</var> is missing any of
+                                          the previously negototiated layers, then
+                                          remove the dictionaries that correspond to
+                                          the missing layers from
+                                          <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}.
+                                        </p>
+                                      </li>
+                                    </ol>
+                                  </li>
+                                  <li>
+                                    <p>
                                       Set
                                       <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendCodecs]]}}
                                       to the codecs that <var>description</var>
@@ -4011,18 +4040,29 @@ interface RTCPeerConnection : EventTarget  {
                         </li>
                         <li>
                           <p>
-                            If the length of the {{RTCRtpSender/[[SendEncodings]]}} slot
-                            of the {{RTCRtpSender}} is larger than 1, then for
-                            each encoding given in {{RTCRtpSender/[[SendEncodings]]}} of
-                            the {{RTCRtpSender}}, add an <code class=
-                            "sdp">a=rid send</code> line to the corresponding
-                            media section, and add an <code class=
-                            "sdp">a=simulcast:send</code> line giving the RIDs
-                            in the same order as given in the
-                            {{RTCRtpSendParameters/encodings}} field. No RID
-                            restrictions are set.
+                            If this is an answer to an offer to receive
+                            simulcast, then for each media section requesting
+                            to receive simulcast, exclude from the media section
+                            in the answer any RID not found in the corresponding
+                            transceiver's
+                            {{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}.
+                            If there are any identically named RIDs, remove all
+                            but the first one. No RID restrictions are set.
                           </p>
                         </li>
+                        <div class="note">
+                          <p>
+                            When a {{RTCPeerConnection/setRemoteDescription(offer)}}
+                            establishes a transceiver's [=simulcast envelope=],
+                            the transceiver's
+                            {{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}} is updated in
+                            {{RTCSignalingState/"have-remote-offer"}}. However,
+                            once a simulcast envelope has been established for
+                            the transceiver, subsequent pruning of the transceiver's
+                            {{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}} happen when this answer is set
+                            with {{RTCPeerConnection/setLocalDescription}}.
+                          </p>
+                        </div>
                       </ol>
                     </li>
                     <li data-tests="RTCPeerConnection-createAnswer.html">

--- a/webrtc.html
+++ b/webrtc.html
@@ -4049,20 +4049,24 @@ interface RTCPeerConnection : EventTarget  {
                             If there are any identically named RIDs, remove all
                             but the first one. No RID restrictions are set.
                           </p>
+                          <div class="note">
+                            <p>
+                              When a
+                              {{RTCPeerConnection/setRemoteDescription(offer)}}
+                              establishes a transceiver's [=simulcast envelope=],
+                              the transceiver's
+                              {{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
+                              is updated in
+                              {{RTCSignalingState/"have-remote-offer"}}. However,
+                              once a simulcast envelope has been established for
+                              the transceiver, subsequent pruning of the
+                              transceiver's
+                              {{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
+                              happen when this answer is set with
+                              {{RTCPeerConnection/setLocalDescription}}.
+                            </p>
+                          </div>
                         </li>
-                        <div class="note">
-                          <p>
-                            When a {{RTCPeerConnection/setRemoteDescription(offer)}}
-                            establishes a transceiver's [=simulcast envelope=],
-                            the transceiver's
-                            {{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}} is updated in
-                            {{RTCSignalingState/"have-remote-offer"}}. However,
-                            once a simulcast envelope has been established for
-                            the transceiver, subsequent pruning of the transceiver's
-                            {{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}} happen when this answer is set
-                            with {{RTCPeerConnection/setLocalDescription}}.
-                          </p>
-                        </div>
                       </ol>
                     </li>
                     <li data-tests="RTCPeerConnection-createAnswer.html">

--- a/webrtc.html
+++ b/webrtc.html
@@ -4048,7 +4048,7 @@ interface RTCPeerConnection : EventTarget  {
                             {{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}.
                             If there are any identically named RIDs in the
                             <code class="sdp">a=simulcast</code> attribute, remove all
-                            but the first one. No RID restrictions are set.
+                            duplicates except the first one. No RID restrictions are set.
                           </p>
                           <div class="note">
                             <p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -2148,7 +2148,7 @@
                               run the following steps for each [= media
                               description =] in <var>description</var>:
                             </p>
-                            <ol>
+                            <ol id="apply-local-description">
                               <li>
                                 <p>
                                   If the [= media description =] was not yet [=
@@ -3994,7 +3994,7 @@ interface RTCPeerConnection : EventTarget  {
                         described in <span data-jsep=
                         "generating-an-answer">[[!RFC8829]]</span>.
                       </p>
-                      <ol>
+                      <ol id="create-answer-restrictions">
                         <li>
                           <p>
                             The <i>codec preferences</i> of an m= section's


### PR DESCRIPTION
A follow-up to https://github.com/w3c/webrtc-pc/pull/2758 whose intent was to defer pruning of [[SendEncodings]] to sLD(answer), but mistakenly relied on the spec's existing pruning language which only applies to sRD(answer).

This adds similar language to sLD(answer), and fixes createAnswer() to direct JSEP on what to prune so pruning actually happens.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2801.html" title="Last updated on Dec 13, 2022, 11:35 PM UTC (b5480e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2801/1dc13d3...jan-ivar:b5480e2.html" title="Last updated on Dec 13, 2022, 11:35 PM UTC (b5480e2)">Diff</a>