### PR TITLE
Allow encoder resolution alignment in scaleResolutionDownBy.

### DIFF
--- a/amendments.json
+++ b/amendments.json
@@ -385,5 +385,15 @@
       "status": "candidate",
       "id": 26
     }
+  ],
+  "rtp-video-rescaled": [
+    {
+      "description": "Allow encoder resolution alignment in scaleResolutionDownBy.",
+      "pr": 2808,
+      "difftype": "modify",
+      "type": "correction",
+      "status": "candidate",
+      "id": 27
+    }
   ]
 }

--- a/base-rec.html
+++ b/base-rec.html
@@ -7718,7 +7718,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-rtc
         and timeline for a more complex handling of this situation. Some
         possible designs have been discussed in <a href="https://github.com/w3c/webrtc-pc/issues/1283">GitHub issue 1283</a>.
       </p></div>
-      <p class="needs-tests">
+      <p class="needs-tests" id="rtp-video-rescaled">
         When video is rescaled, for example for certain combinations of width
         or height and <a data-link-type="idl" href="#dom-rtcrtpencodingparameters-scaleresolutiondownby" class="internalDFN" id="ref-for-dom-rtcrtpencodingparameters-scaleresolutiondownby-2"><code><code>scaleResolutionDownBy</code></code></a>
         values, situations when the resulting width or height is not an integer

--- a/webrtc.html
+++ b/webrtc.html
@@ -7484,13 +7484,15 @@ interface RTCCertificate {
         possible designs have been discussed in <a href=
         "https://github.com/w3c/webrtc-pc/issues/1283">GitHub issue 1283</a>.
       </p>
-      <p>
+      <p id="rtp-video-rescaled">
         When video is rescaled, for example for certain combinations of width
         or height and {{RTCRtpEncodingParameters/ scaleResolutionDownBy}}
         values, situations when the resulting width or height is not an integer
         may occur. In such situations the user agent MUST use <a href=
         "https://tc39.github.io/ecma262/#eqn-floor">the integer part of the
-        result</a>. What to transmit if the integer part of the scaled width or
+        result</a>. The user agent MAY increase the calculated scaled resolution
+        to the nearest alignment supported by the encoder.
+        What to transmit if the integer part of the scaled width or
         height is zero is implementation-specific.
       </p>
       <p>


### PR DESCRIPTION
Fixed #2802.