### PR TITLE
Remove reference to removed test

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -12146,7 +12146,7 @@ interface RTCDtlsTransport : EventTarget {
             </p>
           </li>
           <li data-tests=
-          "RTCIceConnectionState-candidate-pair.https.html,RTCPeerConnection-getStats.https.html,RTCPeerConnection-iceConnectionState-disconnected.https.html,RTCPeerConnection-iceConnectionState.https.html,RTCPeerConnection-track-stats.https.html">
+          "RTCIceConnectionState-candidate-pair.https.html,RTCPeerConnection-getStats.https.html,RTCPeerConnection-iceConnectionState-disconnected.https.html,RTCPeerConnection-iceConnectionState.https.html">
             <p>
               If <var>connectionIceConnectionStateChanged</var> is
               <code>true</code>, [= fire an event =] named
@@ -15265,7 +15265,7 @@ interface RTCDTMFToneChangeEvent : Event {
                     </p>
                   </li>
                   <li data-tests=
-                  "RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html">
+                  "RTCPeerConnection-getStats.https.html">
                     <p>
                       If <var>selectorArg</var> is a {{MediaStreamTrack}} let
                       <var>selector</var> be an {{RTCRtpSender}} or
@@ -15588,7 +15588,7 @@ interface RTCStatsReport {
                 {{RTCInboundRtpStreamStats}}
               </td>
               <td data-tests=
-              "RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCRtpReceiver-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">
+              "RTCPeerConnection-getStats.https.html,RTCRtpReceiver-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">
                 {{RTCInboundRtpStreamStats/trackIdentifier}},
                 {{RTCInboundRtpStreamStats/remoteId}},
                 {{RTCInboundRtpStreamStats/framesDecoded}},
@@ -15630,7 +15630,7 @@ interface RTCStatsReport {
                 {{RTCOutboundRtpStreamStats}}
               </td>
               <td data-tests=
-              "RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCRtpSender-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">
+              "RTCPeerConnection-getStats.https.html,RTCRtpSender-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">
                 {{RTCOutboundRtpStreamStats/remoteId}},
                 {{RTCOutboundRtpStreamStats/framesEncoded}},
                 {{RTCOutboundRtpStreamStats/nackCount}},
@@ -15714,7 +15714,7 @@ interface RTCStatsReport {
                 {{RTCMediaSourceStats}}
               </td>
               <td data-tests=
-              "RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">
+              "RTCPeerConnection-mandatory-getStats.https.html">
                 {{RTCMediaSourceStats/trackIdentifier}},
                 {{RTCMediaSourceStats/kind}}
               </td>
@@ -15724,7 +15724,7 @@ interface RTCStatsReport {
                 {{RTCAudioSourceStats}}
               </td>
               <td data-tests=
-              "RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">
+              "RTCPeerConnection-mandatory-getStats.https.html">
                 {{RTCAudioSourceStats/totalAudioEnergy}},
                 {{RTCAudioSourceStats/totalSamplesDuration}} (for audio tracks
                 attached to senders)
@@ -15735,7 +15735,7 @@ interface RTCStatsReport {
                 {{RTCVideoSourceStats}}
               </td>
               <td data-tests=
-              "RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">
+              "RTCPeerConnection-mandatory-getStats.https.html">
                 {{RTCVideoSourceStats/width}}, {{RTCVideoSourceStats/height}},
                 {{RTCVideoSourceStats/framesPerSecond}} (for video tracks
                 attached to senders)
@@ -15781,7 +15781,7 @@ interface RTCStatsReport {
                 {{RTCTransportStats}}
               </td>
               <td data-tests=
-              "RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">
+              "RTCPeerConnection-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">
                 {{RTCTransportStats/bytesSent}},
                 {{RTCTransportStats/bytesReceived}},
                 {{RTCTransportStats/selectedCandidatePairId}},
@@ -15797,7 +15797,7 @@ interface RTCStatsReport {
                 {{RTCIceCandidatePairStats}}
               </td>
               <td data-tests=
-              "RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">
+              "RTCPeerConnection-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">
                 {{RTCIceCandidatePairStats/transportId}},
                 {{RTCIceCandidatePairStats/localCandidateId}},
                 {{RTCIceCandidatePairStats/remoteCandidateId}},
@@ -15817,7 +15817,7 @@ interface RTCStatsReport {
                 {{RTCIceCandidateStats}}
               </td>
               <td rowspan="2" data-tests=
-              "RTCPeerConnection-getStats.https.html,RTCPeerConnection-track-stats.https.html,RTCPeerConnection-mandatory-getStats.https.html">
+              "RTCPeerConnection-getStats.https.html,RTCPeerConnection-mandatory-getStats.https.html">
                 {{RTCIceCandidateStats/address}},
                 {{RTCIceCandidateStats/port}},
                 {{RTCIceCandidateStats/protocol}},


### PR DESCRIPTION
removes related respec warning from rendered spec


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2809.html" title="Last updated on Dec 14, 2022, 9:07 AM UTC (90feb7c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2809/2a89b13...90feb7c.html" title="Last updated on Dec 14, 2022, 9:07 AM UTC (90feb7c)">Diff</a>