### PR TITLE
add test annotations for msid generation

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7848,7 +7848,7 @@ interface RTCCertificate {
                           to an empty set.
                         </p>
                       </li>
-                      <li>
+                      <li data-tests="protocol/msid-generate.html">
                         <p>
                           For each <var>stream</var> in <var>streams</var>, add
                           <var>stream.id</var> to
@@ -8739,7 +8739,7 @@ interface RTCCertificate {
               empty set.
             </p>
           </li>
-          <li>
+          <li data-tests="protocol/msid-generate.html">
             <p>
               For each <var>stream</var> in <var>streams</var>, add
               <var>stream.id</var> to {{RTCRtpSender/[[AssociatedMediaStreamIds]]}} if
@@ -9404,7 +9404,7 @@ async function updateParameters() {
                       an empty set.
                     </p>
                   </li>
-                  <li data-tests="RTCRtpSender-setStreams.https.html">
+                  <li data-tests="protocol/msid-generate.html">
                     <p>
                       For each <var>stream</var> in <var>streams</var>, add
                       <var>stream.id</var> to


### PR DESCRIPTION
and move test annotiation for setStreams which is currently not tested in that test suite.

@dontcallmedom did I do this right?

(note that currently msid-generate does not test setStreams, i'll fix that soon)