### PR TITLE
Ignore comma-separated rid alternatives.

### DIFF
--- a/amendments.json
+++ b/amendments.json
@@ -364,6 +364,14 @@
       "type": "correction",
       "status": "candidate",
       "id": 25
+    },
+    {
+      "description": "Ignore comma-separated rid alternatives.",
+      "pr": 2813,
+      "difftype": "modify",
+      "type": "correction",
+      "status": "candidate",
+      "id": 27
     }
   ],
   "apply-local-description": [
@@ -384,6 +392,14 @@
       "type": "correction",
       "status": "candidate",
       "id": 26
+    },
+    {
+      "description": "Ignore comma-separated rid alternatives.",
+      "pr": 2813,
+      "difftype": "modify",
+      "type": "correction",
+      "status": "candidate",
+      "id": 27
     }
   ]
 }

--- a/webrtc.html
+++ b/webrtc.html
@@ -2368,7 +2368,9 @@
                                   {{RTCRtpEncodingParameters}} dictionary for
                                   each of the simulcast layers, populating the
                                   {{RTCRtpCodingParameters/rid}} member
-                                  according to the corresponding rid value, and
+                                  according to the corresponding rid value
+                                  (using only the first value if
+                                  comma-separated alternatives exist), and
                                   let <var>proposedSendEncodings</var> be the
                                   list containing the created dictionaries.
                                   Otherwise, let <var>proposedSendEncodings</var>
@@ -4054,13 +4056,32 @@ interface RTCPeerConnection : EventTarget  {
                           <p>
                             If this is an answer to an offer to receive
                             simulcast, then for each media section requesting
-                            to receive simulcast, exclude from the media section
-                            in the answer any RID not found in the corresponding
-                            transceiver's
-                            {{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}.
-                            If there are any identically named RIDs in the
-                            <code class="sdp">a=simulcast</code> attribute, remove all
-                            duplicates except the first one. No RID restrictions are set.
+                            to receive simulcast, run the following steps:
+                          </p>
+                          <ol>
+                            <li>
+                              <p>
+                                If the <code class="sdp">a=simulcast</code>
+                                attribute contains comma-separated alternatives
+                                for RIDs, remove all but the first ones.
+                              </p>
+                            </li>
+                            <li>
+                              <p>
+                                If there are any identically named RIDs in the
+                                <code class="sdp">a=simulcast</code> attribute,
+                                remove all but the first one. No RID
+                                restrictions are set.
+                              </p>
+                            </li>
+                            <li>
+                              <p>
+                                Exclude from the media section in the answer any
+                                RID not found in the corresponding transceiver's
+                                {{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}.
+                              <p>
+                            </li>
+                          </ol>
                           </p>
                           <div class="note">
                             <p>


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2769. @docfaraday PTAL


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2813.html" title="Last updated on Jan 11, 2023, 8:23 PM UTC (048d403)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2813/4781a0d...jan-ivar:048d403.html" title="Last updated on Jan 11, 2023, 8:23 PM UTC (048d403)">Diff</a>