### PR TITLE
Update title of spec, removing 1.0 and making it 'in' rather than 'between' browsers

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <link href="webrtc.css" rel="stylesheet">
     <title>
-      WebRTC 1.0: Real-Time Communication Between Browsers
+      WebRTC: Real-Time Communication in Browsers
     </title>
     <script class="remove" src="respec-w3c-common.js" type="text/javascript">
     // // keep this comment //
@@ -26,7 +26,7 @@
       2011 done by the W3C WebRTC Working Group are under the following
       <a href='https://www.w3.org/Consortium/Legal/ipr-notice#Copyright'>Copyright</a>:<br>
 
-      © 2011-2018 <a href='https://www.w3.org/'><abbr title=
+      © 2011-2023 <a href='https://www.w3.org/'><abbr title=
       'World Wide Web Consortium'>W3C</abbr></a><sup>®</sup> (<a href=
       'https://www.csail.mit.edu/'><abbr title=
       'Massachusetts Institute of Technology'>MIT</abbr></a>, <a href=


### PR DESCRIPTION
This follows previous discussions of removing the numbering scheme of the spec, and a more recent suggestion to 
reflect that it is not limited to RTC between browsers https://lists.w3.org/Archives/Public/public-webrtc/2023Jan/0102.html


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dontcallmedom/webrtc-pc/pull/2823.html" title="Last updated on Feb 10, 2023, 10:31 AM UTC (0c10f52)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2823/ea2964a...dontcallmedom:0c10f52.html" title="Last updated on Feb 10, 2023, 10:31 AM UTC (0c10f52)">Diff</a>