### PR TITLE
Express RTCPeerConnectionState values using [[IceConnectionState]], and reduce complexity

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -824,7 +824,7 @@
   "new",
   "gathering",
   "complete"
-	      };</pre>
+};</pre>
 	    <div id="rtcicegatheringstate-description">
             <table data-link-for="RTCIceGatheringState" data-dfn-for=
             "RTCIceGatheringState" class="simple">
@@ -871,8 +871,8 @@
             </table>
             <p>
               The set of transports considered is the one
-              presently referenced by the PeerConnection's
-              [= set of transceivers =] and the PeerConnection's
+              presently referenced by the {{RTCPeerConnection}}'s
+              [= set of transceivers =] and the {{RTCPeerConnection}}'s
               {{RTCPeerConnection/[[SctpTransport]]}}
               internal slot if not <code>null</code>.
             </p>
@@ -891,7 +891,7 @@
   "new",
   "connecting",
   "connected"
-	      };</pre>
+};</pre>
 	    <div id="rtcpeerconnectionstate-description">
             <table data-link-for="RTCPeerConnectionState" data-dfn-for=
 		   "RTCPeerConnectionState" class="simple">
@@ -908,8 +908,8 @@
                     <dfn data-idl="">closed</dfn>
                   </td>
                   <td>
-                    The {{RTCPeerConnection}} object's {{RTCPeerConnection/[[IsClosed]]}}
-                    slot is <code>true</code>.
+                    {{RTCPeerConnection/[[IceConnectionState]]}} is
+                    {{RTCIceConnectionState/"closed"}}.
                   </td>
                 </tr>
                 <tr>
@@ -917,9 +917,9 @@
                     <dfn data-idl="">failed</dfn>
                   </td>
                   <td>
-                    The previous state doesn't apply and any
-                    {{RTCIceTransport}}s are in the
-                    {{RTCIceTransportState/"failed"}} state or any
+                    The previous state doesn't apply, and either
+                    {{RTCPeerConnection/[[IceConnectionState]]}} is
+                    {{RTCIceConnectionState/"failed"}} or any
                     {{RTCDtlsTransport}}s are in the
                     {{RTCDtlsTransportState/"failed"}} state.
                   </td>
@@ -929,9 +929,9 @@
                     <dfn data-idl="">disconnected</dfn>
                   </td>
                   <td>
-                    None of the previous states apply and any
-                    {{RTCIceTransport}}s are in the
-                    {{RTCIceTransportState/"disconnected"}} state.
+                    None of the previous states apply, and
+                    {{RTCPeerConnection/[[IceConnectionState]]}} is
+                    {{RTCIceConnectionState/"disconnected"}}.
                   </td>
                 </tr>
                 <tr>
@@ -940,10 +940,9 @@
                     <dfn data-idl="">new</dfn>
                   </td>
                   <td>
-                    None of the previous states apply and all
-                    {{RTCIceTransport}}s are in the
-                    {{RTCIceTransportState/"new"}} or
-                    {{RTCIceTransportState/"closed"}} state, and all
+                    None of the previous states apply, and either
+                    {{RTCPeerConnection/[[IceConnectionState]]}} is
+                    {{RTCIceConnectionState/"new"}}, and all
                     {{RTCDtlsTransport}}s are in the
                     {{RTCDtlsTransportState/"new"}} or
                     {{RTCDtlsTransportState/"closed"}} state, or there are no
@@ -953,38 +952,32 @@
                 <tr>
                   <td data-tests=
                   "RTCPeerConnection-connectionState.https.html">
-                    <dfn data-idl="">connecting</dfn>
+                    <dfn data-idl="">connected</dfn>
                   </td>
                   <td>
-                    None of the previous states apply and any
-                    {{RTCIceTransport}} is in the {{RTCIceTransportState/"new"}}
-                    or {{RTCIceTransportState/"checking"}} state or any
-                    {{RTCDtlsTransport}} is in the {{RTCDtlsTransportState/"new"}}
-                    or {{RTCDtlsTransportState/"connecting"}} state.
+                    None of the previous states apply,
+                    {{RTCPeerConnection/[[IceConnectionState]]}} is
+                    {{RTCIceConnectionState/"connected"}}, and all
+                    {{RTCDtlsTransport}}s are in the
+                    {{RTCDtlsTransportState/"connected"}} or
+                    {{RTCDtlsTransportState/"closed"}} state.
                   </td>
                 </tr>
                 <tr>
                   <td data-tests=
                   "RTCPeerConnection-connectionState.https.html">
-                    <dfn data-idl="">connected</dfn>
+                    <dfn data-idl="">connecting</dfn>
                   </td>
                   <td>
-                    None of the previous states apply and all
-                    {{RTCIceTransport}}s are in the
-                    {{RTCIceTransportState/"connected"}},
-                    {{RTCIceTransportState/"completed"}} or
-                    {{RTCIceTransportState/"closed"}} state, and all
-                    {{RTCDtlsTransport}}s are in the
-                    {{RTCDtlsTransportState/"connected"}} or
-                    {{RTCDtlsTransportState/"closed"}} state.
+                    None of the previous states apply.
                   </td>
                 </tr>
               </tbody>
             </table>
              <p>
               The set of transports considered is the one
-              presently referenced by the PeerConnection's
-              [= set of transceivers =] and the PeerConnection's
+              presently referenced by the {{RTCPeerConnection}}'s
+              [= set of transceivers =] and the {{RTCPeerConnection}}'s
               {{RTCPeerConnection/[[SctpTransport]]}}
               internal slot if not <code>null</code>.
              </p>
@@ -1004,7 +997,7 @@
   "checking",
   "completed",
   "connected"
-	      };</pre>
+};</pre>
 	    <div id="rtciceconnectionstate-description">
             <table data-link-for="RTCIceConnectionState" data-dfn-for=
             "RTCIceConnectionState" class="simple">
@@ -1101,8 +1094,8 @@
             </table>
           <p>
             The set of transports considered is the one
-            presently referenced by the PeerConnection's
-            [= set of transceivers =] and the PeerConnection's
+            presently referenced by the {{RTCPeerConnection}}'s
+            [= set of transceivers =] and the {{RTCPeerConnection}}'s
               {{RTCPeerConnection/[[SctpTransport]]}}
               internal slot if not <code>null</code>.
           </p>
@@ -8387,7 +8380,7 @@ interface RTCCertificate {
               </dt>
               <dd>
                 <p>
-                  When the remote PeerConnection's track event fires
+                  When the remote {{RTCPeerConnection}}'s track event fires
                   corresponding to the {{RTCRtpReceiver}} being added, these
                   are the streams that will be put in the event.
                 </p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -974,6 +974,14 @@
                 </tr>
               </tbody>
             </table>
+             <p class="note">
+               In the {{RTCPeerConnectionState/"connecting"}} state, one or more
+               {{RTCIceTransport}}s are in the {{RTCIceTransportState/"new"}}
+               or {{RTCIceTransportState/"checking"}} state, or one or more
+               {{RTCDtlsTransport}}s are in the {{RTCDtlsTransportState/"new"}}
+               or {{RTCDtlsTransportState/"connecting"}} state.
+            </p>
+             <p>
              <p>
               The set of transports considered is the one
               presently referenced by the {{RTCPeerConnection}}'s


### PR DESCRIPTION
Fixes #2827.

Since this depends on #2826, a nicer [Preview](https://rawgit.com/jan-ivar/webrtc-pc/connectstates2/webrtc.html#rtcpeerconnectionstate-enum).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2828.html" title="Last updated on Mar 6, 2023, 3:21 PM UTC (bc4d0da)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2828/c0cd7f2...jan-ivar:bc4d0da.html" title="Last updated on Mar 6, 2023, 3:21 PM UTC (bc4d0da)">Diff</a>