### PR TITLE
add RTCIceCandidatePair.responsesReceived to MTI stats

### DIFF
--- a/amendments.json
+++ b/amendments.json
@@ -114,7 +114,7 @@
   "mti-stats-table": [
     {
       "description": "Align MTI stats with implementations",
-      "pr": [2744, 2748],
+      "pr": [2744, 2748, 2832],
       "type": "correction",
       "status": "candidate",
       "id": 10

--- a/tools/check-rec-amendment.js
+++ b/tools/check-rec-amendment.js
@@ -9,7 +9,7 @@ module.exports = async ({github, context, core}) => {
     return;
   }
   const amendments = require(process.env.GITHUB_WORKSPACE + '/amendments.json');
-  if (!Object.values(amendments).find(list => list.find(a => a.pr === context.issue.number))) {
+  if (!Object.values(amendments).find(list => list.find(a => Array.isArray(a.pr) ? a.pr.includes(context.issue.number) : a.pr === context.issue.number ))) {
      core.setFailed(`Pull request ${context.issue.number} not labeled as editorial and not referenced in amendments.json`);
   }
 

--- a/webrtc.html
+++ b/webrtc.html
@@ -15826,6 +15826,7 @@ interface RTCStatsReport {
                 {{RTCIceCandidatePairStats/bytesSent}},
                 {{RTCIceCandidatePairStats/bytesReceived}},
                 {{RTCIceCandidatePairStats/totalRoundTripTime}},
+                {{RTCIceCandidatePairStats/responsesReceived}},
                 {{RTCIceCandidatePairStats/currentRoundTripTime}}
               </td>
             </tr>


### PR DESCRIPTION
since it is typically paired with the MTI totalRoundTripTime
  https://www.w3.org/TR/webrtc-stats/#dom-rtcicecandidatepairstats-totalroundtriptime
to calculate the average RTT and totalRoundTripTime is meaningless without it.

editorial per [this comment](https://github.com/w3c/webrtc-pc/issues/2819#issuecomment-1456277070)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-pc/pull/2832.html" title="Last updated on Mar 6, 2023, 6:06 PM UTC (977c226)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2832/c0cd7f2...fippo:977c226.html" title="Last updated on Mar 6, 2023, 6:06 PM UTC (977c226)">Diff</a>