### PR TITLE
Fix scaleResolutionDownBy explanatory prose to match normative algorithm

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9752,8 +9752,8 @@ async function updateParameters() {
                     dimension, resulting in sending a video of one quarter the
                     size. If the value is 1.0, the video will not be affected.
                     The value must be greater than or equal to 1.0. By default,
-                    scaling is applied by a factor of two to the power of the
-                    layer's number, in order of smaller to higher resolutions,
+                    scaling is applied in reverse order by a factor of two, to
+                    produce an order of smaller to higher resolutions,
                     e.g. 4:2:1. If there is only one layer, the sender will by
                     default not apply any scaling, (i.e.
                     {{RTCRtpEncodingParameters/scaleResolutionDownBy}} will be


### PR DESCRIPTION
The description of [scaleResolutionDownBy](https://w3c.github.io/webrtc-pc/#dom-rtcrtpencodingparameters-scaleresolutiondownby) is nonsense: _"scaling is applied by a factor of two to the power of the layer's number, in order of smaller to higher resolutions, e.g. 4:2:1"_ ... because as described that would yield 1:2:4 (or 2:4:8).

This PR fixes the language to match the existing normative algorithms elsewhere:
- [sRD](https://w3c.github.io/webrtc-pc/#set-description): _"If proposedSendEncodings is non-empty, set each encoding's [scaleResolutionDownBy](https://w3c.github.io/webrtc-pc/#dom-rtcrtpencodingparameters-scaleresolutiondownby) to 2^(length of proposedSendEncodings - encoding index - 1)."_
- [addTransceiver](https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-addtransceiver): _"add a [scaleResolutionDownBy](https://w3c.github.io/webrtc-pc/#dom-rtcrtpencodingparameters-scaleresolutiondownby) member with the value 2^(length of sendEncodings - encoding index - 1). This results in smaller-to-larger resolutions where the last encoding has no scaling applied to it, e.g. 4:2:1 if the length is 3."_

Normative algorithms here clearly trump attribute descriptions, so I'm marking this `Editorial`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2836.html" title="Last updated on Mar 10, 2023, 11:00 PM UTC (61fad8f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2836/21bd2c7...jan-ivar:61fad8f.html" title="Last updated on Mar 10, 2023, 11:00 PM UTC (61fad8f)">Diff</a>