### PR TITLE
Mark PreferredCodec internal slot as exported

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -10643,7 +10643,7 @@ interface RTCRtpReceiver {
           </li>
           <li>
             <p>
-              Let <var>transceiver</var> have a <dfn data-dfn-for="RTCRtpTransceiver">[[\PreferredCodecs]]</dfn>
+              Let <var>transceiver</var> have a <dfn class="export" data-dfn-for="RTCRtpTransceiver">[[\PreferredCodecs]]</dfn>
               internal slot, initialized to an empty list.
             </p>
           </li>


### PR DESCRIPTION
needed for https://github.com/w3c/webrtc-extensions/pull/147#issuecomment-1477998018


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2843.html" title="Last updated on Mar 21, 2023, 3:55 PM UTC (625bef4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2843/e3e5073...625bef4.html" title="Last updated on Mar 21, 2023, 3:55 PM UTC (625bef4)">Diff</a>