### PR TITLE
Add sender/receiver.getCapabilities() algorithms (and use them in offer/answer)

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3740,38 +3740,41 @@ interface RTCPeerConnection : EventTarget  {
                         <li>
                           <p>
                             The <i>codec preferences</i> of a [= media
-                            description =]'s [= associated =] transceiver is
-                            said to be the value of the
-                            {{RTCRtpTransceiver}}.{{RTCRtpTransceiver/[[PreferredCodecs]]}}
+                            description =]'s [= associated =] transceiver,
+                            <var>transceiver</var>, is said to be the value of
+                            <var>transceiver</var>.{{RTCRtpTransceiver/[[PreferredCodecs]]}}
                             with the following filtering applied (or said not
-                            to be set if {{RTCRtpTransceiver/[[PreferredCodecs]]}} is empty):
+                            to be set if
+                            <var>transceiver</var>.{{RTCRtpTransceiver/[[PreferredCodecs]]}}
+                            is empty):
                           </p>
                           <ol>
                             <li>
+                              <p>Let <var>kind</var> be <var>transceiver</var>'s
+                              {{RTCRtpTransceiver/[[Receiver]]}}'s
+                              {{RTCRtpReceiver/[[ReceiverTrack]]}}'s
+                              {{MediaStreamTrack/kind}}.</p>
+                            <li>
+                            <li>
                               <p>
-                                If the {{RTCRtpTransceiver/direction}} is
-                                {{RTCRtpTransceiverDirection/"sendrecv"}},
+                                If
+                                <var>transceiver</var>.{{RTCRtpTransceiver/direction}}
+                                is {{RTCRtpTransceiverDirection/"sendonly"}}
+                                or {{RTCRtpTransceiverDirection/"sendrecv"}},
                                 exclude any codecs not included in the
-                                intersection of
-                                {{RTCRtpSender}}.{{RTCRtpSender/getCapabilities}}(kind).{{RTCRtpCapabilities/codecs}}
-                                and
-                                {{RTCRtpReceiver}}.{{RTCRtpReceiver/getCapabilities}}(kind).{{RTCRtpCapabilities/codecs}}.
+                                [=list of implemented send codecs=] with
+                                <var>kind</var>.
                               </p>
                             </li>
                             <li>
                               <p>
-                                If the {{RTCRtpTransceiver/direction}} is
-                                {{RTCRtpTransceiverDirection/"sendonly"}},
-                                exclude any codecs not included in
-                                {{RTCRtpSender}}.{{RTCRtpSender/getCapabilities}}(kind).{{RTCRtpCapabilities/codecs}}.
-                              </p>
-                            </li>
-                            <li>
-                              <p>
-                                If the {{RTCRtpTransceiver/direction}} is
-                                {{RTCRtpTransceiverDirection/"recvonly"}},
-                                exclude any codecs not included in
-                                {{RTCRtpReceiver}}.{{RTCRtpReceiver/getCapabilities}}(kind).{{RTCRtpCapabilities/codecs}}.
+                                If
+                                <var>transceiver</var>.{{RTCRtpTransceiver/direction}}
+                                is {{RTCRtpTransceiverDirection/"recvonly"}}
+                                or {{RTCRtpTransceiverDirection/"sendrecv"}},
+                                exclude any codecs not included in the
+                                [=list of implemented receive codecs=] with
+                                <var>kind</var>.
                               </p>
                             </li>
                           </ol>
@@ -4020,38 +4023,41 @@ interface RTCPeerConnection : EventTarget  {
                         <li>
                           <p>
                             The <i>codec preferences</i> of an m= section's
-                            associated transceiver is said to be the value of
-                            the
-                            {{RTCRtpTransceiver}}.{{RTCRtpTransceiver/[[PreferredCodecs]]}}
+                            [= associated =] transceiver,
+                            <var>transceiver</var>, is said to be the value of
+                            <var>transceiver</var>.{{RTCRtpTransceiver/[[PreferredCodecs]]}}
                             with the following filtering applied (or said not
-                            to be set if {{RTCRtpTransceiver/[[PreferredCodecs]]}} is empty):
+                            to be set if
+                            <var>transceiver</var>.{{RTCRtpTransceiver/[[PreferredCodecs]]}}
+                            is empty):
                           </p>
                           <ol>
                             <li>
+                              <p>Let <var>kind</var> be <var>transceiver</var>'s
+                              {{RTCRtpTransceiver/[[Receiver]]}}'s
+                              {{RTCRtpReceiver/[[ReceiverTrack]]}}'s
+                              {{MediaStreamTrack/kind}}.</p>
+                            </li>
+                            <li>
                               <p>
-                                If the {{RTCRtpTransceiver/direction}} is
-                                {{RTCRtpTransceiverDirection/"sendrecv"}},
+                                If
+                                <var>transceiver</var>.{{RTCRtpTransceiver/direction}}
+                                is {{RTCRtpTransceiverDirection/"sendonly"}}
+                                or {{RTCRtpTransceiverDirection/"sendrecv"}},
                                 exclude any codecs not included in the
-                                intersection of
-                                {{RTCRtpSender}}.{{RTCRtpSender/getCapabilities}}(kind).{{RTCRtpCapabilities/codecs}}
-                                and
-                                {{RTCRtpReceiver}}.{{RTCRtpReceiver/getCapabilities}}(kind).{{RTCRtpCapabilities/codecs}}.
+                                [=list of implemented send codecs=] with
+                                <var>kind</var>.
                               </p>
                             </li>
                             <li>
                               <p>
-                                If the {{RTCRtpTransceiver/direction}} is
-                                {{RTCRtpTransceiverDirection/"sendonly"}},
-                                exclude any codecs not included in
-                                {{RTCRtpSender}}.{{RTCRtpSender/getCapabilities}}(kind).{{RTCRtpCapabilities/codecs}}.
-                              </p>
-                            </li>
-                            <li>
-                              <p>
-                                If the {{RTCRtpTransceiver/direction}} is
-                                {{RTCRtpTransceiverDirection/"recvonly"}},
-                                exclude any codecs not included in
-                                {{RTCRtpReceiver}}.{{RTCRtpReceiver/getCapabilities}}(kind).{{RTCRtpCapabilities/codecs}}.
+                                If
+                                <var>transceiver</var>.{{RTCRtpTransceiver/direction}}
+                                is {{RTCRtpTransceiverDirection/"recvonly"}}
+                                or {{RTCRtpTransceiverDirection/"sendrecv"}},
+                                exclude any codecs not included in the
+                                [=list of implemented receive codecs=] with
+                                <var>kind</var>.
                               </p>
                             </li>
                           </ol>

--- a/webrtc.html
+++ b/webrtc.html
@@ -3762,7 +3762,7 @@ interface RTCPeerConnection : EventTarget  {
                                 is {{RTCRtpTransceiverDirection/"sendonly"}}
                                 or {{RTCRtpTransceiverDirection/"sendrecv"}},
                                 exclude any codecs not included in the
-                                [=list of implemented send codecs=] with
+                                [=list of implemented send codecs=] for
                                 <var>kind</var>.
                               </p>
                             </li>
@@ -3773,7 +3773,7 @@ interface RTCPeerConnection : EventTarget  {
                                 is {{RTCRtpTransceiverDirection/"recvonly"}}
                                 or {{RTCRtpTransceiverDirection/"sendrecv"}},
                                 exclude any codecs not included in the
-                                [=list of implemented receive codecs=] with
+                                [=list of implemented receive codecs=] for
                                 <var>kind</var>.
                               </p>
                             </li>
@@ -4045,7 +4045,7 @@ interface RTCPeerConnection : EventTarget  {
                                 is {{RTCRtpTransceiverDirection/"sendonly"}}
                                 or {{RTCRtpTransceiverDirection/"sendrecv"}},
                                 exclude any codecs not included in the
-                                [=list of implemented send codecs=] with
+                                [=list of implemented send codecs=] for
                                 <var>kind</var>.
                               </p>
                             </li>
@@ -4056,7 +4056,7 @@ interface RTCPeerConnection : EventTarget  {
                                 is {{RTCRtpTransceiverDirection/"recvonly"}}
                                 or {{RTCRtpTransceiverDirection/"sendrecv"}},
                                 exclude any codecs not included in the
-                                [=list of implemented receive codecs=] with
+                                [=list of implemented receive codecs=] for
                                 <var>kind</var>.
                               </p>
                             </li>
@@ -8925,7 +8925,7 @@ interface RTCRtpSender {
                   <li class="no-test-needed">
                     <p>Return a new {{RTCRtpCapabilities}} dictionary, with its
                     {{RTCRtpCapabilities/codecs}} member initialized to the
-                    [=list of implemented send codecs=] with <var>kind</var>, and its
+                    [=list of implemented send codecs=] for <var>kind</var>, and its
                     {{RTCRtpCapabilities/headerExtensions}} member initialized to the
                     [=list of implemented header extensions for sending=] with
                     <var>kind</var>.</p>
@@ -10317,9 +10317,9 @@ interface RTCRtpReceiver {
                   <li class="no-test-needed">
                     <p>Return a new {{RTCRtpCapabilities}} dictionary, with its
                     {{RTCRtpCapabilities/codecs}} member initialized to the
-                    [=list of implemented receive codecs=] with <var>kind</var>, and its
+                    [=list of implemented receive codecs=] for <var>kind</var>, and its
                     {{RTCRtpCapabilities/headerExtensions}} member initialized to the
-                    [=list of implemented header extensions for receiving=] with
+                    [=list of implemented header extensions for receiving=] for
                     <var>kind</var>.</p>
                   </li>
                 </ol>

--- a/webrtc.html
+++ b/webrtc.html
@@ -8933,13 +8933,13 @@ interface RTCRtpSender {
                 </ol>
                 <p>
                   The <dfn>list of implemented send codecs</dfn>, given <var>kind</var>, is
-                  an immutable [=implementation-defined=] list of {{RTCRtpCodecCapability}}
+                  an [=implementation-defined=] list of {{RTCRtpCodecCapability}}
                   dictionaries representing the most optimistic view of the codecs the user
                   agent supports for sending media of the given <var>kind</var> (video or audio).
                 </p>
                 <p>
                   The <dfn>list of implemented header extensions for sending</dfn>, given
-                  <var>kind</var>, is an immutable [=implementation-defined=] list of
+                  <var>kind</var>, is an [=implementation-defined=] list of
                   {{RTCRtpHeaderExtensionCapability}} dictionaries representing the most
                   optimistic view of the header extensions the user agent supports for
                   sending media of the given <var>kind</var> (video or audio).
@@ -10325,14 +10325,14 @@ interface RTCRtpReceiver {
                 </ol>
                 <p>
                   The <dfn>list of implemented receive codecs</dfn>, given <var>kind</var>, is an
-                  immutable [=implementation-defined=] list of
+                 [=implementation-defined=] list of
                   {{RTCRtpCodecCapability}} dictionaries representing the most optimistic view of
                   the codecs the user agent supports for receiving media of the given
                   <var>kind</var> (video or audio).
                 </p>
                 <p>
                   The <dfn>list of implemented header extensions for receiving</dfn>, given
-                  <var>kind</var>, is an immutable [=implementation-defined=] list of
+                  <var>kind</var>, is an [=implementation-defined=] list of
                   {{RTCRtpHeaderExtensionCapability}} dictionaries representing an optimistic
                   view of the header extensions the user agent supports for receiving media
                   of the given <var>kind</var> (video or audio).

--- a/webrtc.html
+++ b/webrtc.html
@@ -8901,22 +8901,48 @@ interface RTCRtpSender {
               </dt>
               <dd>
                 <p data-tests="RTCRtpSender-getCapabilities.html">
-                  The {{getCapabilities()}} method returns the most optimistic
-                  view of the capabilities of the system for sending media of
-                  the given kind. It does not reserve any resources, ports, or
-                  other state but is meant to provide a way to discover the
-                  types of capabilities of the browser including which codecs
-                  may be supported. User agents MUST support <var>kind</var>
-                  values of <code>"audio"</code> and <code>"video"</code>. If
-                  the system has no capabilities corresponding to the value of
-                  the <var>kind</var> argument, {{getCapabilities}} returns
-                  <code>null</code>.
+                  The static {{RTCRtpSender}}.{{getCapabilities()}} method provides a way to
+                  discover the types of capabilities the user agent supports for sending media
+                  of the given kind, without reserving any resources, ports, or other state.
+                </p>
+                <p>
+                  When the {{getCapabilities}} method is called, the user agent MUST run the
+                  following steps:
+                </p>
+                <ol class=algorithm>
+                  <li class="no-test-needed">
+                    <p>Let <var>kind</var> be the method's first argument.</p>
+                  </li>
+                  <li class="no-test-needed">
+                    <p>If <var>kind</var> is neither `"video"` nor `"audio"` return `null`.</p>
+                  </li>
+                  <li class="no-test-needed">
+                    <p>Return a new {{RTCRtpCapabilities}} dictionary, with its
+                    {{RTCRtpCapabilities/codecs}} member initialized to the
+                    [=list of implemented send codecs=] with <var>kind</var>, and its
+                    {{RTCRtpCapabilities/headerExtensions}} member initialized to the
+                    [=list of implemented header extensions for sending=] with
+                    <var>kind</var>.</p>
+                  </li>
+                </ol>
+                <p>
+                  The <dfn>list of implemented send codecs</dfn>, given <var>kind</var>, is
+                  an immutable [=implementation-defined=] list of {{RTCRtpCodecCapability}}
+                  dictionaries representing the most optimistic view of the codecs the user
+                  agent supports for sending media of the given <var>kind</var> (video or audio).
+                </p>
+                <p>
+                  The <dfn>list of implemented header extensions for sending</dfn>, given
+                  <var>kind</var>, is an immutable [=implementation-defined=] list of
+                  {{RTCRtpHeaderExtensionCapability}} dictionaries representing the most
+                  optimistic view of the header extensions the user agent supports for
+                  sending media of the given <var>kind</var> (video or audio).
                 </p>
                 <p class="fingerprint">
                   These capabilities provide generally persistent cross-origin
                   information on the device and thus increases the
                   fingerprinting surface of the application. In
-                  privacy-sensitive contexts, browsers can consider mitigations
+                  privacy-sensitive contexts, user agents MAY consider mitigations
                   such as reporting only a common subset of the capabilities.
                 </p>
                 <div class="note">
@@ -10267,22 +10293,49 @@ interface RTCRtpReceiver {
               </dt>
               <dd>
                 <p data-tests="RTCRtpReceiver-getCapabilities.html">
-                  The {{getCapabilities()}} method returns the most optimistic
-                  view of the capabilities of the system for receiving media of
-                  the given kind. It does not reserve any resources, ports, or
-                  other state but is meant to provide a way to discover the
-                  types of capabilities of the browser including which codecs
-                  may be supported. User agents MUST support <var>kind</var>
-                  values of <code>"audio"</code> and <code>"video"</code>. If
-                  the system has no capabilities corresponding to the value of
-                  the <var>kind</var> argument, {{getCapabilities}} returns
-                  <code>null</code>.
+                  The static {{RTCRtpReceiver}}.{{getCapabilities()}} method provides a way to
+                  discover the types of capabilities the user agent supports for receiving media
+                  of the given kind, without reserving any resources, ports, or other state.
+                </p>
+                <p>
+                  When the {{getCapabilities}} method is called, the user agent MUST run the
+                  following steps:
+                </p>
+                <ol class=algorithm>
+                  <li class="no-test-needed">
+                    <p>Let <var>kind</var> be the method's first argument.</p>
+                  </li>
+                  <li class="no-test-needed">
+                    <p>If <var>kind</var> is neither `"video"` nor `"audio"` return `null`.</p>
+                  </li>
+                  <li class="no-test-needed">
+                    <p>Return a new {{RTCRtpCapabilities}} dictionary, with its
+                    {{RTCRtpCapabilities/codecs}} member initialized to the
+                    [=list of implemented receive codecs=] with <var>kind</var>, and its
+                    {{RTCRtpCapabilities/headerExtensions}} member initialized to the
+                    [=list of implemented header extensions for receiving=] with
+                    <var>kind</var>.</p>
+                  </li>
+                </ol>
+                <p>
+                  The <dfn>list of implemented receive codecs</dfn>, given <var>kind</var>, is an
+                  immutable [=implementation-defined=] list of
+                  {{RTCRtpCodecCapability}} dictionaries representing the most optimistic view of
+                  the codecs the user agent supports for receiving media of the given
+                  <var>kind</var> (video or audio).
+                </p>
+                <p>
+                  The <dfn>list of implemented header extensions for receiving</dfn>, given
+                  <var>kind</var>, is an immutable [=implementation-defined=] list of
+                  {{RTCRtpHeaderExtensionCapability}} dictionaries representing an optimistic
+                  view of the header extensions the user agent supports for receiving media
+                  of the given <var>kind</var> (video or audio).
                 </p>
                 <p class="fingerprint">
                   These capabilities provide generally persistent cross-origin
                   information on the device and thus increases the
                   fingerprinting surface of the application. In
-                  privacy-sensitive contexts, browsers can consider mitigations
+                  privacy-sensitive contexts, user agents MAY consider mitigations
                   such as reporting only a common subset of the capabilities.
                 </p>
                 <div class="note">


### PR DESCRIPTION
Fixes #2849.

Regarding touching up uses, this fixes the final steps to create offer and answer. I didn't touch setCodecPreferences yet to not step on work happening there.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2850.html" title="Last updated on Apr 5, 2023, 9:07 PM UTC (d1c2e94)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2850/892d794...jan-ivar:d1c2e94.html" title="Last updated on Apr 5, 2023, 9:07 PM UTC (d1c2e94)">Diff</a>