### PR TITLE
Use the url spec to parse ice server urls (Take 2).

### DIFF
--- a/amendments.json
+++ b/amendments.json
@@ -29,6 +29,13 @@
       "type": "correction",
       "status": "candidate",
       "id": 6
+    },
+    {
+      "description": "Use the url spec to parse ice server urls",
+      "pr": 2853,
+      "type": "correction",
+      "status": "candidate",
+      "id": 33
     }
   ],
   "rtcicegatheringstate-description": [

--- a/webrtc.html
+++ b/webrtc.html
@@ -3117,7 +3117,7 @@
                       <li>
                         <p>
                           If <var>parsedURL</var>'s' [=url/scheme=] is <code>"turn"</code> or
-                          <code>"turns"</code>, and either
+                          <code>"turns"</code>, and either of
                           <var>server</var>.{{RTCIceServer/username}} or
                           <var>server</var>.{{RTCIceServer/credential}} do
                           [=map/exist|not exist=], then [= exception/throw =] an

--- a/webrtc.html
+++ b/webrtc.html
@@ -3063,7 +3063,7 @@
                   <li>
                     <p>
                       If <var>urls</var> is empty, [= exception/throw =] a
-                      {{SyntaxError}}.
+                      "{{SyntaxError}}" {{DOMException}}.
                     </p>
                   </li>
                   <li>
@@ -3073,44 +3073,54 @@
                     </p>
                     <ol>
                       <li>
-                        <p>
-                          Parse the <var>url</var> using the generic URI syntax
-                          defined in [[!RFC3986]] and obtain the <var>scheme
-                          name</var>. If the parsing based on the syntax
-                          defined in [[!RFC3986]] fails, [= exception/throw =]
-                          a {{SyntaxError}}. If the <var>scheme name</var> is
-                          not implemented by the browser [= exception/throw =]
-                          a {{NotSupportedError}}. If <var>scheme name</var> is
-                          <code class="scheme">turn</code> or <code class=
-                          "scheme">turns</code>, and parsing the <var>url</var>
-                          using the syntax defined in [[!RFC7065]] fails, [=
-                          exception/throw =] a {{SyntaxError}}. If <var>scheme
-                          name</var> is <code class="scheme">stun</code> or
-                          <code class="scheme">stuns</code>, and parsing the
-                          <var>url</var> using the syntax defined in
-                          [[!RFC7064]] fails, [= exception/throw =] a
-                          {{SyntaxError}}.
-                        </p>
+                        <p>Let <var>parsedURL</var> be the result of
+                        <a data-cite="!url#concept-url-parser">parsing</a>
+                        <var>url</var>.</p>
+                      </li>
+                      <li>
+                        <p>If any of the following conditions apply, then [=exception/throw=] a
+                        "{{SyntaxError}}" {{DOMException}}:</p>
+                        <ul>
+                          <li><var>parsedURL</var> is failure</li>
+                          <li><var>parsedURL</var>'s [=url/scheme=] is neither `"stun"`,
+                          `"stuns"`, `"turn"`, nor `"turns"`</li>
+                          <li><var>parsedURL</var> does not have an [=url/opaque path=]</li>
+                          <li><var>parsedURL</var>'s' [=url/fragment=] is non-null</li>
+                          <li><var>parsedURL</var>'s' [=url/scheme=] is `"stun"` or `"stuns"`,
+                          and <var>parsedURL</var>'s' [=url/query=] is non-null</li>
+                        </ul>
+                      </li>
+                      <li>
+                        <p>If <var>parsedURL</var>'s [=url/scheme=] is not implemented by the
+                        user agent, then [=exception/throw=] a {{NotSupportedError}}.</p>
+                      </li>
+                      <li>
+                        <p>Let <var>hostAndPortURL</var> be result of
+                        <a data-cite="!url#concept-url-parser">parsing</a> the concatenation of
+                        `"https://"` and <var>parsedURL</var>'s [=url/path=].</p>
+                      </li>
+                      <li>
+                        <p>If <var>hostAndPortURL</var> is failure, then [=exception/throw=] a
+                        "{{SyntaxError}}" {{DOMException}}.</p>
+                        <p class="note">For "stun" and "stuns" schemes, this validates
+                        [[!RFC7064]] section 3.1.<br>
+                        For "turn" and "turns" schemes, this and the steps below validate
+                        [[!RFC7065]] section 3.1.</p>
+                      </li>
+                      <li>
+                        <p>If <var>parsedURL</var>'s [=url/query=] is non-null, run the following
+                        sub-steps:</p>
+                        <ol>
+                          <li><p>TODO: validate ?transport=udp|tcp</p></li>
+                        </ol>
                       </li>
                       <li>
                         <p>
-                          If <var>scheme name</var> is <code class=
-                          "scheme">turn</code> or <code class=
-                          "scheme">turns</code>, and either of
-                          <var>server</var>.{{RTCIceServer/username}} or
-                          <var>server</var>.{{RTCIceServer/credential}} are
-                          omitted, then [= exception/throw =] an
-                          {{InvalidAccessError}}.
-                        </p>
-                      </li>
-                      <li>
-                        <p>
-                          If <var>scheme name</var> is <code class=
-                          "scheme">turn</code> or <code class=
-                          "scheme">turns</code>, and
-                          <var>server</var>.{{RTCIceServer/credential}} is not
-                          a <span class="idlMemberType">DOMString</span>, then
-                          [= exception/throw =] an {{InvalidAccessError}}.
+                          If <var>parsedURL</var>'s' [=url/scheme=] is <code>"turn"</code> or
+                          <code>"turns"</code>, and neither
+                          <var>server</var>.{{RTCIceServer/username}} nor
+                          <var>server</var>.{{RTCIceServer/credential}}
+                          [=map/exist=], then [= exception/throw =] an {{InvalidAccessError}}.
                         </p>
                       </li>
                     </ol>

--- a/webrtc.html
+++ b/webrtc.html
@@ -3117,10 +3117,11 @@
                       <li>
                         <p>
                           If <var>parsedURL</var>'s' [=url/scheme=] is <code>"turn"</code> or
-                          <code>"turns"</code>, and neither
-                          <var>server</var>.{{RTCIceServer/username}} nor
-                          <var>server</var>.{{RTCIceServer/credential}}
-                          [=map/exist=], then [= exception/throw =] an {{InvalidAccessError}}.
+                          <code>"turns"</code>, and either
+                          <var>server</var>.{{RTCIceServer/username}} or
+                          <var>server</var>.{{RTCIceServer/credential}} do
+                          [=map/exist|not exist=], then [= exception/throw =] an
+                          {{InvalidAccessError}}.
                         </p>
                       </li>
                     </ol>

--- a/webrtc.js
+++ b/webrtc.js
@@ -97,7 +97,7 @@ var respecConfig = {
     }
 
   ],
-  xref: ["dom", "hr-time", "webidl", "html", "mediacapture-streams", "fileapi", "webrtc-stats", "websockets", "xhr", "infra"],
+  xref: ["dom", "hr-time", "webidl", "html", "mediacapture-streams", "fileapi", "webrtc-stats", "websockets", "xhr", "infra", "url"],
   preProcess: [
     highlightTests,
     markTestableAssertions,


### PR DESCRIPTION
Fixes #2660. @annevk PTAL.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2853.html" title="Last updated on Apr 4, 2023, 2:11 PM UTC (1a5b430)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2853/fb2be18...jan-ivar:1a5b430.html" title="Last updated on Apr 4, 2023, 2:11 PM UTC (1a5b430)">Diff</a>