### PR TITLE
Export links to addTransceiver/setParameters steps + unnumber some steps

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -8969,7 +8969,9 @@ interface RTCRtpSender {
                     newly [= exception/created =] {{InvalidStateError}}.
                   </li>
                   <li id="setparameters-validation">
-                    Validate <var>parameters</var> by running the following steps:
+                    Validate <var>parameters</var> by running the following
+                    <dfn class="export" data-dfn-for="RTCRtpSender">
+                    setParameters validation steps</dfn>:
                     <ol>
                       <li class="no-test-needed">Let <var>encodings</var> be
                       <var>parameters</var>.{{RTCRtpSendParameters/encodings}}.
@@ -8984,7 +8986,7 @@ interface RTCRtpSender {
                       <li>If any of the following conditions are met, return a
                       promise [= rejected =] with a newly [= exception/created
                       =] {{InvalidModificationError}}:
-                        <ol>
+                        <ul>
                           <li data-tests="RTCRtpParameters-encodings.html">
                             <code><var>encodings</var>.length</code> is
                             different from <var>N</var>.
@@ -9002,7 +9004,7 @@ interface RTCRtpSender {
                           Note that this also applies to
                           <var>transactionId</var>.
                           </li>
-                        </ol>
+                        </ul>
                       </li>
                       <li data-tests="RTCRtpParameters-encodings.html">
                         <p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -8189,38 +8189,38 @@ interface RTCCertificate {
                       {{InvalidStateError}}.
                     </p>
                   </li>
-                  <li>Validate <var>sendEncodings</var> by running the
-                  following steps, where each {{RTCRtpEncodingParameters}}
-                  dictionary in it is an "encoding":
+                  <li>
+                    <p>Validate <var>sendEncodings</var> by running the following
+                    <dfn class="export" data-dfn-for="RTCPeerConnection">
+                    addTransceiver sendEncodings validation steps</dfn>,
+                    where each {{RTCRtpEncodingParameters}}
+                    dictionary in it is an "encoding":</p>
                     <ol id="addtransceiver-sendencodings-validation">
-                      <li data-tests=
-                      "RTCPeerConnection-addTransceiver.https.html">
-                        <p>
-                          If any encoding [=map/contains=] a
-                          {{RTCRtpCodingParameters/rid}} member whose value
-                          does not conform to the grammar requirements specified
-                          in Section 10 of [[RFC8851]], [=
-                          exception/throw =] a {{TypeError}}.
-                        </p>
-                      </li>
-                      <li data-tests=
-                      "RTCPeerConnection-addTransceiver.https.html">
-                        <p>
-                          If some but not all encodings [=map/contain=] a
-                          {{RTCRtpCodingParameters/rid}} member, [=
-                          exception/throw =] a {{TypeError}}.
-                        </p>
-                      </li>
-                      <li data-tests=
-                      "RTCPeerConnection-addTransceiver.https.html">
-                        <p>
-                          If any encoding [=map/contains=] a
-                          {{RTCRtpCodingParameters/rid}} member whose value
-                          is the same as that of a {{RTCRtpCodingParameters/rid}}
-                          [=map/contains | contained=] in another encoding in
-                          <var>sendEncodings</var>, [=exception/throw =] a
-                          {{TypeError}}.
-                        </p>
+                      <li>
+                        If any of the following conditions are met,
+                        [=exception/throw=] a {{TypeError}}:
+                        <ul>
+                          <li data-tests=
+                          "RTCPeerConnection-addTransceiver.https.html">
+                            Any encoding [=map/contains=] a
+                            {{RTCRtpCodingParameters/rid}} member whose value
+                            does not conform to the grammar requirements specified
+                            in Section 10 of [[RFC8851]].
+                          </li>
+                          <li data-tests=
+                          "RTCPeerConnection-addTransceiver.https.html">
+                            Some but not all encodings [=map/contain=] a
+                            {{RTCRtpCodingParameters/rid}} member.
+                          </li>
+                          <li data-tests=
+                          "RTCPeerConnection-addTransceiver.https.html">
+                            Any encoding [=map/contains=] a
+                            {{RTCRtpCodingParameters/rid}} member whose value
+                            is the same as that of a {{RTCRtpCodingParameters/rid}}
+                            [=map/contains | contained=] in another encoding in
+                            <var>sendEncodings</var>.
+                          </li>
+                        </ul>
                       </li>
                       <li>
                         <p>


### PR DESCRIPTION
This should make it simpler for https://github.com/w3c/webrtc-extensions/pull/147 and https://w3c.github.io/webrtc-svc/#setparameters to reference this spec.

Also, the latter extends the list of conditions, which is currently a numbered list, which seems confusing, since there's no sequential order implied AFAIK (these are all conditions that result in the same error thrown, making order unobservable).

This PR makes that list unnumbered, to avoid confusion. WebRTC-SVC should update to match.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2854.html" title="Last updated on Apr 5, 2023, 10:06 PM UTC (43a6330)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2854/fb2be18...jan-ivar:43a6330.html" title="Last updated on Apr 5, 2023, 10:06 PM UTC (43a6330)">Diff</a>