### PR TITLE
Fix connectionState to return [[ConnectionState]].

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3428,7 +3428,7 @@ interface RTCPeerConnection : EventTarget  {
                   <p>
                     The {{connectionState}} attribute MUST return the
                     {{RTCPeerConnection}} object's
-                    {{RTCPeerConnection/[[IceConnectionState]]}}.
+                    {{RTCPeerConnection/[[ConnectionState]]}}.
                   </p>
                 </dd>
                 <dt data-tests=


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2858.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2859.html" title="Last updated on Apr 13, 2023, 9:45 PM UTC (5e283d1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2859/b24d8a9...jan-ivar:5e283d1.html" title="Last updated on Apr 13, 2023, 9:45 PM UTC (5e283d1)">Diff</a>