### PR TITLE
Determine if DTMF can be sent inside queued playout task.

### DIFF
--- a/amendments.json
+++ b/amendments.json
@@ -476,5 +476,14 @@
       "status": "candidate",
       "id": 32
     }
+  ],
+  "dtmf-playout-check": [
+    {
+      "description": "Determine if DTMF can be sent inside queued playout task",
+      "pr": 2861,
+      "type": "correction",
+      "status": "candidate",
+      "id": 33
+    }
   ]
 }

--- a/base-rec.html
+++ b/base-rec.html
@@ -14819,7 +14819,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-rtc
                   steps; otherwise queue a task that runs the following steps
                   (<em>Playout task</em>):
                     <ol>
-                      <li>If
+                      <li id="dtmf-playout-check">If
                       <var>transceiver</var>.<a href="#dfn-currentdirection" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-currentdirection-8">[[CurrentDirection]]</a> is
                       neither "<a data-link-type="idl" href="#dom-rtcrtptransceiverdirection-sendrecv" class="internalDFN" id="ref-for-dom-rtcrtptransceiverdirection-sendrecv-20"><code><code>sendrecv</code></code></a>" nor
                       "<a data-link-type="idl" href="#dom-rtcrtptransceiverdirection-sendonly" class="internalDFN" id="ref-for-dom-rtcrtptransceiverdirection-sendonly-15"><code><code>sendonly</code></code></a>", abort these

--- a/webrtc.html
+++ b/webrtc.html
@@ -15097,10 +15097,8 @@ interface RTCDTMFSender : EventTarget {
                   steps; otherwise queue a task that runs the following steps
                   (<em>Playout task</em>):
                     <ol>
-                      <li>If
-                      <var>transceiver</var>.{{RTCRtpTransceiver/[[CurrentDirection]]}} is
-                      neither {{RTCRtpTransceiverDirection/"sendrecv"}} nor
-                      {{RTCRtpTransceiverDirection/"sendonly"}}, abort these
+                      <li id="dtmf-playout-check">If [=determine if DTMF can be sent=] for
+                      <var>dtmf</var> returns <code>false</code>, abort these
                       steps.
                       </li>
                       <li>If the {{RTCDTMFSender/[[ToneBuffer]]}} slot contains the empty


### PR DESCRIPTION
Fixes #2860.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2861.html" title="Last updated on Apr 14, 2023, 8:30 PM UTC (695d640)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2861/b24d8a9...jan-ivar:695d640.html" title="Last updated on Apr 14, 2023, 8:30 PM UTC (695d640)">Diff</a>