### PR TITLE
editorial: export RTCRtpTransceiver "transceiver kind"

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -7846,7 +7846,7 @@ interface RTCCertificate {
                       </li>
                       <li>
                         <p>
-                          The <a>transceiver kind</a> of the
+                          The {{RTCRtpTransceiver/transceiver kind}} of the
                           {{RTCRtpTransceiver}}, associated with the sender,
                           matches <var>kind</var>.
                         </p>
@@ -9040,7 +9040,7 @@ interface RTCRtpSender {
                       </li>
                       <li data-tests="RTCRtpParameters-encodings.html">
                         <p>
-                          If <a>transceiver kind</a> is `"audio"`, remove the
+                          If {{RTCRtpTransceiver/transceiver kind}} is `"audio"`, remove the
                           {{RTCRtpEncodingParameters/scaleResolutionDownBy}} and
                           {{RTCRtpEncodingParameters/maxFramerate}}
                           members from all <var>encodings</var> that
@@ -9049,7 +9049,7 @@ interface RTCRtpSender {
                       </li>
                       <li data-tests="RTCRtpParameters-encodings.html">
                         <p>
-                          If <a>transceiver kind</a> is `"video"`, then for
+                          If {{RTCRtpTransceiver/transceiver kind}} is `"video"`, then for
                           each encoding in <var>encodings</var> that doesn't
                           [=map/contain=] a
                           {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
@@ -9060,7 +9060,7 @@ interface RTCRtpSender {
                       </li>
                       <li data-tests="RTCRtpParameters-encodings.html">
                         <p>
-                          If <a>transceiver kind</a> is `"video"`,
+                          If {{RTCRtpTransceiver/transceiver kind}} is `"video"`,
                           and any encoding in <var>encodings</var>
                           [=map/contains=] a
                           {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
@@ -9296,7 +9296,7 @@ async function updateParameters() {
                     <p>
                       If <var>withTrack</var> is non-null and
                       <code><var>withTrack</var>.kind</code> differs from the
-                      <a>transceiver kind</a> of <var>transceiver</var>, return
+                      {{RTCRtpTransceiver/transceiver kind}} of <var>transceiver</var>, return
                       a promise [= rejected =] with a newly [=
                       exception/created =] {{TypeError}}.
                     </p>
@@ -11223,8 +11223,7 @@ interface RTCRtpTransceiver {
                   </li>
                   <li class="no-test-needed">
                     <p>
-                      Let <var>kind</var> be the <var>transceiver</var>'s [=
-                      transceiver kind =].
+                      Let <var>kind</var> be the <var>transceiver</var>'s {{RTCRtpTransceiver/transceiver kind}}.
                     </p>
                   </li>
                   <li data-tests="RTCRtpTransceiver-setCodecPreferences.html">

--- a/webrtc.html
+++ b/webrtc.html
@@ -5337,7 +5337,7 @@ interface RTCPeerConnection : EventTarget  {
                         <p>
                           For each non-stopped
                           {{RTCRtpTransceiverDirection/"sendrecv"}} transceiver
-                          of [= transceiver kind =] <var>kind</var>, set
+                          of {{RTCRtpTransceiver/transceiver kind}} <var>kind</var>, set
                           <var>transceiver</var>.{{RTCRtpTransceiver/[[Direction]]}} to
                           {{RTCRtpTransceiverDirection/"sendonly"}}.
                         </p>
@@ -5347,7 +5347,7 @@ interface RTCPeerConnection : EventTarget  {
                         <p>
                           For each non-stopped
                           {{RTCRtpTransceiverDirection/"recvonly"}} transceiver
-                          of [= transceiver kind =] <var>kind</var>, set
+                          of {{RTCRtpTransceiver/transceiver kind}} <var>kind</var>, set
                           <var>transceiver</var>.{{RTCRtpTransceiver/[[Direction]]}} to
                           {{RTCRtpTransceiverDirection/"inactive"}}.
                         </p>
@@ -5363,7 +5363,7 @@ interface RTCPeerConnection : EventTarget  {
                       If <var>connection</var> has any non-stopped
                       {{RTCRtpTransceiverDirection/"sendrecv"}} or
                       {{RTCRtpTransceiverDirection/"recvonly"}} transceivers of
-                      [= transceiver kind =] <var>kind</var>, continue with the
+                      {{RTCRtpTransceiver/transceiver kind}} <var>kind</var>, continue with the
                       next option, if any.
                     </p>
                   </li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -5347,7 +5347,7 @@ interface RTCPeerConnection : EventTarget  {
                         <p>
                           For each non-stopped
                           {{RTCRtpTransceiverDirection/"recvonly"}} transceiver
-                          of {{RTCRtpTransceiver/transceiver kind}} <var>kind</var>, set
+                          of [=RTCRtpTransceiver/transceiver kind=] <var>kind</var>, set
                           <var>transceiver</var>.{{RTCRtpTransceiver/[[Direction]]}} to
                           {{RTCRtpTransceiverDirection/"inactive"}}.
                         </p>
@@ -5363,7 +5363,7 @@ interface RTCPeerConnection : EventTarget  {
                       If <var>connection</var> has any non-stopped
                       {{RTCRtpTransceiverDirection/"sendrecv"}} or
                       {{RTCRtpTransceiverDirection/"recvonly"}} transceivers of
-                      {{RTCRtpTransceiver/transceiver kind}} <var>kind</var>, continue with the
+                      [=RTCRtpTransceiver/transceiver kind=] <var>kind</var>, continue with the
                       next option, if any.
                     </p>
                   </li>
@@ -7846,7 +7846,7 @@ interface RTCCertificate {
                       </li>
                       <li>
                         <p>
-                          The {{RTCRtpTransceiver/transceiver kind}} of the
+                          The [=RTCRtpTransceiver/transceiver kind=] of the
                           {{RTCRtpTransceiver}}, associated with the sender,
                           matches <var>kind</var>.
                         </p>
@@ -9040,7 +9040,7 @@ interface RTCRtpSender {
                       </li>
                       <li data-tests="RTCRtpParameters-encodings.html">
                         <p>
-                          If {{RTCRtpTransceiver/transceiver kind}} is `"audio"`, remove the
+                          If [=RTCRtpTransceiver/transceiver kind=] is `"audio"`, remove the
                           {{RTCRtpEncodingParameters/scaleResolutionDownBy}} and
                           {{RTCRtpEncodingParameters/maxFramerate}}
                           members from all <var>encodings</var> that
@@ -9049,7 +9049,7 @@ interface RTCRtpSender {
                       </li>
                       <li data-tests="RTCRtpParameters-encodings.html">
                         <p>
-                          If {{RTCRtpTransceiver/transceiver kind}} is `"video"`, then for
+                          If [=RTCRtpTransceiver/transceiver kind=] is `"video"`, then for
                           each encoding in <var>encodings</var> that doesn't
                           [=map/contain=] a
                           {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
@@ -9060,7 +9060,7 @@ interface RTCRtpSender {
                       </li>
                       <li data-tests="RTCRtpParameters-encodings.html">
                         <p>
-                          If {{RTCRtpTransceiver/transceiver kind}} is `"video"`,
+                          If [=RTCRtpTransceiver/transceiver kind=] is `"video"`,
                           and any encoding in <var>encodings</var>
                           [=map/contains=] a
                           {{RTCRtpEncodingParameters/scaleResolutionDownBy}}
@@ -9296,7 +9296,7 @@ async function updateParameters() {
                     <p>
                       If <var>withTrack</var> is non-null and
                       <code><var>withTrack</var>.kind</code> differs from the
-                      {{RTCRtpTransceiver/transceiver kind}} of <var>transceiver</var>, return
+                      [=RTCRtpTransceiver/transceiver kind=] of <var>transceiver</var>, return
                       a promise [= rejected =] with a newly [=
                       exception/created =] {{TypeError}}.
                     </p>
@@ -11223,7 +11223,7 @@ interface RTCRtpTransceiver {
                   </li>
                   <li class="no-test-needed">
                     <p>
-                      Let <var>kind</var> be the <var>transceiver</var>'s {{RTCRtpTransceiver/transceiver kind}}.
+                      Let <var>kind</var> be the <var>transceiver</var>'s [=RTCRtpTransceiver/transceiver kind=].
                     </p>
                   </li>
                   <li data-tests="RTCRtpTransceiver-setCodecPreferences.html">

--- a/webrtc.html
+++ b/webrtc.html
@@ -10634,7 +10634,7 @@ interface RTCRtpReceiver {
           </p>
         </div>
         <p>
-          The <dfn>transceiver kind</dfn> of an {{RTCRtpTransceiver}} is
+          The <dfn class="export" data-dfn-for="RTCRtpTransceiver">transceiver kind</dfn> of an {{RTCRtpTransceiver}} is
           defined by the kind of the associated {{RTCRtpReceiver}}'s
           {{MediaStreamTrack}} object.
         </p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -5337,7 +5337,7 @@ interface RTCPeerConnection : EventTarget  {
                         <p>
                           For each non-stopped
                           {{RTCRtpTransceiverDirection/"sendrecv"}} transceiver
-                          of {{RTCRtpTransceiver/transceiver kind}} <var>kind</var>, set
+                          of [=RTCRtpTransceiver/transceiver kind=] <var>kind</var>, set
                           <var>transceiver</var>.{{RTCRtpTransceiver/[[Direction]]}} to
                           {{RTCRtpTransceiverDirection/"sendonly"}}.
                         </p>


### PR DESCRIPTION
needed for https://github.com/w3c/webrtc-extensions/pull/167
I am surprised stats didn't already use this...


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-pc/pull/2872.html" title="Last updated on Jun 1, 2023, 12:40 PM UTC (64f60c7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2872/b8616bd...fippo:64f60c7.html" title="Last updated on Jun 1, 2023, 12:40 PM UTC (64f60c7)">Diff</a>