### PR TITLE
Make removeTrack() a no-op after transceiver.stop()

### DIFF
--- a/amendments.json
+++ b/amendments.json
@@ -485,5 +485,14 @@
       "status": "candidate",
       "id": 33
     }
+  ],
+  "removetrack-algo": [
+    {
+      "description": "Make removeTrack() a no-op after transceiver.stop()",
+      "pr": 2875,
+      "type": "correction",
+      "status": "candidate",
+      "id": 34
+    }
   ]
 }

--- a/base-rec.html
+++ b/base-rec.html
@@ -8195,7 +8195,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-rtc
                   When the <a data-link-type="idl" href="#dom-rtcpeerconnection-removetrack" class="internalDFN" id="ref-for-dom-rtcpeerconnection-removetrack-4"><code><code>removeTrack</code></code></a> method is invoked, the user agent
                   <em class="rfc2119">MUST</em> run the following steps:
                 </p>
-                <ol>
+                <ol id="removetrack-algo">
                   <li class="no-test-needed">
                     <p>
                       Let <var>sender</var> be the argument to <a data-link-type="idl" href="#dom-rtcpeerconnection-removetrack" class="internalDFN" id="ref-for-dom-rtcpeerconnection-removetrack-5"><code><code>removeTrack</code></code></a>.

--- a/webrtc.html
+++ b/webrtc.html
@@ -8025,7 +8025,7 @@ interface RTCCertificate {
                   When the {{removeTrack}} method is invoked, the user agent
                   MUST run the following steps:
                 </p>
-                <ol class=algorithm>
+                <ol class=algorithm id="removetrack-algo">
                   <li class="no-test-needed">
                     <p>
                       Let <var>sender</var> be the argument to {{removeTrack}}.
@@ -8052,6 +8052,18 @@ interface RTCCertificate {
                       {{InvalidAccessError}}.
                     </p>
                   </li>
+                  <li class="no-test-needed">
+                    <p>
+                      Let <var>transceiver</var> be the {{RTCRtpTransceiver}}
+                      object corresponding to <var>sender</var>.
+                    </p>
+                  </li>
+                  <li data-tests="RTCPeerConnection-removeTrack.https.html">
+                    <p>
+                      If <var>transceiver</var>.{{RTCRtpTransceiver/[[Stopping]]}} is
+                      <code>true</code>, abort these steps.
+                    </p>
+                  </li>
                   <li data-tests="RTCPeerConnection-removeTrack.https.html">
                     <p>
                       Let <var>senders</var> be the result of executing the
@@ -8076,12 +8088,6 @@ interface RTCCertificate {
                   <li data-tests="RTCPeerConnection-removeTrack.https.html">
                     <p>
                       Set <var>sender</var>.{{RTCRtpSender/[[SenderTrack]]}} to null.
-                    </p>
-                  </li>
-                  <li class="no-test-needed">
-                    <p>
-                      Let <var>transceiver</var> be the {{RTCRtpTransceiver}}
-                      object corresponding to <var>sender</var>.
                     </p>
                   </li>
                   <li data-tests="RTCPeerConnection-removeTrack.https.html">


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2874.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2875.html" title="Last updated on May 31, 2023, 9:23 PM UTC (3c32d9a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2875/b8616bd...jan-ivar:3c32d9a.html" title="Last updated on May 31, 2023, 9:23 PM UTC (3c32d9a)">Diff</a>