### PR TITLE
Clarify description of "checking" iceConnectionState

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -12695,7 +12695,7 @@ interface RTCIceTransport : EventTarget {
                   </td>
                   <td>
                     The {{RTCIceTransport}} has received at least one remote
-                    candidate (by means of {{addIceCandidate}} or discovered as a
+                    candidate (by means of addIceCandidate or discovered as a
                     peer-reflexive candidate when receiving a STUN binding
                     request) and is checking candidate pairs and has either
                     not yet found a connection or consent checks [[!RFC7675]]

--- a/webrtc.html
+++ b/webrtc.html
@@ -12695,7 +12695,9 @@ interface RTCIceTransport : EventTarget {
                   </td>
                   <td>
                     The {{RTCIceTransport}} has received at least one remote
-                    candidate and is checking candidate pairs and has either
+                    candidate (by means of {{addIceCandidate}} or discovered as a
+                    peer-reflexive candidate when receiving a STUN binding
+                    request) and is checking candidate pairs and has either
                     not yet found a connection or consent checks [[!RFC7675]]
                     have failed on all previously successful candidate pairs.
                     In addition to checking, it may also still be gathering.

--- a/webrtc.html
+++ b/webrtc.html
@@ -12695,7 +12695,7 @@ interface RTCIceTransport : EventTarget {
                   </td>
                   <td>
                     The {{RTCIceTransport}} has received at least one remote
-                    candidate (by means of addIceCandidate or discovered as a
+                    candidate (by means of {{RTCPeerConnection/addIceCandidate()}} or discovered as a
                     peer-reflexive candidate when receiving a STUN binding
                     request) and is checking candidate pairs and has either
                     not yet found a connection or consent checks [[!RFC7675]]


### PR DESCRIPTION
which can happen without explicitly adding remote candidates via addIceCandidate when candidate pairs are formed after discovering a peer-reflexive candidate upon receiving a valid STUN binding request

Fixes #2878

(editorial I would say, no normative change; will add a WPT)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-pc/pull/2884.html" title="Last updated on Jun 27, 2023, 8:57 AM UTC (df92424)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2884/a9d0e22...fippo:df92424.html" title="Last updated on Jun 27, 2023, 8:57 AM UTC (df92424)">Diff</a>