### PR TITLE
Add empty RTCSetParameterOptions dict as argument to setParameters

### DIFF
--- a/amendments.json
+++ b/amendments.json
@@ -512,9 +512,9 @@
       "id": 35
     }
   ],
-  "rtcencodeoptions": [
+  "setparameter-options": [
     {
-      "description": "Add setParameterOptions as second argument to setParameters for extensibility",
+      "description": "Add empty setParameterOptions as second argument to setParameters for extensibility",
       "pr": 2885,
       "type": "addition",
       "status": "candidate",

--- a/amendments.json
+++ b/amendments.json
@@ -511,5 +511,14 @@
       "status": "candidate",
       "id": 35
     }
+  ],
+  "rtcencodeoptions": [
+    {
+      "description": "Add setParameterOptions as second argument to setParameters for extensibility",
+      "pr": 2885,
+      "type": "addition",
+      "status": "candidate",
+      "id": 36
+    }
   ]
 }

--- a/base-rec.html
+++ b/base-rec.html
@@ -10102,7 +10102,6 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-rtc
             </section>
           </div>
         </section>
-        <div id="rtcencodeoptions"></div>
       </section>
       <section id="rtcrtpreceiver-interface">
         <h3 id="x5-3-rtcrtpreceiver-interface"><bdi class="secno">5.3 </bdi>

--- a/base-rec.html
+++ b/base-rec.html
@@ -10102,6 +10102,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-rtc
             </section>
           </div>
         </section>
+        <div id="rtcencodeoptions"></div>
       </section>
       <section id="rtcrtpreceiver-interface">
         <h3 id="x5-3-rtcrtpreceiver-interface"><bdi class="secno">5.3 </bdi>

--- a/base-rec.html
+++ b/base-rec.html
@@ -10102,6 +10102,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-rtc
             </section>
           </div>
         </section>
+        <div id="setparameter-options"></div>
       </section>
       <section id="rtcrtpreceiver-interface">
         <h3 id="x5-3-rtcrtpreceiver-interface"><bdi class="secno">5.3 </bdi>

--- a/webrtc.html
+++ b/webrtc.html
@@ -9000,8 +9000,7 @@ interface RTCRtpSender {
                 </p>
                 <ol class=algorithm id="setparameters-algo">
                   <li class="no-test-needed">Let <var>parameters</var> be the
-                  method's first argument and let <var>setParameterOptions</var> be the second
-                  argument which is ununsed in this specification and shall be ignored.
+                  method's first argument.
                   </li>
                   <li class="no-test-needed">Let <var>sender</var> be the
                   {{RTCRtpSender}} object on which {{setParameters}} is

--- a/webrtc.html
+++ b/webrtc.html
@@ -8867,7 +8867,7 @@ interface RTCRtpSender {
   readonly attribute RTCDtlsTransport? transport;
   static RTCRtpCapabilities? getCapabilities(DOMString kind);
   Promise&lt;undefined&gt; setParameters(RTCRtpSendParameters parameters,
-      optional sequence&lt;RTCEncodeOptions&gt; encodeOptions = []);
+      optional setParameterOptions = {});
   RTCRtpSendParameters getParameters();
   Promise&lt;undefined&gt; replaceTrack(MediaStreamTrack? withTrack);
   undefined setStreams(MediaStream... streams);
@@ -9000,7 +9000,7 @@ interface RTCRtpSender {
                 </p>
                 <ol class=algorithm id="setparameters-algo">
                   <li class="no-test-needed">Let <var>parameters</var> be the
-                  method's first argument and let <var>encodeOptions</var> be second
+                  method's first argument and let <var>setParameterOptions</var> be second
                   argument which is ununsed in this specification and shall be ignored.
                   </li>
                   <li class="no-test-needed">Let <var>sender</var> be the
@@ -10144,23 +10144,6 @@ async function updateParameters() {
               </dl>
             </section>
           </div>
-        </section>
-        <div id="rtcencodeoptions"><!-- kept for candidate amendments management purposes --></div>
-        <section id="rtcencodeoptions">
-          <h3>
-            <dfn>RTCEncodeOptions</dfn> Dictionary
-          </h3>
-          <div>
-            <pre class="idl">dictionary RTCEncodeOptions {
-};</pre>
-          </div>
-          <section>
-            <h2>Dictionary {{RTCEncodeOptions}} Members</h2>
-            <p>
-              RTCEncodeOptions is the WebRTC equivalent of {{VideoEncoderEncodeOptions}} in [[WebCodecs]].
-              It has no members in this specification but allows for extensibility.
-            </p>
-          </section>
         </section>
       </section>
       <section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -9000,7 +9000,7 @@ interface RTCRtpSender {
                 </p>
                 <ol class=algorithm id="setparameters-algo">
                   <li class="no-test-needed">Let <var>parameters</var> be the
-                  method's first argument and let <var>setParameterOptions</var> be second
+                  method's first argument and let <var>setParameterOptions</var> be the second
                   argument which is ununsed in this specification and shall be ignored.
                   </li>
                   <li class="no-test-needed">Let <var>sender</var> be the

--- a/webrtc.html
+++ b/webrtc.html
@@ -8867,7 +8867,7 @@ interface RTCRtpSender {
   readonly attribute RTCDtlsTransport? transport;
   static RTCRtpCapabilities? getCapabilities(DOMString kind);
   Promise&lt;undefined&gt; setParameters(RTCRtpSendParameters parameters,
-      optional setParameterOptions = {});
+      optional RTCSetParameterOptions setParameterOptions = {});
   RTCRtpSendParameters getParameters();
   Promise&lt;undefined&gt; replaceTrack(MediaStreamTrack? withTrack);
   undefined setStreams(MediaStream... streams);
@@ -10144,6 +10144,22 @@ async function updateParameters() {
               </dl>
             </section>
           </div>
+        </section>
+        <div id="setparameter-options"><!-- kept for candidate amendments management purposes --></div>
+        <section id="setparameter-options">
+          <h3>
+            <dfn>RTCSetParameterOptions</dfn> Dictionary
+          </h3>
+          <div>
+            <pre class="idl">dictionary RTCSetParameterOptions {
+};</pre>
+          </div>
+          <section>
+            <h2>Dictionary {{RTCSetParameterOptions}} Members</h2>
+            <p>
+              RTCSetParameterOptions is defined as an empty dictionary to allow for extensibility.
+            </p>
+          </section>
         </section>
       </section>
       <section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -8866,7 +8866,8 @@ interface RTCRtpSender {
   readonly attribute MediaStreamTrack? track;
   readonly attribute RTCDtlsTransport? transport;
   static RTCRtpCapabilities? getCapabilities(DOMString kind);
-  Promise&lt;undefined&gt; setParameters(RTCRtpSendParameters parameters);
+  Promise&lt;undefined&gt; setParameters(RTCRtpSendParameters parameters,
+      optional sequence&lt;RTCEncodeOptions&gt; encodeOptions = []);
   RTCRtpSendParameters getParameters();
   Promise&lt;undefined&gt; replaceTrack(MediaStreamTrack? withTrack);
   undefined setStreams(MediaStream... streams);
@@ -8998,8 +8999,9 @@ interface RTCRtpSender {
                   MUST run the following steps:
                 </p>
                 <ol class=algorithm id="setparameters-algo">
-                  <li class="no-test-needed">Let <var>parameters</var> be the
-                  method's first argument.
+                  <li id="rtcencodeoptions" class="no-test-needed">Let <var>parameters</var> be the
+                  method's first argument and let <var>encodeOptions</var> be second
+                  argument which is ununsed in this specification and shall be ignored.
                   </li>
                   <li class="no-test-needed">Let <var>sender</var> be the
                   {{RTCRtpSender}} object on which {{setParameters}} is
@@ -10142,6 +10144,23 @@ async function updateParameters() {
               </dl>
             </section>
           </div>
+        </section>
+        <div id="rtcencodeoptions"><!-- kept for candidate amendments management purposes --></div>
+        <section id="rtcencodeoptions">
+          <h3>
+            <dfn>RTCEncodeOptions</dfn> Dictionary
+          </h3>
+          <div>
+            <pre class="idl">dictionary RTCEncodeOptions {
+};</pre>
+          </div>
+          <section>
+            <h2>Dictionary {{RTCEncodeOptions}} Members</h2>
+            <p>
+              RTCEncodeOptions is the WebRTC equivalent of {{VideoEncoderEncodeOptions}} in [[WebCodecs]].
+              It has no members in this specification but allows for extensibility.
+            </p>
+          </section>
         </section>
       </section>
       <section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -8999,7 +8999,7 @@ interface RTCRtpSender {
                   MUST run the following steps:
                 </p>
                 <ol class=algorithm id="setparameters-algo">
-                  <li id="rtcencodeoptions" class="no-test-needed">Let <var>parameters</var> be the
+                  <li class="no-test-needed">Let <var>parameters</var> be the
                   method's first argument and let <var>encodeOptions</var> be second
                   argument which is ununsed in this specification and shall be ignored.
                   </li>


### PR DESCRIPTION
Both are defined as empty in order to allow webrtc-extensions to extend them which is done in
  https://github.com/w3c/webrtc-extensions/pull/167


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-pc/pull/2885.html" title="Last updated on Jul 20, 2023, 2:12 PM UTC (3f4afda)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2885/98a2fc0...fippo:3f4afda.html" title="Last updated on Jul 20, 2023, 2:12 PM UTC (3f4afda)">Diff</a>