### PR TITLE
editorial: fix setParameterOptions usage in table of contents

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -10152,13 +10152,13 @@ async function updateParameters() {
           <div>
             <pre class="idl">dictionary RTCSetParameterOptions {
 };</pre>
+            <section>
+              <h2>Dictionary {{RTCSetParameterOptions}} Members</h2>
+              <p>
+                RTCSetParameterOptions is defined as an empty dictionary to allow for extensibility.
+              </p>
+            </section>
           </div>
-          <section>
-            <h2>Dictionary {{RTCSetParameterOptions}} Members</h2>
-            <p>
-              RTCSetParameterOptions is defined as an empty dictionary to allow for extensibility.
-            </p>
-          </section>
         </section>
       </section>
       <section>


### PR DESCRIPTION
follow-up to #2885, removes this extra table of contents line:
![image](https://github.com/w3c/webrtc-pc/assets/289731/1736433b-c4a2-4e70-b86d-ae6fe9bcfa9b)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-pc/pull/2887.html" title="Last updated on Jul 31, 2023, 9:25 AM UTC (d0d48e6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2887/d8489ee...fippo:d0d48e6.html" title="Last updated on Jul 31, 2023, 9:25 AM UTC (d0d48e6)">Diff</a>