### PR TITLE
Export symbols needed by encoded-transform

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -3700,7 +3700,7 @@ interface RTCPeerConnection : EventTarget  {
                     </li>
                   </ol>
                   <p>
-                    The <dfn class="abstract-op">final steps to create an offer</dfn> given
+                    The <dfn class="abstract-op" class="export">final steps to create an offer</dfn> given
                     <var>connection</var> and a promise <var>p</var> are as
                     follows:
                   </p>
@@ -3996,7 +3996,7 @@ interface RTCPeerConnection : EventTarget  {
                     </li>
                   </ol>
                   <p>
-                    The <dfn class="abstract-op">final steps to create an answer</dfn> given a
+                    The <dfn class="abstract-op" class="export">final steps to create an answer</dfn> given a
                     promise <var>p</var> are as follows:
                   </p>
                   <ol class="algorithm">
@@ -10364,7 +10364,7 @@ interface RTCRtpReceiver {
                   </li>
                 </ol>
                 <p>
-                  The <dfn>list of implemented receive codecs</dfn>, given <var>kind</var>, is an
+                  The <dfn class="export">list of implemented receive codecs</dfn>, given <var>kind</var>, is an
                  [=implementation-defined=] list of
                   {{RTCRtpCodecCapability}} dictionaries representing the most optimistic view of
                   the codecs the user agent supports for receiving media of the given


### PR DESCRIPTION
Partial fix for #2881


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2891.html" title="Last updated on Aug 17, 2023, 12:47 PM UTC (4971cdf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2891/4eef5ab...4971cdf.html" title="Last updated on Aug 17, 2023, 12:47 PM UTC (4971cdf)">Diff</a>