### PR TITLE
Prevent GC of non-closed RTCDataChannels

### DIFF
--- a/amendments.json
+++ b/amendments.json
@@ -520,5 +520,14 @@
       "status": "candidate",
       "id": 36
     }
+  ],
+  "closing-procedure": [
+    {
+      "description": "Prevent GC of non-closed RTCDataChannels",
+      "pr": 2902,
+      "type": "addition",
+      "status": "candidate",
+      "id": 38
+    }
   ]
 }

--- a/amendments.json
+++ b/amendments.json
@@ -525,7 +525,7 @@
     {
       "description": "Prevent GC of non-closed RTCDataChannels",
       "pr": 2902,
-      "type": "addition",
+      "type": "correction",
       "status": "candidate",
       "id": 38
     }

--- a/webrtc.html
+++ b/webrtc.html
@@ -13972,7 +13972,7 @@ interface RTCSctpTransport : EventTarget {
                 {{RTCDataChannelState/"closing"}} and [= fire an event =] named
                 {{RTCDataChannel/closing}} at <var>channel</var>.
               </p>
-             </li>
+            </li>
             <li>
               <p>
                 Run the following steps in parallel:

--- a/webrtc.html
+++ b/webrtc.html
@@ -13953,6 +13953,12 @@ interface RTCSctpTransport : EventTarget {
                 [= underlying data transport =] was closed.
               </p>
             </li>
+            <li class="no-test-needed">
+              <p>
+                Let <var>connection</var> be the {{RTCPeerConnection}} object
+                associated with <var>channel</var>.
+              </p>
+            </li>
             <li>
               <p>
                 Remove <var>channel</var> from <var>connection</var>.{{RTCPeerConnection/[[DataChannels]]}}.

--- a/webrtc.html
+++ b/webrtc.html
@@ -1313,6 +1313,13 @@
               </li>
               <li>
                 <p>
+                  Let <var>connection</var> have a
+                  <dfn data-dfn-for="RTCPeerConnection">[[\DataChannels]]</dfn> internal slot, initialized to
+                  an empty [=ordered set=].
+                </p>
+              </li>
+               <li>
+                <p>
                   Let <var>connection</var> have an <dfn data-dfn-for="RTCPeerConnection">[[\Operations]]</dfn>
                   internal slot, representing an [= operations chain =],
                   initialized to an empty list.
@@ -13328,6 +13335,12 @@ interface RTCTrackEvent : Event {
                   </li>
                   <li>
                     <p>
+                      [=list/Append=] <var>channel</var> to
+                      <var>connection</var>.{{RTCPeerConnection/[[DataChannels]]}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
                       Return <var>channel</var> and continue the following
                       steps in parallel.
                     </p>
@@ -13922,7 +13935,7 @@ interface RTCSctpTransport : EventTarget {
             </li>
           </ol>
         </section>
-        <section>
+        <section id="closing-procedure">
           <h4>
             Closing procedure
           </h4>
@@ -13942,13 +13955,18 @@ interface RTCSctpTransport : EventTarget {
             </li>
             <li>
               <p>
+                Remove <var>channel</var> from <var>connection</var>.{{RTCPeerConnection/[[DataChannels]]}}.
+              </p>
+            </li>
+            <li>
+              <p>
                 Unless the procedure was initiated by
                 <var>channel</var>.{{RTCDataChannel/close}}, set
                 <var>channel</var>.{{RTCDataChannel/[[ReadyState]]}} to
                 {{RTCDataChannelState/"closing"}} and [= fire an event =] named
                 {{RTCDataChannel/closing}} at <var>channel</var>.
               </p>
-            </li>
+             </li>
             <li>
               <p>
                 Run the following steps in parallel:

--- a/webrtc.html
+++ b/webrtc.html
@@ -13907,6 +13907,12 @@ interface RTCSctpTransport : EventTarget {
                 <code>false</code>.
               </p>
             </li>
+            <li>
+              <p>
+                [=list/Append=] <var>channel</var> to
+                <var>connection</var>.{{RTCPeerConnection/[[DataChannels]]}}.
+              </p>
+            </li>
             <li data-tests="RTCPeerConnection-ondatachannel.html">
               <p>
                 Set <var>channel</var>.{{RTCDataChannel/[[ReadyState]]}} to
@@ -13961,7 +13967,7 @@ interface RTCSctpTransport : EventTarget {
             </li>
             <li>
               <p>
-                Remove <var>channel</var> from <var>connection</var>.{{RTCPeerConnection/[[DataChannels]]}}.
+                [=list/Remove=] <var>channel</var> from <var>connection</var>.{{RTCPeerConnection/[[DataChannels]]}}.
               </p>
             </li>
             <li>
@@ -14033,6 +14039,12 @@ interface RTCSctpTransport : EventTarget {
               <p>
                 Set <var>channel</var>.{{RTCDataChannel/[[ReadyState]]}} to
                 {{RTCDataChannelState/"closed"}}.
+              </p>
+            </li>
+            <li>
+              <p>
+                [=list/Remove=] <var>channel</var> from <var>connection</var>.{{RTCPeerConnection/[[DataChannels]]}}
+                if it is still there.
               </p>
             </li>
             <li>


### PR DESCRIPTION
Fixes #2624.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2902.html" title="Last updated on Nov 2, 2023, 3:00 PM UTC (0c99003)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2902/682049e...jan-ivar:0c99003.html" title="Last updated on Nov 2, 2023, 3:00 PM UTC (0c99003)">Diff</a>