### PR TITLE
Fix references to RTCIceCandidate attributes.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6034,10 +6034,10 @@ interface RTCSessionDescription {
           </h4>
           <p>
             This interface describes an ICE candidate, described in [[RFC5245]]
-            Section 2. Other than {{RTCIceCandidateInit/candidate}},
-            {{RTCIceCandidateInit/sdpMid}},
-            {{RTCIceCandidateInit/sdpMLineIndex}}, and
-            {{RTCIceCandidateInit/usernameFragment}}, the remaining attributes
+            Section 2. Other than {{RTCIceCandidate/candidate}},
+            {{RTCIceCandidate/sdpMid}},
+            {{RTCIceCandidate/sdpMLineIndex}}, and
+            {{RTCIceCandidate/usernameFragment}}, the remaining attributes
             are derived from parsing the {{RTCIceCandidateInit/candidate}}
             member in <var>candidateInitDict</var>, if it is well formed.
           </p>


### PR DESCRIPTION
Fixes: #2916.

The containing sentence talks about the derivation of the attributes of RTCIceCandidate, and so it should link to the attibutes of RTCIceCandidate and not to the members of RTCIceCandidateInit.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sam-vi/webrtc-pc/pull/2917.html" title="Last updated on Dec 20, 2023, 3:26 PM UTC (91661ba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2917/f9fe00f...sam-vi:91661ba.html" title="Last updated on Dec 20, 2023, 3:26 PM UTC (91661ba)">Diff</a>