### PR TITLE
Move Simulcast envelope concept to RTCRtpSender.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4126,16 +4126,14 @@ interface RTCPeerConnection : EventTarget  {
                             <p>
                               When a
                               {{RTCPeerConnection/setRemoteDescription(offer)}}
-                              establishes a transceiver's [=proposed envelope=],
-                              the transceiver's
-                              {{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
+                              establishes a sender's [=proposed envelope=],
+                              the sender's {{RTCRtpSender/[[SendEncodings]]}}
                               is updated in
                               {{RTCSignalingState/"have-remote-offer"}}, exposing
                               it to rollback. However, once a
                               [=simulcast envelope=] has been established for
-                              the transceiver, subsequent pruning of the
-                              transceiver's
-                              {{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
+                              the sender, subsequent pruning of the
+                              sender's {{RTCRtpSender/[[SendEncodings]]}}
                               happen when this answer is set with
                               {{RTCPeerConnection/setLocalDescription}}.
                             </p>
@@ -11384,7 +11382,7 @@ interface RTCRtpTransceiver {
             object can be used to inspect and modify the functionality.
           </p>
           <p class="needs-test">
-            An {{RTCRtpTransceiver}}'s <dfn>simulcast envelope</dfn> is
+            An {{RTCRtpSender}}'s <dfn>simulcast envelope</dfn> is
             established in the first successful negotiation that involves it
             sending simulcast instead of unicast, and includes the maximum number of
             simulcast streams that can be sent, as well as the ordering of its
@@ -11396,16 +11394,19 @@ interface RTCRtpTransceiver {
             itself cannot be changed by that method.
           </p>
           <p class="needs-test">
+            One way to configure simulcast is with the
+            {{RTCRtpTransceiverInit/sendEncodings}} option to
+            {{RTCPeerConnection/addTransceiver()}}.
             While the {{RTCPeerConnection/addTrack()}} method lacks the
             {{RTCRtpTransceiverInit/sendEncodings}} argument necessary to
-            configure simulcast, transceivers can be promoted to
+            configure simulcast, senders can be promoted to
             simulcast when the user agent is the answerer. Upon calling the
             {{RTCPeerConnection/setRemoteDescription}} method with a remote
             offer to receive simulcast, a <dfn>proposed envelope</dfn> is
-            configured on a {{RTCRtpTransceiver}} to contain the layers
+            configured on an {{RTCRtpSender}} to contain the layers
             described in the specified session description. As long as this
             description isn't rolled back, the [=proposed envelope=] becomes
-            the {{RTCRtpTransceiver}}'s [=simulcast envelope=] when negotiation
+            the {{RTCRtpSender}}'s [=simulcast envelope=] when negotiation
             completes. As above, this [=simulcast envelope=] may be narrowed
             in subsequent renegotiation, but not reexpanded.
           </p>


### PR DESCRIPTION
Fixes #2921.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2922.html" title="Last updated on Jan 8, 2024, 8:26 PM UTC (10a7fca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2922/78be09a...jan-ivar:10a7fca.html" title="Last updated on Jan 8, 2024, 8:26 PM UTC (10a7fca)">Diff</a>