### PR TITLE
make setCodecPreferences only look at receive codecs

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -11183,7 +11183,7 @@ interface RTCRtpTransceiver {
               <dd>
                 <p>
                   The {{setCodecPreferences}} method overrides the default
-                  codec preferences used by the <a>user agent</a>. When
+                  receive codec preferences used by the <a>user agent</a>. When
                   generating a session description using either
                   {{RTCPeerConnection/createOffer}} or
                   {{RTCPeerConnection/createAnswer}}, the <a>user agent</a>
@@ -11221,8 +11221,6 @@ interface RTCRtpTransceiver {
                 <p>
                   {{setCodecPreferences}} will reject attempts to set <var>codecs</var>
                   [= codec match | not matching =] codecs found in
-                  {{RTCRtpSender}}.{{RTCRtpSender/getCapabilities}}(<var>kind</var>)
-                  or
                   {{RTCRtpReceiver}}.{{RTCRtpReceiver/getCapabilities}}(<var>kind</var>),
                   where <var>kind</var> is the kind of the
                   {{RTCRtpTransceiver}} on which the method is called.
@@ -11278,10 +11276,8 @@ interface RTCRtpTransceiver {
                   <li data-tests="RTCRtpTransceiver-setCodecPreferences.html">
                     <p>
                       If the intersection between <var>codecs</var> and
-                      {{RTCRtpSender}}.{{RTCRtpSender/getCapabilities}}(<var>kind</var>).{{RTCRtpParameters/codecs}}
-                      or the intersection between <var>codecs</var> and
                       {{RTCRtpReceiver}}.{{RTCRtpReceiver/getCapabilities}}(<var>kind</var>).{{RTCRtpParameters/codecs}}
-                      only contains RTX, RED or FEC codecs or is an empty set,
+                      only contains RTX, RED, FEC codecs or Comfort Noise codecs or is an empty set,
                       throw {{InvalidModificationError}}. This ensures that we
                       always have something to offer, regardless of
                       <var>transceiver</var>.{{RTCRtpTransceiver/direction}}.
@@ -11289,9 +11285,7 @@ interface RTCRtpTransceiver {
                   </li>
                   <li class="no-test-needed">
                     <p>
-                      Let <var>codecCapabilities</var> be the union of
-                      {{RTCRtpSender}}.{{RTCRtpSender/getCapabilities}}(<var>kind</var>).{{RTCRtpParameters/codecs}}
-                      and
+                      Let <var>codecCapabilities</var> be
                       {{RTCRtpReceiver}}.{{RTCRtpReceiver/getCapabilities}}(<var>kind</var>).{{RTCRtpParameters/codecs}}.
                     </p>
                   </li>
@@ -11357,7 +11351,7 @@ interface RTCRtpTransceiver {
                 </ol>
 		</div>
                 <p class="note">
-                  If set, the offerer's codec preferences will decide the order
+                  If set, the offerer's receive codec preferences will decide the order
                   of the codecs in the offer. If the answerer does not have any
                   codec preferences then the same order will be used in the
                   answer. However, if the answerer also has codec preferences,


### PR DESCRIPTION
aligning with [JSEP](https://www.rfc-editor.org/rfc/rfc8829.html#name-setcodecpreferences): 
> setCodecPreferences does not directly affect which codec the implementation decides to send. 
> It only affects which codecs the implementation indicates that it prefers to receive

partial fix for #2888