### PR TITLE
Redefine SendCodecs and ReceiveCodecs

### DIFF
--- a/amendments.json
+++ b/amendments.json
@@ -555,7 +555,7 @@
       "status": "candidate",
       "id": 40
     }
-  ]
+  ],
   "create-receiver-algo": [
     {
       "description": "Redefine SendCodecs and ReceiveCodecs",
@@ -564,5 +564,5 @@
       "status": "candidate",
       "id": 41
     }
-  ],
+  ]
 }

--- a/amendments.json
+++ b/amendments.json
@@ -310,6 +310,13 @@
       "type": "correction",
       "status": "candidate",
       "id": 24
+    },
+    {
+      "description": "Redefine SendCodecs and ReceiveCodecs",
+      "pr": 2935,
+      "type": "addition",
+      "status": "candidate",
+      "id": 41
     }
   ],
   "webidl-rtcrtpencodingparameters": [
@@ -549,4 +556,13 @@
       "id": 40
     }
   ]
+  "create-receiver-algo": [
+    {
+      "description": "Redefine SendCodecs and ReceiveCodecs",
+      "pr": 2935,
+      "type": "addition",
+      "status": "candidate",
+      "id": 41
+    }
+  ],
 }

--- a/amendments.json
+++ b/amendments.json
@@ -579,5 +579,14 @@
       ],
       "id": 40
     }
+  ],
+  "create-receiver-algo": [
+    {
+      "description": "Redefine SendCodecs and ReceiveCodecs",
+      "pr": 2935,
+      "type": "addition",
+      "status": "candidate",
+      "id": 41
+    }
   ]
 }

--- a/amendments.json
+++ b/amendments.json
@@ -539,7 +539,7 @@
   ],
   "dom-datachannel-binarytype-desc": [
     {
-      "description": "Fix binaryType setter requriements",
+      "description": "Fix binaryType setter requirements",
       "pr": 2909,
       "type": "correction",
       "status": "candidate",
@@ -563,6 +563,21 @@
       "type": "addition",
       "status": "candidate",
       "id": 41
+    }
+  ],
+  "setcodecpreferences-receive": [
+    {
+      "description": "setCodecPreferences only takes into account receive codecs",
+      "pr": 2926,
+      "type": "correction",
+      "status": "candidate",
+      "tests": [
+	"webrtc/RTCRtpTransceiver-setCodecPreferences.html"
+      ],
+      "testUpdates": [
+        "web-platform-tests/wpt#44318"
+      ],
+      "id": 40
     }
   ]
 }

--- a/base-rec.html
+++ b/base-rec.html
@@ -11033,10 +11033,11 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-rtc
                   </li>
                 </ol>
               </dd>
-              <dt id="setcodecpreferences-receive" data-tests="RTCRtpTransceiver-setCodecPreferences.html" class="has-tests">
+              <dt data-tests="RTCRtpTransceiver-setCodecPreferences.html" class="has-tests">
                 <dfn data-idl="operation" data-export="" data-dfn-type="method" id="dom-rtcrtptransceiver-setcodecpreferences" data-title="setCodecPreferences" data-dfn-for="RTCRtpTransceiver" data-type="undefined" data-lt="setCodecPreferences()|setCodecPreferences(codecs)" data-local-lt="RTCRtpTransceiver.setCodecPreferences|RTCRtpTransceiver.setCodecPreferences()|setCodecPreferences"><code>setCodecPreferences</code></dfn>
               </dt>
               <dd>
+		<div id="setcodecpreferences-receive">
                 <p class="needs-tests">
                   The <a data-link-type="idl" href="#dom-rtcrtptransceiver-setcodecpreferences" class="internalDFN" id="ref-for-dom-rtcrtptransceiver-setcodecpreferences-4"><code><code>setCodecPreferences</code></code></a> method overrides the default
                   codec preferences used by the <a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-agent-9">user agent</a>. When
@@ -11101,6 +11102,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-rtc
                   When <a data-link-type="idl" data-lt="setCodecPreferences()" href="#dom-rtcrtptransceiver-setcodecpreferences" class="internalDFN" id="ref-for-dom-rtcrtptransceiver-setcodecpreferences-6"><code><code>setCodecPreferences</code></code></a><code>()</code> in invoked, the <a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-agent-11">user
                   agent</a> <em class="rfc2119">MUST</em> run the following steps:
                 </p>
+		</div>
                 <ol id="setcodecparameters-algorithm">
                   <li class="no-test-needed">
                     <p>

--- a/base-rec.html
+++ b/base-rec.html
@@ -10116,7 +10116,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-rtc
           To <dfn id="dfn-create-an-rtcrtpreceiver">create an RTCRtpReceiver</dfn> with a string,
           <var>kind</var>, run the following steps:
         </p>
-        <ol>
+        <ol id="create-receiver-algo">
           <li class="no-test-needed">
             <p>
               Let <var>receiver</var> be a new <a data-link-type="idl" href="#dom-rtcrtpreceiver" class="internalDFN" id="ref-for-dom-rtcrtpreceiver-24"><code><code>RTCRtpReceiver</code></code></a> object.

--- a/base-rec.html
+++ b/base-rec.html
@@ -11033,7 +11033,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-rtc
                   </li>
                 </ol>
               </dd>
-              <dt data-tests="RTCRtpTransceiver-setCodecPreferences.html" class="has-tests">
+              <dt id="setcodecpreferences-receive" data-tests="RTCRtpTransceiver-setCodecPreferences.html" class="has-tests">
                 <dfn data-idl="operation" data-export="" data-dfn-type="method" id="dom-rtcrtptransceiver-setcodecpreferences" data-title="setCodecPreferences" data-dfn-for="RTCRtpTransceiver" data-type="undefined" data-lt="setCodecPreferences()|setCodecPreferences(codecs)" data-local-lt="RTCRtpTransceiver.setCodecPreferences|RTCRtpTransceiver.setCodecPreferences()|setCodecPreferences"><code>setCodecPreferences</code></dfn>
               </dt>
               <dd>

--- a/webrtc.html
+++ b/webrtc.html
@@ -10279,7 +10279,7 @@ async function updateParameters() {
           <li>
             <p>
               Let <var>receiver</var> have a <dfn data-dfn-for="RTCRtpReceiver">[[\ReceiveCodecs]]</dfn>
-              internal slot, representing a list of {{RTCRtpCodecParameters}}
+              internal slot, representing a list of tuples, each containing a {{RTCRtpCodecParameters}}
               dictionaries, and initialized to an list containing all the codecs in the
               <a>list of implemented receive codecs</a> for <var>kind</var>, and with the "enabled" flag
               set in an implementation defined manner.

--- a/webrtc.html
+++ b/webrtc.html
@@ -2246,11 +2246,13 @@
                               </li>
                               <li>
                                 <p>
-                                  Set
-                                  <var>transceiver</var>.{{RTCRtpTransceiver/[[Receiver]]}}.{{RTCRtpReceiver/[[ReceiveCodecs]]}}
-                                  to the codecs that <var>description</var>
-                                  negotiates for receiving and which the user
-                                  agent is currently prepared to receive.
+                                  For each of the codecs that <var>description</var> negotiates for receiving:
+                                      <ol>
+                                        <li>Locate the matching codec description in <var>transceiver</var>.{{RTCRtpTransceiver/[[Receiver]]}}.{{RTCRtpReceiver/[[ReceiveCodecs]]}}.</li>
+                                        <li>If the matching codec description is not found, abort these steps.</li>
+                                        <li>Set the "enabled" flag in the matching codec description to "true".</li>
+                                      </ol>
+                                  
                                 </p>
                                 <p class='note'>
                                   If the <var>direction</var> is
@@ -2299,13 +2301,15 @@
                                   </li>
                                   <li>
                                     <p>
-                                      Set
-                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendCodecs]]}}
-                                      to the codecs that <var>description</var>
-                                      negotiates for sending and which the user
-                                      agent is currently capable of sending,
-                                      and set
-                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[LastReturnedParameters]]}}
+                                      For each of the codecs that <var>description</var> negotiates for sending, execute the following steps:
+                                      <ol>
+                                        <li>Locate the matching codec description in <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendCodecs]]}}.</li>
+                                        <li>If the matching codec description is not found, abort these steps.</li>
+                                        <li>Set the "enabled" flag in the matching codec description to "true".</li>
+                                      </ol>
+                                  </li>
+                                  <li>
+                                      Set <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[LastReturnedParameters]]}}
                                       to <code>null</code>.
                                     </p>
                                   </li>
@@ -2573,11 +2577,12 @@
                               </li>
                               <li>
                                 <p>
-                                  Set
-                                  <var>transceiver</var>.{{RTCRtpTransceiver/[[Receiver]]}}.{{RTCRtpReceiver/[[ReceiveCodecs]]}}
-                                  to the codecs that <var>description</var>
-                                  negotiates for receiving and which the user
-                                  agent is currently prepared to receive.
+                                  For each of the codecs that <var>description</var> negotiates for receiving:
+                                      <ol>
+                                        <li>Locate the matching codec description in <var>transceiver</var>.{{RTCRtpTransceiver/[[Receiver]]}}.{{RTCRtpReceiver/[[ReceiveCodecs]]}}.</li>
+                                        <li>If the matching codec description is not found, abort these steps.</li>
+                                        <li>Set the "enabled" flag in the matching codec description to "true".</li>
+                                      </ol>
                                 </p>
                               </li>
                               <li>
@@ -2590,11 +2595,12 @@
                                 <ol>
                                   <li>
                                     <p>
-                                      Set
-                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendCodecs]]}}
-                                      to the codecs that <var>description</var>
-                                      negotiates for sending and which the user
-                                      agent is currently capable of sending.
+                                      For each of the codecs that <var>description</var> negotiates for sending:
+                                      <ol>
+                                        <li>Locate the matching codec description in <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendCodecs]]}}.</li>
+                                        <li>If the matching codec description is not found, abort these steps.</li>
+                                        <li>Set the "enabled" flag in the matching codec description to "true".</li>
+                                      </ol>
                                     </p>
                                   </li>
                                   <li>
@@ -3787,8 +3793,7 @@ interface RTCPeerConnection : EventTarget  {
                                 <var>transceiver</var>.{{RTCRtpTransceiver/direction}}
                                 is {{RTCRtpTransceiverDirection/"sendonly"}}
                                 or {{RTCRtpTransceiverDirection/"sendrecv"}},
-                                exclude any codecs not included in the
-                                [=RTCRtpSender/list of implemented send codecs=] for
+                                include all codecs in the <var>transceiver</var>'s {{RTCRtpTransceiver/[[Sender]]}}'s {{RTCRtpSender/[[SendCodecs]]}} for which the "enabled" flag is "true".
                                 <var>kind</var>.
                               </p>
                             </li>
@@ -3798,9 +3803,7 @@ interface RTCPeerConnection : EventTarget  {
                                 <var>transceiver</var>.{{RTCRtpTransceiver/direction}}
                                 is {{RTCRtpTransceiverDirection/"recvonly"}}
                                 or {{RTCRtpTransceiverDirection/"sendrecv"}},
-                                exclude any codecs not included in the
-                                [=list of implemented receive codecs=] for
-                                <var>kind</var>.
+                                include all codecs in the <var>transceiver</var>'s {{RTCRtpTransceiver/[[Receiver]]}}'s {{RTCRtpReceiver/[[ReceiveCodecs]]}} for which the "enabled" flag is "true".
                               </p>
                             </li>
                           </ol>
@@ -8851,8 +8854,10 @@ interface RTCCertificate {
           <li>
             <p>
               Let <var>sender</var> have a <dfn class="export" data-dfn-for="RTCRtpSender">[[\SendCodecs]]</dfn> internal
-              slot, representing a list of {{RTCRtpCodecParameters}}
-              dictionaries, and initialized to an empty list.
+              slot, representing a list where each element contains an {{RTCRtpCodecParameters}}
+              dictionary and an "enabled" boolean, and initialized to the
+              [=RTCRtpSender/list of implemented send codecs=], with the "enabled" flag
+              set in an implementation defined manner.
             </p>
           </li>
           <li class="no-test-needed">
@@ -9232,8 +9237,9 @@ interface RTCRtpSender {
                       </li>
                       <li data-tests=
                       "RTCRtpParameters-codecs.html,protocol/video-codecs.https.html">
-                      {{RTCRtpParameters/codecs}} is set to the value of the
-                      {{RTCRtpSender/[[SendCodecs]]}} internal slot.
+                      {{RTCRtpParameters/codecs}} is set to the codecs from the
+                      {{RTCRtpSender/[[SendCodecs]]}} internal slot where the
+                      "enabled" flag is true.
                       </li>
                       <li data-tests="RTCRtpParameters-encodings.html">
                       {{RTCRtpParameters/rtcp}}.{{RTCRtcpParameters/cname}} is
@@ -10265,7 +10271,9 @@ async function updateParameters() {
             <p>
               Let <var>receiver</var> have a <dfn data-dfn-for="RTCRtpReceiver">[[\ReceiveCodecs]]</dfn>
               internal slot, representing a list of {{RTCRtpCodecParameters}}
-              dictionaries, and initialized to an empty list.
+              dictionaries, and initialized to an list containing all the codecs in the
+              <a>list of implemented receive codecs</a> for <var>kind</var>, and with the "enabled" flag
+              set in an implementation defined manner.
             </p>
           </li>
           <li>
@@ -10427,6 +10435,7 @@ interface RTCRtpReceiver {
                   <li data-tests="RTCRtpReceiver-getParameters.html">
                     <p>
                       {{RTCRtpParameters/codecs}} is set to the value of the
+                      "enabled" codecs from the
                       {{RTCRtpReceiver/[[ReceiveCodecs]]}} internal slot.
                     </p>
                     <div class="note">

--- a/webrtc.html
+++ b/webrtc.html
@@ -11207,7 +11207,7 @@ interface RTCRtpTransceiver {
               <dd>
                 <p>
                   The {{setCodecPreferences}} method overrides the default
-                  codec preferences used by the <a>user agent</a>. When
+                  receive codec preferences used by the <a>user agent</a>. When
                   generating a session description using either
                   {{RTCPeerConnection/createOffer}} or
                   {{RTCPeerConnection/createAnswer}}, the <a>user agent</a>
@@ -11245,8 +11245,6 @@ interface RTCRtpTransceiver {
                 <p>
                   {{setCodecPreferences}} will reject attempts to set <var>codecs</var>
                   [= codec match | not matching =] codecs found in
-                  {{RTCRtpSender}}.{{RTCRtpSender/getCapabilities}}(<var>kind</var>)
-                  or
                   {{RTCRtpReceiver}}.{{RTCRtpReceiver/getCapabilities}}(<var>kind</var>),
                   where <var>kind</var> is the kind of the
                   {{RTCRtpTransceiver}} on which the method is called.
@@ -11302,10 +11300,8 @@ interface RTCRtpTransceiver {
                   <li data-tests="RTCRtpTransceiver-setCodecPreferences.html">
                     <p>
                       If the intersection between <var>codecs</var> and
-                      {{RTCRtpSender}}.{{RTCRtpSender/getCapabilities}}(<var>kind</var>).{{RTCRtpParameters/codecs}}
-                      or the intersection between <var>codecs</var> and
                       {{RTCRtpReceiver}}.{{RTCRtpReceiver/getCapabilities}}(<var>kind</var>).{{RTCRtpParameters/codecs}}
-                      only contains RTX, RED or FEC codecs or is an empty set,
+                      only contains RTX, RED, FEC codecs or Comfort Noise codecs or is an empty set,
                       throw {{InvalidModificationError}}. This ensures that we
                       always have something to offer, regardless of
                       <var>transceiver</var>.{{RTCRtpTransceiver/direction}}.
@@ -11313,9 +11309,7 @@ interface RTCRtpTransceiver {
                   </li>
                   <li class="no-test-needed">
                     <p>
-                      Let <var>codecCapabilities</var> be the union of
-                      {{RTCRtpSender}}.{{RTCRtpSender/getCapabilities}}(<var>kind</var>).{{RTCRtpParameters/codecs}}
-                      and
+                      Let <var>codecCapabilities</var> be
                       {{RTCRtpReceiver}}.{{RTCRtpReceiver/getCapabilities}}(<var>kind</var>).{{RTCRtpParameters/codecs}}.
                     </p>
                   </li>
@@ -11381,7 +11375,7 @@ interface RTCRtpTransceiver {
                 </ol>
 		</div>
                 <p class="note">
-                  If set, the offerer's codec preferences will decide the order
+                  If set, the offerer's receive codec preferences will decide the order
                   of the codecs in the offer. If the answerer does not have any
                   codec preferences then the same order will be used in the
                   answer. However, if the answerer also has codec preferences,

--- a/webrtc.html
+++ b/webrtc.html
@@ -8973,6 +8973,15 @@ interface RTCRtpSender {
                   dictionaries representing the most optimistic view of the codecs the user
                   agent supports for sending media of the given <var>kind</var> (video or audio).
                 </p>
+                <p class="note">
+                  This conceptual list contains every combination of parameters that
+                  the user agent is capable of processing. In practice, this would
+                  be implemented as a piece of code that parses the parameters and
+                  determines whether they are acceptable or not, but this is highly
+                  codec dependent, so for the purpose of specification, we work with
+                  a conceptual list containing all acceptable parameter combinations.
+                </p>
+
                 <p>
                   The <dfn>list of implemented header extensions for sending</dfn>, given
                   <var>kind</var>, is an [=implementation-defined=] list of
@@ -10386,6 +10395,14 @@ interface RTCRtpReceiver {
                   {{RTCRtpCodecCapability}} dictionaries representing the most optimistic view of
                   the codecs the user agent supports for receiving media of the given
                   <var>kind</var> (video or audio).
+                </p>
+                <p class="note">
+                  This conceptual list contains every combination of parameters that
+                  the user agent is capable of processing. In practice, this would
+                  be implemented as a piece of code that parses the parameters and
+                  determines whether they are acceptable or not, but this is highly
+                  codec dependent, so for the purpose of specification, we work with
+                  a conceptual list containing all acceptable parameter combinations.
                 </p>
                 <p>
                   The <dfn>list of implemented header extensions for receiving</dfn>, given

--- a/webrtc.html
+++ b/webrtc.html
@@ -8854,7 +8854,7 @@ interface RTCCertificate {
           <li>
             <p>
               Let <var>sender</var> have a <dfn class="export" data-dfn-for="RTCRtpSender">[[\SendCodecs]]</dfn> internal
-              slot, representing a list of tuples, each containing an {{RTCRtpCodecParameters}}
+              slot, representing a list of [=tuple=]s, each containing an {{RTCRtpCodecParameters}}
               dictionary and an "enabled" boolean, and initialized to the
               [=RTCRtpSender/list of implemented send codecs=], with the "enabled" flag
               set in an implementation defined manner.
@@ -10279,7 +10279,7 @@ async function updateParameters() {
           <li>
             <p>
               Let <var>receiver</var> have a <dfn data-dfn-for="RTCRtpReceiver">[[\ReceiveCodecs]]</dfn>
-              internal slot, representing a list of tuples, each containing a {{RTCRtpCodecParameters}}
+              internal slot, representing a list of [=tuple=]s, each containing a {{RTCRtpCodecParameters}}
               dictionaries, and initialized to an list containing all the codecs in the
               <a>list of implemented receive codecs</a> for <var>kind</var>, and with the "enabled" flag
               set in an implementation defined manner.

--- a/webrtc.html
+++ b/webrtc.html
@@ -11201,10 +11201,11 @@ interface RTCRtpTransceiver {
                   </li>
                 </ol>
               </dd>
-              <dt id="setcodecpreferences-receive" data-tests="RTCRtpTransceiver-setCodecPreferences.html">
+              <dt data-tests="RTCRtpTransceiver-setCodecPreferences.html">
                 <dfn data-idl="">setCodecPreferences</dfn>
               </dt>
               <dd>
+		<div id="setcodecpreferences-receive">
                 <p>
                   The {{setCodecPreferences}} method overrides the default
                   receive codec preferences used by the <a>user agent</a>. When
@@ -11332,6 +11333,7 @@ interface RTCRtpTransceiver {
                     </p>
                   </li>
                 </ol>
+		</div>
                 <div  id="setcodecparameters-algorithm">
                 <p>  The <dfn class="export">codec match</dfn> algorithm given two {{RTCRtpCodec}}
                   <var>first</var> and <var>second</var> is as follows:

--- a/webrtc.html
+++ b/webrtc.html
@@ -4244,7 +4244,7 @@ interface RTCPeerConnection : EventTarget  {
                           </p>
                         </li>
                         <li data-tests=
-                        "RTCPeerConnection-setLocalDescription-offer.html">
+                        "RTCPeerConnection-setLocalDescription-offer.html,legacy/munge-dont.html">
                           <p>
                             If <var>type</var> is {{RTCSdpType/"offer"}}, and
                             <var>sdp</var> is not the empty string and not
@@ -4256,7 +4256,7 @@ interface RTCPeerConnection : EventTarget  {
                           </p>
                         </li>
                         <li data-tests=
-                        "RTCPeerConnection-setLocalDescription-answer.html">
+                        "RTCPeerConnection-setLocalDescription-answer.html,legacy/munge-dont.html">
                           <p>
                             If <var>type</var> is {{RTCSdpType/"answer"}} or
                             {{RTCSdpType/"pranswer"}}, and <var>sdp</var> is

--- a/webrtc.html
+++ b/webrtc.html
@@ -11250,17 +11250,6 @@ interface RTCRtpTransceiver {
                   where <var>kind</var> is the kind of the
                   {{RTCRtpTransceiver}} on which the method is called.
                 </p>
-                <p class="note">
-                  Due to a recommendation in [[!SDP]], calls to
-                  {{RTCPeerConnection/createAnswer}} SHOULD use only the common
-                  subset of the codec preferences and the codecs that appear in
-                  the offer. For example, if codec preferences are "C, B, A",
-                  but only codecs "A, B" were offered, the answer should only
-                  contain codecs "B, A". However, <span data-jsep=
-                  "initial-answers">[[!RFC8829]]</span> allows adding codecs that
-                  were not in the offer, so implementations can behave
-                  differently.
-                </p>
                 <p>
                   When {{setCodecPreferences()}} is invoked, the <a>user
                   agent</a> MUST run the following steps:

--- a/webrtc.html
+++ b/webrtc.html
@@ -8854,7 +8854,7 @@ interface RTCCertificate {
           <li>
             <p>
               Let <var>sender</var> have a <dfn class="export" data-dfn-for="RTCRtpSender">[[\SendCodecs]]</dfn> internal
-              slot, representing a list where each element contains an {{RTCRtpCodecParameters}}
+              slot, representing a list of tuples, each containing an {{RTCRtpCodecParameters}}
               dictionary and an "enabled" boolean, and initialized to the
               [=RTCRtpSender/list of implemented send codecs=], with the "enabled" flag
               set in an implementation defined manner.

--- a/webrtc.html
+++ b/webrtc.html
@@ -10197,7 +10197,7 @@ async function updateParameters() {
           To <dfn class="abstract-op">create an RTCRtpReceiver</dfn> with a string,
           <var>kind</var>, run the following steps:
         </p>
-        <ol class=algorithm>
+        <ol class=algorithm id="create-receiver-algo">
           <li class="no-test-needed">
             <p>
               Let <var>receiver</var> be a new {{RTCRtpReceiver}} object.

--- a/webrtc.html
+++ b/webrtc.html
@@ -11201,7 +11201,7 @@ interface RTCRtpTransceiver {
                   </li>
                 </ol>
               </dd>
-              <dt data-tests="RTCRtpTransceiver-setCodecPreferences.html">
+              <dt id="setcodecpreferences-receive" data-tests="RTCRtpTransceiver-setCodecPreferences.html">
                 <dfn data-idl="">setCodecPreferences</dfn>
               </dt>
               <dd>

--- a/webrtc.html
+++ b/webrtc.html
@@ -2246,7 +2246,7 @@
                               </li>
                               <li>
                                 <p>
-                                  For each of the codecs that <var>description</var> negotiates for receiving:
+                                  For each of the codecs that <var>description</var> negotiates for receiving, execute the following steps:
                                       <ol>
                                         <li>Locate the matching codec description in <var>transceiver</var>.{{RTCRtpTransceiver/[[Receiver]]}}.{{RTCRtpReceiver/[[ReceiveCodecs]]}}.</li>
                                         <li>If the matching codec description is not found, abort these steps.</li>
@@ -2577,7 +2577,7 @@
                               </li>
                               <li>
                                 <p>
-                                  For each of the codecs that <var>description</var> negotiates for receiving:
+                                  For each of the codecs that <var>description</var> negotiates for receiving, execute the following steps:
                                       <ol>
                                         <li>Locate the matching codec description in <var>transceiver</var>.{{RTCRtpTransceiver/[[Receiver]]}}.{{RTCRtpReceiver/[[ReceiveCodecs]]}}.</li>
                                         <li>If the matching codec description is not found, abort these steps.</li>
@@ -2595,7 +2595,7 @@
                                 <ol>
                                   <li>
                                     <p>
-                                      For each of the codecs that <var>description</var> negotiates for sending:
+                                      For each of the codecs that <var>description</var> negotiates for sending, execute the following steps:
                                       <ol>
                                         <li>Locate the matching codec description in <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendCodecs]]}}.</li>
                                         <li>If the matching codec description is not found, abort these steps.</li>


### PR DESCRIPTION
to contain all supported codecs, revealing only those that are "enabled" at any given time.

Fixes: #2925


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2935.html" title="Last updated on Feb 23, 2024, 2:15 PM UTC (c2d1b55)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2935/3d6e620...c2d1b55.html" title="Last updated on Feb 23, 2024, 2:15 PM UTC (c2d1b55)">Diff</a>