### PR TITLE
remove setCodecPreferences note already covered by JSEP

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -11224,17 +11224,6 @@ interface RTCRtpTransceiver {
                   where <var>kind</var> is the kind of the
                   {{RTCRtpTransceiver}} on which the method is called.
                 </p>
-                <p class="note">
-                  Due to a recommendation in [[!SDP]], calls to
-                  {{RTCPeerConnection/createAnswer}} SHOULD use only the common
-                  subset of the codec preferences and the codecs that appear in
-                  the offer. For example, if codec preferences are "C, B, A",
-                  but only codecs "A, B" were offered, the answer should only
-                  contain codecs "B, A". However, <span data-jsep=
-                  "initial-answers">[[!RFC8829]]</span> allows adding codecs that
-                  were not in the offer, so implementations can behave
-                  differently.
-                </p>
                 <p>
                   When {{setCodecPreferences()}} is invoked, the <a>user
                   agent</a> MUST run the following steps:


### PR DESCRIPTION
fixes #2933

I'd classify this as editorial


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-pc/pull/2941.html" title="Last updated on Feb 20, 2024, 7:13 PM UTC (5ede816)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2941/92bc258...fippo:5ede816.html" title="Last updated on Feb 20, 2024, 7:13 PM UTC (5ede816)">Diff</a>