### PR TITLE
Clarify when RTCIceCandidate's relayProtocol and url members are null.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -6366,24 +6366,21 @@ interface RTCIceCandidate {
                 </dd>
                 <dt class="add-to-usernameFragment-desc">
                   <dfn>relayProtocol</dfn> of type <span class=
-                  "idlMemberType">RTCIceServerTransportProtocol</span>
+                  "idlMemberType">RTCIceServerTransportProtocol</span>, readonly, nullable
                 </dt>
                 <dd class="add-to-usernameFragment-desc">
-                  <p>
-                    The protocol used by the endpoint to communicate with the TURN server. This
-                    is only present for local relay candidates.
-                  </p>
+                  For local relay candidates this is the protocol used by the endpoint to
+                  communicate with the TURN server. For all other candidates it is `null`.
                 </dd>
                 <dt class="add-to-usernameFragment-desc">
                   <dfn>url</dfn> of type <span class=
-                  "idlMemberType">DOMString</span>
+                  "idlMemberType">DOMString</span>, readonly, nullable
                 </dt>
                 <dd class="add-to-usernameFragment-desc">
-                  <p>
-                    For local candidates of type {{RTCIceCandidateType/"srflx"}} or type
-                    {{RTCIceCandidateType/"relay"}} this is the URL of the ICE server
-                    from which the candidate was obtained.
-                  </p>
+                  For local candidates of type {{RTCIceCandidateType/"srflx"}} or type
+                  {{RTCIceCandidateType/"relay"}} this is the URL of the ICE server
+                  from which the candidate was obtained. For all other candidates it is
+                  `null`.
                 </dd>
               </dl>
             </section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -6369,8 +6369,9 @@ interface RTCIceCandidate {
                   "idlMemberType">RTCIceServerTransportProtocol</span>, readonly, nullable
                 </dt>
                 <dd class="add-to-usernameFragment-desc">
-                  For local relay candidates this is the protocol used by the endpoint to
-                  communicate with the TURN server. For all other candidates it is `null`.
+                  For local candidates of type {{RTCIceCandidateType/"relay"}} this is the
+                  protocol used by the endpoint to communicate with the TURN server. For
+                  all other candidates it is `null`.
                 </dd>
                 <dt class="add-to-usernameFragment-desc">
                   <dfn>url</dfn> of type <span class=


### PR DESCRIPTION
Fixes #2947.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2948.html" title="Last updated on Mar 19, 2024, 10:03 PM UTC (8ea7c8b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2948/a913714...jan-ivar:8ea7c8b.html" title="Last updated on Mar 19, 2024, 10:03 PM UTC (8ea7c8b)">Diff</a>