### PR TITLE
Make RTCIceCandidatePair members required

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -12559,8 +12559,8 @@ interface RTCIceTransport : EventTarget {
           </h3>
           <div>
             <pre class="idl">dictionary RTCIceCandidatePair {
-  RTCIceCandidate local;
-  RTCIceCandidate remote;
+  required RTCIceCandidate local;
+  required RTCIceCandidate remote;
 };</pre>
             <section>
               <h2>


### PR DESCRIPTION
In webrtc-pc this dictionary is only used as a return type of getSelectedCandidatePair(), which will include both local and remote. This is not a problem.

In https://w3c.github.io/webrtc-extensions/#rtcicetransport the dictionary is used as a non-optional argument, and Web IDL requires that dictionary arguments are optional if there are no required members. Fix this by making them required.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/webrtc-pc/pull/2951.html" title="Last updated on Mar 27, 2024, 11:15 AM UTC (8ca8cd0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2951/252ff88...foolip:8ca8cd0.html" title="Last updated on Mar 27, 2024, 11:15 AM UTC (8ca8cd0)">Diff</a>