### PR TITLE
Convert RTCIceCandidatePair dictionary to an interface

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -12670,35 +12670,56 @@ interface RTCIceTransport : EventTarget {
         </section>
         <section id="rtcicecandidatepair">
           <h3>
-            <dfn>RTCIceCandidatePair</dfn> Dictionary
+            <dfn>RTCIceCandidatePair</dfn> Interface
           </h3>
+          <p>
+            This interface represents an ICE candidate pair, described in Section 4 in [[RFC8445]]. An {{RTCIceCandidatePair}} is a pairing of a local and a remote {{RTCIceCandidate}}.
+          </p>
+          <p>
+            To <dfn class="abstract-op">create an RTCIceCandidatePair</dfn> with {{RTCIceCandidate}} objects, |local:RTCIceCandidate| and |remote:RTCIceCandidate|, run the following steps:
+          </p>
+          <ol class="algorithm">
+            <li>
+              Let |candidatePair:RTCIceCandidatePair| be a newly created {{RTCIceCandidatePair}} object.
+            </li>
+            <li>
+              Let |candidatePair| have a <dfn data-dfn-for="RTCIceCandidatePair">[[\Local]]</dfn> internal slot, initialized to |local|.
+            </li>
+            <li>
+              Let |candidatePair| have a <dfn data-dfn-for="RTCIceCandidatePair">[[\Remote]]</dfn> internal slot, initialized to |remote|.
+            </li>
+            <li>
+              Return |candidatePair|.
+            </li>
+          </ol>
           <div>
-            <pre class="idl">dictionary RTCIceCandidatePair {
-  required RTCIceCandidate local;
-  required RTCIceCandidate remote;
+            <pre class="idl">[Exposed=Window]
+interface RTCIceCandidatePair {
+  [SameObject] readonly attribute RTCIceCandidate local;
+  [SameObject] readonly attribute RTCIceCandidate remote;
 };</pre>
             <section>
               <h2>
-                Dictionary {{RTCIceCandidatePair}} Members
+                Attributes
               </h2>
               <dl data-link-for="RTCIceCandidatePair" data-dfn-for=
-              "RTCIceCandidatePair" class="dictionary-members">
+              "RTCIceCandidatePair" class="attributes">
                 <dt>
                   <dfn data-idl="">local</dfn> of type <span class=
-                  "idlMemberType">{{RTCIceCandidate}}</span>
+                  "idlAttrType">{{RTCIceCandidate}}</span>, readonly
                 </dt>
                 <dd>
                   <p>
-                    The local ICE candidate.
+                    The {{local}} attribute MUST, on getting, return the value of the {{RTCIceCandidatePair/[[Local]]}} internal slot.
                   </p>
                 </dd>
                 <dt>
                   <dfn data-idl="">remote</dfn> of type <span class=
-                  "idlMemberType">{{RTCIceCandidate}}</span>
+                  "idlAttrType">{{RTCIceCandidate}}</span>, readonly
                 </dt>
                 <dd>
                   <p>
-                    The remote ICE candidate.
+                    The {{remote}} attribute MUST, on getting, return the value of the {{RTCIceCandidatePair/[[Remote]]}} internal slot.
                   </p>
                 </dd>
               </dl>

--- a/webrtc.html
+++ b/webrtc.html
@@ -12344,9 +12344,7 @@ interface RTCDtlsTransport : EventTarget {
             <ol>
               <li>
                 <p>
-                  Let <var>newCandidatePair</var> be a newly created
-                  {{RTCIceCandidatePair}} representing the indicated pair if
-                  one is selected, and <code>null</code> otherwise.
+                  Let <var>newCandidatePair</var> be the result of [= creating an RTCIceCandidatePair =] with |local:RTCIceCandidate| and |remote:RTCIceCandidate|, representing the local and remote candidates of the indicated pair if one is selected, and <code>null</code> otherwise.
                 </p>
               </li>
               <li data-tests="RTCIceTransport.html">
@@ -12676,7 +12674,7 @@ interface RTCIceTransport : EventTarget {
             This interface represents an ICE candidate pair, described in Section 4 in [[RFC8445]]. An {{RTCIceCandidatePair}} is a pairing of a local and a remote {{RTCIceCandidate}}.
           </p>
           <p>
-            To <dfn class="abstract-op">create an RTCIceCandidatePair</dfn> with {{RTCIceCandidate}} objects, |local:RTCIceCandidate| and |remote:RTCIceCandidate|, run the following steps:
+            To <dfn class="abstract-op" data-lt="creating an RTCIceCandidatePair">create an RTCIceCandidatePair</dfn> with {{RTCIceCandidate}} objects, |local:RTCIceCandidate| and |remote:RTCIceCandidate|, run the following steps:
           </p>
           <ol class="algorithm">
             <li>


### PR DESCRIPTION
Addresses: #2930.

Change the `RTCIceCandidatePair` dictionary to an interface and change the required dictionary members to readonly attributes backed by internal slots.

No constructor is described in the IDL to prevent an application from constructing arbitrary pairs. Only the user agent can construct valid `RTCIceCandidatePair` in response to the ICE agent forming candidate pairs, and to represent the selected candidate pair.