### PR TITLE
Avoid setCodecPreferences confusion over which duplicates are removed

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -11330,8 +11330,8 @@ interface RTCRtpTransceiver {
                   <li>
                     <p>
                       Remove any [= codec dictionary match | duplicate =] values in
-                      <var>codecs</var>. Start at the back of the list such
-                      that the order of the codecs is maintained.
+                      <var>codecs</var>, ensuring that the first occurrence of each
+                      value remains in place.
                     </p>
                   </li>
                   <li class="no-test-needed">


### PR DESCRIPTION
The best direction of walking can depend on whether filtering is applied to the original or during a move.