### PR TITLE
Replace references to RFC8829 with RFC9429

### DIFF
--- a/amendments.json
+++ b/amendments.json
@@ -895,5 +895,15 @@
         "web-platform-tests/wpt#45427"
       ]
     }
+  ],
+  "normative-references": [
+    {
+      "description": "Replace RFC8829 reference with RFC9429",
+      "type": "correction",
+      "status": "candidate",
+      "pr": 2966,
+      "id": 46,
+      "testUpdates": "already-tested"
+    }
   ]
 }

--- a/webrtc.html
+++ b/webrtc.html
@@ -342,7 +342,7 @@
                   <p>
                     Size of the prefetched ICE pool as defined in
                     <span data-jsep=
-                    "ice-candidate-pool pc-constructor">[[!RFC8829]]</span>.
+                    "ice-candidate-pool pc-constructor">[[!RFC9429]]</span>.
                   </p>
                 </dd>
               </dl>
@@ -427,10 +427,10 @@
             <dfn>RTCIceTransportPolicy</dfn> Enum
           </h4>
           <p>
-            As described in <span data-jsep="pc-constructor">[[!RFC8829]]</span>, if
+            As described in <span data-jsep="pc-constructor">[[!RFC9429]]</span>, if
             the {{RTCConfiguration/iceTransportPolicy}} member of the
             {{RTCConfiguration}} is specified, it defines the <span data-jsep=
-            "ice-candidate-policy">ICE candidate policy [[!RFC8829]]</span> the
+            "ice-candidate-policy">ICE candidate policy [[!RFC9429]]</span> the
             browser uses to surface the permitted candidates to the
             application; only these candidates will be used for connectivity
             checks.
@@ -494,7 +494,7 @@
             <dfn>RTCBundlePolicy</dfn> Enum
           </h4>
           <p>
-            As described in <span data-jsep="pc-constructor">[[!RFC8829]]</span>,
+            As described in <span data-jsep="pc-constructor">[[!RFC9429]]</span>,
             bundle policy affects which media tracks are negotiated if the
             remote endpoint is not bundle-aware, and what ICE candidates are
             gathered. If the remote endpoint is bundle-aware, all media tracks
@@ -558,7 +558,7 @@
             <dfn>RTCRtcpMuxPolicy</dfn> Enum
           </h4>
           <p>
-            As described in <span data-jsep="pc-constructor">[[!RFC8829]]</span>, the
+            As described in <span data-jsep="pc-constructor">[[!RFC9429]]</span>, the
             {{RTCRtcpMuxPolicy}} affects what ICE candidates are gathered to
             support non-multiplexed RTCP. The only value defined in this spec
             is {{RTCRtcpMuxPolicy/"require"}}.
@@ -1122,9 +1122,9 @@
           RTCPeerConnection Interface
         </h3>
         <p>
-          The [[!RFC8829]] specification, as a whole, describes the details of how
+          The [[!RFC9429]] specification, as a whole, describes the details of how
           the {{RTCPeerConnection}} operates. References to specific
-          subsections of [[!RFC8829]] are provided as appropriate.
+          subsections of [[!RFC9429]] are provided as appropriate.
         </p>
         <section id="operation">
           <h4>
@@ -1157,7 +1157,7 @@
             Agent =], namely {{addIceCandidate}}, {{setConfiguration}},
             {{setLocalDescription}}, {{setRemoteDescription}} and {{close}}.
             These interactions are described in the relevant sections in this
-            document and in [[!RFC8829]]. The [= ICE Agent =] also provides
+            document and in [[!RFC9429]]. The [= ICE Agent =] also provides
             indications to the user agent when the state of its internal
             representation of an {{RTCIceTransport}} changes, as described in
             <a href="#rtcicetransport"></a>.
@@ -1669,7 +1669,7 @@
                 <p data-tests="">
                   In parallel, start the process to apply
                   <var>description</var> as described in <span data-jsep=
-                  "processing-a-local-desc processing-a-remote-desc">[[!RFC8829]]</span>,
+                  "processing-a-local-desc processing-a-remote-desc">[[!RFC9429]]</span>,
                   with these additional restrictions:
                 </p>
                 <ol>
@@ -1684,7 +1684,7 @@
                   <li class="add-to-apply-description-restrictions">
                     <p>If <var>remote</var> is <code>false</code> and this
                     triggers the ICE candidate gathering process in <span data-jsep=
-                     "applying-a-local-desc">[[!RFC8829]]</span>, the [= ICE Agent =]
+                     "applying-a-local-desc">[[!RFC9429]]</span>, the [= ICE Agent =]
                     MUST NOT gather candidates that would be
                     [= administratively prohibited =].
                     </p>
@@ -1692,7 +1692,7 @@
                   <li class="add-to-apply-description-restrictions">
                     <p>If <var>remote</var> is <code>true</code> and this
                     triggers ICE connectivity checks in <span data-jsep=
-                     "applying-a-remote-desc">[[!RFC8829]]</span>, the
+                     "applying-a-remote-desc">[[!RFC9429]]</span>, the
                     [= ICE Agent =] MUST NOT attempt to connect to candidates
                     that are [= administratively prohibited =].
                     </p>
@@ -1728,7 +1728,7 @@
                           <var>connection</var>.{{RTCPeerConnection/[[SignalingState]]}}
                           as described in
                           <span data-jsep="processing-a-local-desc processing-a-remote-desc">
-                          [[!RFC8829]]</span>, then [= reject =] <var>p</var> with
+                          [[!RFC9429]]</span>, then [= reject =] <var>p</var> with
                           a newly [= exception/created =] {{InvalidStateError}}
                           and abort these steps.
                         </p>
@@ -2362,7 +2362,7 @@
                               <li>
                                 <p>
                                   As described by <span data-jsep=
-                                  "applying-a-remote-desc">[[!RFC8829]]</span>,
+                                  "applying-a-remote-desc">[[!RFC9429]]</span>,
                                   attempt to find an existing
                                   {{RTCRtpTransceiver}} object,
                                   <var>transceiver</var>, to represent the [=
@@ -3099,7 +3099,7 @@
                   value of
                   <var>configuration</var>.{{RTCConfiguration/iceTransportPolicy}}.
                   As defined in <span data-jsep=
-                  "setconfiguration">[[!RFC8829]]</span>, if the new [= ICE
+                  "setconfiguration">[[!RFC9429]]</span>, if the new [= ICE
                   transports setting =] changes the existing setting, no action
                   will be taken until the next gathering phase. If a script
                   wants this to happen immediately, it should do an ICE
@@ -3110,14 +3110,14 @@
                 <p>
                   Set the [= ICE Agent =]'s prefetched <dfn>ICE candidate pool
                   size</dfn> as defined in <span data-jsep=
-                  "ice-candidate-pool pc-constructor">[[!RFC8829]]</span> to the
+                  "ice-candidate-pool pc-constructor">[[!RFC9429]]</span> to the
                   value of
                   <var>configuration</var>.{{RTCConfiguration/iceCandidatePoolSize}}.
                   If the new [= ICE candidate pool size =] changes the existing
                   setting, this may result in immediate gathering of new pooled
                   candidates, or discarding of existing pooled candidates, as
                   defined in <span data-jsep=
-                  "setconfiguration">[[!RFC8829]]</span>.
+                  "setconfiguration">[[!RFC9429]]</span>.
                 </p>
               </li>
               <li>
@@ -3128,7 +3128,7 @@
                 </p>
                 <p>
                   As defined in <span data-jsep=
-                  "setconfiguration">[[!RFC8829]]</span>, if a new list of servers
+                  "setconfiguration">[[!RFC9429]]</span>, if a new list of servers
                   replaces the [= ICE Agent =]'s existing [= ICE servers list=], no
                   action will be taken until the next gathering phase. If a
                   script wants this to happen immediately, it should do an ICE
@@ -3417,7 +3417,7 @@ interface RTCPeerConnection : EventTarget  {
                     the remote peer is able to accept trickled ICE candidates
                     [[RFC8838]]. The value is determined based on whether a
                     remote description indicates support for trickle ICE, as
-                    defined in <span data-jsep="cantrickle">[[!RFC8829]]</span>.
+                    defined in <span data-jsep="cantrickle">[[!RFC9429]]</span>.
                     Prior to the completion of
                     {{RTCPeerConnection/setRemoteDescription}}, this value is
                     <code>null</code>.
@@ -3520,10 +3520,10 @@ interface RTCPeerConnection : EventTarget  {
                   <p data-tests=
                   "RTCRtpTransceiver-stop.html,protocol/jsep-initial-offer.https.html">
                     Creating the SDP MUST follow the appropriate process for
-                    generating an offer described in [[!RFC8829]], except the user
+                    generating an offer described in [[!RFC9429]], except the user
                     agent MUST treat a {{RTCRtpTransceiver/stopping}}
                     transceiver as {{RTCRtpTransceiver/stopped}} for the
-                    purposes of RFC8829 in this case.
+                    purposes of RFC9429 in this case.
                   </p>
                   <p>
                     As an offer, the generated SDP will contain the full set of
@@ -3642,7 +3642,7 @@ interface RTCPeerConnection : EventTarget  {
                         Inspect the <dfn>offerer's system state</dfn> to
                         determine the currently available resources as
                         necessary for generating the offer, as described in
-                        <span data-jsep="createoffer">[[!RFC8829]]</span>.
+                        <span data-jsep="createoffer">[[!RFC9429]]</span>.
                       </p>
                     </li>
                     <li class="untestable">
@@ -3695,7 +3695,7 @@ interface RTCPeerConnection : EventTarget  {
                         inspection, the current state of <var>connection</var>
                         and its {{RTCRtpTransceiver}}s, generate an SDP offer,
                         <var>sdpString</var>, as described in <span data-jsep=
-                        "create-offer">[[!RFC8829]]</span>.
+                        "create-offer">[[!RFC9429]]</span>.
                       </p>
                       <ol>
                         <li data-tests="RTCRtpSender-transport.https.html">
@@ -3832,7 +3832,7 @@ interface RTCPeerConnection : EventTarget  {
                     corresponding offer, specifies how the media plane should
                     be established. The generation of the SDP MUST follow the
                     appropriate process for generating an answer described in
-                    [[!RFC8829]].
+                    [[!RFC9429]].
                   </p>
                   <p>
                     The generated SDP will also contain the [= ICE agent =]'s
@@ -3854,7 +3854,7 @@ interface RTCPeerConnection : EventTarget  {
                   "RTCPeerConnection-setLocalDescription-pranswer.html,RTCPeerConnection-setRemoteDescription-pranswer.html">
                     An answer can be marked as provisional, as described in
                     <span data-jsep=
-                    "use-of-provisional-answer">[[!RFC8829]]</span>, by setting
+                    "use-of-provisional-answer">[[!RFC9429]]</span>, by setting
                     the {{RTCSessionDescriptionInit/type}} to
                     {{RTCSdpType/"pranswer"}}.
                   </p>
@@ -3935,7 +3935,7 @@ interface RTCPeerConnection : EventTarget  {
                         Inspect the <dfn>answerer's system state</dfn> to
                         determine the currently available resources as
                         necessary for generating the answer, as described in
-                        <span data-jsep="createanswer">[[!RFC8829]]</span>.
+                        <span data-jsep="createanswer">[[!RFC9429]]</span>.
                       </p>
                     </li>
                     <li class="untestable">
@@ -3989,7 +3989,7 @@ interface RTCPeerConnection : EventTarget  {
                         <var>connection</var> and its {{RTCRtpTransceiver}}s,
                         generate an SDP answer, <var>sdpString</var>, as
                         described in <span data-jsep=
-                        "generating-an-answer">[[!RFC8829]]</span>.
+                        "generating-an-answer">[[!RFC9429]]</span>.
                       </p>
                       <ol id="create-answer-restrictions">
                         <li>
@@ -4138,7 +4138,7 @@ interface RTCPeerConnection : EventTarget  {
                     Passing in a description is optional. If left out, then
                     {{setLocalDescription}} will implicitly [= create an offer
                     =] or [= create an answer =], as needed. As noted in
-                    <span data-jsep="modifying-sdp">[[!RFC8829]]</span>, if a
+                    <span data-jsep="modifying-sdp">[[!RFC9429]]</span>, if a
                     description with SDP is passed in, that SDP is not allowed
                     to have changed from when it was returned from either
                     {{createOffer}} or {{createAnswer}}.
@@ -4302,7 +4302,7 @@ interface RTCPeerConnection : EventTarget  {
                   <div class="note">
                     <p>
                       As noted in <span data-jsep=
-                      "applying-a-local-desc">[[!RFC8829]]</span>, calling this
+                      "applying-a-local-desc">[[!RFC9429]]</span>, calling this
                       method may trigger the ICE candidate gathering process by
                       the [= ICE Agent =].
                     </p>
@@ -4353,7 +4353,7 @@ interface RTCPeerConnection : EventTarget  {
                             <var>connection</var>.{{RTCPeerConnection/[[SignalingState]]}}
                             as described in
                             <span data-jsep=
-                            "processing-a-local-desc processing-a-remote-desc">[[!RFC8829]]</span>,
+                            "processing-a-local-desc processing-a-remote-desc">[[!RFC9429]]</span>,
                             then run the following sub steps:
                           </p>
                           <ol>
@@ -4517,7 +4517,7 @@ interface RTCPeerConnection : EventTarget  {
                             In parallel, if the candidate is not [=
                             administratively prohibited =], add the ICE
                             candidate <var>candidate</var> as described in
-                            <span data-jsep="addicecandidate">[[!RFC8829]]</span>.
+                            <span data-jsep="addicecandidate">[[!RFC9429]]</span>.
                             Use
                             <var>candidate</var>.{{RTCIceCandidate/usernameFragment}}
                             to identify the ICE [= generation =]; if
@@ -4717,7 +4717,7 @@ interface RTCPeerConnection : EventTarget  {
                     The {{setConfiguration}} method updates the configuration
                     of this {{RTCPeerConnection}} object. This includes
                     changing the configuration of the [= ICE Agent =]. As noted
-                    in <span data-jsep="ice-gather-overview">[[!RFC8829]]</span>,
+                    in <span data-jsep="ice-gather-overview">[[!RFC9429]]</span>,
                     when the ICE configuration changes in a way that requires a
                     new gathering phase, an ICE restart is required.
                   </p>
@@ -5939,7 +5939,7 @@ interface RTCSessionDescription {
                         does not match
                         <var>transceiver</var>.{{RTCRtpTransceiver/[[Direction]]}}
                         intersected with the offered direction (as described in
-                        <span data-jsep="initial-answers">[[!RFC8829]]</span>),
+                        <span data-jsep="initial-answers">[[!RFC9429]]</span>),
                         return <code>true</code>.
                       </p>
                     </li>
@@ -7479,7 +7479,7 @@ interface RTCCertificate {
         detection or bandwidth estimation.
       </p>
       <p>
-        Following the rules in <span data-jsep="imageattr">[[!RFC8829]]</span>,
+        Following the rules in <span data-jsep="imageattr">[[!RFC9429]]</span>,
         the video MAY be downscaled. The
         media MUST NOT be upscaled to create fake data that did not occur in
         the input source, the media MUST NOT be cropped except as needed to
@@ -7799,7 +7799,7 @@ interface RTCCertificate {
                       "sdp">sendrecv</code> or <code class=
                       "sdp">sendonly</code> and add the MSID of the sender's
                       streams, as defined in <span data-jsep=
-                      "subsequent-offers subsequent-answers">[[!RFC8829]]</span>.
+                      "subsequent-offers subsequent-answers">[[!RFC9429]]</span>.
                     </p>
                     <p>
                       If any {{RTCRtpSender}} object in <var>senders</var>
@@ -7968,7 +7968,7 @@ interface RTCCertificate {
                   media description =] for the corresponding transceiver as
                   {{RTCRtpTransceiverDirection/"recvonly"}} or
                   {{RTCRtpTransceiverDirection/"inactive"}}, as defined in
-                  <span data-jsep="subsequent-offers">[[!RFC8829]]</span>.
+                  <span data-jsep="subsequent-offers">[[!RFC9429]]</span>.
                   <!-- onended -->
                 </p>
                 <p>
@@ -8094,7 +8094,7 @@ interface RTCCertificate {
                   Adding a transceiver will cause future calls to
                   {{createOffer}} to add a [= media description =] for the
                   corresponding transceiver, as defined in <span data-jsep=
-                  "subsequent-offers">[[!RFC8829]]</span>.
+                  "subsequent-offers">[[!RFC9429]]</span>.
                 </p>
                 <p data-tests="RTCPeerConnection-addTransceiver.https.html">
                   The initial value of {{RTCRtpTransceiver/mid}} is null.
@@ -8308,11 +8308,11 @@ interface RTCCertificate {
                       If <var>sendEncodings</var> is set, then subsequent calls
                       to {{createOffer}} will be configured to send multiple
                       RTP encodings as defined in <span data-jsep=
-                      "subsequent-offers initial-offers">[[!RFC8829]]</span>. When
+                      "subsequent-offers initial-offers">[[!RFC9429]]</span>. When
                       {{RTCPeerConnection/setRemoteDescription}} is called with
                       a corresponding remote description that is able to
                       receive multiple RTP encodings as defined in
-                      <span data-jsep="simulcast">[[!RFC8829]]</span>, the
+                      <span data-jsep="simulcast">[[!RFC9429]]</span>, the
                       {{RTCRtpSender}} may send multiple RTP encodings and the
                       parameters retrieved via the transceiver's
                       {{RTCRtpTransceiver/sender}}.{{RTCRtpSender/getParameters()}}
@@ -8746,7 +8746,7 @@ interface RTCCertificate {
               sender is to be associated with. The
               {{RTCRtpSender/[[AssociatedMediaStreamIds]]}} slot is used when
               <var>sender</var> is represented in SDP as described in
-              <span data-jsep="initial-offers">[[!RFC8829]]</span>.
+              <span data-jsep="initial-offers">[[!RFC9429]]</span>.
             </p>
           </li>
           <li>
@@ -9667,7 +9667,7 @@ async function updateParameters() {
                   <p>
                     If set, this RTP encoding will be sent with the RID header
                     extension as defined by <span data-jsep=
-                    "initial-offers">[[!RFC8829]]</span>. The RID is not
+                    "initial-offers">[[!RFC9429]]</span>. The RID is not
                     modifiable via {{RTCRtpSender/setParameters}}. It can only
                     be set or modified in {{RTCPeerConnection/addTransceiver}}
                     on the sending side. <a>Read-only parameter</a>.
@@ -9969,7 +9969,7 @@ async function updateParameters() {
                     The "format specific parameters" field from the
                     <code class="sdp">a=fmtp</code> line in the SDP
                     corresponding to the codec, if one exists, as defined by
-                    <span data-jsep="parsing-a-desc">[[!RFC8829]]</span>.
+                    <span data-jsep="parsing-a-desc">[[!RFC9429]]</span>.
                   </p>
                 </dd>
               </dl>
@@ -10746,7 +10746,7 @@ interface RTCRtpReceiver {
           The {{RTCRtpTransceiver}} interface represents a combination of an
           {{RTCRtpSender}} and an {{RTCRtpReceiver}} that share a common [=
           media stream "identification-tag" =]. As defined in <span data-jsep=
-          "rtptransceivers">[[!RFC8829]]</span>, an {{RTCRtpTransceiver}} is said
+          "rtptransceivers">[[!RFC9429]]</span>, an {{RTCRtpTransceiver}} is said
           to be <dfn>associated</dfn> with a [= media description =] if its
           "mid" property is non-null and matches a [= media stream
           "identification-tag" =] in the [= media description =]; otherwise it
@@ -10755,7 +10755,7 @@ interface RTCRtpReceiver {
         <div class="note">
           <p>
             A {{RTCRtpTransceiver}} may become associated with a new pending
-            description in RFC8829 while still being disassociated with the
+            description in RFC9429 while still being disassociated with the
             current description. This may happen in [= check if negotiation is
             needed =].
           </p>
@@ -10841,7 +10841,7 @@ interface RTCRtpReceiver {
               Let <var>transceiver</var> have a <dfn data-dfn-for="RTCRtpTransceiver">[[\JsepMid]]</dfn>
               internal slot, initialized to <code>null</code>. This is the
               "RtpTransceiver mid property" defined in <span data-jsep=
-              "initial-offers initial-answers">[[!RFC8829]]</span>, and is only
+              "initial-offers initial-answers">[[!RFC9429]]</span>, and is only
               modified there.
             </p>
           </li>
@@ -10927,7 +10927,7 @@ interface RTCRtpTransceiver {
               <dd>
                 <p>
                   As defined in <span data-jsep=
-                  "transceiver-direction">[[!RFC8829]]</span>, the
+                  "transceiver-direction">[[!RFC9429]]</span>, the
                   <var>direction</var> attribute indicates the preferred
                   direction of this transceiver, which will be used in calls to
                   {{RTCPeerConnection/createOffer}} and
@@ -10939,7 +10939,7 @@ interface RTCRtpTransceiver {
                   <code class="sdp">sendonly</code>, <code class=
                   "sdp">recvonly</code> or <code class="sdp">inactive</code> as
                   defined in <span data-jsep=
-                  "subsequent-offers subsequent-answers">[[!RFC8829]]</span>
+                  "subsequent-offers subsequent-answers">[[!RFC9429]]</span>
                 </p>
                 <p>
                   On getting, the user agent MUST run the following steps:
@@ -11031,7 +11031,7 @@ interface RTCRtpTransceiver {
               <dd>
                 <p>
                   As defined in <span data-jsep=
-                  "transceiver-current-direction">[[!RFC8829]]</span>, the
+                  "transceiver-current-direction">[[!RFC9429]]</span>, the
                   <var>currentDirection</var> attribute indicates the current
                   direction negotiated for this transceiver. The value of
                   <var>currentDirection</var> is independent of the value of
@@ -11093,9 +11093,9 @@ interface RTCRtpTransceiver {
                   {{RTCPeerConnection/createOffer}} to generate a zero port in
                   the [= media description =] for the corresponding
                   transceiver, as defined in <span data-jsep=
-                  "transceiver-stop">[[!RFC8829]]</span> (The user agent MUST treat a
+                  "transceiver-stop">[[!RFC9429]]</span> (The user agent MUST treat a
                   {{stopping}} transceiver as {{stopped}} for the purposes of
-                  RFC8829 only in this case). However, to avoid problems with
+                  RFC9429 only in this case). However, to avoid problems with
                   [[RFC8843]], a transceiver that is {{stopping}}, but not
                   {{stopped}}, will not affect
                   {{RTCPeerConnection/createAnswer}}.
@@ -11106,7 +11106,7 @@ interface RTCRtpTransceiver {
                   {{RTCPeerConnection/createAnswer}} to generate a zero port in
                   the [= media description =] for the corresponding
                   transceiver, as defined in <span data-jsep=
-                  "transceiver-stop">[[!RFC8829]]</span>.
+                  "transceiver-stop">[[!RFC9429]]</span>.
                 </p>
                 <p>
                   The transceiver will remain in the {{stopping}} state, unless
@@ -11291,7 +11291,7 @@ interface RTCRtpTransceiver {
                   codecs. These payload types are referenced by the m=video or
                   m=audio lines in the order of preference, and codecs that are
                   not negotiated do not appear in this list as defined in
-                  section 5.2.1 of [[!RFC8829]]. A previously negotiated codec
+                  section 5.2.1 of [[!RFC9429]]. A previously negotiated codec
                   that is subsequently removed disappears from the m=video or
                   m=audio line, and while its codec payload type is not to be
                   reused in future offers or answers, its payload type may also
@@ -11499,7 +11499,7 @@ interface RTCRtpTransceiver {
             agent is expected to stop sending some of the simulcast streams.
           </p>
           <p data-tests="simulcast/basic.https.html">
-            As defined in <span data-jsep="simulcast">[[!RFC8829]]</span>, an
+            As defined in <span data-jsep="simulcast">[[!RFC9429]]</span>, an
             offer from a user-agent will only contain a "send" description and
             no "recv" description on the <code class="sdp">a=simulcast</code>
             line. Alternatives and restrictions (described in
@@ -11512,7 +11512,7 @@ interface RTCRtpTransceiver {
             {{RTCPeerConnection/addTransceiver}}. However when
             {{RTCPeerConnection/setRemoteDescription}} is called with a
             corresponding remote description that is able to send multiple RTP
-            encodings as defined in [[!RFC8829]], and the browser supports
+            encodings as defined in [[!RFC9429]], and the browser supports
             receiving multiple RTP encodings, the {{RTCRtpReceiver}} may
             receive multiple RTP encodings and the parameters retrieved via the
             transceiver's


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2966.html" title="Last updated on Apr 23, 2024, 5:54 AM UTC (49c99ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2966/35056c2...49c99ac.html" title="Last updated on Apr 23, 2024, 5:54 AM UTC (49c99ac)">Diff</a>