### PR TITLE
Clarify description.toJSON() returns RTCSessionDescriptionInit

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -5555,7 +5555,7 @@ interface RTCSessionDescription {
   constructor(RTCSessionDescriptionInit descriptionInitDict);
   readonly attribute RTCSdpType type;
   readonly attribute DOMString sdp;
-  [Default] object toJSON();
+  [Default] RTCSessionDescriptionInit toJSON();
 };</pre>
             <section>
               <h2>


### PR DESCRIPTION
For clarity (we do this with [RTCIceCandidate](https://w3c.github.io/webrtc-pc/#rtcicecandidate-interface) already).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2969.html" title="Last updated on May 2, 2024, 5:17 PM UTC (ef54f5a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2969/012e071...jan-ivar:ef54f5a.html" title="Last updated on May 2, 2024, 5:17 PM UTC (ef54f5a)">Diff</a>