### PR TITLE
Separate Send/ReceiveCodecs and NegotiatedCodecs

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1864,9 +1864,9 @@
                           <li>
                             <p>
                               Set
-                              <var>transceiver</var>.{{RTCRtpTransceiver/[[Receiver]]}}.{{RTCRtpReceiver/[[LastStableStateReceiveCodecs]]}}
+                              <var>transceiver</var>.{{RTCRtpTransceiver/[[Receiver]]}}.{{RTCRtpReceiver/[[LastStableStateNegotiatedCodecs]]}}
                               to
-                              <var>transceiver</var>.{{RTCRtpTransceiver/[[Receiver]]}}.{{RTCRtpReceiver/[[ReceiveCodecs]]}}.
+                              <var>transceiver</var>.{{RTCRtpTransceiver/[[Receiver]]}}.{{RTCRtpReceiver/[[NegotiatedCodecs]]}}.
                             </p>
                           </li>
                         </ol>
@@ -2189,11 +2189,15 @@
                               </li>
                               <li>
                                 <p>
-                                  For each of the codecs that <var>description</var> negotiates for receiving, execute the following steps:
+                                  Clear the <var>transceiver</var>.{{RTCRtpTransceiver/[[Receiver]]}}.{{RTCRtpReceiver/[[NegotiatedCodecs]]}} slot.
+                                </p>
+                                <p>
+                                  Then, For each of the codecs that <var>description</var> negotiates for receiving, execute the following steps:
                                       <ol>
                                         <li>Locate the matching codec description in <var>transceiver</var>.{{RTCRtpTransceiver/[[Receiver]]}}.{{RTCRtpReceiver/[[ReceiveCodecs]]}}.</li>
                                         <li>If the matching codec description is not found, abort these steps.</li>
                                         <li>Set the "enabled" flag in the matching codec description to "true".</li>
+                                        <li>Add the codec description to the {{RTCRtpReceiver/[[NegotiatedCodecs]]}} internal slot.</li>
                                       </ol>
                                   
                                 </p>
@@ -2244,11 +2248,15 @@
                                   </li>
                                   <li>
                                     <p>
-                                      For each of the codecs that <var>description</var> negotiates for sending, execute the following steps:
+                                      Clear the <var>transceiver</var>.{{RTCRtpTransceiver/[[Receiver]]}}.{{RTCRtpReceiver/[[NegotiatedCodecs]]}} slot.
+                                    </p>
+                                    <p>
+                                      Then, for each of the codecs that <var>description</var> negotiates for sending, execute the following steps:
                                       <ol>
                                         <li>Locate the matching codec description in <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendCodecs]]}}.</li>
                                         <li>If the matching codec description is not found, abort these steps.</li>
                                         <li>Set the "enabled" flag in the matching codec description to "true".</li>
+                                        <li>Add the codec description to the {{RTCRtpReceiver/[[NegotiatedCodecs]]}} internal slot.</li>
                                       </ol>
                                   </li>
                                   <li>
@@ -2693,9 +2701,9 @@
                               <li>
                                 <p>
                                   Set
-                                  <var>transceiver</var>.{{RTCRtpTransceiver/[[Receiver]]}}.{{RTCRtpReceiver/[[ReceiveCodecs]]}}
+                                  <var>transceiver</var>.{{RTCRtpTransceiver/[[Receiver]]}}.{{RTCRtpReceiver/[[NegotiatedCodecs]]}}
                                   to
-                                  <var>transceiver</var>.{{RTCRtpTransceiver/[[Receiver]]}}.{{RTCRtpReceiver/[[LastStableStateReceiveCodecs]]}}.
+                                  <var>transceiver</var>.{{RTCRtpTransceiver/[[Receiver]]}}.{{RTCRtpReceiver/[[LastStableStateNegotiatedCodecs]]}}.
                                 </p>
                               </li>
                               <li>
@@ -8801,6 +8809,10 @@ interface RTCCertificate {
               set in an implementation defined manner.
             </p>
           </li>
+            <p>
+              Let <var>sender</var> have a <dfn data-dfn-for="RTCRtpSender">[[\NegotiatedCodecs]]</dfn> internal slot, consisting of {{RTCRtpCodecParameters}}, and initialized to an empty list.
+            </p>
+          </li>
           <li class="no-test-needed">
             <p>
               Let <var>sender</var> have a
@@ -9188,8 +9200,7 @@ interface RTCRtpSender {
                       <li data-tests=
                       "RTCRtpParameters-codecs.html,protocol/video-codecs.https.html">
                       {{RTCRtpParameters/codecs}} is set to the codecs from the
-                      {{RTCRtpSender/[[SendCodecs]]}} internal slot where the
-                      "enabled" flag is true.
+                      {{RTCRtpSender/[[NegotiatedCodecs]]}} internal slot.
                       </li>
                       <li data-tests="RTCRtpParameters-encodings.html">
                       {{RTCRtpParameters/rtcp}}.{{RTCRtcpParameters/cname}} is
@@ -10225,11 +10236,14 @@ async function updateParameters() {
               <a>list of implemented receive codecs</a> for <var>kind</var>, and with the "enabled" flag
               set in an implementation defined manner.
             </p>
+            <p>
+              Let <var>receiver</var> have a <dfn data-dfn-for="RTCRtpReceiver">[[\NegotiatedCodecs]]</dfn> internal slot, consisting of {{RTCRtpCodecParameters}}, and initialized to an empty list.
+            </p>
           </li>
           <li id="rtcrtpreceiver-laststablestatereceivecodecs">
             <p>
               Let <var>receiver</var> have a
-              <dfn data-dfn-for="RTCRtpReceiver">[[\LastStableStateReceiveCodecs]]</dfn> internal slot and
+              <dfn data-dfn-for="RTCRtpReceiver">[[\LastStableStateNegotiatedCodecs]]</dfn> internal slot and
               initialize it to an empty list.
             </p>
           </li>
@@ -10507,7 +10521,7 @@ interface RTCRtpReceiver {
                     <p>
                       {{RTCRtpParameters/codecs}} is set to the value of the
                       "enabled" codecs from the
-                      {{RTCRtpReceiver/[[ReceiveCodecs]]}} internal slot.
+                      {{RTCRtpReceiver/[[NegotiatedCodecs]]}} internal slot.
                     </p>
                     <div class="note">
                       Both the local and remote description may affect this


### PR DESCRIPTION
This makes it unambiguous what to return in RTCRtpSender/Receiver's getParameters() function (null before negotiation, filled in after, which corresponds to implementations).

Fixes #2956