### PR TITLE
setCodecPreferences() must use case-insensitive mimeType comparison

### DIFF
--- a/amendments.json
+++ b/amendments.json
@@ -697,7 +697,7 @@
 	"webrtc/RTCRtpTransceiver-setCodecPreferences.html"
       ],
       "testUpdates": [
-	"web-platform-tests/wpt#TBD"
+	"web-platform-tests/wpt#46526"
       ],
       "type": "correction",
       "status": "candidate",

--- a/amendments.json
+++ b/amendments.json
@@ -689,6 +689,20 @@
       "status": "candidate",
       "difftype": "append",
       "id": 31
+    },
+    {
+      "description": "setCodecPreferences() must use case-insensitive mimeType comparison",
+      "pr": 2975,
+      "tests": [
+	"webrtc/RTCRtpTransceiver-setCodecPreferences.html"
+      ],
+      "testUpdates": [
+	"web-platform-tests/wpt#TBD"
+      ],
+      "type": "correction",
+      "status": "candidate",
+      "difftype": "append",
+      "id": 47
     }
   ],
   "replacetrack-reject": [

--- a/webrtc.html
+++ b/webrtc.html
@@ -11382,7 +11382,8 @@ interface RTCRtpTransceiver {
                 <ol class=algorithm>
                   <li>
                     <p>
-                      If <var>first</var>.{{RTCRtpCodec/mimeType}} is different from
+                      If <var>first</var>.{{RTCRtpCodec/mimeType}} is not an
+                      [=ASCII case-insensitive=] match for
                       <var>second</var>.{{RTCRtpCodec/mimeType}}, return <code>false</code>.
                     </p>
                   </li>


### PR DESCRIPTION
Fixes #2971. WPT to be provided in [bug 1898362](https://bugzil.la/1898362).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2975.html" title="Last updated on May 29, 2024, 4:26 PM UTC (086d12f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2975/ff28f21...jan-ivar:086d12f.html" title="Last updated on May 29, 2024, 4:26 PM UTC (086d12f)">Diff</a>