### PR TITLE
Make data channels transferable to DedicatedWorker

### DIFF
--- a/amendments.json
+++ b/amendments.json
@@ -1033,7 +1033,7 @@
       ]
     }
   ],
-  "rtcdatachannel-slots-init": [
+  "rtcdatachannel-istransferable-init-1": [
     {
       "description": "Make RTCDataChannel transferable to DedicatedWorker",
       "pr": 2988,
@@ -1049,7 +1049,7 @@
       ]
     }
   ],
-  "rtcdatachannel-send-1": [
+  "rtcdatachannel-istransferable-init-2": [
     {
       "description": "Make RTCDataChannel transferable to DedicatedWorker",
       "pr": 2988,
@@ -1065,7 +1065,23 @@
       ]
     }
   ],
-  "announcing-a-data-channel-as-closed": [
+  "rtcdatachannel-send-istransferable": [
+    {
+      "description": "Make RTCDataChannel transferable to DedicatedWorker",
+      "pr": 2988,
+      "type": "addition",
+      "status": "candidate",
+      "difftype": "append",
+      "id": 48,
+      "tests": [
+	"webrtc/transfer-datachannel.html"
+      ],
+      "testUpdates": [
+	"web-platform-tests/wpt#47707"
+      ]
+    }
+  ],
+  "transfering-a-data-channel": [
     {
       "description": "Make RTCDataChannel transferable to DedicatedWorker",
       "pr": 2988,

--- a/amendments.json
+++ b/amendments.json
@@ -1017,5 +1017,68 @@
 	"web-platform-tests/wpt#47663"
       ]
     }
+  ],
+  "webidl-rtcdatachannel": [
+    {
+      "description": "Make RTCDataChannel transferable to DedicatedWorker",
+      "pr": 2988,
+      "type": "addition",
+      "status": "candidate",
+      "id": 48,
+      "tests": [
+	"webrtc/transfer-datachannel.html"
+      ],
+      "testUpdates": [
+	"web-platform-tests/wpt#47707"
+      ]
+    }
+  ],
+  "rtcdatachannel-slots-init": [
+    {
+      "description": "Make RTCDataChannel transferable to DedicatedWorker",
+      "pr": 2988,
+      "type": "addition",
+      "status": "candidate",
+      "difftype": "append",
+      "id": 48,
+      "tests": [
+	"webrtc/transfer-datachannel.html"
+      ],
+      "testUpdates": [
+	"web-platform-tests/wpt#47707"
+      ]
+    }
+  ],
+  "rtcdatachannel-send-1": [
+    {
+      "description": "Make RTCDataChannel transferable to DedicatedWorker",
+      "pr": 2988,
+      "type": "addition",
+      "status": "candidate",
+      "difftype": "append",
+      "id": 48,
+      "tests": [
+	"webrtc/transfer-datachannel.html"
+      ],
+      "testUpdates": [
+	"web-platform-tests/wpt#47707"
+      ]
+    }
+  ],
+  "announcing-a-data-channel-as-closed": [
+    {
+      "description": "Make RTCDataChannel transferable to DedicatedWorker",
+      "pr": 2988,
+      "type": "addition",
+      "status": "candidate",
+      "difftype": "append",
+      "id": 48,
+      "tests": [
+	"webrtc/transfer-datachannel.html"
+      ],
+      "testUpdates": [
+	"web-platform-tests/wpt#47707"
+      ]
+    }
   ]
 }

--- a/base-rec.html
+++ b/base-rec.html
@@ -13525,7 +13525,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-rtc
                 internal slot initialized to <code>0</code>.
               </p>
             </li>
-            <li class="no-test-needed">
+            <li class="no-test-needed" id="rtcdatachannel-slots-init">
               <p>
                 Let <var>channel</var> have internal slots named
                 <dfn data-dfn-type="idl" id="dfn-datachannellabel">[[DataChannelLabel]]</dfn>, <dfn data-dfn-type="idl" id="dfn-ordered">[[Ordered]]</dfn>,
@@ -13891,7 +13891,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-rtc
           </ol>
         </section>
         <div>
-          <pre class="idl has-tests def" data-tests="idlharness.https.window.js" id="webidl-1143016005"><span class="idlHeader"><a class="self-link" href="#webidl-1143016005">WebIDL</a></span><span data-idl="" class="idlInterface" id="idl-def-rtcdatachannel" data-title="RTCDataChannel">[<span class="extAttr"><a data-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<a data-type="interface" href="https://html.spec.whatwg.org/multipage/window-object.html#window">Window</a></span>]
+          <pre class="idl has-tests def" data-tests="idlharness.https.window.js" id="webidl-rtcdatachannel"><span class="idlHeader"><a class="self-link" href="#webidl-1143016005">WebIDL</a></span><span data-idl="" class="idlInterface" id="idl-def-rtcdatachannel" data-title="RTCDataChannel">[<span class="extAttr"><a data-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<a data-type="interface" href="https://html.spec.whatwg.org/multipage/window-object.html#window">Window</a></span>]
 interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-rtcdatachannel" id="ref-for-dom-rtcdatachannel-42"><code>RTCDataChannel</code></a> : <span class="idlSuperclass"><a data-type="interface" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a></span> {<span data-idl="" class="idlAttribute" id="idl-def-rtcdatachannel-label" data-title="label" data-dfn-for="RTCDataChannel">
   readonly attribute<span class="idlType"> <a data-type="interface" href="https://heycam.github.io/webidl/#idl-USVString">USVString</a></span> <a class="internalDFN idlName" data-link-type="attribute" href="#dom-datachannel-label" id="ref-for-dom-datachannel-label-1"><code>label</code></a>;</span><span data-idl="" class="idlAttribute" id="idl-def-rtcdatachannel-ordered" data-title="ordered" data-dfn-for="RTCDataChannel">
   readonly attribute<span class="idlType"> <a data-type="interface" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a></span> <a class="internalDFN idlName" data-link-type="attribute" href="#dom-datachannel-ordered" id="ref-for-dom-datachannel-ordered-1"><code>ordered</code></a>;</span><span data-idl="" class="idlAttribute" id="idl-def-rtcdatachannel-maxpacketlifetime" data-title="maxPacketLifeTime" data-dfn-for="RTCDataChannel">
@@ -14231,7 +14231,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-rtc
               steps</dfn>:
             </p>
             <ol>
-              <li class="no-test-needed">
+              <li class="no-test-needed" id="rtcdatachannel-send-1">
                 <p>
                   Let <var>channel</var> be the <a data-link-type="idl" href="#dom-rtcdatachannel" class="internalDFN" id="ref-for-dom-rtcdatachannel-56"><code><code>RTCDataChannel</code></code></a> object on
                   which data is to be sent.

--- a/base-rec.html
+++ b/base-rec.html
@@ -13525,7 +13525,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-rtc
                 internal slot initialized to <code>0</code>.
               </p>
             </li>
-            <li class="no-test-needed" id="rtcdatachannel-slots-init">
+            <li class="no-test-needed">
               <p>
                 Let <var>channel</var> have internal slots named
                 <dfn data-dfn-type="idl" id="dfn-datachannellabel">[[DataChannelLabel]]</dfn>, <dfn data-dfn-type="idl" id="dfn-ordered">[[Ordered]]</dfn>,
@@ -14231,7 +14231,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-rtc
               steps</dfn>:
             </p>
             <ol>
-              <li class="no-test-needed" id="rtcdatachannel-send-1">
+              <li class="no-test-needed">
                 <p>
                   Let <var>channel</var> be the <a data-link-type="idl" href="#dom-rtcdatachannel" class="internalDFN" id="ref-for-dom-rtcdatachannel-56"><code><code>RTCDataChannel</code></code></a> object on
                   which data is to be sent.

--- a/webrtc.html
+++ b/webrtc.html
@@ -14032,7 +14032,7 @@ interface RTCSctpTransport : EventTarget {
                 internal slot initialized to <code>0</code>.
               </p>
             </li>
-            <li class="no-test-needed" id="rtcdatachannel-slots-init">
+            <li class="no-test-needed">
               <p>
                 Let <var>channel</var> have internal slots named
                 <dfn data-dfn-for="RTCDataChannel">[[\DataChannelLabel]]</dfn>, <dfn data-dfn-for="RTCDataChannel">[[\Ordered]]</dfn>,
@@ -14042,8 +14042,8 @@ interface RTCSctpTransport : EventTarget {
                 <dfn data-dfn-for="RTCDataChannel">[[\Negotiated]]</dfn>, and <dfn data-dfn-for="RTCDataChannel">[[\DataChannelId]]</dfn>.
               </p>
             </li>
-	    <li class="add-to-rtcdatachannel-slots-init">Let <var>channel</var> have a <dfn data-dfn-for="RTCDataChannel">[[\IsTransferable]]</dfn> internal slot initialized to <code>true</code>.</li>
-	    <li class="add-to-rtcdatachannel-slots-init">[=Queue a task=] to run the following step:<ol>
+	    <li id="rtcdatachannel-istransferable-init-1">Let <var>channel</var> have a <dfn data-dfn-for="RTCDataChannel">[[\IsTransferable]]</dfn> internal slot initialized to <code>true</code>.</li>
+	    <li id="rtcdatachannel-istransferable-init-2">[=Queue a task=] to run the following step:<ol>
 		<li>Set <var>channel</var>.{{RTCDataChannel/[[IsTransferable]]}} to <code>false</code>.
 		</li>
 	      </ol>
@@ -14262,7 +14262,7 @@ interface RTCSctpTransport : EventTarget {
             </li>
           </ol>
         </section>
-        <section id="announcing-a-data-channel-as-closed">
+        <section>
           <h4>
             <dfn class="abstract-op">Announcing a data channel as closed</dfn>
           </h4>
@@ -14310,7 +14310,7 @@ interface RTCSctpTransport : EventTarget {
             </li>
           </ol>
         </section>
-	<section class="add-to-announcing-a-data-channel-as-closed">
+	<section id="transfering-a-data-channel">
 	  <h4>Transfering data channel</h4>
 	  <p>The {{RTCDataChannel}} [=transfer steps=], given <var>value</var> and <var>dataHolder</var>, are:</p>
       <ol>
@@ -14832,13 +14832,13 @@ interface RTCDataChannel : EventTarget {
               steps</dfn>:
             </p>
             <ol class=algorithm>
-              <li class="no-test-needed" id="rtcdatachannel-send-1">
+              <li class="no-test-needed">
                 <p>
                   Let <var>channel</var> be the {{RTCDataChannel}} object on
                   which data is to be sent.
                 </p>
               </li>
-	      <li class="add-to-rtcdatachannel-send-1"><p>Set <var>channel</var>.{{RTCDataChannel/[[IsTransferable]]}} to <code>false</code>.</p></li>
+	      <li id="rtcdatachannel-send-istransferable"><p>Set <var>channel</var>.{{RTCDataChannel/[[IsTransferable]]}} to <code>false</code>.</p></li>
 
               <li data-tests="RTCDataChannel-send.html">
                 <p>

--- a/webrtc.html
+++ b/webrtc.html
@@ -14032,7 +14032,7 @@ interface RTCSctpTransport : EventTarget {
                 internal slot initialized to <code>0</code>.
               </p>
             </li>
-            <li class="no-test-needed">
+            <li class="no-test-needed" id="rtcdatachannel-slots-init">
               <p>
                 Let <var>channel</var> have internal slots named
                 <dfn data-dfn-for="RTCDataChannel">[[\DataChannelLabel]]</dfn>, <dfn data-dfn-for="RTCDataChannel">[[\Ordered]]</dfn>,
@@ -14042,6 +14042,14 @@ interface RTCSctpTransport : EventTarget {
                 <dfn data-dfn-for="RTCDataChannel">[[\Negotiated]]</dfn>, and <dfn data-dfn-for="RTCDataChannel">[[\DataChannelId]]</dfn>.
               </p>
             </li>
+	    <li class="add-to-rtcdatachannel-slots-init">Let <var>channel</var> have a <dfn data-dfn-for="RTCDataChannel">[[\IsTransferable]]</dfn> internal slot initialized to <code>true</code>.</li>
+	    <li class="add-to-rtcdatachannel-slots-init">[=Queue a task=] to run the following step:<ol>
+		<li>Set <var>channel</var>.{{RTCDataChannel/[[IsTransferable]]}} to <code>false</code>.
+		</li>
+	      </ol>
+	      <p>This task needs to run before any task enqueued by the [=receiving messages on a data channel=] algorithm for <var>channel</var>.
+		This ensures that no message is lost during the transfer of a {{RTCDataChannel}}.</p>
+	    </li>
             <li class="no-test-needed">
               <p>
                 Return <var>channel</var>.
@@ -14254,9 +14262,9 @@ interface RTCSctpTransport : EventTarget {
             </li>
           </ol>
         </section>
-        <section>
+        <section id="announcing-a-data-channel-as-closed">
           <h4>
-            Announcing a data channel as closed
+            <dfn class="abstract-op">Announcing a data channel as closed</dfn>
           </h4>
           <p>
             When an {{RTCDataChannel}} object's [= underlying data transport =]
@@ -14302,6 +14310,42 @@ interface RTCSctpTransport : EventTarget {
             </li>
           </ol>
         </section>
+	<section class="add-to-announcing-a-data-channel-as-closed">
+	  <h4>Transfering data channel</h4>
+	  <p>The {{RTCDataChannel}} [=transfer steps=], given <var>value</var> and <var>dataHolder</var>, are:</p>
+      <ol>
+        <li><p>If <var>value</var>.{{RTCDataChannel/[[IsTransferable]]}} is <code>false</code>, throw a {{DataCloneError}} DOMException.</p></li>
+        <li><p>Set <var>dataHolder</var>.{{RTCDataChannel/[[ReadyState]]}} to <var>value</var>.{{RTCDataChannel/[[ReadyState]]}}.</p></li>
+        <li><p>Set <var>dataHolder</var>.{{RTCDataChannel/[[DataChannelLabel]]}} to <var>value</var>.{{RTCDataChannel/[[DataChannelLabel]]}}.</p></li>
+        <li><p>Set <var>dataHolder</var>.{{RTCDataChannel/[[Ordered]]}} to <var>value</var>.{{RTCDataChannel/[[Ordered]]}}.</p></li>
+        <li><p>Set <var>dataHolder</var>.{{RTCDataChannel/[[MaxPacketLifeTime]]}} to <var>value</var>..{{RTCDataChannel/[[MaxPacketLifeTime]]}}</p></li>
+        <li><p>Set <var>dataHolder</var>.{{RTCDataChannel/[[MaxRetransmits]]}} to <var>value</var>.{{RTCDataChannel/[[MaxRetransmits]]}}.</p></li>
+        <li><p>Set <var>dataHolder</var>.{{RTCDataChannel/[[DataChannelProtocol]]}} to <var>value</var>.{{RTCDataChannel/[[DataChannelProtocol]]}}.</p></li>
+        <li><p>Set <var>dataHolder</var>.{{RTCDataChannel/[[Negotiated]]}} to <var>value</var>.{{RTCDataChannel/[[Negotiated]]}}.</p></li>
+        <li><p>Set <var>dataHolder</var>.{{RTCDataChannel/[[DataChannelId]]}} to <var>value</var>.{{RTCDataChannel/[[DataChannelId]]}}.</p></li>
+        <li><p>Set <var>dataHolder</var>’s [= underlying data transport =]  to <var>value</var> [=underlying data transport=].</p></li>
+        <li><p>Set <var>value</var>.{{RTCDataChannel/[[IsTransferable]]}} to <code>false</code>.</p></li>
+        <li><p>Set <var>value</var>.{{RTCDataChannel/[[ReadyState]]}} to "closed".</p></li>
+      </ol>
+    </div>
+    <div><p>The {{RTCDataChannel}} [=transfer-receiving steps=], given <var>dataHolder</var> and <var>channel</var>, are:</p>
+      <ol>
+        <li><p>Initialize <var>channel</var>.{{RTCDataChannel/[[ReadyState]]}} to <var>dataHolder</var>.{{RTCDataChannel/[[ReadyState]]}}.</p></li>
+        <li><p>Initialize <var>channel</var>.{{RTCDataChannel/[[DataChannelLabel]]}} to <var>dataHolder</var>.{{RTCDataChannel/[[DataChannelLabel]]}}.</p></li>
+        <li><p>Initialize <var>channel</var>.{{RTCDataChannel/[[Ordered]]}} to <var>dataHolder</var>.{{RTCDataChannel/[[Ordered]]}}.</p></li>
+        <li><p>Initialize <var>channel</var>.{{RTCDataChannel/[[MaxPacketLifeTime]]}} to <var>dataHolder</var>.{{RTCDataChannel/[[MaxPacketLifeTime]]}}.</p></li>
+        <li><p>Initialize <var>channel</var>.{{RTCDataChannel/[[MaxRetransmits]]}} to <var>dataHolder</var>.{{RTCDataChannel/[[MaxRetransmits]]}}.</p></li>
+        <li><p>Initialize <var>channel</var>.{{RTCDataChannel/[[DataChannelProtocol]]}} to <var>dataHolder</var>.{{RTCDataChannel/[[DataChannelProtocol]]}}.</p></li>
+        <li><p>Initialize <var>channel</var>.{{RTCDataChannel/[[Negotiated]]}} to <var>dataHolder</var>.{{RTCDataChannel/[[Negotiated]]}}.</p></li>
+        <li><p>Initialize <var>channel</var>.{{RTCDataChannel/[[DataChannelId]]}} to <var>dataHolder</var>.{{RTCDataChannel/[[DataChannelId]]}}.</p></li>
+        <li><p>Initialize <var>channel</var>’s [=underlying data transport=] to <var>dataHolder</var>’s [= underlying data transport =].</p></li>
+      </ol>
+      <p>The above steps do not need to transfer {{RTCDataChannel/[[BufferedAmount]]}} as its value will always be equal to <code>0</code>.
+      The reason is an {{RTCDataChannel}} can be transferred only if its [=send() algorithm=] was not called prior the transfer.</p>
+      <p>If the [=underlying data transport=] is closed at the time of the [=transfer-receiving steps=],
+      the {{RTCDataChannel}} object will be closed by running the [=announcing a data channel as closed=] algorithm immediately after the [=transfer-receiving steps=].</p>
+
+	</section>
         <section>
           <h4>
             Error on creating data channels
@@ -14347,7 +14391,7 @@ interface RTCSctpTransport : EventTarget {
         </section>
         <section>
           <h4>
-            Receiving messages on a data channel
+            <dfn class="abstract-op">Receiving messages on a data channel</dfn>
           </h4>
           <p>
             When an {{RTCDataChannel}} message has
@@ -14432,7 +14476,7 @@ interface RTCSctpTransport : EventTarget {
           </ol>
         </section>
         <div>
-          <pre class="idl" data-tests="idlharness.https.window.js">[Exposed=Window]
+          <pre class="idl" id="webidl-rtcdatachannel" data-tests="idlharness.https.window.js">[Exposed=(Window,DedicatedWorker), Transferable]
 interface RTCDataChannel : EventTarget {
   readonly attribute USVString label;
   readonly attribute boolean ordered;
@@ -14788,12 +14832,14 @@ interface RTCDataChannel : EventTarget {
               steps</dfn>:
             </p>
             <ol class=algorithm>
-              <li class="no-test-needed">
+              <li class="no-test-needed" id="rtcdatachannel-send-1">
                 <p>
                   Let <var>channel</var> be the {{RTCDataChannel}} object on
                   which data is to be sent.
                 </p>
               </li>
+	      <li class="add-to-rtcdatachannel-send-1"><p>Set <var>channel</var>.{{RTCDataChannel/[[IsTransferable]]}} to <code>false</code>.</p></li>
+
               <li data-tests="RTCDataChannel-send.html">
                 <p>
                   If <var>channel</var>.{{RTCDataChannel/[[ReadyState]]}} is not


### PR DESCRIPTION
Moved from https://w3c.github.io/webrtc-extensions/#rtcdatachannel-extensions based on discussion in https://github.com/w3c/webrtc-extensions/issues/214

related WPT migration https://github.com/web-platform-tests/wpt/pull/47707


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2988.html" title="Last updated on Sep 12, 2024, 2:54 PM UTC (bfa8768)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2988/39897d1...bfa8768.html" title="Last updated on Sep 12, 2024, 2:54 PM UTC (bfa8768)">Diff</a>