### PR TITLE
Reference the codec parameter in algorithms.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -2821,8 +2821,11 @@
                                 <p>If <var>codecs</var> is not an empty list:</p>
                                 <ol>
                                   <li>
-                                    <p>Remove any <var>codec</var> value in <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
-                                      that does not [= codec dictionary match | match =] any entry in <var>codecs</var>.</p>
+                                    <p>For each <var>encoding</var> in
+                                    <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}},
+                                    if <var>encoding</var>.{{RTCRtpEncodingParameters/codec}} does not
+                                    [= codec dictionary match | match =] any entry in <var>codecs</var>,
+                                    [=map/remove=] <var>encoding</var>[{{RTCRtpEncodingParameters/codec}}].</p>
                                   </li>
                                 </ol>
                               </li>
@@ -8229,7 +8232,8 @@ interface RTCCertificate {
                       </li>
                       <li>
                         <p>
-                          If any <var>codec</var> parameter in <var>sendEncodings</var> does
+                          If any encoding [=map/contains=] a
+                          {{RTCRtpEncodingParameters/codec}} member whose value does
                           [= codec dictionary match | not match =] any codec in {{RTCRtpSender.getCapabilities(kind)}}.<code>codecs</code>,
                           [= exception/throw =] an {{OperationError}}.</p>
                       </li>


### PR DESCRIPTION
Help readers find where in algorithms the `codec` parameter is used.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/2990.html" title="Last updated on Aug 28, 2024, 10:06 PM UTC (fa3f4b5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2990/7f95b53...jan-ivar:fa3f4b5.html" title="Last updated on Aug 28, 2024, 10:06 PM UTC (fa3f4b5)">Diff</a>