### PR TITLE
Reject ICE servers with an authority component or /

### DIFF
--- a/amendments.json
+++ b/amendments.json
@@ -57,7 +57,7 @@
   "validate-ice-server-algo": [
     {
       "description": "Use the url spec to parse ice server urls",
-      "pr": [2853, 2996],
+      "pr": [2853, 2996, 2998],
       "type": "correction",
       "tests": [
 	"webrtc/RTCConfiguration-iceServers.html"

--- a/webrtc.html
+++ b/webrtc.html
@@ -3110,7 +3110,7 @@
             <ol id="validate-ice-server-algo" class="algorithm">
               <li>
                 <p>Let <var>parsedURL</var> be the result of
-                  <a data-cite="!url#concept-url-parser">parsing</a>
+                  [=basic url parser|parsing=]
                   <var>url</var>.</p>
               </li>
               <li>
@@ -3121,9 +3121,10 @@
                   <li><var>parsedURL</var>'s [=url/scheme=] is neither `"stun"`,
                     `"stuns"`, `"turn"`, nor `"turns"`</li>
                   <li><var>parsedURL</var> does not have an [=url/opaque path=]</li>
-                  <li><var>parsedURL</var>'s' [=url/fragment=] is non-null</li>
-                  <li><var>parsedURL</var>'s' [=url/scheme=] is `"stun"` or `"stuns"`,
-                    and <var>parsedURL</var>'s' [=url/query=] is non-null</li>
+		  <li><var>parsedURL</var>'s [=url/opaque path=] contains one or more `"/"` or `"@"`</li>
+                  <li><var>parsedURL</var>'s [=url/fragment=] is non-null</li>
+                  <li><var>parsedURL</var>'s [=url/scheme=] is `"stun"` or `"stuns"`,
+                    and <var>parsedURL</var>'s [=url/query=] is non-null</li>
                 </ul>
               </li>
               <li>
@@ -3132,12 +3133,15 @@
               </li>
               <li>
                 <p>Let <var>hostAndPortURL</var> be result of
-                  <a data-cite="!url#concept-url-parser">parsing</a> the concatenation of
+                  [=basic url parser|parsing=] the concatenation of
                   `"https://"` and <var>parsedURL</var>'s [=url/path=].</p>
               </li>
               <li>
                 <p>If <var>hostAndPortURL</var> is failure, then [=exception/throw=] a
                   "{{SyntaxError}}" {{DOMException}}.</p>
+		<p>If <var>hostAndPortURL</var>'s [=url/path=],
+		  [=url/username=], or [=url/password=] is non-null, then
+		  [=exception/throw=] a "{{SyntaxError}}" {{DOMException}}.</p>
                 <p class="note">For "stun" and "stuns" schemes, this validates
                   [[!RFC7064]] section 3.1.<br>
                   For "turn" and "turns" schemes, this and the steps below validate


### PR DESCRIPTION
Complete integration of URL parser from #2853
see also https://github.com/w3c/webrtc-pc/issues/2997#issuecomment-2328528755 This aligns with the constraints set in the respective RFC (and thus with the current WebRTC Rec)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/2998.html" title="Last updated on Oct 30, 2024, 9:46 AM UTC (1253b4d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/2998/e00c759...1253b4d.html" title="Last updated on Oct 30, 2024, 9:46 AM UTC (1253b4d)">Diff</a>