### PR TITLE
Revert "Merge pull request #2935 from w3c/redefine-codecs"

### DIFF
--- a/amendments.json
+++ b/amendments.json
@@ -310,13 +310,6 @@
       "type": "correction",
       "status": "candidate",
       "id": 24
-    },
-    {
-      "description": "Redefine SendCodecs and ReceiveCodecs",
-      "pr": 2935,
-      "type": "addition",
-      "status": "candidate",
-      "id": 41
     }
   ],
   "webidl-rtcrtpencodingparameters": [
@@ -569,15 +562,6 @@
         "web-platform-tests/wpt#44318"
       ],
       "id": 40
-    }
-  ],
-  "create-receiver-algo": [
-    {
-      "description": "Redefine SendCodecs and ReceiveCodecs",
-      "pr": 2935,
-      "type": "addition",
-      "status": "candidate",
-      "id": 41
     }
   ]
 }

--- a/base-rec.html
+++ b/base-rec.html
@@ -10116,7 +10116,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-rtc
           To <dfn id="dfn-create-an-rtcrtpreceiver">create an RTCRtpReceiver</dfn> with a string,
           <var>kind</var>, run the following steps:
         </p>
-        <ol id="create-receiver-algo">
+        <ol>
           <li class="no-test-needed">
             <p>
               Let <var>receiver</var> be a new <a data-link-type="idl" href="#dom-rtcrtpreceiver" class="internalDFN" id="ref-for-dom-rtcrtpreceiver-24"><code><code>RTCRtpReceiver</code></code></a> object.

--- a/webrtc.html
+++ b/webrtc.html
@@ -2246,13 +2246,11 @@
                               </li>
                               <li>
                                 <p>
-                                  For each of the codecs that <var>description</var> negotiates for receiving, execute the following steps:
-                                      <ol>
-                                        <li>Locate the matching codec description in <var>transceiver</var>.{{RTCRtpTransceiver/[[Receiver]]}}.{{RTCRtpReceiver/[[ReceiveCodecs]]}}.</li>
-                                        <li>If the matching codec description is not found, abort these steps.</li>
-                                        <li>Set the "enabled" flag in the matching codec description to "true".</li>
-                                      </ol>
-                                  
+                                  Set
+                                  <var>transceiver</var>.{{RTCRtpTransceiver/[[Receiver]]}}.{{RTCRtpReceiver/[[ReceiveCodecs]]}}
+                                  to the codecs that <var>description</var>
+                                  negotiates for receiving and which the user
+                                  agent is currently prepared to receive.
                                 </p>
                                 <p class='note'>
                                   If the <var>direction</var> is
@@ -2301,15 +2299,13 @@
                                   </li>
                                   <li>
                                     <p>
-                                      For each of the codecs that <var>description</var> negotiates for sending, execute the following steps:
-                                      <ol>
-                                        <li>Locate the matching codec description in <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendCodecs]]}}.</li>
-                                        <li>If the matching codec description is not found, abort these steps.</li>
-                                        <li>Set the "enabled" flag in the matching codec description to "true".</li>
-                                      </ol>
-                                  </li>
-                                  <li>
-                                      Set <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[LastReturnedParameters]]}}
+                                      Set
+                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendCodecs]]}}
+                                      to the codecs that <var>description</var>
+                                      negotiates for sending and which the user
+                                      agent is currently capable of sending,
+                                      and set
+                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[LastReturnedParameters]]}}
                                       to <code>null</code>.
                                     </p>
                                   </li>
@@ -2577,12 +2573,11 @@
                               </li>
                               <li>
                                 <p>
-                                  For each of the codecs that <var>description</var> negotiates for receiving, execute the following steps:
-                                      <ol>
-                                        <li>Locate the matching codec description in <var>transceiver</var>.{{RTCRtpTransceiver/[[Receiver]]}}.{{RTCRtpReceiver/[[ReceiveCodecs]]}}.</li>
-                                        <li>If the matching codec description is not found, abort these steps.</li>
-                                        <li>Set the "enabled" flag in the matching codec description to "true".</li>
-                                      </ol>
+                                  Set
+                                  <var>transceiver</var>.{{RTCRtpTransceiver/[[Receiver]]}}.{{RTCRtpReceiver/[[ReceiveCodecs]]}}
+                                  to the codecs that <var>description</var>
+                                  negotiates for receiving and which the user
+                                  agent is currently prepared to receive.
                                 </p>
                               </li>
                               <li>
@@ -2595,12 +2590,11 @@
                                 <ol>
                                   <li>
                                     <p>
-                                      For each of the codecs that <var>description</var> negotiates for sending, execute the following steps:
-                                      <ol>
-                                        <li>Locate the matching codec description in <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendCodecs]]}}.</li>
-                                        <li>If the matching codec description is not found, abort these steps.</li>
-                                        <li>Set the "enabled" flag in the matching codec description to "true".</li>
-                                      </ol>
+                                      Set
+                                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendCodecs]]}}
+                                      to the codecs that <var>description</var>
+                                      negotiates for sending and which the user
+                                      agent is currently capable of sending.
                                     </p>
                                   </li>
                                   <li>
@@ -3793,7 +3787,8 @@ interface RTCPeerConnection : EventTarget  {
                                 <var>transceiver</var>.{{RTCRtpTransceiver/direction}}
                                 is {{RTCRtpTransceiverDirection/"sendonly"}}
                                 or {{RTCRtpTransceiverDirection/"sendrecv"}},
-                                include all codecs in the <var>transceiver</var>'s {{RTCRtpTransceiver/[[Sender]]}}'s {{RTCRtpSender/[[SendCodecs]]}} for which the "enabled" flag is "true".
+                                exclude any codecs not included in the
+                                [=RTCRtpSender/list of implemented send codecs=] for
                                 <var>kind</var>.
                               </p>
                             </li>
@@ -3803,7 +3798,9 @@ interface RTCPeerConnection : EventTarget  {
                                 <var>transceiver</var>.{{RTCRtpTransceiver/direction}}
                                 is {{RTCRtpTransceiverDirection/"recvonly"}}
                                 or {{RTCRtpTransceiverDirection/"sendrecv"}},
-                                include all codecs in the <var>transceiver</var>'s {{RTCRtpTransceiver/[[Receiver]]}}'s {{RTCRtpReceiver/[[ReceiveCodecs]]}} for which the "enabled" flag is "true".
+                                exclude any codecs not included in the
+                                [=list of implemented receive codecs=] for
+                                <var>kind</var>.
                               </p>
                             </li>
                           </ol>
@@ -8854,10 +8851,8 @@ interface RTCCertificate {
           <li>
             <p>
               Let <var>sender</var> have a <dfn class="export" data-dfn-for="RTCRtpSender">[[\SendCodecs]]</dfn> internal
-              slot, representing a list of [=tuple=]s, each containing an {{RTCRtpCodecParameters}}
-              dictionary and an "enabled" boolean, and initialized to the
-              [=RTCRtpSender/list of implemented send codecs=], with the "enabled" flag
-              set in an implementation defined manner.
+              slot, representing a list of {{RTCRtpCodecParameters}}
+              dictionaries, and initialized to an empty list.
             </p>
           </li>
           <li class="no-test-needed">
@@ -8973,15 +8968,6 @@ interface RTCRtpSender {
                   dictionaries representing the most optimistic view of the codecs the user
                   agent supports for sending media of the given <var>kind</var> (video or audio).
                 </p>
-                <p class="note">
-                  This conceptual list contains every combination of parameters that
-                  the user agent is capable of processing. In practice, this would
-                  be implemented as a piece of code that parses the parameters and
-                  determines whether they are acceptable or not, but this is highly
-                  codec dependent, so for the purpose of specification, we work with
-                  a conceptual list containing all acceptable parameter combinations.
-                </p>
-
                 <p>
                   The <dfn>list of implemented header extensions for sending</dfn>, given
                   <var>kind</var>, is an [=implementation-defined=] list of
@@ -9246,9 +9232,8 @@ interface RTCRtpSender {
                       </li>
                       <li data-tests=
                       "RTCRtpParameters-codecs.html,protocol/video-codecs.https.html">
-                      {{RTCRtpParameters/codecs}} is set to the codecs from the
-                      {{RTCRtpSender/[[SendCodecs]]}} internal slot where the
-                      "enabled" flag is true.
+                      {{RTCRtpParameters/codecs}} is set to the value of the
+                      {{RTCRtpSender/[[SendCodecs]]}} internal slot.
                       </li>
                       <li data-tests="RTCRtpParameters-encodings.html">
                       {{RTCRtpParameters/rtcp}}.{{RTCRtcpParameters/cname}} is
@@ -10197,7 +10182,7 @@ async function updateParameters() {
           To <dfn class="abstract-op">create an RTCRtpReceiver</dfn> with a string,
           <var>kind</var>, run the following steps:
         </p>
-        <ol class=algorithm id="create-receiver-algo">
+        <ol class=algorithm>
           <li class="no-test-needed">
             <p>
               Let <var>receiver</var> be a new {{RTCRtpReceiver}} object.
@@ -10279,10 +10264,8 @@ async function updateParameters() {
           <li>
             <p>
               Let <var>receiver</var> have a <dfn data-dfn-for="RTCRtpReceiver">[[\ReceiveCodecs]]</dfn>
-              internal slot, representing a list of [=tuple=]s, each containing a {{RTCRtpCodecParameters}}
-              dictionaries, and initialized to an list containing all the codecs in the
-              <a>list of implemented receive codecs</a> for <var>kind</var>, and with the "enabled" flag
-              set in an implementation defined manner.
+              internal slot, representing a list of {{RTCRtpCodecParameters}}
+              dictionaries, and initialized to an empty list.
             </p>
           </li>
           <li>
@@ -10396,14 +10379,6 @@ interface RTCRtpReceiver {
                   the codecs the user agent supports for receiving media of the given
                   <var>kind</var> (video or audio).
                 </p>
-                <p class="note">
-                  This conceptual list contains every combination of parameters that
-                  the user agent is capable of processing. In practice, this would
-                  be implemented as a piece of code that parses the parameters and
-                  determines whether they are acceptable or not, but this is highly
-                  codec dependent, so for the purpose of specification, we work with
-                  a conceptual list containing all acceptable parameter combinations.
-                </p>
                 <p>
                   The <dfn>list of implemented header extensions for receiving</dfn>, given
                   <var>kind</var>, is an [=implementation-defined=] list of
@@ -10452,7 +10427,6 @@ interface RTCRtpReceiver {
                   <li data-tests="RTCRtpReceiver-getParameters.html">
                     <p>
                       {{RTCRtpParameters/codecs}} is set to the value of the
-                      "enabled" codecs from the
                       {{RTCRtpReceiver/[[ReceiveCodecs]]}} internal slot.
                     </p>
                     <div class="note">


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/2956 for REC update.

This reverts commit dc1fc15194d45f4535e0ee5186540469e2f85360, reversing changes made to 3d6e620cab9755263618d35a428d3d63001111bf.

Reason for revert is the changes to [[ReceiveCodecs]] were incompatible.