### PR TITLE
Clarify that stopping of sending and receiving happens in parallel

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -11233,18 +11233,14 @@ interface RTCRtpTransceiver {
                   </li>
                   <li class="needs-test">
                     <p>
-                      Stop sending media with <var>sender</var>.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Send an RTCP BYE for each RTP stream that was being sent
+                      [=In parallel=], stop sending media with <var>sender</var>, and
+                      send an RTCP BYE for each RTP stream that was being sent
                       by <var>sender</var>, as specified in [[!RFC3550]].
                     </p>
                   </li>
                   <li>
                     <p>
-                      Stop receiving media with <var>receiver</var>.
+                      [=In parallel=], stop receiving media with <var>receiver</var>.
                     </p>
                   </li>
                   <li>


### PR DESCRIPTION
Transmission of media happens off main thread, so stopping it necessarily needs to as well, to not block main thread on it.