### PR TITLE
Update copyright links

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -20,7 +20,8 @@
     <script src="diff.js" defer>
     </script>
   </head>
-  <body>    <p class="copyright">
+  <body>
+    <p class="copyright">
       Initial Author of this Specification was Ian Hickson, Google Inc., with
       the following copyright statement:<br>
       © Copyright 2004-2011 Apple Computer, Inc., Mozilla Foundation, and Opera

--- a/webrtc.html
+++ b/webrtc.html
@@ -20,17 +20,16 @@
     <script src="diff.js" defer>
     </script>
   </head>
-  <body>
-    <p class='copyright'>
+  <body>    <p class="copyright">
       Initial Author of this Specification was Ian Hickson, Google Inc., with
       the following copyright statement:<br>
       © Copyright 2004-2011 Apple Computer, Inc., Mozilla Foundation, and Opera
       Software ASA. You are granted a license to use, reproduce and create
       derivative works of this document. All subsequent changes since 26 July
       2011 done by the W3C WebRTC Working Group are under the following
-      <a href='https://www.w3.org/Consortium/Legal/ipr-notice#Copyright'>Copyright</a>:<br>
+      <a href="https://www.w3.org/policies/#copyright">Copyright</a>:<br>
 
-      <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2011-2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/copyright/software-license/">permissive document license</a> rules apply.</p>
+      <a href="https://www.w3.org/policies/#copyright">Copyright</a> © 2011-2024 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/policies/#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/policies/#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/copyright/software-license/">permissive document license</a> rules apply.</p>
 
     <section id="abstract">
       <p>


### PR DESCRIPTION
The copyright links have recently been updated and pubrules is now expecting specs to use these links


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/pull/3007.html" title="Last updated on Oct 3, 2024, 12:07 PM UTC (ac1a554)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/3007/0c2ee4b...ac1a554.html" title="Last updated on Oct 3, 2024, 12:07 PM UTC (ac1a554)">Diff</a>