### PR TITLE
Filter codecs preferences on transceiver direction

### DIFF
--- a/amendments.json
+++ b/amendments.json
@@ -894,14 +894,14 @@
   "setcodecpreferences-filter-direction": [
     {
       "description": "setCodecPreferences takes both send and receive codecs which get filtered at negotiation based on transceiver direction",
-      "pr": 1337,
-      "type": "correction",
+      "pr": 3018,
+      "type": "addition",
       "status": "candidate",
       "tests": [
 	"webrtc/RTCRtpTransceiver-setCodecPreferences-direction.html"
       ],
       "testUpdates": [
-        "web-platform-tests/wpt#1337"
+        "web-platform-tests/wpt#1234"
       ],
       "id": 50
     }

--- a/amendments.json
+++ b/amendments.json
@@ -876,24 +876,9 @@
       "id": 40
     }
   ],
-  "setcodecpreferences-receive": [
+  "setcodecpreferences-send-and-receive": [
     {
-      "description": "setCodecPreferences only takes into account receive codecs",
-      "pr": 2926,
-      "type": "correction",
-      "status": "candidate",
-      "tests": [
-	"webrtc/RTCRtpTransceiver-setCodecPreferences.html"
-      ],
-      "testUpdates": [
-        "web-platform-tests/wpt#44318"
-      ],
-      "id": 42
-    }
-  ],
-  "setcodecpreferences-filter-direction": [
-    {
-      "description": "setCodecPreferences takes both send and receive codecs which get filtered at negotiation based on transceiver direction",
+      "description": "setCodecPreferences supports both send and receive codecs (filtered by direction)",
       "pr": 3018,
       "type": "addition",
       "status": "candidate",

--- a/amendments.json
+++ b/amendments.json
@@ -891,6 +891,21 @@
       "id": 42
     }
   ],
+  "setcodecpreferences-filter-direction": [
+    {
+      "description": "setCodecPreferences takes both send and receive codecs which get filtered at negotiation based on transceiver direction",
+      "pr": 1337,
+      "type": "correction",
+      "status": "candidate",
+      "tests": [
+	"webrtc/RTCRtpTransceiver-setCodecPreferences-direction.html"
+      ],
+      "testUpdates": [
+        "web-platform-tests/wpt#1337"
+      ],
+      "id": 50
+    }
+  ],
   "internalslot-jitterbuffertarget": [
     {
       "description": "Add control for the receiver's jitter buffer",

--- a/amendments.json
+++ b/amendments.json
@@ -1029,12 +1029,12 @@
       "type": "addition",
       "status": "candidate",
       "tests": [
-	"webrtc/RTCRtpTransceiver-setCodecPreferences-direction.html"
+  "webrtc/protocol/h264-unidirectional-codec-offer.https.html"
       ],
       "testUpdates": [
-        "web-platform-tests/wpt#1234"
+        "web-platform-tests/wpt#49421"
       ],
-      "id": 50
+      "id": 51
     }
   ],
   "internalslot-jitterbuffertarget": [

--- a/base-rec.html
+++ b/base-rec.html
@@ -11036,8 +11036,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-rtc
                 <dfn data-idl="operation" data-export="" data-dfn-type="method" id="dom-rtcrtptransceiver-setcodecpreferences" data-title="setCodecPreferences" data-dfn-for="RTCRtpTransceiver" data-type="undefined" data-lt="setCodecPreferences()|setCodecPreferences(codecs)" data-local-lt="RTCRtpTransceiver.setCodecPreferences|RTCRtpTransceiver.setCodecPreferences()|setCodecPreferences"><code>setCodecPreferences</code></dfn>
               </dt>
               <dd>
-		<div id="setcodecpreferences-filter-direction"><!-- To replace setcodecpreferences-receive --></div>
-		<div id="setcodecpreferences-receive">
+		<div id="setcodecpreferences-send-and-receive">
                 <p class="needs-tests">
                   The <a data-link-type="idl" href="#dom-rtcrtptransceiver-setcodecpreferences" class="internalDFN" id="ref-for-dom-rtcrtptransceiver-setcodecpreferences-4"><code><code>setCodecPreferences</code></code></a> method overrides the default
                   codec preferences used by the <a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-agent-9">user agent</a>. When

--- a/base-rec.html
+++ b/base-rec.html
@@ -11036,6 +11036,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-rtc
                 <dfn data-idl="operation" data-export="" data-dfn-type="method" id="dom-rtcrtptransceiver-setcodecpreferences" data-title="setCodecPreferences" data-dfn-for="RTCRtpTransceiver" data-type="undefined" data-lt="setCodecPreferences()|setCodecPreferences(codecs)" data-local-lt="RTCRtpTransceiver.setCodecPreferences|RTCRtpTransceiver.setCodecPreferences()|setCodecPreferences"><code>setCodecPreferences</code></dfn>
               </dt>
               <dd>
+		<div id="setcodecpreferences-filter-direction"><!-- To replace setcodecpreferences-receive --></div>
 		<div id="setcodecpreferences-receive">
                 <p class="needs-tests">
                   The <a data-link-type="idl" href="#dom-rtcrtptransceiver-setcodecpreferences" class="internalDFN" id="ref-for-dom-rtcrtptransceiver-setcodecpreferences-4"><code><code>setCodecPreferences</code></code></a> method overrides the default

--- a/webrtc.html
+++ b/webrtc.html
@@ -3729,14 +3729,11 @@ interface RTCPeerConnection : EventTarget  {
                         </li>
                         <li>
                           <p>
-                            The <i>codec preferences</i> of a [= media
-                            description =]'s [= associated =] transceiver,
-                            <var>transceiver</var>, is said to be the value of
-                            <var>transceiver</var>.{{RTCRtpTransceiver/[[PreferredCodecs]]}}
-                            with the following filtering applied (or said not
-                            to be set if
-                            <var>transceiver</var>.{{RTCRtpTransceiver/[[PreferredCodecs]]}}
-                            is empty):
+                            Let <var>filteredCodecs</var> be the result of
+                            applying the following filter on
+                            <var>transceiver</var>.{{RTCRtpTransceiver/[[PreferredCodecs]]}}.
+                            The filtering MUST NOT change the order of the codec
+                            preferences:
                           </p>
                           <ol>
                             <li>
@@ -3769,8 +3766,11 @@ interface RTCPeerConnection : EventTarget  {
                             </li>
                           </ol>
                           <p>
-                            The filtering MUST NOT change the order of the
-                            codec preferences.
+                            The <i>codec preferences</i> of a [= media
+                            description =]'s [= associated =] transceiver,
+                            <var>transceiver</var>, is said to be the value of
+                            <var>filteredCodecs</var> if non-empty and said to
+                            be unset otherwise.
                           </p>
                         </li>
                         <li>
@@ -4012,14 +4012,11 @@ interface RTCPeerConnection : EventTarget  {
                       <ol id="create-answer-restrictions">
                         <li>
                           <p>
-                            The <i>codec preferences</i> of an m= section's
-                            [= associated =] transceiver,
-                            <var>transceiver</var>, is said to be the value of
-                            <var>transceiver</var>.{{RTCRtpTransceiver/[[PreferredCodecs]]}}
-                            with the following filtering applied (or said not
-                            to be set if
-                            <var>transceiver</var>.{{RTCRtpTransceiver/[[PreferredCodecs]]}}
-                            is empty):
+                            Let <var>filteredCodecs</var> be the result of
+                            applying the following filter on
+                            <var>transceiver</var>.{{RTCRtpTransceiver/[[PreferredCodecs]]}}.
+                            The filtering MUST NOT change the order of the
+                            codec preferences:
                           </p>
                           <ol>
                             <li>
@@ -4052,8 +4049,11 @@ interface RTCPeerConnection : EventTarget  {
                             </li>
                           </ol>
                           <p>
-                            The filtering MUST NOT change the order of the
-                            codec preferences.
+                            The <i>codec preferences</i> of a [= media
+                            description =]'s [= associated =] transceiver,
+                            <var>transceiver</var>, is said to be the value of
+                            <var>filteredCodecs</var> if non-empty and said to
+                            be unset otherwise.
                           </p>
                         </li>
                         <li>
@@ -11325,22 +11325,30 @@ interface RTCRtpTransceiver {
                 <dfn data-idl="">setCodecPreferences</dfn>
               </dt>
               <dd>
-		<div id="setcodecpreferences-receive">
+		<div id="setcodecpreferences-receive"><!-- kept for candidate amendments management purposes --></div>
+    <div id="setcodecpreferences-filter-direction">
                 <p>
                   The {{setCodecPreferences}} method overrides the default
-                  receive codec preferences used by the <a>user agent</a>. When
+                  codec preferences used by the <a>user agent</a>. When
                   generating a session description using either
                   {{RTCPeerConnection/createOffer}} or
-                  {{RTCPeerConnection/createAnswer}}, the <a>user agent</a>
-                  MUST use the indicated codecs, in the order specified in the
-                  <var>codecs</var> argument, for the media section
-                  corresponding to this {{RTCRtpTransceiver}}.
+                  {{RTCPeerConnection/createAnswer}}, the <a>user agent</a> MUST
+                  filter the preferred codecs on {{RTCRtpTransceiver/direction}}
+                  and, if this results in a non-empty list, it MUST use the
+                  specified codecs in the order of the <var>codecs</var>
+                  argument, for the media section corresponding to this
+                  {{RTCRtpTransceiver}}.
                 </p>
                 <p>
                   This method allows applications to disable the negotiation of
                   specific codecs (including RTX/RED/FEC). It also allows an
-                  application to cause a remote peer to prefer the codec that
-                  appears first in the list for sending.
+                  application to affect the remote peer's default codecs;
+                  influencing both what they should send by default and the
+                  default codec order of subsequently generated remote SDP. But
+                  just like the local peer can override its defaults, so can the
+                  remote peer. The local peer MUST be prepared to receive any
+                  codec that it has been negotiated, even ones not first in the
+                  list.
                 </p>
                 <!-- 'until this method is called again' is not clear. Ditto for 'any default value' -->
                 <p class="needs-test">
@@ -11348,8 +11356,9 @@ interface RTCRtpTransceiver {
                   {{RTCPeerConnection/createOffer}} and
                   {{RTCPeerConnection/createAnswer}} that include this
                   {{RTCRtpTransceiver}} until this method is called again.
-                  Setting <var>codecs</var> to an empty sequence resets codec
-                  preferences to any default value.
+                  Setting <var>codecs</var> to an empty sequence, or one that
+                  becomes empty after {{RTCRtpTransceiver/direction}} filtering,
+                  resets codec preferences to any default value.
                 </p>
                 <p class="note">
                   Codecs have their payload types listed under each m= section
@@ -11364,8 +11373,11 @@ interface RTCRtpTransceiver {
                   be removed from the mapping of payload types in the SDP.
                 </p>
                 <p>
-                  {{setCodecPreferences}} will reject attempts to set <var>codecs</var>
-                  [= codec dictionary match | not matching =] codecs found in
+                  {{setCodecPreferences}} will reject attempts to set
+                  <var>codecs</var> [= codec dictionary match | not matching =]
+                  codecs found in either
+                  {{RTCRtpSender}}.{{RTCRtpSender/getCapabilities}}(<var>kind</var>)
+                  or
                   {{RTCRtpReceiver}}.{{RTCRtpReceiver/getCapabilities}}(<var>kind</var>),
                   where <var>kind</var> is the kind of the
                   {{RTCRtpTransceiver}} on which the method is called.
@@ -11407,7 +11419,9 @@ interface RTCRtpTransceiver {
                   </li>
                   <li class="no-test-needed">
                     <p>
-                      Let <var>codecCapabilities</var> be
+                      Let <var>codecCapabilities</var> be the union of
+                      {{RTCRtpSender}}.{{RTCRtpSender/getCapabilities}}(<var>kind</var>).{{RTCRtpParameters/codecs}}
+                      and
                       {{RTCRtpReceiver}}.{{RTCRtpReceiver/getCapabilities}}(<var>kind</var>).{{RTCRtpParameters/codecs}}.
                     </p>
                   </li>

--- a/webrtc.html
+++ b/webrtc.html
@@ -11347,7 +11347,7 @@ interface RTCRtpTransceiver {
                   default codec order of subsequently generated remote SDP. But
                   just like the local peer can override its defaults, so can the
                   remote peer. The local peer MUST be prepared to receive any
-                  codec that it has been negotiated, even ones not first in the
+                  codec that has been negotiated, even ones not first in the
                   list.
                 </p>
                 <!-- 'until this method is called again' is not clear. Ditto for 'any default value' -->
@@ -11358,7 +11358,7 @@ interface RTCRtpTransceiver {
                   {{RTCRtpTransceiver}} until this method is called again.
                   Setting <var>codecs</var> to an empty sequence, or one that
                   becomes empty after {{RTCRtpTransceiver/direction}} filtering,
-                  resets codec preferences to any default value.
+                  results in default codec preferences.
                 </p>
                 <p class="note">
                   Codecs have their payload types listed under each m= section

--- a/webrtc.html
+++ b/webrtc.html
@@ -11340,14 +11340,23 @@ interface RTCRtpTransceiver {
                 </p>
                 <p>
                   This method allows applications to disable the negotiation of
-                  specific codecs (including RTX/RED/FEC). It also allows an
-                  application to affect the remote peer's default codecs;
-                  influencing both what they should send by default and the
-                  default codec order of subsequently generated remote SDP. But
-                  just like the local peer can override its defaults, so can the
-                  remote peer. The local peer MUST be prepared to receive any
-                  codec that has been negotiated, even ones not first in the
-                  list.
+                  specific codecs (including RTX/RED/FEC) by listing all codecs
+                  except for the ones to disable.
+                </p>
+                <p class="note">
+                  If the m= section is used for receiving, the order of the
+                  codecs in the SDP (both the offer and the answer) tells the
+                  remote endpoint which codec the local endpoint prefers to
+                  receive. The answerer defaults to using the order in the SDP
+                  offer, but overrides this with their own codec preferences if
+                  they have any.
+                </p>
+                <p class="note">
+                  An RTCRtpSender defaults to sending what the remote endpoint
+                  indicated that it prefers to receive, but the application can
+                  change which codec to send amongst negotiated codecs in
+                  setParameters() at any time. An RTCRtpReceiver is prepared to
+                  receive any negotiated codec.
                 </p>
                 <!-- 'until this method is called again' is not clear. Ditto for 'any default value' -->
                 <p class="needs-test">

--- a/webrtc.html
+++ b/webrtc.html
@@ -11325,8 +11325,7 @@ interface RTCRtpTransceiver {
                 <dfn data-idl="">setCodecPreferences</dfn>
               </dt>
               <dd>
-		<div id="setcodecpreferences-receive"><!-- kept for candidate amendments management purposes --></div>
-    <div id="setcodecpreferences-filter-direction">
+    <div id="setcodecpreferences-send-and-receive">
                 <p>
                   The {{setCodecPreferences}} method overrides the default
                   codec preferences used by the <a>user agent</a>. When

--- a/webrtc.html
+++ b/webrtc.html
@@ -9051,7 +9051,9 @@ interface RTCRtpSender {
                       </li>
                       <li id="setparameters-codec-validation-2">
                         <p>If <var>choosableCodecs</var> is an empty list, set <var>choosableCodecs</var>
-                          to transceiver.{{RTCRtpTransceiver/[[PreferredCodecs]]}}.</p>
+                          to transceiver.{{RTCRtpTransceiver/[[PreferredCodecs]]}}
+                          and exclude any codecs not included in the
+                          [=RTCRtpSender/list of implemented send codecs=].</p>
                       </li>
                       <li id="setparameters-codec-validation-3">
                           <p>If <var>choosableCodecs</var> is still an empty list, set <var>choosableCodecs</var>
@@ -11326,9 +11328,9 @@ interface RTCRtpTransceiver {
     <div id="setcodecpreferences-send-and-receive">
                 <p>
                   The {{setCodecPreferences}} method overrides the default
-                  codec preferences used by the <a>user agent</a>. When
-                  generating a session description using either
-                  {{RTCPeerConnection/createOffer}} or
+                  codec preferences used by the <a>user agent</a> as input to
+                  negotiation. When generating a session description using
+                  either {{RTCPeerConnection/createOffer}} or
                   {{RTCPeerConnection/createAnswer}}, the <a>user agent</a> MUST
                   filter the preferred codecs on {{RTCRtpTransceiver/direction}}
                   and, if this results in a non-empty list, it MUST use the
@@ -11345,16 +11347,19 @@ interface RTCRtpTransceiver {
                   If the m= section is used for receiving, the order of the
                   codecs in the SDP (both the offer and the answer) tells the
                   remote endpoint which codec the local endpoint prefers to
-                  receive. The answerer defaults to using the order in the SDP
-                  offer, but overrides this with their own codec preferences if
-                  they have any.
+                  receive. Even if the m= section is not used for receiving, an
+                  answerer that does not have any codec preferences of their own
+                  defaults to using the same order for its SDP answer.
                 </p>
                 <p class="note">
-                  An RTCRtpSender defaults to sending what the remote endpoint
-                  indicated that it prefers to receive, but the application can
-                  change which codec to send amongst negotiated codecs in
-                  setParameters() at any time. An RTCRtpReceiver is prepared to
-                  receive any negotiated codec.
+                  An {{RTCRtpSender}} defaults to sending what the remote
+                  endpoint indicated that it prefers to receive, but the
+                  application can change which codec to send amongst negotiated
+                  {{RTCRtpParameters/codecs}} by calling
+                  {{RTCRtpSender/setParameters}} and specifying which
+                  {{RTCRtpEncodingParameters/codec}} to send. An
+                  {{RTCRtpReceiver}} is prepared to receive any negotiated
+                  codec.
                 </p>
                 <!-- 'until this method is called again' is not clear. Ditto for 'any default value' -->
                 <p class="needs-test">


### PR DESCRIPTION
Fixes #3006.

As decided by the WG, this PR implements [Proposal A at TPAC](https://docs.google.com/presentation/d/1dFntwgSd9MrLnd1Sf58eBHstkodUd30WSKGIaK5K2CM/edit#slide=id.g302dfc81162_4_26), i.e:
- A sendonly transceiver can prefer sendonly codecs.
- A recvonly transceiver can prefer recvonly codecs.
- A sendrecv transceiver can only prefer codecs that we can both send and receive with. If you want to use both sendonly codecs and recvonly codecs you need to have two transceivers.

This is supported via filtering based on RTCRtpTransceiver.direction. In addition, the case where filtering results in an empty codec preferences this is treated as "no preference" as per [Proposal A at Virtual Interim](https://docs.google.com/presentation/d/1tfFiR2xqyEybbmnGUALqdWHpDx2W47YnlO65gI0HvBA/edit#slide=id.g30790f41697_14_26).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/3018.html" title="Last updated on Nov 28, 2024, 1:44 PM UTC (50e9841)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/3018/9db156a...henbos:50e9841.html" title="Last updated on Nov 28, 2024, 1:44 PM UTC (50e9841)">Diff</a>