### PR TITLE
Clarify sender is limited to codecs negotiated for sending.

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -9813,7 +9813,7 @@ async function updateParameters() {
                 <dd>
                   <p>
                     Optional value selecting which codec is used for this encoding's
-                    RTP stream. If absent, the user agent can choose to use any coded negotiated for sending.
+                    RTP stream. If absent, the user agent can choose to use any codec negotiated for sending.
                   </p>
                   <p>
                     When {{codec}} is set and {{RTCRtpSender/[[SendCodecs]]}} have been negotiated,

--- a/webrtc.html
+++ b/webrtc.html
@@ -9813,7 +9813,7 @@ async function updateParameters() {
                 <dd>
                   <p>
                     Optional value selecting which codec is used for this encoding's
-                    RTP stream. If absent, the user agent can chose to use any negotiated codec.
+                    RTP stream. If absent, the user agent can choose to use any coded negotiated for sending.
                   </p>
                   <p>
                     When {{codec}} is set and {{RTCRtpSender/[[SendCodecs]]}} have been negotiated,


### PR DESCRIPTION
Drive-by.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/3036.html" title="Last updated on Feb 19, 2025, 11:21 PM UTC (ccbe937)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/3036/ace68df...jan-ivar:ccbe937.html" title="Last updated on Feb 19, 2025, 11:21 PM UTC (ccbe937)">Diff</a>