### PR TITLE
Update codec match algorithm to be more general (work with AV1)

### DIFF
--- a/amendments.json
+++ b/amendments.json
@@ -600,7 +600,7 @@
         "webrtc/protocol/av1-profile-asymmetry.https.html"
       ],
       "testUpdates": [
-        "web-platform-tests/wpt#0000"
+        "web-platform-tests/wpt#51637"
       ]
     }
   ]

--- a/amendments.json
+++ b/amendments.json
@@ -587,5 +587,21 @@
         "web-platform-tests/wpt#49990"
       ]
     }
+  ],
+  "codec-match-asymmetrical": [
+    {
+      "description": "Compare symmetrical or asymmetrical parameters (not just level-id)",
+      "type": "correction",
+      "status": "candidate",
+      "difftype": "modify",
+      "id": 53,
+      "pr": 3043,
+      "tests": [
+        "webrtc/protocol/av1-profile-asymmetry.https.html"
+      ],
+      "testUpdates": [
+        "web-platform-tests/wpt#0000"
+      ]
+    }
   ]
 }

--- a/base-rec.html
+++ b/base-rec.html
@@ -11400,6 +11400,7 @@ interface <a class="internalDFN idlID" data-link-for="" data-link-type="interfac
                         </p></div>
                       </li>
                       <li class="needs-tests">
+                        <div id="codec-match-asymmetrical"></div>
                         <p>
                           If <var>firstMediaFormat</var> is not equal to <var>secondMediaFormat</var>, return
                           <code>false</code>.

--- a/webrtc.html
+++ b/webrtc.html
@@ -2819,8 +2819,9 @@
                                     <p>For each <var>encoding</var> in
                                     <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}},
                                     if <var>encoding</var>.{{RTCRtpEncodingParameters/codec}} does not match any entry in
-                                    <var>codecs</var>, using the [= codec dictionary match =] algorithm with <var>ignoreLevels</var>
-                                    set to <code>true</code>, [=map/remove=] <var>encoding</var>.{{RTCRtpEncodingParameters/codec}}.</p>
+                                    <var>codecs</var>, using the [= codec dictionary match =] algorithm with
+                                    <var>ignoreAsymmetricalParameters</var> set to <code>true</code>, [=map/remove=]
+                                    <var>encoding</var>.{{RTCRtpEncodingParameters/codec}}.</p>
                                   </li>
                                 </ol>
                               </li>
@@ -3749,8 +3750,8 @@ interface RTCPeerConnection : EventTarget  {
                                 exclude any codecs not included in the
                                 [=RTCRtpSender/list of implemented send codecs=] for
                                 <var>kind</var>, using the [= codec dictionary match =]
-                                algorithm with <var>ignoreLevels</var> set to
-                                <code>true</code>.</p>
+                                algorithm with <var>ignoreAsymmetricalParameters</var>
+                                set to <code>true</code>.</p>
                               </p>
                             </li>
                             <li>
@@ -3762,8 +3763,8 @@ interface RTCPeerConnection : EventTarget  {
                                 exclude any codecs not included in the
                                 [=list of implemented receive codecs=] for
                                 <var>kind</var>, using the [= codec dictionary match =]
-                                algorithm with <var>ignoreLevels</var> set to
-                                <code>true</code>.
+                                algorithm with <var>ignoreAsymmetricalParameters</var>
+                                set to <code>true</code>.
                               </p>
                             </li>
                           </ol>
@@ -4036,8 +4037,8 @@ interface RTCPeerConnection : EventTarget  {
                                 exclude any codecs not included in the
                                 [=RTCRtpSender/list of implemented send codecs=] for
                                 <var>kind</var>, using the [= codec dictionary match =]
-                                algorithm with <var>ignoreLevels</var> set to
-                                <code>true</code>.
+                                algorithm with <var>ignoreAsymmetricalParameters</var>
+                                set to <code>true</code>.
                               </p>
                             </li>
                             <li>
@@ -4049,8 +4050,8 @@ interface RTCPeerConnection : EventTarget  {
                                 exclude any codecs not included in the
                                 [=list of implemented receive codecs=] for
                                 <var>kind</var>, using the [= codec dictionary match =]
-                                algorithm with <var>ignoreLevels</var> set to
-                                <code>true</code>.
+                                algorithm with <var>ignoreAsymmetricalParameters</var>
+                                set to <code>true</code>.
                               </p>
                             </li>
                           </ol>
@@ -9097,7 +9098,7 @@ interface RTCRtpSender {
                           <li  id="setparameters-codec-validation-4">
                             Any <var>encoding</var> in encodings [=map/exists|contains=] a codec
                             not found in <var>choosableCodecs</var>, using the [= codec dictionary match =]
-                            algorithm with <var>ignoreLevels</var> set to <code>true</code>.
+                            algorithm with <var>ignoreAsymmetricalParameters</var> set to <code>true</code>.
                           </li>
                         </ul>
                       </li>
@@ -9819,7 +9820,7 @@ async function updateParameters() {
                     When {{codec}} is set and {{RTCRtpSender/[[SendCodecs]]}} have been negotiated,
                     the user agent SHOULD use the first {{RTCRtpSender/[[SendCodecs]]}} matching
                     {{codec}} for sending, according to the [= codec dictionary match =] algorithm
-                    with <var>ignoreLevels</var> set to <code>true</code>.
+                    with <var>ignoreAsymmetricalParameters</var> set to <code>true</code>.
                   </p>
                 </dd>
 		</div>
@@ -11498,8 +11499,8 @@ interface RTCRtpTransceiver {
                 <p>
                   The <dfn class="export">codec dictionary match</dfn> algorithm given two
                   {{RTCRtpCodec}} dictionaries <var>first</var> and <var>second</var>, and
-                  an <var>ignoreLevels</var> boolean defaulting to <code>false</code> if not
-                  specified, is as follows:
+                  an <var>ignoreAsymmetricalParameters</var> boolean defaulting to
+                  <code>false</code> if not specified, is as follows:
                 </p>
                 </div>
                 <ol class=algorithm>
@@ -11562,21 +11563,25 @@ interface RTCRtpTransceiver {
                         </p>
                       </li>
                       <li>
+                        <div id="codec-match-asymmetrical">
                         <p>
-                          If <var>firstMediaFormat</var> is not equal to <var>secondMediaFormat</var>, return
-                          <code>false</code>.
+                          If the media configurations described by <var>firstMediaFormat</var> and
+                          <var>secondMediaFormat</var> are not compatible, meaning they contain symmetrical
+                          parameters that are not equal, return <code>false</code>.
+                        </p>
+                        <p class="note">
+                          Which parameters are symmetrical or asymmetrical is codec-specific. For example,
+                          AV1's profile, level-idx and tier parameters may all be asymmetrical between the
+                          offerer and answerer while H.265's profile-id needs to be symmetrical and its
+                          level-id may be asymmetrical.
                         </p>
                       </li>
                       <li>
                         <div id="codec-match-without-level-id">
                         <p>
-                          If <var>ignoreLevels</var> is <code>false</code> and the highest complying bitstream
-                          levels inferred from <var>first</var>.{{RTCRtpCodec/sdpFmtpLine}} and
-                          <var>second</var>.{{RTCRtpCodec/sdpFmtpLine}} are different, return <code>false</code>.
-                        </p>
-                        <p class="note">
-                          Even if <var>ignoreLevels</var> is <code>true</code>, some codecs (such as H.264) include
-                          levels in the media format, so that ignoring the level requires codec-specific parsing.
+                          If <var>ignoreAsymmetricalParameters</var> is <code>false</code> and any parameter
+                          is not equal between <var>firstMediaFormat</var> and <var>secondMediaFormat</var>,
+                          return <code>false</code>. This includes comparing the asymmetrical parameters.
                         </p>
                         </div>
                       </li>


### PR DESCRIPTION
Fixes #3037


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/3043.html" title="Last updated on Mar 27, 2025, 12:21 PM UTC (dbe38ee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/3043/b725976...henbos:dbe38ee.html" title="Last updated on Mar 27, 2025, 12:21 PM UTC (dbe38ee)">Diff</a>