### PR TITLE
Clear the associated remote media stream lists so that they can be garbage collected more eagerly

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -11323,6 +11323,12 @@ interface RTCRtpTransceiver {
                   <code>false</code>, is as follows:
                 </p>
                 <ol class=algorithm>
+                  <li class="no-test-needed">
+                    <p>
+                      Let <var>receiver</var> be
+                      <var>transceiver</var>.{{RTCRtpTransceiver/[[Receiver]]}}.
+                    </p>
+                  </li>
                   <li>
                     <p>
                       If <var>transceiver</var>.{{RTCRtpTransceiver/[[Stopping]]}} is
@@ -11346,6 +11352,18 @@ interface RTCRtpTransceiver {
                     <p>
                       Set <var>transceiver</var>.{{RTCRtpTransceiver/[[CurrentDirection]]}}
                       to <code>null</code>.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set <var>receiver</var>.{{RTCRtpReceiver/[[AssociatedRemoteMediaStreams]]}}
+                      to an empty list.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set <var>receiver</var>.{{RTCRtpReceiver/[[LastStableStateAssociatedRemoteMediaStreams]]}}
+                      to an empty list.
                     </p>
                   </li>
                 </ol>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-pc/pull/3044.html" title="Last updated on Apr 17, 2025, 8:32 AM UTC (73cc4be)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/3044/b725976...youennf:73cc4be.html" title="Last updated on Apr 17, 2025, 8:32 AM UTC (73cc4be)">Diff</a>