### PR TITLE
Remove the muting on RTCP timeout sentence

### DIFF
--- a/amendments.json
+++ b/amendments.json
@@ -674,5 +674,19 @@
       "pr": 3070,
       "testUpdates": "not-testable"
     }
+  ],
+  "do-not-mute-on-rtcp-timeout": [
+    {
+      "description": "RTCP timeout is not a reason to mute a remote track",
+      "type": "correction",
+      "status": "candidate",
+      "difftype": "modify",
+      "id": 57,
+      "pr": 3082,
+      "tests": [
+        "webrtc/RTCPeerConnection-remote-track-mute.https.html"
+      ],
+      "testUpdates": "already-tested"
+    }
   ]
 }

--- a/base-rec.html
+++ b/base-rec.html
@@ -16124,7 +16124,7 @@ interface <a class="internalDFN idlID" data-link-for="" data-link-type="interfac
           a task to <a data-link-type="dfn|abstract-op" href="#set-track-muted" class="internalDFN" id="ref-for-set-track-muted-2">set the muted state</a> of the corresponding
           <a data-xref-type="_IDL_" data-link-type="idl" data-lt="MediaStreamTrack"><code>MediaStreamTrack</code></a> to <code>false</code>.
         </p>
-        <p class="needs-test needs-tests">
+        <p id="do-not-mute-on-rtcp-timeout" class="needs-test needs-tests">
           When one of the SSRCs for RTP source media streams received by an
           <a data-xref-type="_IDL_" data-link-type="idl" data-lt="RTCRtpReceiver" href="#dom-rtcrtpreceiver" class="internalDFN" id="ref-for-dom-rtcrtpreceiver-64"><code>RTCRtpReceiver</code></a> is removed either due to reception of a BYE or via
           timeout, it <em class="rfc2119">MUST</em> queue a task to <a data-link-type="dfn|abstract-op" href="#set-track-muted" class="internalDFN" id="ref-for-set-track-muted-3">set the muted state</a> of the

--- a/webrtc.html
+++ b/webrtc.html
@@ -16632,7 +16632,8 @@ async function gatherStats(pc) {
           a task to [= set the muted state =] of the corresponding
           {{MediaStreamTrack}} to <code>false</code>.
         </p>
-        <p data-tests="RTCPeerConnection-remote-track-mute.https.html">
+        <p id="do-not-mute-on-rtcp-timeout"
+           data-tests="RTCPeerConnection-remote-track-mute.https.html">
           When one of the SSRCs for RTP source media streams received by an
           {{RTCRtpReceiver}} is removed due to reception of a BYE,
           it MUST queue a task to [= set the muted state =] of the


### PR DESCRIPTION
Fixes #3077.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-pc/pull/3082.html" title="Last updated on Oct 23, 2025, 11:02 AM UTC (5912ed0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/3082/d5c73dd...henbos:5912ed0.html" title="Last updated on Oct 23, 2025, 11:02 AM UTC (5912ed0)">Diff</a>