### PR TITLE
Fix syntax of `send()` step that fires an `error` event

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -15114,8 +15114,10 @@ interface RTCDataChannel : EventTarget {
                   [=In parallel=], transmit <var>data</var> on
                   <var>channel</var>'s [= underlying data transport =].
                   If transmitting <var>data</var> leads to an SCTP-level error, [=queue a task=]
-                  to [= fire an event =] named {{RTCDataChannel/onerror}} at the
-                  the {{RTCDataChannel}} object.
+                  to [= fire an event =] named {{RTCDataChannel/error}} using the
+                  {{RTCErrorEvent}} interface with the {{RTCError/errorDetail}}
+                  attribute set to {{RTCErrorDetailType/"sctp-failure"}} at
+                  <var>channel</var>.
                 </p>
               </li>
               <li data-tests="RTCDataChannel-bufferedAmount.html">


### PR DESCRIPTION
This fixes the "fire an error" step that was introduced in #3101:
- Event name is `error`, not `onerror`
- Step needed to be explicit that the `RTCErrorEvent` interface is being used, as done in other steps that fire error events.
- The `errorDetail` attribute needed to be clarified as well (I used `sctp-failure` because that seems to match the error).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/webrtc-pc/pull/3102.html" title="Last updated on Apr 23, 2026, 1:58 AM UTC (594134f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/3102/c57a6fc...tidoust:594134f.html" title="Last updated on Apr 23, 2026, 1:58 AM UTC (594134f)">Diff</a>