### PR TITLE
Expand definition of "administratively prohibited."

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -1199,6 +1199,16 @@
               </p>
             </li>
           </ol>
+		  <section>
+		  	<h4>
+			  User Agent Restrictions
+		    </h4>
+			<p>
+			  The user agent may disallow some or all behavior of {{RTCPeerConnection}},
+			  including disabling use of the interface entirely. Such behavior is defined
+			  as <dfn>administratively prohibited</dfn>.
+		    </p>
+		  </section>
           <section>
             <h4>
               Constructor
@@ -1215,6 +1225,12 @@
                   specified here, [= exception/throw =] an {{UnknownError}}
                   with the {{DOMException/message}} attribute set to an
                   appropriate description.
+                </p>
+              </li>
+			  <li class="no-test-needed">
+                <p>
+                  If the use of {{RTCPeerConnection}} is [= administratively
+				  prohibited =], throw a {{NotAllowedError}}.
                 </p>
               </li>
               <li class="no-test-needed">
@@ -4691,7 +4707,7 @@ interface RTCPeerConnection : EventTarget  {
                     </li>
                   </ol>
                   <p>
-                    A candidate is <dfn>administratively prohibited</dfn> if
+                    A candidate is [= administratively prohibited =] if
                     the UA has decided not to allow connection attempts to this
                     address.
                   </p>


### PR DESCRIPTION
I am working on the Connection Allowlists specification being incubated in WICG: https://github.com/WICG/connection-allowlists

This feature will allow sites to restrict network access to particular allowlisted endpoints. WebRTC is handled by providing a boolean flag to either fully enable or fully disable RTCPeerConnection usage. The corresponding spec PR monkey-patches the RTCPeerConnection constructor to throw an error when disabling: https://github.com/WICG/connection-allowlists/pull/13

This mirrors the concept of "administratively prohibited", but applies to the entire PC interface instead of individual ICE candidates. This PR defines a new subsection containing the definition of "administratively prohibited", and has the RTCPeerConnection constructor and addIceCandidate refer to this common definition.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/VergeA/webrtc-pc/pull/3121.html" title="Last updated on Jun 30, 2026, 5:31 PM UTC (7f90593)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/3121/42d503e...VergeA:7f90593.html" title="Last updated on Jun 30, 2026, 5:31 PM UTC (7f90593)">Diff</a>