### PR TITLE
Clarify that administratively prohibited applies to both local and remote candidates

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4691,7 +4691,7 @@ interface RTCPeerConnection : EventTarget  {
                     </li>
                   </ol>
                   <p>
-                    A candidate or a gathering source can be <dfn>administratively prohibited</dfn>.
+                    A candidate or a [= gathering source =] can be <dfn>administratively prohibited</dfn>.
                     A remote candidate is [= administratively prohibited =] if
                     the UA decides not to allow connection attempts to this
                     address.

--- a/webrtc.html
+++ b/webrtc.html
@@ -4695,7 +4695,7 @@ interface RTCPeerConnection : EventTarget  {
                     A remote candidate is [= administratively prohibited =] if
                     the UA decides not to allow connection attempts to this
                     address.
-                    Local candidates are gathered from a gathering source which
+                    Local candidates are gathered from a <dfn>gathering source</dfn> which
                     can be local (network interface) or remote (remote candidate,
                     STUN server or TURN server).
                     A local gathering source is [= administratively prohibited =]

--- a/webrtc.html
+++ b/webrtc.html
@@ -4699,7 +4699,7 @@ interface RTCPeerConnection : EventTarget  {
                     can be local (network interface) or remote (remote candidate,
                     STUN server or TURN server).
                     A local gathering source is [= administratively prohibited =]
-                    if the UA does not use the source network interface for
+                    if the UA decides not to use the source network interface for
                     WebRTC traffic.
                     A remote gathering source is [= administratively prohibited =]
                     if the UA decides not to allow connection attempts to the

--- a/webrtc.html
+++ b/webrtc.html
@@ -4691,7 +4691,7 @@ interface RTCPeerConnection : EventTarget  {
                     </li>
                   </ol>
                   <p>
-                    A candidate can be <dfn>administratively prohibited</dfn>.
+                    A candidate or a gathering source can be <dfn>administratively prohibited</dfn>.
                     A remote candidate is [= administratively prohibited =] if
                     the UA decides not to allow connection attempts to this
                     address.

--- a/webrtc.html
+++ b/webrtc.html
@@ -1693,7 +1693,7 @@
                     <p>If <var>remote</var> is <code>false</code> and this
                     triggers the ICE candidate gathering process in <span data-jsep=
                      "applying-a-local-desc">[[!RFC9429]]</span>, the [= ICE Agent =]
-                    MUST NOT gather candidates that would be
+                    MUST NOT gather candidates from gathering sources that are
                     [= administratively prohibited =].
                     </p>
                   </li>
@@ -4691,9 +4691,22 @@ interface RTCPeerConnection : EventTarget  {
                     </li>
                   </ol>
                   <p>
-                    A candidate is <dfn>administratively prohibited</dfn> if
-                    the UA has decided not to allow connection attempts to this
+                    A candidate can be <dfn>administratively prohibited</dfn>.
+                    A remote candidate is [= administratively prohibited =] if
+                    the UA decides not to allow connection attempts to this
                     address.
+                    Local candidates are gathered from a gathering source which
+                    can be local (network interface) or remote (remote candidate,
+                    STUN server or TURN server).
+                    A local gathering source is [= administratively prohibited =]
+                    if the UA does not use the source network interface for
+                    WebRTC traffic.
+                    A remote gathering source is [= administratively prohibited =]
+                    if the UA decides not to allow connection attempts to the
+                    source address.
+                    If all candidates are said to be [= administratively prohibited =],
+                    the UA MUST NOT allow connection to any remote candidate and MUST
+                    NOT gather candidates from any gathering source.
                   </p>
                   <p>
                     For privacy reasons, there is no indication to the


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/3122


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-pc/pull/3125.html" title="Last updated on Jul 23, 2026, 2:27 PM UTC (738c2cd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/3125/42d503e...youennf:738c2cd.html" title="Last updated on Jul 23, 2026, 2:27 PM UTC (738c2cd)">Diff</a>