### PR TITLE
Check signaling state in one place, before applying SDP

### DIFF
--- a/amendments.json
+++ b/amendments.json
@@ -731,5 +731,19 @@
       ],
       "testUpdates": "already-tested"
     }
+  ],
+  "set-desc-signaling-state-check": [
+    {
+      "description": "Check signaling state in one place, before applying the description.",
+      "difftype": "modify",
+      "type": "correction",
+      "status": "candidate",
+      "id": 60,
+      "pr": 3130,
+      "tests": [
+        "webrtc/RTCPeerConnection-setLocalDescription-answer.html"
+      ],
+      "testUpdates": "already-tested"
+    }
   ]
 }

--- a/base-rec.html
+++ b/base-rec.html
@@ -2333,7 +2333,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
                           <code>true</code>, then abort these steps.
                         </p>
                       </li>
-                      <li data-tests="RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setLocalDescription-pranswer.html,RTCPeerConnection-setRemoteDescription-answer.html,RTCPeerConnection-setRemoteDescription-offer.html,RTCPeerConnection-setRemoteDescription-pranswer.html" class="has-tests">
+                      <li id="set-desc-signaling-state-check" data-tests="RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setLocalDescription-pranswer.html,RTCPeerConnection-setRemoteDescription-answer.html,RTCPeerConnection-setRemoteDescription-offer.html,RTCPeerConnection-setRemoteDescription-pranswer.html" class="has-tests">
                         <p>
                           If
                           <var>description</var>.<a data-link-type="idl" data-xref-type="attribute|dict-member|const" data-link-for="RTCSessionDescriptionInit" data-xref-for="RTCSessionDescriptionInit" href="#dom-rtcsessiondescriptioninit-type" class="internalDFN" id="ref-for-dom-rtcsessiondescriptioninit-type-2"><code>type</code></a>

--- a/webrtc.html
+++ b/webrtc.html
@@ -1667,6 +1667,20 @@
                   {{InvalidStateError}} and abort these steps.
                 </p>
               </li>
+              <li id="set-desc-signaling-state-check" data-tests=
+              "RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setLocalDescription-pranswer.html,RTCPeerConnection-setRemoteDescription-answer.html,RTCPeerConnection-setRemoteDescription-offer.html,RTCPeerConnection-setRemoteDescription-pranswer.html">
+                <p>
+                  If
+                  <var>description</var>.{{RTCSessionDescriptionInit/type}}
+                  is invalid for the current
+                  <var>connection</var>.{{RTCPeerConnection/[[SignalingState]]}}
+                  as described in
+                  <span data-jsep="processing-a-local-desc processing-a-remote-desc">
+                  [[!RFC9429]]</span>, then [= reject =] <var>p</var> with
+                  a newly [= exception/created =] {{InvalidStateError}}
+                  and abort these steps.
+                </p>
+              </li>
               <li>
                 <p>
                   Let <var>jsepSetOfTransceivers</var> be a shallow copy of
@@ -1725,20 +1739,6 @@
                         <p>
                           If <var>connection</var>.{{RTCPeerConnection/[[IsClosed]]}} is
                           <code>true</code>, then abort these steps.
-                        </p>
-                      </li>
-                      <li data-tests=
-                      "RTCPeerConnection-setLocalDescription-answer.html,RTCPeerConnection-setLocalDescription-pranswer.html,RTCPeerConnection-setRemoteDescription-answer.html,RTCPeerConnection-setRemoteDescription-offer.html,RTCPeerConnection-setRemoteDescription-pranswer.html">
-                        <p>
-                          If
-                          <var>description</var>.{{RTCSessionDescriptionInit/type}}
-                          is invalid for the current
-                          <var>connection</var>.{{RTCPeerConnection/[[SignalingState]]}}
-                          as described in
-                          <span data-jsep="processing-a-local-desc processing-a-remote-desc">
-                          [[!RFC9429]]</span>, then [= reject =] <var>p</var> with
-                          a newly [= exception/created =] {{InvalidStateError}}
-                          and abort these steps.
                         </p>
                       </li>
                       <li data-tests=


### PR DESCRIPTION
Move the InvalidStateError type-vs-state check up next to the rollback check, ahead of the in-parallel JSEP processing.

Fixes #3129


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-pc/pull/3130.html" title="Last updated on Jul 24, 2026, 8:31 PM UTC (f209330)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-pc/3130/42d503e...jan-ivar:f209330.html" title="Last updated on Jul 24, 2026, 8:31 PM UTC (f209330)">Diff</a>